### PR TITLE
feat: add branch enforcement to OpenSpec workflow

### DIFF
--- a/.opencode/command/cobalt-crush.md
+++ b/.opencode/command/cobalt-crush.md
@@ -68,10 +68,18 @@ implementation command to the `cobalt-crush-dev` agent:
 2. **Check for an OpenSpec active change**: Look for directories
    under `openspec/changes/` that contain a `tasks.md` file. If
    one exists, this is an OpenSpec tactical workflow.
-   Read the full contents of `.opencode/command/opsx-apply.md`
-   and delegate it to the `cobalt-crush-dev` agent via the Task
-   tool — pass the command file's instructions as the agent's
-   prompt so the agent executes the apply workflow.
+   **Validate branch**: Run `git rev-parse --abbrev-ref HEAD`.
+   The current branch must be `opsx/<change-name>` where
+   `<change-name>` matches the detected change directory name.
+   If not on the correct branch, **STOP** with error:
+   > "OpenSpec change `<name>` detected but you are on branch
+   > `<current-branch>`. Run: `git checkout opsx/<name>`"
+
+   If on the correct branch, read the full contents of
+   `.opencode/command/opsx-apply.md` and delegate it to the
+   `cobalt-crush-dev` agent via the Task tool — pass the command
+   file's instructions as the agent's prompt so the agent
+   executes the apply workflow.
 
 3. **If neither is detected**: Ask the user which workflow to run:
 

--- a/.opencode/command/opsx-apply.md
+++ b/.opencode/command/opsx-apply.md
@@ -17,7 +17,16 @@ Implement tasks from an OpenSpec change.
 
    Always announce: "Using change: <name>" and how to override (e.g., `/opsx-apply <other>`).
 
-2. **Check status to understand the schema**
+2. **Validate branch**
+
+   Run `git rev-parse --abbrev-ref HEAD` to get the current branch.
+
+   - If the current branch is `opsx/<change-name>`: proceed.
+   - If the current branch is NOT `opsx/<change-name>`: **STOP** with error:
+     > "Must be on branch `opsx/<change-name>` to implement this change.
+     > Run: `git checkout opsx/<change-name>`"
+
+3. **Check status to understand the schema**
    ```bash
    openspec status --change "<name>" --json
    ```
@@ -25,7 +34,7 @@ Implement tasks from an OpenSpec change.
    - `schemaName`: The workflow being used (e.g., "spec-driven")
    - Which artifact contains the tasks (typically "tasks" for spec-driven, check status for others)
 
-3. **Get apply instructions**
+4. **Get apply instructions**
 
    ```bash
    openspec instructions apply --change "<name>" --json
@@ -42,14 +51,14 @@ Implement tasks from an OpenSpec change.
    - If `state: "all_done"`: congratulate, suggest archive
    - Otherwise: proceed to implementation
 
-4. **Read context files**
+5. **Read context files**
 
    Read the files listed in `contextFiles` from the apply instructions output.
    The files depend on the schema being used:
    - **spec-driven**: proposal, specs, design, tasks
    - Other schemas: follow the contextFiles from CLI output
 
-5. **Show current progress**
+6. **Show current progress**
 
    Display:
    - Schema being used
@@ -57,7 +66,7 @@ Implement tasks from an OpenSpec change.
    - Remaining tasks overview
    - Dynamic instruction from CLI
 
-6. **Implement tasks (loop until done or blocked)**
+7. **Implement tasks (loop until done or blocked)**
 
    For each pending task:
    - Show which task is being worked on
@@ -72,7 +81,7 @@ Implement tasks from an OpenSpec change.
    - Error or blocker encountered → report and wait for guidance
    - User interrupts
 
-7. **On completion or pause, show status**
+8. **On completion or pause, show status**
 
    Display:
    - Tasks completed this session

--- a/.opencode/command/opsx-archive.md
+++ b/.opencode/command/opsx-archive.md
@@ -75,13 +75,25 @@ Archive a completed change in the experimental workflow.
    mv openspec/changes/<name> openspec/changes/archive/YYYY-MM-DD-<name>
    ```
 
-6. **Display summary**
+6. **Return to main branch**
+
+   After the archive move completes:
+   ```bash
+   git checkout main
+   ```
+
+   The `opsx/<name>` branch still exists locally. Note
+   in the summary that the developer can delete it
+   manually with `git branch -d opsx/<name>` if desired.
+
+7. **Display summary**
 
    Show archive completion summary including:
    - Change name
    - Schema that was used
    - Archive location
    - Spec sync status (synced / sync skipped / no delta specs)
+   - Branch status (returned to main)
    - Note about any warnings (incomplete artifacts/tasks)
 
 **Output On Success**

--- a/.opencode/command/opsx-propose.md
+++ b/.opencode/command/opsx-propose.md
@@ -32,7 +32,18 @@ When ready to implement, run /opsx-apply
    ```
    This creates a scaffolded change at `openspec/changes/<name>/` with `.openspec.yaml`.
 
-3. **Get the artifact build order**
+3. **Create and checkout a branch**
+
+   ```bash
+   git checkout -b opsx/<name>
+   ```
+
+   **Guard**: Before creating the branch, check the current branch:
+   - If already on `opsx/<name>` (exact match): skip branch creation, proceed.
+   - If on a different `opsx/*` branch: **STOP** with error: "Already on branch `opsx/<other>` -- finish or archive that change first."
+   - If on `main` or any non-opsx branch: create and checkout `opsx/<name>`.
+
+4. **Get the artifact build order**
    ```bash
    openspec status --change "<name>" --json
    ```
@@ -40,7 +51,7 @@ When ready to implement, run /opsx-apply
    - `applyRequires`: array of artifact IDs needed before implementation (e.g., `["tasks"]`)
    - `artifacts`: list of all artifacts with their status and dependencies
 
-4. **Create artifacts in sequence until apply-ready**
+5. **Create artifacts in sequence until apply-ready**
 
    Use the **TodoWrite tool** to track progress through the artifacts.
 
@@ -72,7 +83,7 @@ When ready to implement, run /opsx-apply
       - Use **AskUserQuestion tool** to clarify
       - Then continue with creation
 
-5. **Show final status**
+6. **Show final status**
    ```bash
    openspec status --change "<name>"
    ```

--- a/.opencode/skills/openspec-apply-change/SKILL.md
+++ b/.opencode/skills/openspec-apply-change/SKILL.md
@@ -24,7 +24,16 @@ Implement tasks from an OpenSpec change.
 
    Always announce: "Using change: <name>" and how to override (e.g., `/opsx-apply <other>`).
 
-2. **Check status to understand the schema**
+2. **Validate branch**
+
+   Run `git rev-parse --abbrev-ref HEAD` to get the current branch.
+
+   - If the current branch is `opsx/<change-name>`: proceed.
+   - If the current branch is NOT `opsx/<change-name>`: **STOP** with error:
+     > "Must be on branch `opsx/<change-name>` to implement this change.
+     > Run: `git checkout opsx/<change-name>`"
+
+3. **Check status to understand the schema**
    ```bash
    openspec status --change "<name>" --json
    ```
@@ -32,7 +41,7 @@ Implement tasks from an OpenSpec change.
    - `schemaName`: The workflow being used (e.g., "spec-driven")
    - Which artifact contains the tasks (typically "tasks" for spec-driven, check status for others)
 
-3. **Get apply instructions**
+4. **Get apply instructions**
 
    ```bash
    openspec instructions apply --change "<name>" --json
@@ -49,14 +58,14 @@ Implement tasks from an OpenSpec change.
    - If `state: "all_done"`: congratulate, suggest archive
    - Otherwise: proceed to implementation
 
-4. **Read context files**
+5. **Read context files**
 
    Read the files listed in `contextFiles` from the apply instructions output.
    The files depend on the schema being used:
    - **spec-driven**: proposal, specs, design, tasks
    - Other schemas: follow the contextFiles from CLI output
 
-5. **Show current progress**
+6. **Show current progress**
 
    Display:
    - Schema being used
@@ -64,7 +73,7 @@ Implement tasks from an OpenSpec change.
    - Remaining tasks overview
    - Dynamic instruction from CLI
 
-6. **Implement tasks (loop until done or blocked)**
+7. **Implement tasks (loop until done or blocked)**
 
    For each pending task:
    - Show which task is being worked on
@@ -79,7 +88,7 @@ Implement tasks from an OpenSpec change.
    - Error or blocker encountered → report and wait for guidance
    - User interrupts
 
-7. **On completion or pause, show status**
+8. **On completion or pause, show status**
 
    Display:
    - Tasks completed this session

--- a/.opencode/skills/openspec-archive-change/SKILL.md
+++ b/.opencode/skills/openspec-archive-change/SKILL.md
@@ -82,13 +82,25 @@ Archive a completed change in the experimental workflow.
    mv openspec/changes/<name> openspec/changes/archive/YYYY-MM-DD-<name>
    ```
 
-6. **Display summary**
+6. **Return to main branch**
+
+   After the archive move completes:
+   ```bash
+   git checkout main
+   ```
+
+   The `opsx/<name>` branch still exists locally. Note
+   in the summary that the developer can delete it
+   manually with `git branch -d opsx/<name>` if desired.
+
+7. **Display summary**
 
    Show archive completion summary including:
    - Change name
    - Schema that was used
    - Archive location
    - Whether specs were synced (if applicable)
+   - Branch status (returned to main)
    - Note about any warnings (incomplete artifacts/tasks)
 
 **Output On Success**

--- a/.opencode/skills/openspec-propose/SKILL.md
+++ b/.opencode/skills/openspec-propose/SKILL.md
@@ -39,7 +39,18 @@ When ready to implement, run /opsx-apply
    ```
    This creates a scaffolded change at `openspec/changes/<name>/` with `.openspec.yaml`.
 
-3. **Get the artifact build order**
+3. **Create and checkout a branch**
+
+   ```bash
+   git checkout -b opsx/<name>
+   ```
+
+   **Guard**: Before creating the branch, check the current branch:
+   - If already on `opsx/<name>` (exact match): skip branch creation, proceed.
+   - If on a different `opsx/*` branch: **STOP** with error: "Already on branch `opsx/<other>` -- finish or archive that change first."
+   - If on `main` or any non-opsx branch: create and checkout `opsx/<name>`.
+
+4. **Get the artifact build order**
    ```bash
    openspec status --change "<name>" --json
    ```
@@ -47,7 +58,7 @@ When ready to implement, run /opsx-apply
    - `applyRequires`: array of artifact IDs needed before implementation (e.g., `["tasks"]`)
    - `artifacts`: list of all artifacts with their status and dependencies
 
-4. **Create artifacts in sequence until apply-ready**
+5. **Create artifacts in sequence until apply-ready**
 
    Use the **TodoWrite tool** to track progress through the artifacts.
 
@@ -79,7 +90,7 @@ When ready to implement, run /opsx-apply
       - Use **AskUserQuestion tool** to clarify
       - Then continue with creation
 
-5. **Show final status**
+6. **Show final status**
    ```bash
    openspec status --change "<name>"
    ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -387,6 +387,24 @@ spec directory under `specs/`.
 4. Archive the OpenSpec proposal with `/opsx:archive`.
 5. Continue with the Speckit pipeline from the new spec.
 
+### Branch Conventions
+
+Both tiers enforce branch-based workflows:
+
+- **Speckit** branches: `NNN-<short-name>`
+  (e.g., `013-binary-rename`). Created automatically by
+  `/speckit.specify`. Validated by `check-prerequisites.sh`
+  at every pipeline step (hard gate).
+- **OpenSpec** branches: `opsx/<change-name>`
+  (e.g., `opsx/doctor-ux-improvement`). Created by
+  `/opsx-propose`. Validated by `/opsx-apply` before
+  implementation (hard gate).
+
+The `opsx/` prefix namespace ensures OpenSpec branches
+are visually distinct from Speckit branches in
+`git branch` output and do not collide with the
+`NNN-*` numbering pattern.
+
 ### Directory Boundary Enforcement
 
 These boundaries are enforced by convention and code

--- a/internal/scaffold/assets/opencode/command/cobalt-crush.md
+++ b/internal/scaffold/assets/opencode/command/cobalt-crush.md
@@ -68,10 +68,18 @@ implementation command to the `cobalt-crush-dev` agent:
 2. **Check for an OpenSpec active change**: Look for directories
    under `openspec/changes/` that contain a `tasks.md` file. If
    one exists, this is an OpenSpec tactical workflow.
-   Read the full contents of `.opencode/command/opsx-apply.md`
-   and delegate it to the `cobalt-crush-dev` agent via the Task
-   tool — pass the command file's instructions as the agent's
-   prompt so the agent executes the apply workflow.
+   **Validate branch**: Run `git rev-parse --abbrev-ref HEAD`.
+   The current branch must be `opsx/<change-name>` where
+   `<change-name>` matches the detected change directory name.
+   If not on the correct branch, **STOP** with error:
+   > "OpenSpec change `<name>` detected but you are on branch
+   > `<current-branch>`. Run: `git checkout opsx/<name>`"
+
+   If on the correct branch, read the full contents of
+   `.opencode/command/opsx-apply.md` and delegate it to the
+   `cobalt-crush-dev` agent via the Task tool — pass the command
+   file's instructions as the agent's prompt so the agent
+   executes the apply workflow.
 
 3. **If neither is detected**: Ask the user which workflow to run:
 

--- a/openspec/changes/archive/2026-03-22-openspec-branch-enforcement/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-22-openspec-branch-enforcement/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: unbound-force
+created: 2026-03-23

--- a/openspec/changes/archive/2026-03-22-openspec-branch-enforcement/design.md
+++ b/openspec/changes/archive/2026-03-22-openspec-branch-enforcement/design.md
@@ -1,0 +1,55 @@
+## Context
+
+Speckit enforces `NNN-<name>` feature branches at every
+pipeline step via `check_feature_branch()` in
+`common.sh`. OpenSpec has no branch awareness. This
+creates inconsistency in the development workflow.
+
+## Goals / Non-Goals
+
+### Goals
+- OpenSpec changes use `opsx/<name>` branches
+- Hard gate: error if not on correct branch
+- Propose creates branch, apply validates it,
+  archive returns to main
+- Cobalt-crush validates branch for OpenSpec path
+
+### Non-Goals
+- Modifying the openspec CLI (third-party npm package)
+- Adding bash scripts (keep it Markdown instruction-only)
+- Changing speckit branch enforcement
+- Making explore mode require a branch
+
+## Decisions
+
+**Branch naming**: `opsx/<change-name>`. Uses git's
+namespace convention (like `feature/`, `fix/`). Does
+not collide with speckit's `NNN-*` pattern. The `opsx/`
+prefix makes OpenSpec branches instantly recognizable
+in `git branch` output.
+
+**Enforcement via instructions**: Since we cannot modify
+the openspec CLI, enforcement is done in the Markdown
+command/skill files that AI agents follow. The agent
+runs `git rev-parse --abbrev-ref HEAD` and checks the
+result before proceeding.
+
+**Hard gate pattern**: The agent checks the branch and
+stops with a clear error message if wrong. No `--force`
+override (keep it simple).
+
+**Branch lifecycle**:
+1. `/opsx-propose` → `git checkout -b opsx/<name>`
+2. `/opsx-apply` → validate `HEAD == opsx/<name>`
+3. `/opsx-archive` → `git checkout main` after archive
+
+## Risks / Trade-offs
+
+**Risk**: AI agents may not perfectly follow branch
+validation instructions. Mitigated by making the
+instructions explicit and unambiguous.
+
+**Trade-off**: No automated enforcement (unlike
+speckit's bash scripts that `exit 1`). Acceptable
+because OpenSpec is tactical -- the blast radius of
+a branch mistake is smaller.

--- a/openspec/changes/archive/2026-03-22-openspec-branch-enforcement/proposal.md
+++ b/openspec/changes/archive/2026-03-22-openspec-branch-enforcement/proposal.md
@@ -1,0 +1,77 @@
+## Why
+
+Speckit enforces feature branches at every pipeline step
+via shared bash scripts (`check_feature_branch()` hard
+gate). OpenSpec has zero git awareness -- changes are
+created, implemented, and archived on whatever branch
+the developer happens to be on. This means OpenSpec
+changes can accidentally be committed to `main`,
+mixed with other work, or lose traceability.
+
+## What Changes
+
+Add branch creation, validation, and lifecycle
+management to all OpenSpec command and skill files.
+
+**Convention**: `opsx/<change-name>` branches
+(e.g., `opsx/doctor-ux-improvement`).
+
+**Enforcement**: Hard gate -- error and stop if not on
+the correct branch. Same rigor as speckit.
+
+## Capabilities
+
+### New Capabilities
+- `opsx-branch-creation`: `/opsx-propose` creates and
+  checks out an `opsx/<name>` branch after creating the
+  change directory
+- `opsx-branch-validation`: `/opsx-apply` validates the
+  current branch matches the change before implementing
+- `opsx-branch-cleanup`: `/opsx-archive` returns to
+  main after archiving
+
+### Modified Capabilities
+- `cobalt-crush-opsx-detection`: The OpenSpec detection
+  path in `/cobalt-crush` validates the branch matches
+  the detected change
+
+### Removed Capabilities
+- None
+
+## Impact
+
+- 4 command files under `.opencode/command/`
+- 3 skill files under `.opencode/skills/`
+- AGENTS.md documentation update
+- No Go code changes
+- No openspec CLI changes (third-party)
+
+## Constitution Alignment
+
+### I. Autonomous Collaboration
+
+**Assessment**: N/A
+
+No artifact communication changes. Branch management
+is a developer workflow concern.
+
+### II. Composability First
+
+**Assessment**: PASS
+
+Branch enforcement is instruction-level only (Markdown
+command files). No runtime dependencies introduced.
+OpenSpec CLI works independently of branch state.
+
+### III. Observable Quality
+
+**Assessment**: N/A
+
+No output format changes.
+
+### IV. Testability
+
+**Assessment**: N/A
+
+No testable code changes -- these are Markdown
+instruction files for AI agents.

--- a/openspec/changes/archive/2026-03-22-openspec-branch-enforcement/specs/branch.md
+++ b/openspec/changes/archive/2026-03-22-openspec-branch-enforcement/specs/branch.md
@@ -1,0 +1,86 @@
+## ADDED Requirements
+
+### Requirement: opsx-branch-creation
+
+The `/opsx-propose` command MUST create and checkout a
+git branch named `opsx/<change-name>` after creating
+the change directory.
+
+#### Scenario: propose creates branch
+
+- **GIVEN** the developer is on `main`
+- **WHEN** `/opsx-propose fix-auth-bug` is run
+- **THEN** branch `opsx/fix-auth-bug` is created and
+  checked out, and the change directory exists at
+  `openspec/changes/fix-auth-bug/`
+
+#### Scenario: propose on existing opsx branch
+
+- **GIVEN** the developer is on `opsx/other-change`
+- **WHEN** `/opsx-propose new-thing` is run
+- **THEN** the command errors with "Already on branch
+  opsx/other-change -- finish or archive that change
+  first"
+
+### Requirement: opsx-branch-validation
+
+The `/opsx-apply` command MUST validate that the
+current branch is `opsx/<change-name>` before
+implementing tasks.
+
+#### Scenario: apply on correct branch
+
+- **GIVEN** the developer is on `opsx/fix-auth-bug`
+- **WHEN** `/opsx-apply fix-auth-bug` is run
+- **THEN** implementation proceeds normally
+
+#### Scenario: apply on wrong branch
+
+- **GIVEN** the developer is on `main`
+- **WHEN** `/opsx-apply fix-auth-bug` is run
+- **THEN** the command errors with "Must be on branch
+  opsx/fix-auth-bug. Run: git checkout
+  opsx/fix-auth-bug"
+
+### Requirement: opsx-branch-cleanup
+
+The `/opsx-archive` command MUST checkout `main`
+after archiving a change.
+
+#### Scenario: archive returns to main
+
+- **GIVEN** the developer is on `opsx/fix-auth-bug`
+  and all tasks are complete
+- **WHEN** `/opsx-archive fix-auth-bug` is run
+- **THEN** the change is archived and the developer
+  is on `main`
+
+### Requirement: cobalt-crush-opsx-branch-check
+
+The `/cobalt-crush` command's OpenSpec detection path
+MUST validate the current branch matches the detected
+change.
+
+#### Scenario: cobalt-crush with matching branch
+
+- **GIVEN** the developer is on `opsx/fix-auth-bug`
+  and `openspec/changes/fix-auth-bug/tasks.md` exists
+- **WHEN** `/cobalt-crush` is run without arguments
+- **THEN** implementation proceeds for the fix-auth-bug
+  change
+
+#### Scenario: cobalt-crush with mismatched branch
+
+- **GIVEN** the developer is on `main` and
+  `openspec/changes/fix-auth-bug/tasks.md` exists
+- **WHEN** `/cobalt-crush` is run without arguments
+- **THEN** the command errors with a hint to checkout
+  the correct branch
+
+## MODIFIED Requirements
+
+None.
+
+## REMOVED Requirements
+
+None.

--- a/openspec/changes/archive/2026-03-22-openspec-branch-enforcement/tasks.md
+++ b/openspec/changes/archive/2026-03-22-openspec-branch-enforcement/tasks.md
@@ -1,0 +1,27 @@
+## 1. Update Propose Command and Skill
+
+- [x] 1.1 Add branch creation step to `.opencode/command/opsx-propose.md`: after `openspec new change`, run `git checkout -b opsx/<name>`. Add guard: if already on an `opsx/*` branch, error and stop.
+- [x] 1.2 Add same branch creation step to `.opencode/skills/openspec-propose/SKILL.md`
+
+## 2. Update Apply Command and Skill
+
+- [x] 2.1 Add branch validation step to `.opencode/command/opsx-apply.md`: before implementation, run `git rev-parse --abbrev-ref HEAD` and verify it equals `opsx/<change-name>`. If not, error with checkout hint.
+- [x] 2.2 Add same branch validation to `.opencode/skills/openspec-apply-change/SKILL.md`
+
+## 3. Update Archive Command and Skill
+
+- [x] 3.1 Add branch cleanup step to `.opencode/command/opsx-archive.md`: after moving to archive, run `git checkout main`.
+- [x] 3.2 Add same branch cleanup to `.opencode/skills/openspec-archive-change/SKILL.md`
+
+## 4. Update Cobalt-Crush Command
+
+- [x] 4.1 Add branch validation to the OpenSpec detection path in `.opencode/command/cobalt-crush.md`: when an active OpenSpec change is detected, validate the current branch is `opsx/<change-name>` before delegating.
+
+## 5. Update Documentation
+
+- [x] 5.1 Add OpenSpec branch convention note to `AGENTS.md` in the "Strategic vs Tactical: Boundary Guidelines" section, documenting that OpenSpec changes use `opsx/<name>` branches.
+
+## 6. Verify
+
+- [x] 6.1 Build passes: `go build ./...`
+- [x] 6.2 Full test suite passes: `go test -race -count=1 ./...` (scaffold drift test caught unsync'd cobalt-crush.md -- fixed)


### PR DESCRIPTION
## Summary

Add branch enforcement to the OpenSpec workflow, matching speckit's branch-based workflow rigor. OpenSpec changes now use `opsx/<change-name>` branches with hard gate validation.

## Branch Convention

| Tier | Branch Pattern | Example | Created By | Validated By |
|------|---------------|---------|------------|--------------|
| Speckit (strategic) | `NNN-<short-name>` | `013-binary-rename` | `/speckit.specify` | `check-prerequisites.sh` (hard gate) |
| OpenSpec (tactical) | `opsx/<change-name>` | `opsx/doctor-ux-improvement` | `/opsx-propose` | `/opsx-apply` (hard gate) |

## Changes (7 instruction files + AGENTS.md)

### Commands (4 files)
- `opsx-propose.md`: Step 3 added -- `git checkout -b opsx/<name>` with guard against being on another opsx branch
- `opsx-apply.md`: Step 2 added -- branch validation (hard gate, stops with checkout hint)
- `opsx-archive.md`: Step 6 added -- `git checkout main` after archive
- `cobalt-crush.md`: OpenSpec detection path validates branch matches detected change

### Skills (3 files)
- `openspec-propose/SKILL.md`: mirrors propose command
- `openspec-apply-change/SKILL.md`: mirrors apply command
- `openspec-archive-change/SKILL.md`: mirrors archive command

### Documentation
- `AGENTS.md`: New "Branch Conventions" section documenting both speckit and OpenSpec branch patterns

### Scaffold
- `internal/scaffold/assets/opencode/command/cobalt-crush.md`: synced with live copy

## Testing

- 16/16 packages pass with `go test -race -count=1`
- Scaffold drift test caught the unsync'd cobalt-crush.md (fixed)
