### PR TITLE
fix: add guardrails to /opsx-propose to prevent phase boundary violations

### DIFF
--- a/.opencode/command/uf-init.md
+++ b/.opencode/command/uf-init.md
@@ -485,7 +485,38 @@ commands (`speckit.specify.md`, `speckit.plan.md`,
 
 This step is read-only — it verifies but does not modify.
 
-### Step 8: Report Results
+### Step 8: OpenSpec Command Guardrails
+
+For `.opencode/command/opsx-propose.md`:
+
+1. **Read** the file content
+2. **Check** if a `## Guardrails` section exists at the
+   end of the file (search for the heading text
+   `## Guardrails`)
+3. **If already present**: Report
+   `⊘ opsx-propose.md: guardrails already present (skipped)`
+4. **If not present**: Append the following block at the
+   very end of the file. Report
+   `✅ opsx-propose.md: guardrails injected`
+
+The guardrails block to append:
+
+```markdown
+
+## Guardrails
+
+- **NEVER implement code changes** — this command
+  creates artifacts ONLY (proposal, design, specs,
+  tasks)
+- **NEVER commit, push, or create PRs** — those are
+  /finale's responsibility
+- **NEVER run /opsx-apply or /cobalt-crush** — the
+  user decides when to implement
+- After artifacts are complete, STOP and prompt the
+  user to run /opsx-apply or /cobalt-crush
+```
+
+### Step 9: Report Results
 
 After processing all customizations, display a summary:
 
@@ -518,6 +549,10 @@ After processing all customizations, display a summary:
   ...
 
 ### Speckit UF Customizations
+  [status] [filename]: [action]
+  ...
+
+### OpenSpec Command Guardrails
   [status] [filename]: [action]
   ...
 

--- a/internal/scaffold/assets/opencode/command/uf-init.md
+++ b/internal/scaffold/assets/opencode/command/uf-init.md
@@ -485,7 +485,38 @@ commands (`speckit.specify.md`, `speckit.plan.md`,
 
 This step is read-only — it verifies but does not modify.
 
-### Step 8: Report Results
+### Step 8: OpenSpec Command Guardrails
+
+For `.opencode/command/opsx-propose.md`:
+
+1. **Read** the file content
+2. **Check** if a `## Guardrails` section exists at the
+   end of the file (search for the heading text
+   `## Guardrails`)
+3. **If already present**: Report
+   `⊘ opsx-propose.md: guardrails already present (skipped)`
+4. **If not present**: Append the following block at the
+   very end of the file. Report
+   `✅ opsx-propose.md: guardrails injected`
+
+The guardrails block to append:
+
+```markdown
+
+## Guardrails
+
+- **NEVER implement code changes** — this command
+  creates artifacts ONLY (proposal, design, specs,
+  tasks)
+- **NEVER commit, push, or create PRs** — those are
+  /finale's responsibility
+- **NEVER run /opsx-apply or /cobalt-crush** — the
+  user decides when to implement
+- After artifacts are complete, STOP and prompt the
+  user to run /opsx-apply or /cobalt-crush
+```
+
+### Step 9: Report Results
 
 After processing all customizations, display a summary:
 
@@ -518,6 +549,10 @@ After processing all customizations, display a summary:
   ...
 
 ### Speckit UF Customizations
+  [status] [filename]: [action]
+  ...
+
+### OpenSpec Command Guardrails
   [status] [filename]: [action]
   ...
 

--- a/openspec/changes/opsx-propose-guardrails/.openspec.yaml
+++ b/openspec/changes/opsx-propose-guardrails/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: unbound-force
+created: 2026-04-14

--- a/openspec/changes/opsx-propose-guardrails/design.md
+++ b/openspec/changes/opsx-propose-guardrails/design.md
@@ -1,0 +1,56 @@
+## Context
+
+The OpenSpec commands (`opsx-propose.md`,
+`opsx-apply.md`, `opsx-explore.md`, `opsx-archive.md`)
+are created by `openspec init --tools opencode`, not
+by `uf init`. They are OpenSpec-owned files.
+
+The `/uf-init` slash command applies UF-specific
+customizations to files created by external tools.
+The `opsx/workflow-phase-boundaries` change added
+customization sections for Speckit commands but not
+for OpenSpec commands.
+
+## Goals / Non-Goals
+
+### Goals
+
+- Add a Guardrails section to `/opsx-propose` via
+  `/uf-init` customization
+- Prevent the agent from implementing code changes
+  or running /finale during a /opsx-propose invocation
+
+### Non-Goals
+
+- No guardrails for `/opsx-apply` (it IS the
+  implementation command — it should modify code)
+- No guardrails for `/opsx-explore` (read-only by
+  nature)
+- No guardrails for `/opsx-archive` (cleanup command)
+
+## Decisions
+
+### D1: Apply via /uf-init, not direct edit
+
+Since `opsx-propose.md` is owned by OpenSpec (created
+by `openspec init`), we add the guardrails via a
+`/uf-init` customization step — the same approach used
+for Speckit command guardrails.
+
+### D2: Guardrails content
+
+The guardrails section states:
+
+```markdown
+## Guardrails
+
+- **NEVER implement code changes** — this command
+  creates artifacts ONLY (proposal, design, specs,
+  tasks)
+- **NEVER commit, push, or create PRs** — those are
+  /finale's responsibility
+- **NEVER run /opsx-apply or /cobalt-crush** — the
+  user decides when to implement
+- After artifacts are complete, STOP and prompt the
+  user to run /opsx-apply or /cobalt-crush
+```

--- a/openspec/changes/opsx-propose-guardrails/proposal.md
+++ b/openspec/changes/opsx-propose-guardrails/proposal.md
@@ -1,0 +1,44 @@
+## Why
+
+The `/opsx-propose` command creates OpenSpec artifacts
+(proposal, design, specs, tasks) but has no guardrail
+preventing the agent from immediately jumping into
+implementation and `/finale` afterward. This happened
+in practice during the `sandbox-vertex-envvars` change
+— the agent created the artifacts, then implemented
+the code change and merged the PR, all in response to
+a single `/opsx-propose` invocation.
+
+The Speckit pipeline commands received guardrails in
+the `opsx/workflow-phase-boundaries` change, but the
+OpenSpec commands (`/opsx-propose`, `/opsx-explore`,
+`/opsx-archive`) were not covered.
+
+## What Changes
+
+### Modified Capabilities
+
+- `/opsx-propose` (`.opencode/command/opsx-propose.md`
+  or equivalent OpenSpec-managed file): Add a Guardrails
+  section stating the command creates artifacts only —
+  never implements, commits, pushes, or creates PRs.
+
+### New Capabilities
+
+None.
+
+### Removed Capabilities
+
+None.
+
+## Impact
+
+- 1 command file modified (via `/uf-init` customization,
+  since OpenSpec commands are created by `openspec init`)
+- No Go code changes
+- No test changes
+
+## Constitution Alignment
+
+All N/A — this is a behavioral instruction addition to
+a Markdown command file.

--- a/openspec/changes/opsx-propose-guardrails/specs/guardrails.md
+++ b/openspec/changes/opsx-propose-guardrails/specs/guardrails.md
@@ -1,0 +1,35 @@
+## ADDED Requirements
+
+### Requirement: /opsx-propose Guardrails
+
+The `/uf-init` slash command MUST include a
+customization step that injects a `## Guardrails`
+section into `.opencode/command/opsx-propose.md` if
+one does not already exist.
+
+The guardrails MUST state:
+- The command creates artifacts only
+- The command must not implement code changes
+- The command must not commit, push, or create PRs
+- The command must stop after artifacts are complete
+  and prompt the user
+
+Injection is idempotent — if the section exists, skip.
+
+#### Scenario: /uf-init adds guardrails to opsx-propose
+
+- **GIVEN** `opsx-propose.md` exists without a
+  `## Guardrails` section
+- **WHEN** the engineer runs `/uf-init`
+- **THEN** a `## Guardrails` section is appended
+
+#### Scenario: /uf-init skips existing guardrails
+
+- **GIVEN** `opsx-propose.md` already has a
+  `## Guardrails` section
+- **WHEN** the engineer runs `/uf-init`
+- **THEN** the existing section is not duplicated
+
+## REMOVED Requirements
+
+None.

--- a/openspec/changes/opsx-propose-guardrails/tasks.md
+++ b/openspec/changes/opsx-propose-guardrails/tasks.md
@@ -1,0 +1,18 @@
+## 1. /uf-init Customization
+
+- [x] 1.1 Add "OpenSpec Command Guardrails" section to
+  `.opencode/command/uf-init.md` — instructions for
+  the AI agent to inject a `## Guardrails` section
+  into `.opencode/command/opsx-propose.md` if not
+  already present. Idempotent (check for existing
+  section before appending).
+- [x] 1.2 Copy updated `.opencode/command/uf-init.md`
+  to `internal/scaffold/assets/opencode/command/`
+
+## 2. Verification
+
+- [x] 2.1 Run `go build ./...` to verify clean
+  compilation
+- [x] 2.2 Run `go test -race -count=1
+  -run TestEmbeddedAssets_MatchSource
+  ./internal/scaffold/...` to verify drift detection


### PR DESCRIPTION
## Summary

Adds a Guardrails section to `/opsx-propose` via `/uf-init` customization. Prevents the agent from jumping into implementation or `/finale` after creating artifacts — the same phase boundary protection that Speckit commands received in PR #96.

### What Happened

During the `sandbox-vertex-envvars` change, the agent received `/opsx-propose`, created the 4 artifacts correctly, then immediately implemented the code change and ran `/finale` to merge — all in one invocation. The user only asked for artifacts.

### What This Fixes

`/uf-init` now injects a `## Guardrails` section into `opsx-propose.md` stating:
- NEVER implement code changes (artifacts only)
- NEVER commit, push, or create PRs
- NEVER run /opsx-apply or /cobalt-crush
- STOP after artifacts are complete and prompt the user

Injection is idempotent (checks for existing section before appending).

### Files Changed

- `.opencode/command/uf-init.md` — Added Step 8: OpenSpec Command Guardrails
- `internal/scaffold/assets/opencode/command/uf-init.md` — Scaffold sync
- OpenSpec change artifacts (proposal, design, specs, tasks)