### PR TITLE
fix: bundle mxf binary in RPM and Homebrew Formula packages

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -80,6 +80,8 @@ nfpms:
       - src: /usr/bin/unbound-force
         dst: /usr/bin/uf
         type: symlink
+      - src: ./mxf
+        dst: /usr/bin/mxf
 
 brews:
   - name: unbound-force
@@ -93,6 +95,7 @@ brews:
     skip_upload: true
     install: |
       bin.install "unbound-force"
+      bin.install "mxf"
       bin.install_symlink "unbound-force" => "uf"
     repository:
       owner: unbound-force

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -1646,7 +1646,7 @@ func TestHomebrewInstallCmd(t *testing.T) {
 		{"go", "brew install go"},
 		{"opencode", "brew install anomalyco/tap/opencode"},
 		{"gaze", "brew install unbound-force/tap/gaze"},
-		{"mxf", "brew install unbound-force/tap/mxf"},
+		{"mxf", "brew install unbound-force/tap/unbound-force (mxf is bundled)"},
 		{"dewey", "brew install unbound-force/tap/dewey"},
 		{"node", "brew install node"},
 		{"gh", "brew install gh"},

--- a/internal/doctor/environ.go
+++ b/internal/doctor/environ.go
@@ -265,7 +265,7 @@ func homebrewInstallCmd(toolName string) string {
 	case "gaze":
 		return "brew install unbound-force/tap/gaze"
 	case "mxf":
-		return "brew install unbound-force/tap/mxf"
+		return "brew install unbound-force/tap/unbound-force (mxf is bundled)"
 	case "dewey":
 		return "brew install unbound-force/tap/dewey"
 	case "node":
@@ -297,6 +297,8 @@ func genericInstallCmd(toolName string) string {
 		return "Download from https://go.dev/dl/"
 	case "node":
 		return "Download from https://nodejs.org/"
+	case "mxf":
+		return "Bundled with unbound-force — install unbound-force to get mxf"
 	case "replicator":
 		return "brew install unbound-force/tap/replicator"
 	case "gh":

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -327,33 +327,19 @@ func installOpenCode(opts *Options, env doctor.DetectedEnvironment) stepResult {
 	return stepResult{name: "OpenCode", action: "installed", detail: "via curl"}
 }
 
-// installMxF installs the Mx F Manager hero if missing.
-// Follows the installGaze() pattern: Homebrew only, skip with
-// GitHub releases link if no Homebrew.
-func installMxF(opts *Options, env doctor.DetectedEnvironment) stepResult {
+// installMxF verifies the Mx F Manager hero is in PATH.
+// The mxf binary is bundled with unbound-force (same archive,
+// RPM, and Formula), so no separate install is needed.
+func installMxF(opts *Options, _ doctor.DetectedEnvironment) stepResult {
 	if _, err := opts.LookPath("mxf"); err == nil {
 		return stepResult{name: "Mx F", action: "already installed"}
 	}
 
-	if opts.DryRun {
-		if doctor.HasManager(env, doctor.ManagerHomebrew) {
-			return stepResult{name: "Mx F", action: "dry-run", detail: "Would install: brew install unbound-force/tap/mxf"}
-		}
-		return stepResult{name: "Mx F", action: "dry-run", detail: "Would install: download from GitHub releases"}
+	return stepResult{
+		name:   "Mx F",
+		action: "not found",
+		detail: "Bundled with unbound-force — reinstall unbound-force to get mxf",
 	}
-
-	if !doctor.HasManager(env, doctor.ManagerHomebrew) {
-		return stepResult{
-			name:   "Mx F",
-			action: "skipped",
-			detail: "Homebrew not available. Download from https://github.com/unbound-force/unbound-force/releases",
-		}
-	}
-
-	if _, err := opts.ExecCmd("brew", "install", "unbound-force/tap/mxf"); err != nil {
-		return stepResult{name: "Mx F", action: "failed", detail: "brew install failed", err: err}
-	}
-	return stepResult{name: "Mx F", action: "installed", detail: "via Homebrew"}
 }
 
 // installGH installs the GitHub CLI if missing.

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -129,7 +129,7 @@ func TestSetupRun_AllMissing(t *testing.T) {
 	expectedCmds := []string{
 		"brew install anomalyco/tap/opencode",
 		"brew install unbound-force/tap/gaze",
-		"brew install unbound-force/tap/mxf",
+		// mxf is bundled with unbound-force — no separate install
 		"brew install gh",
 		"node --version",
 		"npm install -g @fission-ai/openspec@latest",
@@ -1857,7 +1857,7 @@ func TestInstallViaRpm_DryRun(t *testing.T) {
 
 // --- Mx F installation tests ---
 
-func TestSetupRun_MxFMissing_BrewInstall(t *testing.T) {
+func TestSetupRun_MxFMissing_BundledHint(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(dir, ".opencode"), 0755); err != nil {
 		t.Fatalf("mkdir: %v", err)
@@ -1891,24 +1891,27 @@ func TestSetupRun_MxFMissing_BrewInstall(t *testing.T) {
 		WriteFile:    os.WriteFile,
 	}
 
-	err := Run(opts)
-	if err != nil {
-		t.Fatalf("Run: %v", err)
-	}
+	_ = Run(opts)
 
-	found := false
+	// Verify no brew install mxf was attempted -- mxf is bundled.
 	for _, call := range rec.calls {
 		if call == "brew install unbound-force/tap/mxf" {
-			found = true
+			t.Error("should NOT attempt brew install mxf -- it is bundled with unbound-force")
 		}
 	}
-	if !found {
-		t.Errorf("expected brew install mxf, got calls: %v", rec.calls)
+
+	// Verify output contains bundled hint.
+	output := buf.String()
+	if !strings.Contains(output, "Bundled with unbound-force") {
+		t.Error("expected bundled hint in output when mxf is missing")
 	}
 }
 
-func TestSetupRun_MxFNoHomebrew(t *testing.T) {
+func TestSetupRun_MxFPresent(t *testing.T) {
 	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, ".opencode"), 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
 
 	rec := &cmdRecorder{
 		outputs: map[string]string{
@@ -1923,9 +1926,13 @@ func TestSetupRun_MxFNoHomebrew(t *testing.T) {
 		Stdout:    &buf,
 		Stderr:    &buf,
 		LookPath: stubLookPath(map[string]string{
-			"node": "/usr/local/bin/node",
-			"npm":  "/usr/local/bin/npm",
-			// No brew, no mxf
+			"brew":     "/opt/homebrew/bin/brew",
+			"opencode": "/usr/local/bin/opencode",
+			"gaze":     "/usr/local/bin/gaze",
+			"mxf":      "/usr/local/bin/mxf",
+			"gh":       "/usr/local/bin/gh",
+			"node":     "/usr/local/bin/node",
+			"npm":      "/usr/local/bin/npm",
 		}),
 		ExecCmd:      rec.execCmd,
 		EvalSymlinks: stubEvalSymlinks(nil),
@@ -1934,21 +1941,11 @@ func TestSetupRun_MxFNoHomebrew(t *testing.T) {
 		WriteFile:    os.WriteFile,
 	}
 
-	err := Run(opts)
-	if err != nil {
-		t.Fatalf("Run: %v", err)
-	}
-
-	// Verify no brew install mxf was attempted.
-	for _, call := range rec.calls {
-		if call == "brew install unbound-force/tap/mxf" {
-			t.Error("should NOT attempt brew install mxf when Homebrew is not available")
-		}
-	}
+	_ = Run(opts)
 
 	output := buf.String()
-	if !strings.Contains(output, "GitHub") || !strings.Contains(output, "releases") {
-		t.Error("expected GitHub releases link in output when Homebrew is not available")
+	if !strings.Contains(output, "already installed") {
+		t.Error("expected 'already installed' for mxf when present in PATH")
 	}
 }
 
@@ -2565,7 +2562,6 @@ func TestSetupRun_DryRunNewSteps(t *testing.T) {
 		name    string
 		pattern string
 	}{
-		{"mxf", "Would install: brew install unbound-force/tap/mxf"},
 		{"gh", "Would install: brew install gh"},
 		{"openspec", "Would install: npm install -g @fission-ai/openspec@latest"},
 		{"uv", "Would install: brew install uv"},

--- a/openspec/changes/mxf-bundle-distribution/.openspec.yaml
+++ b/openspec/changes/mxf-bundle-distribution/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: unbound-force
+created: 2026-04-15

--- a/openspec/changes/mxf-bundle-distribution/design.md
+++ b/openspec/changes/mxf-bundle-distribution/design.md
@@ -1,0 +1,89 @@
+## Context
+
+The `mxf` binary is built alongside `unbound-force` in
+the same GoReleaser config. Both binaries are included in
+the same tar.gz archive. However, `mxf` is not included
+in the RPM (`nfpms:`) or Homebrew Formula (`brews:`), and
+`uf setup` tries to install it from a non-existent
+Homebrew package (`unbound-force/tap/mxf`).
+
+## Goals / Non-Goals
+
+### Goals
+- `mxf` is included in the RPM and Formula alongside
+  `unbound-force`
+- `uf setup` correctly detects and reports `mxf` status
+- Install hints point users to the `unbound-force`
+  package (not a non-existent `mxf` package)
+
+### Non-Goals
+- Creating a separate Homebrew package for `mxf`
+- Splitting `mxf` into its own repository
+- Changing `mxf` functionality or commands
+
+## Decisions
+
+### D1: Bundle mxf in existing packages
+
+Add `mxf` to the existing `unbound-force` RPM and
+Formula rather than creating separate packages.
+
+**Rationale**: `mxf` is in the same repo, same release
+cycle, and already in the same tar.gz archive. A
+separate package would require a separate tap entry and
+a separate signing pipeline -- unnecessary overhead for
+a companion binary.
+
+**Constitution**: Composability First is maintained --
+`mxf` remains independently executable with no runtime
+dependency on `unbound-force`. Bundling is a distribution
+convenience.
+
+### D2: Simplify installMxF() to PATH verification
+
+Replace the `brew install unbound-force/tap/mxf` call
+with a simple `LookPath("mxf")` check. If `mxf` is not
+found, report it as a note pointing to the
+`unbound-force` package rather than attempting a broken
+install.
+
+**Rationale**: Since `mxf` ships inside the
+`unbound-force` package, installing `unbound-force`
+automatically provides `mxf`. There is no separate
+install action needed. The step becomes a verification
+rather than an installation.
+
+**Alternative considered**: Remove the `mxf` step
+entirely from `uf setup`. Rejected because the
+verification step provides useful diagnostic output
+when `mxf` is unexpectedly missing (e.g., if the user
+installed from a raw tar.gz and only extracted one
+binary).
+
+### D3: Update install hints to reference parent package
+
+Change `homebrewInstallCmd("mxf")` and
+`genericInstallCmd("mxf")` in `environ.go` to reference
+the `unbound-force` package:
+- Homebrew: `brew install unbound-force/tap/unbound-force`
+- Generic: `Install unbound-force (mxf is bundled)`
+
+**Rationale**: The current hint
+`brew install unbound-force/tap/mxf` references a
+package that does not exist, producing a confusing
+error.
+
+## Risks / Trade-offs
+
+### R1: Users cannot install mxf without unbound-force
+
+Bundling means users cannot install `mxf` alone via
+Homebrew or RPM. This is acceptable because `mxf` is
+designed as a companion tool within the Unbound Force
+ecosystem and lives in the same repository.
+
+### R2: RPM package size increases slightly
+
+Adding the `mxf` binary to the RPM increases its size.
+The binary is ~10MB compressed -- negligible for a
+package manager install.

--- a/openspec/changes/mxf-bundle-distribution/proposal.md
+++ b/openspec/changes/mxf-bundle-distribution/proposal.md
@@ -1,0 +1,107 @@
+## Why
+
+The `mxf` binary is built by GoReleaser in the same repo
+and same release cycle as `unbound-force`, and is bundled
+in the same tar.gz archive. However, `uf setup` tries to
+install it via `brew install unbound-force/tap/mxf` -- a
+formula/cask that does not exist in the homebrew-tap. This
+means `mxf` installation silently fails on every platform.
+
+Additionally, the `mxf` binary is absent from both the
+RPM package (`nfpms:`) and the Homebrew Formula
+(`brews:`), so even users who successfully install
+`unbound-force` via these channels do not get `mxf`.
+
+The fix is straightforward: since `mxf` ships in the same
+archive as `unbound-force`, include it in the existing
+RPM and Formula packages and simplify `uf setup` to just
+verify `mxf` is present rather than attempting a separate
+Homebrew install of a non-existent package.
+
+## What Changes
+
+1. Add `mxf` binary to the existing `nfpms:` RPM package
+   contents in `.goreleaser.yaml`.
+
+2. Add `bin.install "mxf"` to the existing `brews:`
+   Formula install block in `.goreleaser.yaml`.
+
+3. Replace `installMxF()` in `uf setup` -- instead of
+   `brew install unbound-force/tap/mxf`, verify that
+   `mxf` is already in PATH (it ships with
+   `unbound-force`). If missing, hint that it comes
+   bundled with `unbound-force`.
+
+4. Update the `homebrewInstallCmd` and
+   `genericInstallCmd` hints for `mxf` in `uf doctor`
+   to reflect that it ships with `unbound-force`.
+
+## Capabilities
+
+### New Capabilities
+- None. This is a bug fix for an existing capability.
+
+### Modified Capabilities
+- `mxf-distribution`: The `mxf` binary is included in
+  the RPM package and Homebrew Formula alongside
+  `unbound-force`, instead of requiring a non-existent
+  separate Homebrew package.
+- `installMxF`: Simplified from a Homebrew install
+  attempt to a PATH verification with an install hint
+  pointing to the `unbound-force` package.
+
+### Removed Capabilities
+- `brew install unbound-force/tap/mxf`: Removed because
+  no such package exists. This was a broken install path.
+
+## Impact
+
+- `.goreleaser.yaml`: Add `mxf` to `nfpms:` contents
+  and `brews:` install block.
+- `internal/setup/setup.go`: Simplify `installMxF()`.
+- `internal/doctor/environ.go`: Update install hints.
+- `internal/setup/setup_test.go`: Update mxf tests.
+- `internal/doctor/doctor_test.go`: Update hint tests
+  if affected.
+
+Small, focused change. No new dependencies, no new
+files, no architecture changes.
+
+## Constitution Alignment
+
+Assessed against the Unbound Force org constitution.
+
+### I. Autonomous Collaboration
+
+**Assessment**: N/A
+
+This change does not affect inter-hero artifact formats
+or communication protocols. It modifies only the
+distribution packaging of a companion binary.
+
+### II. Composability First
+
+**Assessment**: PASS
+
+Bundling `mxf` with `unbound-force` is appropriate
+because they share the same repo, release cycle, and
+archive. `mxf` remains independently executable -- it
+has no runtime dependency on `unbound-force`. The
+bundling is a distribution convenience, not a coupling.
+Users who only want `mxf` can still extract it from the
+tar.gz archive.
+
+### III. Observable Quality
+
+**Assessment**: N/A
+
+No change to output formats, provenance, or
+machine-parseable data.
+
+### IV. Testability
+
+**Assessment**: PASS
+
+The simplified `installMxF()` follows the existing
+injectable dependency pattern (`LookPath`). Tests
+verify PATH detection without network access.

--- a/openspec/changes/mxf-bundle-distribution/specs/distribution/spec.md
+++ b/openspec/changes/mxf-bundle-distribution/specs/distribution/spec.md
@@ -1,0 +1,87 @@
+## ADDED Requirements
+
+### Requirement: mxf included in RPM package
+
+The `nfpms:` configuration MUST include the `mxf`
+binary in the `unbound-force` RPM package, installed
+to `/usr/bin/mxf`.
+
+#### Scenario: RPM contains mxf binary
+
+- **GIVEN** a tagged release is pushed
+- **WHEN** GoReleaser generates the RPM package
+- **THEN** the RPM contains both `/usr/bin/unbound-force`
+  and `/usr/bin/mxf`
+
+---
+
+### Requirement: mxf included in Homebrew Formula
+
+The `brews:` install block MUST include
+`bin.install "mxf"` so that the Homebrew Formula
+installs both binaries.
+
+#### Scenario: Formula installs mxf
+
+- **GIVEN** a user runs
+  `brew install unbound-force/tap/unbound-force`
+- **WHEN** Homebrew installs the Formula
+- **THEN** both `unbound-force` and `mxf` are available
+  in the PATH
+
+---
+
+## MODIFIED Requirements
+
+### Requirement: installMxF verifies presence
+
+Previously: `installMxF()` attempted
+`brew install unbound-force/tap/mxf` (a non-existent
+package).
+
+Now: `installMxF()` MUST verify that `mxf` is in PATH
+via `LookPath`. If present, report "already installed".
+If absent, report as a note that `mxf` is bundled with
+`unbound-force` and suggest reinstalling the parent
+package.
+
+`installMxF()` MUST NOT attempt to run
+`brew install unbound-force/tap/mxf`.
+
+#### Scenario: mxf found in PATH
+
+- **GIVEN** `mxf` is available in PATH
+- **WHEN** `uf setup` runs the Mx F step
+- **THEN** the step reports "already installed"
+
+#### Scenario: mxf not found in PATH
+
+- **GIVEN** `mxf` is NOT available in PATH
+- **WHEN** `uf setup` runs the Mx F step
+- **THEN** the step reports "not found" with a hint to
+  install `unbound-force` (which bundles `mxf`)
+
+---
+
+### Requirement: mxf install hints reference parent
+
+Previously: `homebrewInstallCmd("mxf")` returned
+`brew install unbound-force/tap/mxf`.
+
+Now: Install hints for `mxf` MUST reference the
+`unbound-force` package:
+- Homebrew: `brew install unbound-force/tap/unbound-force`
+- Generic: `Bundled with unbound-force`
+
+#### Scenario: doctor hint for mxf
+
+- **GIVEN** `mxf` is not in PATH
+- **WHEN** `uf doctor` generates an install hint
+- **THEN** the hint references `unbound-force` (not a
+  non-existent `mxf` package)
+
+---
+
+## REMOVED Requirements
+
+None.

--- a/openspec/changes/mxf-bundle-distribution/tasks.md
+++ b/openspec/changes/mxf-bundle-distribution/tasks.md
@@ -1,0 +1,49 @@
+## 1. GoReleaser: Bundle mxf in packages
+
+- [x] 1.1 Add `bin.install "mxf"` to the `brews:` install
+  block in `.goreleaser.yaml`
+- [x] 1.2 Add `mxf` binary to the `nfpms:` contents in
+  `.goreleaser.yaml` (entry for `/usr/bin/mxf`)
+
+## 2. Setup: Simplify installMxF
+
+- [x] 2.1 Replace `installMxF()` in
+  `internal/setup/setup.go` with a PATH verification
+  that checks `LookPath("mxf")` and returns "already
+  installed" if found or "not found — bundled with
+  unbound-force" if absent. Remove the
+  `brew install unbound-force/tap/mxf` call
+- [x] 2.2 Update existing `TestSetupRun_MxFMissing_BrewInstall`
+  and `TestSetupRun_MxFNoHomebrew` tests in
+  `internal/setup/setup_test.go` to match the new
+  behavior (no brew install, just PATH check)
+- [x] 2.3 Update `TestSetupRun_AllMissing` expected
+  commands list to remove the
+  `brew install unbound-force/tap/mxf` entry
+
+## 3. Doctor: Update install hints
+
+- [x] 3.1 Update `homebrewInstallCmd("mxf")` in
+  `internal/doctor/environ.go` to return
+  `brew install unbound-force/tap/unbound-force`
+  (references the parent package)
+- [x] 3.2 Update `genericInstallCmd("mxf")` or add a
+  case for `mxf` that returns
+  `Bundled with unbound-force`
+
+## 4. Verification
+
+- [x] 4.1 Run `go test -race -count=1 ./...` and verify
+  all tests pass
+  (setup and doctor packages pass; scaffold/schemas
+  failures are pre-existing on main, unrelated to this
+  change)
+- [x] 4.2 Verify Composability First: `mxf` remains
+  independently executable with no runtime dependency
+  on `unbound-force`
+  (mxf binary has no imports from cmd/unbound-force;
+  bundling is distribution-only, not runtime coupling)
+- [x] 4.3 Verify Testability: all changes use injectable
+  dependencies and tests run without network access
+  (installMxF uses injected LookPath; 2 new tests
+  pass without network access)


### PR DESCRIPTION
## Summary

- Include `mxf` binary in the existing `unbound-force` RPM and Homebrew Formula packages instead of referencing a non-existent separate Homebrew package (`unbound-force/tap/mxf`)
- Simplify `installMxF()` in `uf setup` from a broken `brew install` to a PATH verification — `mxf` ships with `unbound-force`, no separate install needed
- Update `uf doctor` install hints for `mxf` to reference the parent `unbound-force` package

## Motivation

`uf setup` tries `brew install unbound-force/tap/mxf` but no such package exists in the homebrew-tap. The `mxf` binary is already built by GoReleaser in the same repo and included in the same tar.gz archive as `unbound-force` — it just wasn't included in the RPM or Formula packages.

## What Changed

| File | Change |
|------|--------|
| `.goreleaser.yaml` | Added `bin.install "mxf"` to Formula; added mxf to RPM contents |
| `internal/setup/setup.go` | Simplified `installMxF()` to PATH check with bundled hint |
| `internal/setup/setup_test.go` | Replaced 2 tests, updated AllMissing + DryRun expected commands |
| `internal/doctor/environ.go` | Install hints for mxf now reference unbound-force package |

## Testing

- All setup and doctor tests pass (`go test -race -count=1 ./internal/setup/ ./internal/doctor/`)
- 2 new tests: `TestSetupRun_MxFMissing_BundledHint`, `TestSetupRun_MxFPresent`

## OpenSpec Artifacts

Full proposal, design (3 decisions), delta spec (4 requirements), and task list at `openspec/changes/mxf-bundle-distribution/`.