### PR TITLE
Fix Ollama installation on Linux with platform-aware brew commands

### DIFF
--- a/internal/doctor/environ.go
+++ b/internal/doctor/environ.go
@@ -271,7 +271,10 @@ func homebrewInstallCmd(toolName string) string {
 	case "swarm":
 		return "npm install -g opencode-swarm-plugin@latest"
 	case "ollama":
-		return "brew install --cask ollama-app && ollama pull granite-embedding:30m"
+		if runtime.GOOS == "darwin" {
+			return "brew install --cask ollama-app && ollama pull granite-embedding:30m"
+		}
+		return "brew install ollama && ollama pull granite-embedding:30m"
 	default:
 		return "brew install " + toolName
 	}
@@ -294,7 +297,10 @@ func genericInstallCmd(toolName string) string {
 	case "gh":
 		return "Download from https://cli.github.com/"
 	case "ollama":
-		return "brew install --cask ollama-app && ollama pull granite-embedding:30m"
+		if runtime.GOOS == "darwin" {
+			return "brew install --cask ollama-app && ollama pull granite-embedding:30m"
+		}
+		return "brew install ollama && ollama pull granite-embedding:30m"
 	default:
 		return "Install " + toolName
 	}

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -689,7 +689,10 @@ func installOllama(opts *Options, env doctor.DetectedEnvironment) stepResult {
 
 	if opts.DryRun {
 		if doctor.HasManager(env, doctor.ManagerHomebrew) {
-			return stepResult{name: "Ollama", action: "dry-run", detail: "Would install: brew install --cask ollama-app"}
+			if runtime.GOOS == "darwin" {
+				return stepResult{name: "Ollama", action: "dry-run", detail: "Would install: brew install --cask ollama-app"}
+			}
+			return stepResult{name: "Ollama", action: "dry-run", detail: "Would install: brew install ollama"}
 		}
 		return stepResult{name: "Ollama", action: "dry-run", detail: "Would install: download from https://ollama.com/download"}
 	}
@@ -702,7 +705,14 @@ func installOllama(opts *Options, env doctor.DetectedEnvironment) stepResult {
 		}
 	}
 
-	if _, err := opts.ExecCmd("brew", "install", "--cask", "ollama-app"); err != nil {
+	// Platform-specific installation: macOS uses cask (GUI app), Linux uses formula (CLI).
+	var err error
+	if runtime.GOOS == "darwin" {
+		_, err = opts.ExecCmd("brew", "install", "--cask", "ollama-app")
+	} else {
+		_, err = opts.ExecCmd("brew", "install", "ollama")
+	}
+	if err != nil {
 		return stepResult{name: "Ollama", action: "failed", detail: "brew install failed", err: err}
 	}
 	return stepResult{name: "Ollama", action: "installed", detail: "via Homebrew"}

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -128,7 +128,7 @@ func TestSetupRun_AllMissing(t *testing.T) {
 		"npm install -g opencode-swarm-plugin@latest",
 		"swarm setup",
 		"swarm init",
-		"brew install --cask ollama-app",
+		"brew install ollama",
 		"brew install unbound-force/tap/dewey",
 	}
 
@@ -1261,13 +1261,13 @@ func TestSetupRun_OllamaInstall(t *testing.T) {
 	// Verify Ollama was installed via Homebrew (no tip, actual install).
 	found := false
 	for _, call := range rec.calls {
-		if call == "brew install --cask ollama-app" {
+		if call == "brew install ollama" {
 			found = true
 			break
 		}
 	}
 	if !found {
-		t.Error("expected 'brew install --cask ollama-app' in recorded commands")
+		t.Error("expected 'brew install ollama' in recorded commands")
 	}
 
 	// Verify no Ollama tip in output (removed -- now installed automatically).
@@ -1363,10 +1363,10 @@ func TestSetupRun_OllamaNoHomebrew(t *testing.T) {
 		t.Fatalf("Run: %v", err)
 	}
 
-	// Verify no brew install ollama-app was attempted.
+	// Verify no brew install ollama was attempted.
 	for _, call := range rec.calls {
-		if call == "brew install --cask ollama-app" {
-			t.Error("should NOT attempt brew install --cask ollama-app when Homebrew is not available")
+		if call == "brew install ollama" {
+			t.Error("should NOT attempt brew install ollama when Homebrew is not available")
 		}
 	}
 
@@ -1392,7 +1392,7 @@ func TestSetupRun_OllamaBrewFails(t *testing.T) {
 			"node --version": "v22.15.0",
 		},
 		errors: map[string]error{
-			"brew install --cask ollama-app": fmt.Errorf("brew: cask not found"),
+			"brew install ollama": fmt.Errorf("brew: formula not found"),
 		},
 	}
 


### PR DESCRIPTION
## Problem

  Running `uf setup` on Linux fails when installing Ollama:

  ✗ Ollama           failed (brew install failed)
                     Error: exit status 1

  This happens because the code is hardcoded to run `brew install --cask ollama-app`, but casks are macOS-only GUI applications. On
  Linux, Ollama is available as a regular Homebrew formula.

  ## Solution

  Make Ollama installation platform-aware using `runtime.GOOS`:

  - **macOS**: `brew install --cask ollama-app` (GUI application)
  - **Linux**: `brew install ollama` (CLI formula)

  ## Changes

  - `internal/setup/setup.go`: Platform-aware install logic in `installOllama()`
  - `internal/doctor/environ.go`: Platform-aware hints in `homebrewInstallCmd()` and `genericInstallCmd()`
  - `internal/setup/setup_test.go`: Updated test expectations for Linux behavior

  ## Testing

  - ✅ Code syntax validated with `go fmt`
  - ✅ Matches the approach used in unbound-force/homebrew-tap#2

  ## Related

  - Fixes the same issue addressed in unbound-force/homebrew-tap#2 for the `dewey.rb` formula
  - Both changes ensure consistent cross-platform Ollama installation


Co-Authored-By: Claude Sonnet 4.5