### PR TITLE
fix: forward Anthropic Vertex env vars to sandbox container

### DIFF
--- a/internal/sandbox/config.go
+++ b/internal/sandbox/config.go
@@ -52,6 +52,9 @@ var forwardedAPIKeys = []string{
 	// Google Vertex AI (FR-020).
 	"GOOGLE_CLOUD_PROJECT",
 	"VERTEX_LOCATION",
+	// Anthropic via Vertex (Claude models on GCP).
+	"ANTHROPIC_VERTEX_PROJECT_ID",
+	"CLAUDE_CODE_USE_VERTEX",
 }
 
 // DefaultConfig resolves image, memory, and CPU settings from

--- a/internal/sandbox/sandbox_test.go
+++ b/internal/sandbox/sandbox_test.go
@@ -291,6 +291,10 @@ func TestForwardedEnvVars(t *testing.T) {
 			return "sk-ant-xxx"
 		case "OPENAI_API_KEY":
 			return "sk-xxx"
+		case "ANTHROPIC_VERTEX_PROJECT_ID":
+			return "my-gcp-project"
+		case "CLAUDE_CODE_USE_VERTEX":
+			return "1"
 		default:
 			return ""
 		}
@@ -305,6 +309,13 @@ func TestForwardedEnvVars(t *testing.T) {
 	}
 	if !strings.Contains(joined, "-e OPENAI_API_KEY") {
 		t.Errorf("expected OPENAI_API_KEY, got: %s", joined)
+	}
+	// Verify Vertex-specific vars are forwarded.
+	if !strings.Contains(joined, "-e ANTHROPIC_VERTEX_PROJECT_ID") {
+		t.Errorf("expected ANTHROPIC_VERTEX_PROJECT_ID, got: %s", joined)
+	}
+	if !strings.Contains(joined, "-e CLAUDE_CODE_USE_VERTEX") {
+		t.Errorf("expected CLAUDE_CODE_USE_VERTEX, got: %s", joined)
 	}
 	// Verify absent keys are NOT forwarded.
 	if strings.Contains(joined, "GEMINI_API_KEY") {

--- a/openspec/changes/sandbox-vertex-envvars/.openspec.yaml
+++ b/openspec/changes/sandbox-vertex-envvars/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: unbound-force
+created: 2026-04-13

--- a/openspec/changes/sandbox-vertex-envvars/design.md
+++ b/openspec/changes/sandbox-vertex-envvars/design.md
@@ -1,0 +1,45 @@
+## Context
+
+The `forwardedAPIKeys` slice in `config.go` lists env
+vars forwarded from host to container via Podman's
+`-e VAR` syntax. Currently includes 6 entries covering
+Anthropic (direct), OpenAI, Gemini, OpenRouter, and
+Google Cloud (project + location).
+
+The Anthropic-via-Vertex integration path uses
+different env vars from the native Google Vertex AI
+path:
+
+| Integration | Env Vars |
+|-------------|----------|
+| Google Vertex AI (native) | `GOOGLE_CLOUD_PROJECT`, `VERTEX_LOCATION` |
+| Anthropic via Vertex | `ANTHROPIC_VERTEX_PROJECT_ID`, `VERTEX_LOCATION`, `CLAUDE_CODE_USE_VERTEX` |
+
+Both `VERTEX_LOCATION` is already forwarded. The missing
+vars are `ANTHROPIC_VERTEX_PROJECT_ID` (which GCP
+project to use) and `CLAUDE_CODE_USE_VERTEX` (signals
+to use the Vertex backend).
+
+## Goals / Non-Goals
+
+### Goals
+
+- Forward `ANTHROPIC_VERTEX_PROJECT_ID` and
+  `CLAUDE_CODE_USE_VERTEX` to the container
+- Verify forwarding works in tests
+
+### Non-Goals
+
+- No changes to the Google Cloud credential mounting
+  logic (already handles service account keys and ADC)
+- No changes to CDE backend credential injection
+
+## Decisions
+
+### D1: Add both vars unconditionally
+
+Both vars are added to `forwardedAPIKeys`. They are
+only forwarded when set in the host environment
+(the `if v := opts.Getenv(key); v != ""` check in
+`forwardedEnvVars()` handles this). No conditional
+logic needed.

--- a/openspec/changes/sandbox-vertex-envvars/proposal.md
+++ b/openspec/changes/sandbox-vertex-envvars/proposal.md
@@ -1,0 +1,48 @@
+## Why
+
+`uf sandbox start` forwards LLM API keys to the
+container but is missing the environment variables
+needed for OpenCode's Anthropic-via-Vertex integration.
+Without `ANTHROPIC_VERTEX_PROJECT_ID` and
+`CLAUDE_CODE_USE_VERTEX`, OpenCode inside the container
+cannot connect to Claude models hosted on Google
+Vertex AI.
+
+The current forwarded list covers direct Anthropic,
+OpenAI, Gemini, OpenRouter, and Google Cloud project/
+location — but not the Anthropic SDK's Vertex-specific
+variables that OpenCode uses when the model string is
+`google-vertex-anthropic/claude-*`.
+
+## What Changes
+
+### Modified Capabilities
+
+- `forwardedAPIKeys` in `internal/sandbox/config.go`:
+  Add `ANTHROPIC_VERTEX_PROJECT_ID` and
+  `CLAUDE_CODE_USE_VERTEX` to the forwarded list.
+
+### New Capabilities
+
+None.
+
+### Removed Capabilities
+
+None.
+
+## Impact
+
+- 1 file modified: `internal/sandbox/config.go`
+  (2 lines added to `forwardedAPIKeys`)
+- 1 test file updated: `internal/sandbox/sandbox_test.go`
+  (verify new vars are forwarded)
+- No new Go logic — adding string entries to an
+  existing slice
+
+## Constitution Alignment
+
+### I–IV: All N/A
+
+This is a 2-line config change to a string slice.
+No architectural, composability, quality, or
+testability implications.

--- a/openspec/changes/sandbox-vertex-envvars/specs/envvars.md
+++ b/openspec/changes/sandbox-vertex-envvars/specs/envvars.md
@@ -1,0 +1,27 @@
+## MODIFIED Requirements
+
+### Requirement: Forwarded Environment Variables
+
+The `forwardedAPIKeys` list MUST include
+`ANTHROPIC_VERTEX_PROJECT_ID` and
+`CLAUDE_CODE_USE_VERTEX` in addition to the existing
+6 entries.
+
+#### Scenario: Vertex AI user starts sandbox
+
+- **GIVEN** `ANTHROPIC_VERTEX_PROJECT_ID` and
+  `CLAUDE_CODE_USE_VERTEX` are set in the host env
+- **WHEN** the engineer runs `uf sandbox start`
+- **THEN** both vars are forwarded to the container
+  via `-e` flags
+
+#### Scenario: Non-Vertex user unaffected
+
+- **GIVEN** `ANTHROPIC_VERTEX_PROJECT_ID` is NOT set
+- **WHEN** the engineer runs `uf sandbox start`
+- **THEN** the var is not included in the `-e` flags
+  (existing conditional check handles this)
+
+## REMOVED Requirements
+
+None.

--- a/openspec/changes/sandbox-vertex-envvars/tasks.md
+++ b/openspec/changes/sandbox-vertex-envvars/tasks.md
@@ -1,0 +1,16 @@
+## 1. Implementation
+
+- [x] 1.1 Add `ANTHROPIC_VERTEX_PROJECT_ID` and
+  `CLAUDE_CODE_USE_VERTEX` to the `forwardedAPIKeys`
+  slice in `internal/sandbox/config.go`
+
+## 2. Tests
+
+- [x] 2.1 Update `TestForwardedEnvVars` in
+  `internal/sandbox/sandbox_test.go` to verify the
+  new vars are forwarded when set
+
+## 3. Verification
+
+- [x] 3.1 Run `go build ./...` and
+  `go test -race -count=1 ./internal/sandbox/...`


### PR DESCRIPTION
## Summary

Adds `ANTHROPIC_VERTEX_PROJECT_ID` and `CLAUDE_CODE_USE_VERTEX` to the `forwardedAPIKeys` list in `internal/sandbox/config.go`. Without these, OpenCode inside the container cannot connect to Claude models hosted on Google Vertex AI.

### What Changed

```go
var forwardedAPIKeys = []string{
    "ANTHROPIC_API_KEY",
    "OPENAI_API_KEY",
    "GEMINI_API_KEY",
    "OPENROUTER_API_KEY",
    "GOOGLE_CLOUD_PROJECT",
    "VERTEX_LOCATION",
    "ANTHROPIC_VERTEX_PROJECT_ID",  // ← new
    "CLAUDE_CODE_USE_VERTEX",       // ← new
}
```

### Why

OpenCode uses the `google-vertex-anthropic` provider prefix for Claude on Vertex. This integration requires `ANTHROPIC_VERTEX_PROJECT_ID` (which GCP project) and `CLAUDE_CODE_USE_VERTEX` (enables the Vertex backend). Both were missing from the forwarded list.