### PR TITLE
feat: add AGENTS.md behavioral guidance injection to /uf-init (Spec 030, closes #104)

### DIFF
--- a/.opencode/command/uf-init.md
+++ b/.opencode/command/uf-init.md
@@ -516,7 +516,390 @@ The guardrails block to append:
   user to run /opsx-apply or /cobalt-crush
 ```
 
-### Step 9: Report Results
+### Step 9: AGENTS.md Behavioral Guidance
+
+For the repo's `AGENTS.md` file, inject standardized
+behavioral guidance sections if not already present.
+
+1. **Check** if `AGENTS.md` exists at the repo root.
+   If not, report `⊘ AGENTS.md: not found (skipped)`
+   and skip this entire step.
+
+2. **Read** the full contents of `AGENTS.md`.
+
+3. For each of the 8 guidance blocks below, in the order
+   listed (Core Mission first, Knowledge Retrieval last):
+   a. Check if the detection phrase (or semantic
+      equivalent heading) exists in the file
+   b. If present: report `⊘ <block>: already present
+      (skipped)`
+   c. If not present: find the appropriate insertion
+      point per the placement guidance and append the
+      block text. Report `✅ <block>: injected`
+
+4. After processing all 8 blocks, save the file once.
+
+**Injection order** (optimized for document flow):
+1. Core Mission
+2. Gatekeeping Value Protection
+3. Workflow Phase Boundaries
+4. CI Parity Gate
+5. Review Council PR Prerequisite
+6. Spec-First Development
+7. Website Documentation Sync Gate
+8. Knowledge Retrieval
+
+#### Block 1: Core Mission
+
+**Detection phrases**: `## Core Mission`, or both
+`Strategic Architecture` AND `Outcome Orientation`
+present in the same section.
+
+**Placement**: After `## Project Overview`, before
+`## Behavioral Constraints`. If neither heading exists,
+append near the top of the file after any frontmatter
+and title.
+
+**Text to inject**:
+
+```markdown
+## Core Mission
+
+- **Strategic Architecture**: Engineers shift from manual
+  coding to directing an "infinite supply of junior
+  developers" (AI agents).
+- **Outcome Orientation**: Focus on conveying business
+  value and user intent rather than low-level technical
+  sub-tasks.
+- **Intent-to-Context**: Treat specs and rules as the
+  medium through which human intent is manifested into
+  code.
+```
+
+#### Block 2: Gatekeeping Value Protection
+
+**Detection phrases**: `Gatekeeping Value Protection`
+heading, or `MUST NOT modify values that serve as
+quality`.
+
+**Placement**: Inside `## Behavioral Constraints`
+section. If `## Behavioral Constraints` does not exist,
+create it and place it after `## Core Mission` (or after
+`## Project Overview` if Core Mission is absent).
+
+**Text to inject**:
+
+```markdown
+### Gatekeeping Value Protection
+
+Agents MUST NOT modify values that serve as quality or
+governance gates to make an implementation pass. The
+following categories are protected:
+
+1. **Coverage thresholds and CRAP scores** — minimum
+   coverage percentages, CRAP score limits, coverage
+   ratchets
+2. **Severity definitions and auto-fix policies** —
+   CRITICAL/HIGH/MEDIUM/LOW boundaries, auto-fix
+   eligibility rules
+3. **Convention pack rule classifications** —
+   MUST/SHOULD/MAY designations on convention pack rules
+   (downgrading MUST to SHOULD is prohibited)
+4. **CI flags and linter configuration** — `-race`,
+   `-count=1`, `govulncheck`, `golangci-lint` rules,
+   pinned action SHAs
+5. **Agent temperature and tool-access settings** —
+   frontmatter `temperature`, `tools.write`, `tools.edit`,
+   `tools.bash` restrictions
+6. **Constitution MUST rules** — any MUST rule in
+   `.specify/memory/constitution.md` or hero constitutions
+7. **Review iteration limits and worker concurrency** —
+   max review iterations, max concurrent Swarm workers,
+   retry limits
+8. **Workflow gate markers** — `<!-- spec-review: passed
+   -->`, task completion checkboxes used as gates, phase
+   checkpoint requirements
+
+**What to do instead**: When an implementation cannot
+meet a gate, the agent MUST stop, report which gate is
+blocking and why, and let the human decide whether to
+adjust the gate or rework the implementation. Modifying
+a gate without explicit human authorization is a
+constitution violation (CRITICAL severity).
+```
+
+#### Block 3: Workflow Phase Boundaries
+
+**Detection phrases**: `Workflow Phase Boundaries`
+heading, or `MUST NOT cross workflow phase boundaries`.
+
+**Placement**: Inside `## Behavioral Constraints`,
+after Gatekeeping Value Protection (if present). If
+`## Behavioral Constraints` does not exist, create it.
+
+**Text to inject**:
+
+```markdown
+### Workflow Phase Boundaries
+
+Agents MUST NOT cross workflow phase boundaries:
+
+- **Specify/Clarify/Plan/Tasks/Analyze/Checklist** phases:
+  spec artifacts ONLY (`specs/NNN-*/` directory). No
+  source code, test, agent, command, or config changes.
+- **Implement** phase: source code changes allowed,
+  guided by spec artifacts.
+- **Review** phase: findings and minor fixes only. No new
+  features.
+
+A phase boundary violation is treated as a process error.
+The agent MUST stop and report the violation rather than
+proceeding with out-of-phase changes.
+```
+
+#### Block 4: CI Parity Gate
+
+**Detection phrases**: `CI Parity Gate` heading or bold
+text, or `replicate the CI checks locally`.
+
+**Placement**: Inside `## Behavioral Constraints` or
+`## Technical Guardrails`, after Workflow Phase
+Boundaries (if present). If neither section exists,
+create `## Behavioral Constraints` and place it there.
+
+**Text to inject**:
+
+```markdown
+### CI Parity Gate
+
+Before marking any implementation task complete or
+declaring a PR ready, agents MUST replicate the CI checks
+locally. Read `.github/workflows/` to identify the exact
+commands CI runs, then execute those same commands. Any
+failure is a blocking error — a task is not complete
+until all CI-equivalent checks pass locally. Do not rely
+on a memorized list of commands; always derive them from
+the workflow files, which are the source of truth.
+```
+
+#### Block 5: Review Council PR Prerequisite
+
+**Detection phrases**: Both `Review Council` AND
+`PR Prerequisite` present, or `/review-council` as a
+command reference in a PR workflow context.
+
+**Placement**: After behavioral constraints, before
+build commands or testing conventions. If no clear
+anchor exists, append after the last behavioral
+constraint block.
+
+**Text to inject**:
+
+```markdown
+### Review Council as PR Prerequisite
+
+Before submitting a pull request, agents **must** run
+`/review-council` and resolve all REQUEST CHANGES
+findings until all reviewers return APPROVE. There must
+be **minimal to no code changes** between the council's
+APPROVE verdict and the PR submission — the council
+reviews the final code, not a draft that changes
+afterward.
+
+Workflow:
+
+1. Complete all implementation tasks
+2. Run CI checks locally (build, test, vet)
+3. Run `/review-council` — fix any findings, re-run
+   until APPROVE
+4. Commit, push, and submit PR immediately after council
+   APPROVE
+5. Do NOT make further code changes between APPROVE and
+   PR submission
+
+Exempt from council review:
+
+- Constitution amendments (governance documents, not code)
+- Documentation-only changes (README, AGENTS.md, spec
+  artifacts)
+- Emergency hotfixes (must be retroactively reviewed)
+```
+
+#### Block 6: Spec-First Development
+
+**Detection phrases**: `Spec-First Development` heading,
+or `preceded by a spec workflow`.
+
+**Placement**: After behavioral constraints, before
+build commands. If no clear anchor exists, append after
+the last behavioral constraint or workflow rule block.
+
+**Text to inject**:
+
+```markdown
+## Spec-First Development
+
+All changes that modify production code, test code, agent
+prompts, embedded assets, or CI configuration **must** be
+preceded by a spec workflow. The constitution
+(`.specify/memory/constitution.md`) is the highest-
+authority document in this project — all work must align
+with it.
+
+Two spec workflows are available:
+
+| Workflow | Location | Best For |
+|----------|----------|----------|
+| **Speckit** | `specs/NNN-name/` | Numbered feature specs with the full pipeline |
+| **OpenSpec** | `openspec/changes/name/` | Targeted changes with lightweight artifacts |
+
+**What requires a spec** (no exceptions without explicit
+user override):
+
+- New features or capabilities
+- Refactoring that changes function signatures, extracts
+  helpers, or moves code between packages
+- Test additions or assertion strengthening across
+  multiple functions
+- Agent prompt changes
+- CI workflow modifications
+- Data model changes (new struct fields, schema updates)
+
+**What is exempt** (may be done directly):
+
+- Constitution amendments (governed by the constitution's
+  own Governance section)
+- Typo corrections, comment-only changes, single-line
+  formatting fixes
+- Emergency hotfixes for critical production bugs (must
+  be retroactively documented)
+
+When an agent is unsure whether a change is trivial, it
+**must** ask the user rather than proceeding without a
+spec. The cost of an unnecessary spec is minutes; the
+cost of an unplanned change is rework, drift, and broken
+CI.
+```
+
+#### Block 7: Website Documentation Sync Gate
+
+**Detection phrases**: `Website Documentation` AND
+`Gate` in a heading, or `gh issue create --repo` with
+`unbound-force/website`.
+
+**Placement**: Near documentation validation gate or
+spec commit gate. If no clear anchor exists, append
+after Spec-First Development.
+
+**Text to inject**:
+
+````markdown
+### Website Documentation Gate
+
+When a change affects user-facing behavior, hero
+capabilities, CLI commands, or workflows, a GitHub issue
+**MUST** be created in the `unbound-force/website`
+repository to track required documentation or website
+updates. The issue must be created before the
+implementing PR is merged.
+
+```bash
+gh issue create --repo unbound-force/website \
+  --title "docs: <brief description of what changed>" \
+  --body "<what changed, why it matters, which pages
+          need updating>"
+```
+
+**Exempt changes** (no website issue needed):
+- Internal refactoring with no user-facing behavior
+  change
+- Test-only changes
+- CI/CD pipeline changes
+- Spec artifacts (specs are internal planning documents)
+
+**Examples requiring a website issue**:
+- New CLI command or flag added
+- Hero capabilities changed (new agent, removed feature)
+- Installation steps changed (`uf setup` flow)
+- New convention pack added
+- Breaking changes to any user-facing workflow
+````
+
+#### Block 8: Knowledge Retrieval
+
+**Detection phrases**: `## Knowledge Retrieval` heading,
+or `dewey_semantic_search` as a tool reference (in a
+table or code block, not just prose), or
+`Tool Selection Matrix`.
+
+**Placement**: After coding conventions, before testing
+conventions. If neither section exists, append near the
+end of the file before any appendix or changelog.
+
+**Text to inject**:
+
+```markdown
+## Knowledge Retrieval
+
+Agents SHOULD prefer Dewey MCP tools over grep/glob/read
+for cross-repo context, design decisions, and
+architectural patterns. Dewey provides semantic search
+across all indexed Markdown files, specs, and web
+documentation — returning ranked results with provenance
+metadata that grep cannot match.
+
+### Tool Selection Matrix
+
+| Query Intent | Dewey Tool | When to Use |
+|-------------|-----------|-------------|
+| Conceptual understanding | `dewey_semantic_search` | "How does X work?" |
+| Keyword lookup | `dewey_search` | Known terms, FR numbers |
+| Read specific page | `dewey_get_page` | Known document path |
+| Relationship discovery | `dewey_find_connections` | "How are X and Y related?" |
+| Similar documents | `dewey_similar` | "Find specs like this one" |
+| Tag-based discovery | `dewey_find_by_tag` | "All pages tagged #decision" |
+| Property queries | `dewey_query_properties` | "All specs with status: draft" |
+| Filtered semantic | `dewey_semantic_search_filtered` | Semantic search within source type |
+| Graph navigation | `dewey_traverse` | Dependency chain walking |
+
+### When to Fall Back to grep/glob/read
+
+Use direct file operations instead of Dewey when:
+- **Dewey is unavailable** — MCP tools return errors or
+  are not configured
+- **Exact string matching is needed** — searching for a
+  specific error message, variable name, or code pattern
+- **Specific file path is known** — reading a file you
+  already know the path to (use Read directly)
+- **Binary/non-Markdown content** — Dewey indexes
+  Markdown; use grep for Go source, JSON, YAML, etc.
+
+### Graceful Degradation (3-Tier Pattern)
+
+**Tier 3 (Full Dewey)** — semantic + structured search:
+- `dewey_semantic_search` — natural language queries
+- `dewey_search` — keyword queries
+- `dewey_get_page`, `dewey_find_connections`,
+  `dewey_traverse` — structured navigation
+- `dewey_find_by_tag`, `dewey_query_properties` —
+  metadata queries
+
+**Tier 2 (Graph-only, no embedding model)** — structured
+search only:
+- `dewey_search` — keyword queries (no embeddings needed)
+- `dewey_get_page`, `dewey_traverse`,
+  `dewey_find_connections` — graph navigation
+- `dewey_find_by_tag`, `dewey_query_properties` —
+  metadata queries
+- Semantic search unavailable — use exact keyword matches
+
+**Tier 1 (No Dewey)** — direct file access:
+- Use Read tool for direct file access
+- Use Grep for keyword search across the codebase
+- Use Glob for file pattern matching
+```
+
+### Step 10: Report Results
 
 After processing all customizations, display a summary:
 
@@ -555,6 +938,16 @@ After processing all customizations, display a summary:
 ### OpenSpec Command Guardrails
   [status] [filename]: [action]
   ...
+
+### AGENTS.md Guidance
+  [status] Core Mission: [action]
+  [status] Gatekeeping Value Protection: [action]
+  [status] Workflow Phase Boundaries: [action]
+  [status] CI Parity Gate: [action]
+   [status] Review Council PR Prerequisite: [action]
+   [status] Spec-First Development: [action]
+   [status] Website Documentation Sync Gate: [action]
+  [status] Knowledge Retrieval: [action]
 
 ### Summary
 Applied: N | Already present: N | Errors: N

--- a/internal/scaffold/assets/opencode/command/uf-init.md
+++ b/internal/scaffold/assets/opencode/command/uf-init.md
@@ -516,7 +516,390 @@ The guardrails block to append:
   user to run /opsx-apply or /cobalt-crush
 ```
 
-### Step 9: Report Results
+### Step 9: AGENTS.md Behavioral Guidance
+
+For the repo's `AGENTS.md` file, inject standardized
+behavioral guidance sections if not already present.
+
+1. **Check** if `AGENTS.md` exists at the repo root.
+   If not, report `⊘ AGENTS.md: not found (skipped)`
+   and skip this entire step.
+
+2. **Read** the full contents of `AGENTS.md`.
+
+3. For each of the 8 guidance blocks below, in the order
+   listed (Core Mission first, Knowledge Retrieval last):
+   a. Check if the detection phrase (or semantic
+      equivalent heading) exists in the file
+   b. If present: report `⊘ <block>: already present
+      (skipped)`
+   c. If not present: find the appropriate insertion
+      point per the placement guidance and append the
+      block text. Report `✅ <block>: injected`
+
+4. After processing all 8 blocks, save the file once.
+
+**Injection order** (optimized for document flow):
+1. Core Mission
+2. Gatekeeping Value Protection
+3. Workflow Phase Boundaries
+4. CI Parity Gate
+5. Review Council PR Prerequisite
+6. Spec-First Development
+7. Website Documentation Sync Gate
+8. Knowledge Retrieval
+
+#### Block 1: Core Mission
+
+**Detection phrases**: `## Core Mission`, or both
+`Strategic Architecture` AND `Outcome Orientation`
+present in the same section.
+
+**Placement**: After `## Project Overview`, before
+`## Behavioral Constraints`. If neither heading exists,
+append near the top of the file after any frontmatter
+and title.
+
+**Text to inject**:
+
+```markdown
+## Core Mission
+
+- **Strategic Architecture**: Engineers shift from manual
+  coding to directing an "infinite supply of junior
+  developers" (AI agents).
+- **Outcome Orientation**: Focus on conveying business
+  value and user intent rather than low-level technical
+  sub-tasks.
+- **Intent-to-Context**: Treat specs and rules as the
+  medium through which human intent is manifested into
+  code.
+```
+
+#### Block 2: Gatekeeping Value Protection
+
+**Detection phrases**: `Gatekeeping Value Protection`
+heading, or `MUST NOT modify values that serve as
+quality`.
+
+**Placement**: Inside `## Behavioral Constraints`
+section. If `## Behavioral Constraints` does not exist,
+create it and place it after `## Core Mission` (or after
+`## Project Overview` if Core Mission is absent).
+
+**Text to inject**:
+
+```markdown
+### Gatekeeping Value Protection
+
+Agents MUST NOT modify values that serve as quality or
+governance gates to make an implementation pass. The
+following categories are protected:
+
+1. **Coverage thresholds and CRAP scores** — minimum
+   coverage percentages, CRAP score limits, coverage
+   ratchets
+2. **Severity definitions and auto-fix policies** —
+   CRITICAL/HIGH/MEDIUM/LOW boundaries, auto-fix
+   eligibility rules
+3. **Convention pack rule classifications** —
+   MUST/SHOULD/MAY designations on convention pack rules
+   (downgrading MUST to SHOULD is prohibited)
+4. **CI flags and linter configuration** — `-race`,
+   `-count=1`, `govulncheck`, `golangci-lint` rules,
+   pinned action SHAs
+5. **Agent temperature and tool-access settings** —
+   frontmatter `temperature`, `tools.write`, `tools.edit`,
+   `tools.bash` restrictions
+6. **Constitution MUST rules** — any MUST rule in
+   `.specify/memory/constitution.md` or hero constitutions
+7. **Review iteration limits and worker concurrency** —
+   max review iterations, max concurrent Swarm workers,
+   retry limits
+8. **Workflow gate markers** — `<!-- spec-review: passed
+   -->`, task completion checkboxes used as gates, phase
+   checkpoint requirements
+
+**What to do instead**: When an implementation cannot
+meet a gate, the agent MUST stop, report which gate is
+blocking and why, and let the human decide whether to
+adjust the gate or rework the implementation. Modifying
+a gate without explicit human authorization is a
+constitution violation (CRITICAL severity).
+```
+
+#### Block 3: Workflow Phase Boundaries
+
+**Detection phrases**: `Workflow Phase Boundaries`
+heading, or `MUST NOT cross workflow phase boundaries`.
+
+**Placement**: Inside `## Behavioral Constraints`,
+after Gatekeeping Value Protection (if present). If
+`## Behavioral Constraints` does not exist, create it.
+
+**Text to inject**:
+
+```markdown
+### Workflow Phase Boundaries
+
+Agents MUST NOT cross workflow phase boundaries:
+
+- **Specify/Clarify/Plan/Tasks/Analyze/Checklist** phases:
+  spec artifacts ONLY (`specs/NNN-*/` directory). No
+  source code, test, agent, command, or config changes.
+- **Implement** phase: source code changes allowed,
+  guided by spec artifacts.
+- **Review** phase: findings and minor fixes only. No new
+  features.
+
+A phase boundary violation is treated as a process error.
+The agent MUST stop and report the violation rather than
+proceeding with out-of-phase changes.
+```
+
+#### Block 4: CI Parity Gate
+
+**Detection phrases**: `CI Parity Gate` heading or bold
+text, or `replicate the CI checks locally`.
+
+**Placement**: Inside `## Behavioral Constraints` or
+`## Technical Guardrails`, after Workflow Phase
+Boundaries (if present). If neither section exists,
+create `## Behavioral Constraints` and place it there.
+
+**Text to inject**:
+
+```markdown
+### CI Parity Gate
+
+Before marking any implementation task complete or
+declaring a PR ready, agents MUST replicate the CI checks
+locally. Read `.github/workflows/` to identify the exact
+commands CI runs, then execute those same commands. Any
+failure is a blocking error — a task is not complete
+until all CI-equivalent checks pass locally. Do not rely
+on a memorized list of commands; always derive them from
+the workflow files, which are the source of truth.
+```
+
+#### Block 5: Review Council PR Prerequisite
+
+**Detection phrases**: Both `Review Council` AND
+`PR Prerequisite` present, or `/review-council` as a
+command reference in a PR workflow context.
+
+**Placement**: After behavioral constraints, before
+build commands or testing conventions. If no clear
+anchor exists, append after the last behavioral
+constraint block.
+
+**Text to inject**:
+
+```markdown
+### Review Council as PR Prerequisite
+
+Before submitting a pull request, agents **must** run
+`/review-council` and resolve all REQUEST CHANGES
+findings until all reviewers return APPROVE. There must
+be **minimal to no code changes** between the council's
+APPROVE verdict and the PR submission — the council
+reviews the final code, not a draft that changes
+afterward.
+
+Workflow:
+
+1. Complete all implementation tasks
+2. Run CI checks locally (build, test, vet)
+3. Run `/review-council` — fix any findings, re-run
+   until APPROVE
+4. Commit, push, and submit PR immediately after council
+   APPROVE
+5. Do NOT make further code changes between APPROVE and
+   PR submission
+
+Exempt from council review:
+
+- Constitution amendments (governance documents, not code)
+- Documentation-only changes (README, AGENTS.md, spec
+  artifacts)
+- Emergency hotfixes (must be retroactively reviewed)
+```
+
+#### Block 6: Spec-First Development
+
+**Detection phrases**: `Spec-First Development` heading,
+or `preceded by a spec workflow`.
+
+**Placement**: After behavioral constraints, before
+build commands. If no clear anchor exists, append after
+the last behavioral constraint or workflow rule block.
+
+**Text to inject**:
+
+```markdown
+## Spec-First Development
+
+All changes that modify production code, test code, agent
+prompts, embedded assets, or CI configuration **must** be
+preceded by a spec workflow. The constitution
+(`.specify/memory/constitution.md`) is the highest-
+authority document in this project — all work must align
+with it.
+
+Two spec workflows are available:
+
+| Workflow | Location | Best For |
+|----------|----------|----------|
+| **Speckit** | `specs/NNN-name/` | Numbered feature specs with the full pipeline |
+| **OpenSpec** | `openspec/changes/name/` | Targeted changes with lightweight artifacts |
+
+**What requires a spec** (no exceptions without explicit
+user override):
+
+- New features or capabilities
+- Refactoring that changes function signatures, extracts
+  helpers, or moves code between packages
+- Test additions or assertion strengthening across
+  multiple functions
+- Agent prompt changes
+- CI workflow modifications
+- Data model changes (new struct fields, schema updates)
+
+**What is exempt** (may be done directly):
+
+- Constitution amendments (governed by the constitution's
+  own Governance section)
+- Typo corrections, comment-only changes, single-line
+  formatting fixes
+- Emergency hotfixes for critical production bugs (must
+  be retroactively documented)
+
+When an agent is unsure whether a change is trivial, it
+**must** ask the user rather than proceeding without a
+spec. The cost of an unnecessary spec is minutes; the
+cost of an unplanned change is rework, drift, and broken
+CI.
+```
+
+#### Block 7: Website Documentation Sync Gate
+
+**Detection phrases**: `Website Documentation` AND
+`Gate` in a heading, or `gh issue create --repo` with
+`unbound-force/website`.
+
+**Placement**: Near documentation validation gate or
+spec commit gate. If no clear anchor exists, append
+after Spec-First Development.
+
+**Text to inject**:
+
+````markdown
+### Website Documentation Gate
+
+When a change affects user-facing behavior, hero
+capabilities, CLI commands, or workflows, a GitHub issue
+**MUST** be created in the `unbound-force/website`
+repository to track required documentation or website
+updates. The issue must be created before the
+implementing PR is merged.
+
+```bash
+gh issue create --repo unbound-force/website \
+  --title "docs: <brief description of what changed>" \
+  --body "<what changed, why it matters, which pages
+          need updating>"
+```
+
+**Exempt changes** (no website issue needed):
+- Internal refactoring with no user-facing behavior
+  change
+- Test-only changes
+- CI/CD pipeline changes
+- Spec artifacts (specs are internal planning documents)
+
+**Examples requiring a website issue**:
+- New CLI command or flag added
+- Hero capabilities changed (new agent, removed feature)
+- Installation steps changed (`uf setup` flow)
+- New convention pack added
+- Breaking changes to any user-facing workflow
+````
+
+#### Block 8: Knowledge Retrieval
+
+**Detection phrases**: `## Knowledge Retrieval` heading,
+or `dewey_semantic_search` as a tool reference (in a
+table or code block, not just prose), or
+`Tool Selection Matrix`.
+
+**Placement**: After coding conventions, before testing
+conventions. If neither section exists, append near the
+end of the file before any appendix or changelog.
+
+**Text to inject**:
+
+```markdown
+## Knowledge Retrieval
+
+Agents SHOULD prefer Dewey MCP tools over grep/glob/read
+for cross-repo context, design decisions, and
+architectural patterns. Dewey provides semantic search
+across all indexed Markdown files, specs, and web
+documentation — returning ranked results with provenance
+metadata that grep cannot match.
+
+### Tool Selection Matrix
+
+| Query Intent | Dewey Tool | When to Use |
+|-------------|-----------|-------------|
+| Conceptual understanding | `dewey_semantic_search` | "How does X work?" |
+| Keyword lookup | `dewey_search` | Known terms, FR numbers |
+| Read specific page | `dewey_get_page` | Known document path |
+| Relationship discovery | `dewey_find_connections` | "How are X and Y related?" |
+| Similar documents | `dewey_similar` | "Find specs like this one" |
+| Tag-based discovery | `dewey_find_by_tag` | "All pages tagged #decision" |
+| Property queries | `dewey_query_properties` | "All specs with status: draft" |
+| Filtered semantic | `dewey_semantic_search_filtered` | Semantic search within source type |
+| Graph navigation | `dewey_traverse` | Dependency chain walking |
+
+### When to Fall Back to grep/glob/read
+
+Use direct file operations instead of Dewey when:
+- **Dewey is unavailable** — MCP tools return errors or
+  are not configured
+- **Exact string matching is needed** — searching for a
+  specific error message, variable name, or code pattern
+- **Specific file path is known** — reading a file you
+  already know the path to (use Read directly)
+- **Binary/non-Markdown content** — Dewey indexes
+  Markdown; use grep for Go source, JSON, YAML, etc.
+
+### Graceful Degradation (3-Tier Pattern)
+
+**Tier 3 (Full Dewey)** — semantic + structured search:
+- `dewey_semantic_search` — natural language queries
+- `dewey_search` — keyword queries
+- `dewey_get_page`, `dewey_find_connections`,
+  `dewey_traverse` — structured navigation
+- `dewey_find_by_tag`, `dewey_query_properties` —
+  metadata queries
+
+**Tier 2 (Graph-only, no embedding model)** — structured
+search only:
+- `dewey_search` — keyword queries (no embeddings needed)
+- `dewey_get_page`, `dewey_traverse`,
+  `dewey_find_connections` — graph navigation
+- `dewey_find_by_tag`, `dewey_query_properties` —
+  metadata queries
+- Semantic search unavailable — use exact keyword matches
+
+**Tier 1 (No Dewey)** — direct file access:
+- Use Read tool for direct file access
+- Use Grep for keyword search across the codebase
+- Use Glob for file pattern matching
+```
+
+### Step 10: Report Results
 
 After processing all customizations, display a summary:
 
@@ -555,6 +938,16 @@ After processing all customizations, display a summary:
 ### OpenSpec Command Guardrails
   [status] [filename]: [action]
   ...
+
+### AGENTS.md Guidance
+  [status] Core Mission: [action]
+  [status] Gatekeeping Value Protection: [action]
+  [status] Workflow Phase Boundaries: [action]
+  [status] CI Parity Gate: [action]
+   [status] Review Council PR Prerequisite: [action]
+   [status] Spec-First Development: [action]
+   [status] Website Documentation Sync Gate: [action]
+  [status] Knowledge Retrieval: [action]
 
 ### Summary
 Applied: N | Already present: N | Errors: N

--- a/internal/scaffold/scaffold_test.go
+++ b/internal/scaffold/scaffold_test.go
@@ -3860,3 +3860,38 @@ func TestEnsureGitignore_Idempotent(t *testing.T) {
 			string(content1), string(content2))
 	}
 }
+
+// TestUFInitAsset_GuidanceBlockPresence verifies the /uf-init
+// scaffold asset contains all 8 AGENTS.md guidance block
+// detection phrases. This catches missing or truncated blocks
+// without new test infrastructure. Added by Spec 030.
+func TestUFInitAsset_GuidanceBlockPresence(t *testing.T) {
+	content, err := assetContent("opencode/command/uf-init.md")
+	if err != nil {
+		t.Fatalf("read uf-init.md asset: %v", err)
+	}
+	text := string(content)
+
+	// Each entry is a detection phrase that must appear in the
+	// uf-init.md asset to confirm the guidance block is defined.
+	requiredPhrases := []struct {
+		block  string
+		phrase string
+	}{
+		{"Core Mission", "## Core Mission"},
+		{"Gatekeeping Value Protection", "Gatekeeping Value Protection"},
+		{"Workflow Phase Boundaries", "Workflow Phase Boundaries"},
+		{"CI Parity Gate", "CI Parity Gate"},
+		{"Review Council PR Prerequisite", "Review Council"},
+		{"Website Documentation Sync Gate", "Website Documentation"},
+		{"Spec-First Development", "Spec-First Development"},
+		{"Knowledge Retrieval", "Knowledge Retrieval"},
+	}
+
+	for _, rp := range requiredPhrases {
+		if !strings.Contains(text, rp.phrase) {
+			t.Errorf("uf-init.md asset missing guidance block %q (detection phrase %q not found)",
+				rp.block, rp.phrase)
+		}
+	}
+}

--- a/specs/030-agents-md-guidance/checklists/requirements.md
+++ b/specs/030-agents-md-guidance/checklists/requirements.md
@@ -1,0 +1,42 @@
+# Specification Quality Checklist: AGENTS.md Behavioral Guidance Injection
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2026-04-15  
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All 16 items pass validation on first iteration.
+- The 8 guidance blocks are enumerated in FR-003 with
+  specific content descriptions for each.
+- Idempotency is defined via semantic heading matching,
+  not exact string comparison — appropriate for
+  AI-assisted injection.
+- Cross-repo audit summary table in issue #104 documents
+  the current gap for each repo.
+- Spec is ready for `/speckit.clarify` or `/speckit.plan`.

--- a/specs/030-agents-md-guidance/contracts/uf-init-guidance.md
+++ b/specs/030-agents-md-guidance/contracts/uf-init-guidance.md
@@ -1,0 +1,157 @@
+# Contract: /uf-init AGENTS.md Guidance Injection
+
+**Branch**: `030-agents-md-guidance` | **Date**: 2026-04-15
+**Phase**: 1 (Design)
+
+## Overview
+
+This contract defines the behavioral interface for the
+AGENTS.md guidance injection step in `/uf-init`. Since
+this feature is Markdown-only (no Go code), the contract
+describes the **observable behavior** of the AI agent
+executing the command, not function signatures.
+
+## Contract: Step 9 — AGENTS.md Behavioral Guidance
+
+### Preconditions
+
+1. Steps 1-8 of `/uf-init` have completed (prerequisites
+   verified, customizations applied)
+2. The AI agent has access to the Read and Edit tools
+
+### Inputs
+
+- `AGENTS.md` at the repository root (may or may not
+  exist)
+
+### Behavior
+
+#### Case 1: AGENTS.md Does Not Exist
+
+**When** `AGENTS.md` is not found at the repo root,
+**Then** the step is skipped with the message:
+> "No AGENTS.md found — skipping behavioral guidance
+> injection."
+
+No files are modified. The report shows:
+```
+⊘ AGENTS.md: not found (skipped)
+```
+
+#### Case 2: AGENTS.md Exists, No Guidance Sections
+
+**When** `AGENTS.md` exists and contains none of the 8
+guidance sections,
+**Then** all 8 sections are injected at appropriate
+locations within the document.
+
+The report shows 8 `✅` entries:
+```
+✅ Core Mission: injected
+✅ Gatekeeping Value Protection: injected
+✅ Workflow Phase Boundaries: injected
+✅ CI Parity Gate: injected
+✅ Review Council PR Prerequisite: injected
+✅ Website Documentation Sync Gate: injected
+✅ Spec-First Development: injected
+✅ Knowledge Retrieval: injected
+```
+
+#### Case 3: AGENTS.md Exists, Some Sections Present
+
+**When** `AGENTS.md` exists and contains some (but not
+all) of the 8 guidance sections,
+**Then** only the missing sections are injected. Existing
+sections are preserved unchanged.
+
+The report shows a mix of `✅` and `⊘` entries.
+
+#### Case 4: AGENTS.md Exists, All Sections Present
+
+**When** `AGENTS.md` exists and contains all 8 guidance
+sections,
+**Then** no modifications are made to `AGENTS.md`.
+
+The report shows 8 `⊘` entries:
+```
+⊘ Core Mission: already present (skipped)
+⊘ Gatekeeping Value Protection: already present (skipped)
+⊘ Workflow Phase Boundaries: already present (skipped)
+⊘ CI Parity Gate: already present (skipped)
+⊘ Review Council PR Prerequisite: already present (skipped)
+⊘ Website Documentation Sync Gate: already present (skipped)
+⊘ Spec-First Development: already present (skipped)
+⊘ Knowledge Retrieval: already present (skipped)
+```
+
+### Postconditions
+
+1. `AGENTS.md` contains all 8 guidance sections (or was
+   not modified if they were already present, or does not
+   exist)
+2. No other files were modified by this step
+3. The report summary includes an "AGENTS.md Guidance"
+   section with status for each block
+
+### Idempotency Guarantee
+
+Running Step 9 twice on the same `AGENTS.md` produces
+identical file content. The second run detects all 8
+sections as already present and makes no modifications.
+
+Formally: `f(f(x)) = f(x)` where `f` is the injection
+function and `x` is the `AGENTS.md` content.
+
+## Contract: Report Extension (Step 10)
+
+### Preconditions
+
+1. Step 9 has completed (guidance injection or skip)
+2. All previous steps (1-8) have completed
+
+### Behavior
+
+The report template gains a new section between
+"OpenSpec Command Guardrails" and "Summary":
+
+```
+### AGENTS.md Guidance
+  [status] Core Mission: [action]
+  [status] Gatekeeping Value Protection: [action]
+  [status] Workflow Phase Boundaries: [action]
+  [status] CI Parity Gate: [action]
+  [status] Review Council PR Prerequisite: [action]
+  [status] Website Documentation Sync Gate: [action]
+  [status] Spec-First Development: [action]
+  [status] Knowledge Retrieval: [action]
+```
+
+The "Summary" line's counters (Applied, Already present,
+Errors) include the AGENTS.md guidance results.
+
+## Contract: Scaffold Asset Synchronization
+
+### Preconditions
+
+1. `.opencode/command/uf-init.md` has been modified
+
+### Behavior
+
+`internal/scaffold/assets/opencode/command/uf-init.md`
+MUST be byte-identical to `.opencode/command/uf-init.md`.
+
+### Verification
+
+`TestScaffoldAssetDrift` (existing test) verifies this
+automatically. No new test code is needed.
+
+## Non-Functional Requirements
+
+- **No new Go code**: This contract is enforced by AI
+  agent behavior, not compiled code
+- **No new embedded assets**: The `expectedAssetPaths`
+  count does not change
+- **No new dependencies**: No new imports, packages, or
+  external tools
+- **Backward compatible**: Existing `/uf-init` behavior
+  for Steps 1-8 is unchanged

--- a/specs/030-agents-md-guidance/data-model.md
+++ b/specs/030-agents-md-guidance/data-model.md
@@ -1,0 +1,447 @@
+# Data Model: AGENTS.md Behavioral Guidance Injection
+
+**Branch**: `030-agents-md-guidance` | **Date**: 2026-04-15
+**Phase**: 1 (Design)
+
+## Overview
+
+This feature has no traditional data model — it does not
+introduce new Go structs, JSON schemas, database tables,
+or API endpoints. The "data" is Markdown text injected
+into `AGENTS.md` files.
+
+This document defines the **guidance block schema** — the
+structure and content of each of the 8 standardized
+blocks that `/uf-init` injects.
+
+## Guidance Block Schema
+
+Each guidance block has the following properties:
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `id` | string | Unique identifier (e.g., `core-mission`) |
+| `heading` | string | Markdown heading text |
+| `heading_level` | int | Heading level (2 = `##`, 3 = `###`) |
+| `detection_phrases` | string[] | Phrases to search for in idempotency check |
+| `placement` | string | Where to insert in AGENTS.md |
+| `priority` | P1/P2/P3 | Implementation priority (from spec) |
+| `content` | string | The Markdown text to inject |
+| `source` | string | Canonical source file and lines |
+
+## Block Definitions
+
+### Block 1: Core Mission
+
+```yaml
+id: core-mission
+heading: "## Core Mission"
+heading_level: 2
+detection_phrases:
+  - "## Core Mission"
+  - "Strategic Architecture"
+  - "Outcome Orientation"
+placement: "After ## Project Overview, before ## Behavioral Constraints"
+priority: P3
+source: "meta AGENTS.md lines 12-16, gaze AGENTS.md lines 12-16"
+```
+
+**Content** (generalized):
+
+```markdown
+## Core Mission
+
+- **Strategic Architecture**: Engineers shift from manual
+  coding to directing an "infinite supply of junior
+  developers" (AI agents).
+- **Outcome Orientation**: Focus on conveying business
+  value and user intent rather than low-level technical
+  sub-tasks.
+- **Intent-to-Context**: Treat specs and rules as the
+  medium through which human intent is manifested into
+  code.
+```
+
+### Block 2: Gatekeeping Value Protection
+
+```yaml
+id: gatekeeping-value-protection
+heading: "### Gatekeeping Value Protection"
+heading_level: 3
+detection_phrases:
+  - "Gatekeeping Value Protection"
+  - "MUST NOT modify values that serve as quality"
+placement: "Inside ## Behavioral Constraints"
+priority: P1
+source: "meta AGENTS.md lines 25-38"
+```
+
+**Content** (generalized):
+
+```markdown
+### Gatekeeping Value Protection
+
+Agents MUST NOT modify values that serve as quality or
+governance gates to make an implementation pass. The
+following categories are protected:
+
+1. **Coverage thresholds and CRAP scores** — minimum
+   coverage percentages, CRAP score limits, coverage
+   ratchets
+2. **Severity definitions and auto-fix policies** —
+   CRITICAL/HIGH/MEDIUM/LOW boundaries, auto-fix
+   eligibility rules
+3. **Convention pack rule classifications** —
+   MUST/SHOULD/MAY designations on convention pack rules
+   (downgrading MUST to SHOULD is prohibited)
+4. **CI flags and linter configuration** — `-race`,
+   `-count=1`, `govulncheck`, `golangci-lint` rules,
+   pinned action SHAs
+5. **Agent temperature and tool-access settings** —
+   frontmatter `temperature`, `tools.write`, `tools.edit`,
+   `tools.bash` restrictions
+6. **Constitution MUST rules** — any MUST rule in
+   `.specify/memory/constitution.md` or hero constitutions
+7. **Review iteration limits and worker concurrency** —
+   max review iterations, max concurrent Swarm workers,
+   retry limits
+8. **Workflow gate markers** — `<!-- spec-review: passed
+   -->`, task completion checkboxes used as gates, phase
+   checkpoint requirements
+
+**What to do instead**: When an implementation cannot
+meet a gate, the agent MUST stop, report which gate is
+blocking and why, and let the human decide whether to
+adjust the gate or rework the implementation. Modifying
+a gate without explicit human authorization is a
+constitution violation (CRITICAL severity).
+```
+
+### Block 3: Workflow Phase Boundaries
+
+```yaml
+id: workflow-phase-boundaries
+heading: "### Workflow Phase Boundaries"
+heading_level: 3
+detection_phrases:
+  - "Workflow Phase Boundaries"
+  - "MUST NOT cross workflow phase boundaries"
+placement: "Inside ## Behavioral Constraints, after Gatekeeping"
+priority: P1
+source: "meta AGENTS.md lines 40-54"
+```
+
+**Content** (generalized):
+
+```markdown
+### Workflow Phase Boundaries
+
+Agents MUST NOT cross workflow phase boundaries:
+
+- **Specify/Clarify/Plan/Tasks/Analyze/Checklist** phases:
+  spec artifacts ONLY (`specs/NNN-*/` directory). No
+  source code, test, agent, command, or config changes.
+- **Implement** phase: source code changes allowed,
+  guided by spec artifacts.
+- **Review** phase: findings and minor fixes only. No new
+  features.
+
+A phase boundary violation is treated as a process error.
+The agent MUST stop and report the violation rather than
+proceeding with out-of-phase changes.
+```
+
+### Block 4: CI Parity Gate
+
+```yaml
+id: ci-parity-gate
+heading: "CI Parity Gate"
+heading_level: 3  # or bold bullet
+detection_phrases:
+  - "CI Parity Gate"
+  - "replicate the CI checks locally"
+placement: "Inside ## Technical Guardrails or ## Behavioral Constraints"
+priority: P1
+source: "gaze AGENTS.md line 27"
+```
+
+**Content** (generalized):
+
+```markdown
+### CI Parity Gate
+
+Before marking any implementation task complete or
+declaring a PR ready, agents MUST replicate the CI checks
+locally. Read `.github/workflows/` to identify the exact
+commands CI runs, then execute those same commands. Any
+failure is a blocking error — a task is not complete
+until all CI-equivalent checks pass locally. Do not rely
+on a memorized list of commands; always derive them from
+the workflow files, which are the source of truth.
+```
+
+### Block 5: Review Council PR Prerequisite
+
+```yaml
+id: review-council-pr-prerequisite
+heading: "### Review Council as PR Prerequisite"
+heading_level: 3
+detection_phrases:
+  - "Review Council"
+  - "PR Prerequisite"
+  - "/review-council"
+placement: "After behavioral constraints, before build commands"
+priority: P2
+source: "gaze AGENTS.md lines 38-54"
+```
+
+**Content** (generalized):
+
+```markdown
+### Review Council as PR Prerequisite
+
+Before submitting a pull request, agents **must** run
+`/review-council` and resolve all REQUEST CHANGES
+findings until all reviewers return APPROVE. There must
+be **minimal to no code changes** between the council's
+APPROVE verdict and the PR submission — the council
+reviews the final code, not a draft that changes
+afterward.
+
+Workflow:
+
+1. Complete all implementation tasks
+2. Run CI checks locally (build, test, vet)
+3. Run `/review-council` — fix any findings, re-run
+   until APPROVE
+4. Commit, push, and submit PR immediately after council
+   APPROVE
+5. Do NOT make further code changes between APPROVE and
+   PR submission
+
+Exempt from council review:
+
+- Constitution amendments (governance documents, not code)
+- Documentation-only changes (README, AGENTS.md, spec
+  artifacts)
+- Emergency hotfixes (must be retroactively reviewed)
+```
+
+### Block 6: Website Documentation Sync Gate
+
+```yaml
+id: website-documentation-sync-gate
+heading: "### Website Documentation Gate"
+heading_level: 3
+detection_phrases:
+  - "Website Documentation"
+  - "gh issue create --repo"
+  - "unbound-force/website"
+placement: "Near documentation validation gate or spec commit gate"
+priority: P2
+source: "meta AGENTS.md lines 397-418"
+```
+
+**Content** (generalized):
+
+````markdown
+### Website Documentation Gate
+
+When a change affects user-facing behavior, hero
+capabilities, CLI commands, or workflows, a GitHub issue
+**MUST** be created in the `unbound-force/website`
+repository to track required documentation or website
+updates. The issue must be created before the
+implementing PR is merged.
+
+```bash
+gh issue create --repo unbound-force/website \
+  --title "docs: <brief description of what changed>" \
+  --body "<what changed, why it matters, which pages
+          need updating>"
+```
+
+**Exempt changes** (no website issue needed):
+- Internal refactoring with no user-facing behavior
+  change
+- Test-only changes
+- CI/CD pipeline changes
+- Spec artifacts (specs are internal planning documents)
+
+**Examples requiring a website issue**:
+- New CLI command or flag added
+- Hero capabilities changed (new agent, removed feature)
+- Installation steps changed (`uf setup` flow)
+- New convention pack added
+- Breaking changes to any user-facing workflow
+````
+
+### Block 7: Spec-First Development
+
+```yaml
+id: spec-first-development
+heading: "## Spec-First Development"
+heading_level: 2
+detection_phrases:
+  - "Spec-First Development"
+  - "preceded by a spec workflow"
+placement: "After behavioral constraints, before build commands"
+priority: P2
+source: "gaze AGENTS.md lines 56-82"
+```
+
+**Content** (generalized):
+
+```markdown
+## Spec-First Development
+
+All changes that modify production code, test code, agent
+prompts, embedded assets, or CI configuration **must** be
+preceded by a spec workflow. The constitution
+(`.specify/memory/constitution.md`) is the highest-
+authority document in this project — all work must align
+with it.
+
+Two spec workflows are available:
+
+| Workflow | Location | Best For |
+|----------|----------|----------|
+| **Speckit** | `specs/NNN-name/` | Numbered feature specs with the full pipeline |
+| **OpenSpec** | `openspec/changes/name/` | Targeted changes with lightweight artifacts |
+
+**What requires a spec** (no exceptions without explicit
+user override):
+
+- New features or capabilities
+- Refactoring that changes function signatures, extracts
+  helpers, or moves code between packages
+- Test additions or assertion strengthening across
+  multiple functions
+- Agent prompt changes
+- CI workflow modifications
+- Data model changes (new struct fields, schema updates)
+
+**What is exempt** (may be done directly):
+
+- Constitution amendments (governed by the constitution's
+  own Governance section)
+- Typo corrections, comment-only changes, single-line
+  formatting fixes
+- Emergency hotfixes for critical production bugs (must
+  be retroactively documented)
+
+When an agent is unsure whether a change is trivial, it
+**must** ask the user rather than proceeding without a
+spec. The cost of an unnecessary spec is minutes; the
+cost of an unplanned change is rework, drift, and broken
+CI.
+```
+
+### Block 8: Knowledge Retrieval
+
+```yaml
+id: knowledge-retrieval
+heading: "## Knowledge Retrieval"
+heading_level: 2
+detection_phrases:
+  - "## Knowledge Retrieval"
+  - "dewey_semantic_search"
+  - "Tool Selection Matrix"
+placement: "After coding conventions, before testing conventions"
+priority: P3
+source: "meta AGENTS.md lines 533-592"
+```
+
+**Content** (generalized):
+
+```markdown
+## Knowledge Retrieval
+
+Agents SHOULD prefer Dewey MCP tools over grep/glob/read
+for cross-repo context, design decisions, and
+architectural patterns. Dewey provides semantic search
+across all indexed Markdown files, specs, and web
+documentation — returning ranked results with provenance
+metadata that grep cannot match.
+
+### Tool Selection Matrix
+
+| Query Intent | Dewey Tool | When to Use |
+|-------------|-----------|-------------|
+| Conceptual understanding | `dewey_semantic_search` | "How does X work?" |
+| Keyword lookup | `dewey_search` | Known terms, FR numbers |
+| Read specific page | `dewey_get_page` | Known document path |
+| Relationship discovery | `dewey_find_connections` | "How are X and Y related?" |
+| Similar documents | `dewey_similar` | "Find specs like this one" |
+| Tag-based discovery | `dewey_find_by_tag` | "All pages tagged #decision" |
+| Property queries | `dewey_query_properties` | "All specs with status: draft" |
+| Filtered semantic | `dewey_semantic_search_filtered` | Semantic search within source type |
+| Graph navigation | `dewey_traverse` | Dependency chain walking |
+
+### When to Fall Back to grep/glob/read
+
+Use direct file operations instead of Dewey when:
+- **Dewey is unavailable** — MCP tools return errors or
+  are not configured
+- **Exact string matching is needed** — searching for a
+  specific error message, variable name, or code pattern
+- **Specific file path is known** — reading a file you
+  already know the path to (use Read directly)
+- **Binary/non-Markdown content** — Dewey indexes
+  Markdown; use grep for Go source, JSON, YAML, etc.
+
+### Graceful Degradation (3-Tier Pattern)
+
+**Tier 3 (Full Dewey)** — semantic + structured search:
+- `dewey_semantic_search` — natural language queries
+- `dewey_search` — keyword queries
+- `dewey_get_page`, `dewey_find_connections`,
+  `dewey_traverse` — structured navigation
+- `dewey_find_by_tag`, `dewey_query_properties` —
+  metadata queries
+
+**Tier 2 (Graph-only, no embedding model)** — structured
+search only:
+- `dewey_search` — keyword queries (no embeddings needed)
+- `dewey_get_page`, `dewey_traverse`,
+  `dewey_find_connections` — graph navigation
+- `dewey_find_by_tag`, `dewey_query_properties` —
+  metadata queries
+- Semantic search unavailable — use exact keyword matches
+
+**Tier 1 (No Dewey)** — direct file access:
+- Use Read tool for direct file access
+- Use Grep for keyword search across the codebase
+- Use Glob for file pattern matching
+```
+
+## Injection Order
+
+When multiple blocks are missing, they should be injected
+in this order to maintain a logical document flow:
+
+1. Core Mission (top of document, after Project Overview)
+2. Gatekeeping Value Protection (inside Behavioral
+   Constraints)
+3. Workflow Phase Boundaries (inside Behavioral
+   Constraints)
+4. CI Parity Gate (inside Technical Guardrails or
+   Behavioral Constraints)
+5. Review Council PR Prerequisite (after constraints)
+6. Spec-First Development (after constraints)
+7. Website Documentation Sync Gate (near documentation
+   gates)
+8. Knowledge Retrieval (after coding conventions)
+
+## No Persistent Data Model
+
+This feature introduces no persistent data structures:
+- No new Go structs
+- No new JSON schemas
+- No database tables
+- No configuration files
+- No state files
+
+The guidance text is defined inline in the `/uf-init`
+command file and injected directly into `AGENTS.md` at
+runtime.

--- a/specs/030-agents-md-guidance/plan.md
+++ b/specs/030-agents-md-guidance/plan.md
@@ -1,0 +1,234 @@
+# Implementation Plan: AGENTS.md Behavioral Guidance Injection
+
+**Branch**: `030-agents-md-guidance` | **Date**: 2026-04-15 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `specs/030-agents-md-guidance/spec.md`
+
+## Summary
+
+Add a new step to the `/uf-init` command that injects 8
+standardized behavioral guidance sections into a repo's
+`AGENTS.md`. The guidance blocks codify critical agent
+behavioral rules — gatekeeping protection, workflow phase
+boundaries, CI parity, review council prerequisites,
+website documentation sync, spec-first development,
+knowledge retrieval, and core mission — ensuring every
+repo in the Unbound Force ecosystem enforces the same
+quality gates and process discipline.
+
+The implementation modifies exactly 2 files: the live
+`/uf-init` command file and its scaffold asset copy.
+No Go code, no tests, no agent files, no convention
+packs. The 8 guidance block texts are defined inline
+in the command instructions.
+
+## Technical Context
+
+**Language/Version**: Markdown (OpenCode command file)
+**Primary Dependencies**: OpenCode agent runtime (renders
+  Markdown instructions), existing `/uf-init` command
+  (Steps 1-9)
+**Storage**: N/A (modifies `AGENTS.md` in target repo at
+  runtime; no persistent state)
+**Testing**: Manual verification — run `/uf-init` in a
+  repo and check `AGENTS.md` content. Existing scaffold
+  drift detection tests verify the asset copy stays in
+  sync.
+**Target Platform**: Any Unbound Force repository with an
+  `AGENTS.md` file
+**Project Type**: Command file (Markdown instructions for
+  AI agent execution)
+**Performance Goals**: N/A
+**Constraints**: Must be idempotent. Must not modify
+  `AGENTS.md` files that already have the sections. Must
+  skip gracefully when `AGENTS.md` does not exist.
+**Scale/Scope**: 6 repos in the Unbound Force org (meta,
+  gaze, website, dewey, homebrew-tap, replicator)
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after
+Phase 1 design.*
+
+### I. Autonomous Collaboration — PASS
+
+The guidance blocks are self-contained text injected into
+`AGENTS.md`. No runtime coupling between repos. Each repo
+gets its own copy of the guidance — no shared mutable
+state, no cross-repo dependencies at injection time. The
+`/uf-init` command reads the target repo's `AGENTS.md`
+and writes to it locally.
+
+### II. Composability First — PASS
+
+The guidance injection step is additive — it does not
+require any other hero to be installed. If `AGENTS.md`
+does not exist, the step is skipped gracefully (FR-004).
+The 8 blocks are independently useful: a repo can have
+some but not all, and each block provides value on its
+own. No mandatory dependencies introduced.
+
+### III. Observable Quality — PASS
+
+The `/uf-init` report summary (Step 9, extended by
+FR-006) includes an "AGENTS.md Guidance" section showing
+which blocks were injected, which were already present,
+and which were skipped. This provides machine-readable
+(structured summary) and human-readable (status
+indicators) output for every injection action.
+
+### IV. Testability — PASS
+
+The implementation is Markdown-only — no Go code changes,
+so no new functions to unit test. Testability is verified
+through:
+1. Existing scaffold drift detection tests ensure the
+   asset copy matches the live file.
+2. Manual acceptance testing: run `/uf-init` in a repo,
+   verify sections appear, run again, verify idempotent.
+3. The idempotency check (section heading detection) is
+   deterministic and reproducible.
+4. Content correctness test: add assertions to an
+   existing scaffold test that verify the `/uf-init`
+   command file contains all 8 detection phrases (one
+   per guidance block). This catches typos, missing
+   sections, or malformed content without introducing
+   new test infrastructure.
+
+**Coverage strategy**: No new Go code → no coverage
+impact. Existing `TestScaffoldAssetDrift` continues to
+verify the scaffold asset copy stays synchronized. A
+lightweight content-presence test (string assertions
+for 8 detection phrases in the scaffold asset) provides
+automated verification that all guidance blocks are
+defined in the command file.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/030-agents-md-guidance/
+├── spec.md              # Feature specification
+├── plan.md              # This file
+├── research.md          # Phase 0: canonical text sources
+├── data-model.md        # Phase 1: guidance block schema
+├── quickstart.md        # Phase 1: implementation guide
+├── checklists/
+│   └── requirements.md  # Pre-existing checklist
+└── tasks.md             # Phase 2 output (/speckit.tasks)
+```
+
+### Source Code (repository root)
+
+```text
+.opencode/command/
+└── uf-init.md                              # Live command (add Step 10)
+
+internal/scaffold/assets/opencode/command/
+└── uf-init.md                              # Scaffold asset copy (sync)
+```
+
+**Structure Decision**: This feature modifies exactly 2
+files — the live `/uf-init` command and its scaffold
+asset copy. Both are Markdown. No new directories, no
+new packages, no new Go source files.
+
+## Implementation Approach
+
+### Step 10 Design
+
+The new step is inserted after Step 8 (OpenSpec Command
+Guardrails) and before Step 9 (Report Results). The
+existing Step 9 is renumbered to Step 10, and the new
+AGENTS.md guidance injection becomes Step 9. The report
+in the new Step 10 is extended with an "AGENTS.md
+Guidance" section.
+
+**Alternative considered**: Inserting as a sub-step of
+an existing step. Rejected because the AGENTS.md
+guidance injection is conceptually distinct from OpenSpec
+or Speckit customizations — it operates on a different
+target file (`AGENTS.md` vs. skill/command files).
+
+### Idempotency Strategy
+
+Each guidance block has a **detection heading** — a
+specific Markdown heading or key phrase that the AI agent
+searches for in `AGENTS.md`. If the heading (or semantic
+equivalent) is found, the block is skipped. This mirrors
+the idempotency pattern already used in Steps 2-4 of
+`/uf-init`.
+
+| Block | Detection Heading |
+|-------|-------------------|
+| Core Mission | `## Core Mission` |
+| Gatekeeping Value Protection | `### Gatekeeping Value Protection` |
+| Workflow Phase Boundaries | `### Workflow Phase Boundaries` |
+| CI Parity Gate | `CI Parity Gate` |
+| Review Council PR Prerequisite | `Review Council` + `PR Prerequisite` |
+| Website Documentation Sync Gate | `Website Documentation` + `Gate` |
+| Spec-First Development | `Spec-First Development` |
+| Knowledge Retrieval | `## Knowledge Retrieval` |
+
+### Canonical Text Sources
+
+The 8 guidance blocks are derived from two canonical
+sources:
+
+1. **Meta repo AGENTS.md** (`unbound-force/unbound-force`):
+   - Core Mission (lines 12-16)
+   - Gatekeeping Value Protection (lines 25-38)
+   - Workflow Phase Boundaries (lines 40-54)
+   - Website Documentation Sync Gate (lines 397-418)
+   - Knowledge Retrieval (lines 533-592)
+
+2. **Gaze AGENTS.md** (`unbound-force/gaze`):
+   - CI Parity Gate (line 27)
+   - Review Council PR Prerequisite (lines 38-54)
+   - Spec-First Development (lines 56-82)
+   - Core Mission (lines 12-16, identical to meta repo)
+
+The inline text in `/uf-init` is a **generalized version**
+of these canonical sources — repo-specific details
+(hero names, specific constitution principles) are
+replaced with generic placeholders that apply to any
+repo. See `research.md` for the full canonical text
+extraction and generalization analysis.
+
+### Report Extension
+
+The existing Step 9 report template gains a new section:
+
+```
+### AGENTS.md Guidance
+  [status] Core Mission: [action]
+  [status] Gatekeeping Value Protection: [action]
+  [status] Workflow Phase Boundaries: [action]
+  [status] CI Parity Gate: [action]
+  [status] Review Council PR Prerequisite: [action]
+  [status] Website Documentation Sync Gate: [action]
+  [status] Spec-First Development: [action]
+  [status] Knowledge Retrieval: [action]
+```
+
+Using the same status indicators as existing sections:
+`✅` (inserted), `⊘` (already present), `❌` (error).
+
+## Risk Assessment
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| AI agent misidentifies section as present when it's not | Low | Medium | Use specific heading text, not vague keywords |
+| AI agent inserts at wrong location in AGENTS.md | Low | Low | Provide explicit placement guidance (after which section) |
+| Scaffold asset copy drifts from live file | Medium | Low | Existing `TestScaffoldAssetDrift` catches this |
+| Guidance text is too meta-repo-specific | Medium | Medium | Generalize all text; remove hero names, specific principles |
+| Large AGENTS.md causes context window issues | Low | Medium | Guidance blocks are self-contained; agent reads headings first |
+
+## Complexity Tracking
+
+> No constitution violations to justify. All four
+> principles pass cleanly.
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| (none) | — | — |

--- a/specs/030-agents-md-guidance/quickstart.md
+++ b/specs/030-agents-md-guidance/quickstart.md
@@ -1,0 +1,124 @@
+# Quickstart: AGENTS.md Behavioral Guidance Injection
+
+**Branch**: `030-agents-md-guidance` | **Date**: 2026-04-15
+**Phase**: 1 (Design)
+
+## What This Feature Does
+
+Adds a new step to the `/uf-init` command that
+automatically injects 8 standardized behavioral guidance
+sections into a repo's `AGENTS.md`. This ensures every
+repo in the Unbound Force ecosystem enforces the same
+quality gates, workflow boundaries, and documentation
+requirements.
+
+## Implementation Summary
+
+### Files to Modify
+
+| # | File | Change |
+|---|------|--------|
+| 1 | `.opencode/command/uf-init.md` | Add Step 9 (AGENTS.md guidance injection), renumber existing Step 9 → Step 10, extend report |
+| 2 | `internal/scaffold/assets/opencode/command/uf-init.md` | Sync copy of file #1 |
+
+### What NOT to Modify
+
+- No Go source files
+- No test files
+- No agent files
+- No convention packs
+- No CI workflows
+- No constitution
+
+## Step-by-Step Implementation Guide
+
+### Step 1: Add Step 9 to `/uf-init`
+
+Open `.opencode/command/uf-init.md`. Insert a new
+`### Step 9: AGENTS.md Behavioral Guidance` section
+between the current Step 8 (OpenSpec Command Guardrails)
+and Step 9 (Report Results).
+
+The new step should:
+
+1. **Check** if `AGENTS.md` exists at the repo root
+2. **If not**: Report `⊘ AGENTS.md: not found (skipped)`
+   and skip the entire step
+3. **If yes**: Read `AGENTS.md` and check for each of the
+   8 guidance blocks
+4. For each block:
+   - Search for the detection heading/phrases
+   - If found: Report `⊘ <block>: already present`
+   - If not found: Find the correct insertion point and
+     inject the block text. Report `✅ <block>: injected`
+
+### Step 2: Renumber Existing Step 9
+
+The current "Step 9: Report Results" becomes
+"Step 10: Report Results".
+
+### Step 3: Extend the Report
+
+Add an "AGENTS.md Guidance" section to the report
+template in the new Step 10:
+
+```
+### AGENTS.md Guidance
+  [status] Core Mission: [action]
+  [status] Gatekeeping Value Protection: [action]
+  [status] Workflow Phase Boundaries: [action]
+  [status] CI Parity Gate: [action]
+  [status] Review Council PR Prerequisite: [action]
+  [status] Website Documentation Sync Gate: [action]
+  [status] Spec-First Development: [action]
+  [status] Knowledge Retrieval: [action]
+```
+
+### Step 4: Sync Scaffold Asset Copy
+
+Copy the modified `.opencode/command/uf-init.md` to
+`internal/scaffold/assets/opencode/command/uf-init.md`.
+The files must be byte-identical.
+
+### Step 5: Verify
+
+1. Run `go test -race -count=1 ./...` — all tests must
+   pass (especially `TestScaffoldAssetDrift`)
+2. Run `git diff` to review changes
+3. Verify only 2 files are modified
+
+## Verification Checklist
+
+- [ ] New Step 9 is present in `/uf-init`
+- [ ] All 8 guidance block texts are defined inline
+- [ ] Each block has detection phrases for idempotency
+- [ ] `AGENTS.md` not found case is handled gracefully
+- [ ] Existing Step 9 is renumbered to Step 10
+- [ ] Report template includes "AGENTS.md Guidance"
+- [ ] Scaffold asset copy is synchronized
+- [ ] `go test -race -count=1 ./...` passes
+- [ ] Only 2 files modified (live + asset copy)
+
+## Key Design Decisions
+
+1. **Inline text, not file references**: The guidance
+   block text is defined directly in the `/uf-init`
+   command instructions, not in separate template files.
+   This keeps the implementation self-contained and
+   avoids adding new embedded assets.
+
+2. **Heading-based idempotency**: Detection uses Markdown
+   heading text (with semantic fallback) rather than
+   marker comments. This matches the existing pattern in
+   Steps 2-4 and works with manually-added sections.
+
+3. **Generalized text**: The injected text is
+   repo-agnostic. Repo-specific customization is done by
+   the user editing the injected text after `/uf-init`
+   runs.
+
+4. **Step 9 placement**: The AGENTS.md guidance step is
+   placed after all OpenSpec/Speckit customizations
+   (Steps 2-8) and before the report (Step 10). This
+   groups all file-modification steps together, with the
+   report as the final action.

--- a/specs/030-agents-md-guidance/research.md
+++ b/specs/030-agents-md-guidance/research.md
@@ -1,0 +1,200 @@
+# Research: AGENTS.md Behavioral Guidance Injection
+
+**Branch**: `030-agents-md-guidance` | **Date**: 2026-04-15
+**Phase**: 0 (Research)
+
+## R1: Canonical Text Sources
+
+The 8 guidance blocks are derived from two existing
+`AGENTS.md` files in the Unbound Force ecosystem. This
+section documents the exact source locations and the
+generalization decisions for each block.
+
+### Source 1: Meta Repo AGENTS.md
+
+**File**: `unbound-force/unbound-force/AGENTS.md`
+
+| Block | Location | Generalization Needed |
+|-------|----------|----------------------|
+| Core Mission | Lines 12-16 (`## Core Mission`) | None — already generic |
+| Gatekeeping Value Protection | Lines 25-38 (`### Gatekeeping Value Protection`) | Minimal — remove meta-repo-specific examples |
+| Workflow Phase Boundaries | Lines 40-54 (`### Workflow Phase Boundaries`) | Minimal — `specs/NNN-*/` is universal |
+| Website Documentation Sync Gate | Lines 397-418 (`### Website Documentation Gate`) | None — already generic with `gh` template |
+| Knowledge Retrieval | Lines 533-592 (`## Knowledge Retrieval`) | Minimal — tool matrix is universal |
+
+### Source 2: Gaze AGENTS.md
+
+**File**: `unbound-force/gaze/AGENTS.md`
+
+| Block | Location | Generalization Needed |
+|-------|----------|----------------------|
+| CI Parity Gate | Line 27 (`- **CI Parity Gate**:`) | None — already generic |
+| Review Council PR Prerequisite | Lines 38-54 (`### Review Council as PR Prerequisite`) | None — already generic |
+| Spec-First Development | Lines 56-82 (`## Spec-First Development`) | Minimal — remove Gaze-specific spec examples |
+| Core Mission | Lines 12-16 (`## Core Mission`) | Identical to meta repo |
+
+## R2: Current `/uf-init` Structure
+
+The `/uf-init` command currently has 9 steps:
+
+| Step | Name | Target Files | Action |
+|------|------|-------------|--------|
+| 1 | Check Prerequisites | `.opencode/`, skills, commands | Verify existence |
+| 2 | Apply Branch Enforcement | 6 OpenSpec files | Insert branch management |
+| 3 | Apply Dewey Context | 7 OpenSpec files | Insert Dewey queries |
+| 4 | Apply 3-Tier Degradation | 3 skill files | Insert fallback tiers |
+| 5 | Speckit Custom Commands | 4 command files | Create if missing |
+| 6 | Speckit Command Guardrails | 9 command files | Append guardrails |
+| 7 | Speckit UF Customizations | 5 command files | Verify (read-only) |
+| 8 | OpenSpec Command Guardrails | 1 command file | Append guardrails |
+| 9 | Report Results | N/A | Display summary |
+
+The new AGENTS.md guidance injection fits naturally as
+**Step 9** (before the report), with the existing Step 9
+renumbered to **Step 10**.
+
+### Pattern Analysis
+
+All existing steps follow the same pattern:
+1. Read target file
+2. Check if customization is already present (idempotent)
+3. If not present, insert at correct location
+4. Report status with `✅`/`⊘`/`❌` indicators
+
+The AGENTS.md guidance step follows this identical
+pattern, ensuring consistency with the rest of `/uf-init`.
+
+## R3: Idempotency Detection Strategy
+
+### Existing Patterns in `/uf-init`
+
+| Step | Detection Method |
+|------|-----------------|
+| Branch Enforcement | Semantic: look for `opsx/<name>`, `git checkout -b opsx/` |
+| Dewey Context | Tool invocation: `dewey_semantic_search` or `dewey_search` |
+| 3-Tier Degradation | Keywords: "Tier 1", "Tier 2", "Tier 3", "graceful degradation" |
+| Speckit Commands | File existence: check if `.opencode/command/speckit.*.md` exists |
+| Speckit Guardrails | Heading: `## Guardrails` |
+| OpenSpec Guardrails | Heading: `## Guardrails` |
+
+### Recommended Detection for Guidance Blocks
+
+Use **heading-based detection** (matching the Guardrails
+pattern) as the primary strategy, with **semantic
+fallback** for blocks that might exist under different
+headings.
+
+| Block | Primary Detection | Semantic Fallback |
+|-------|-------------------|-------------------|
+| Core Mission | `## Core Mission` heading | "Strategic Architecture" + "Outcome Orientation" |
+| Gatekeeping Value Protection | `Gatekeeping Value Protection` in heading | "MUST NOT modify values that serve as quality" |
+| Workflow Phase Boundaries | `Workflow Phase Boundaries` in heading | "MUST NOT cross workflow phase boundaries" |
+| CI Parity Gate | `CI Parity Gate` in heading or bold text | "replicate the CI checks locally" |
+| Review Council PR Prerequisite | `Review Council` in heading | "/review-council" + "APPROVE" |
+| Website Documentation Sync Gate | `Website Documentation` in heading | "gh issue create --repo" + "website" |
+| Spec-First Development | `Spec-First Development` in heading | "preceded by a spec workflow" |
+| Knowledge Retrieval | `## Knowledge Retrieval` heading | "dewey_semantic_search" tool reference |
+
+## R4: Insertion Point Strategy
+
+Each guidance block has a natural placement within a
+typical `AGENTS.md` structure:
+
+| Block | Placement | Rationale |
+|-------|-----------|-----------|
+| Core Mission | After `## Project Overview`, before `## Behavioral Constraints` | Sets strategic context early |
+| Gatekeeping Value Protection | Inside `## Behavioral Constraints` (as subsection) | Behavioral rule |
+| Workflow Phase Boundaries | Inside `## Behavioral Constraints` (as subsection) | Behavioral rule |
+| CI Parity Gate | Inside `## Technical Guardrails` or `## Behavioral Constraints` | Technical behavioral rule |
+| Review Council PR Prerequisite | After behavioral constraints, before build commands | Process rule |
+| Website Documentation Sync Gate | Near documentation validation gate or spec commit gate | Documentation process |
+| Spec-First Development | After behavioral constraints, before build commands | Development process |
+| Knowledge Retrieval | After coding conventions, before testing conventions | Tool usage guidance |
+
+**Key insight**: The AI agent executing `/uf-init` uses
+LLM reasoning to find insertion points. The instructions
+should describe the *concept* of where to insert (e.g.,
+"after the project overview section") rather than exact
+line numbers, because each repo's `AGENTS.md` has a
+different structure.
+
+## R5: Generalization Analysis
+
+### Blocks Requiring No Generalization
+
+These blocks are already repo-agnostic:
+
+1. **Core Mission** — 3 bullets about strategic framing.
+   No repo-specific content.
+2. **CI Parity Gate** — "Read `.github/workflows/`" is
+   universal. No repo-specific commands.
+3. **Review Council PR Prerequisite** — References
+   `/review-council` command (available in all repos
+   via `uf init`). No repo-specific content.
+
+### Blocks Requiring Minimal Generalization
+
+4. **Gatekeeping Value Protection** — The 8 protected
+   categories are universal. The "What to do instead"
+   instruction is universal. Remove any meta-repo-specific
+   examples.
+5. **Workflow Phase Boundaries** — `specs/NNN-*/` is the
+   universal convention. Phase-to-output mapping is
+   universal.
+6. **Website Documentation Sync Gate** — The `gh issue
+   create` template is universal. Exemption list is
+   universal.
+7. **Spec-First Development** — "What requires a spec"
+   list needs generalization: remove Gaze-specific items
+   (e.g., "embedded assets under `internal/scaffold/
+   assets/`") and use generic descriptions.
+8. **Knowledge Retrieval** — Tool selection matrix is
+   universal. 3-tier degradation is universal.
+
+## R6: Cross-Repo Audit
+
+Current state of the 8 guidance sections across Unbound
+Force repos:
+
+| Block | meta | gaze | website | dewey | homebrew-tap | replicator |
+|-------|:----:|:----:|:-------:|:-----:|:------------:|:----------:|
+| Core Mission | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |
+| Gatekeeping Protection | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Phase Boundaries | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| CI Parity Gate | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ |
+| Review Council | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ |
+| Website Doc Sync | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Spec-First Dev | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ |
+| Knowledge Retrieval | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
+
+**Observation**: No single repo has all 8 sections. The
+meta repo has 4, Gaze has 3 (different set), and the
+remaining 4 repos have none. This validates the need for
+standardized injection.
+
+## R7: File Modification Scope
+
+### Files Modified
+
+| File | Change Type | Lines Added |
+|------|------------|-------------|
+| `.opencode/command/uf-init.md` | Add Step 9 (AGENTS.md guidance), renumber Step 9→10 | ~200-250 |
+| `internal/scaffold/assets/opencode/command/uf-init.md` | Sync copy | Same |
+
+### Files NOT Modified
+
+- No Go source files (`*.go`)
+- No test files (`*_test.go`)
+- No agent files (`*.md` under `.opencode/agents/`)
+- No convention packs (`*.md` under `.opencode/uf/packs/`)
+- No CI workflows (`.github/workflows/`)
+- No schema files (`schemas/`)
+- No constitution (`.specify/memory/constitution.md`)
+
+### Test Impact
+
+- `TestScaffoldAssetDrift` — will verify the asset copy
+  stays in sync (existing test, no changes needed)
+- `expectedAssetPaths` — no change (no new embedded
+  assets added, just modifying existing `uf-init.md`)
+- All existing tests pass without modification (FR-008)

--- a/specs/030-agents-md-guidance/spec.md
+++ b/specs/030-agents-md-guidance/spec.md
@@ -1,0 +1,275 @@
+# Feature Specification: AGENTS.md Behavioral Guidance Injection
+
+**Feature Branch**: `030-agents-md-guidance`  
+**Created**: 2026-04-15  
+**Status**: Draft  
+**Issue**: #104  
+**Input**: User description: "issue #104 — Add AGENTS.md behavioral guidance injection to /uf-init"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — Standardize Critical Behavioral Rules Across Repos (Priority: P1)
+
+When an engineer runs `/uf-init` in any Unbound Force
+repository, the command ensures 8 standardized behavioral
+guidance sections are present in the repo's `AGENTS.md`.
+Today, these rules exist inconsistently — some repos
+have gatekeeping protection, others have CI parity gates,
+most have neither. After this change, every repo that
+runs `/uf-init` gets the same behavioral foundation,
+ensuring agents follow the same quality gates, workflow
+boundaries, and documentation requirements regardless
+of which repo they're working in.
+
+**Why this priority**: Without consistent behavioral
+rules, agents in one repo may skip CI checks, write
+code during planning phases, or merge without review
+— behaviors that are prevented in other repos. The
+inconsistency creates a quality gradient across the
+ecosystem.
+
+**Independent Test**: Run `/uf-init` in a repo with a
+minimal `AGENTS.md` that has none of the 8 guidance
+sections. Verify all 8 are injected. Run `/uf-init`
+again. Verify none are duplicated (idempotent).
+
+**Acceptance Scenarios**:
+
+1. **Given** a repo's `AGENTS.md` has no behavioral
+   guidance sections, **When** the engineer runs
+   `/uf-init`, **Then** all 8 standardized sections
+   are appended to `AGENTS.md` at appropriate locations.
+2. **Given** a repo's `AGENTS.md` already has some of
+   the 8 sections (e.g., from manual addition), **When**
+   the engineer runs `/uf-init`, **Then** only the
+   missing sections are added (existing ones preserved).
+3. **Given** a repo's `AGENTS.md` already has all 8
+   sections, **When** the engineer runs `/uf-init`,
+   **Then** no changes are made to `AGENTS.md`
+   (idempotent).
+4. **Given** a repo has no `AGENTS.md` at all, **When**
+   the engineer runs `/uf-init`, **Then** the AGENTS.md
+   guidance step is skipped with a message: "No
+   AGENTS.md found — skipping behavioral guidance
+   injection."
+
+---
+
+### User Story 2 — Consistent Quality Gates (Priority: P1)
+
+The 3 most critical behavioral rules — gatekeeping
+value protection, workflow phase boundaries, and CI
+parity gate — are present in every repo after running
+`/uf-init`. These rules prevent the most damaging agent
+behaviors: modifying quality thresholds, writing code
+during planning, and skipping CI checks.
+
+**Why this priority**: These 3 rules are the highest-
+impact behavioral controls. Without them, an agent can
+silently degrade the project's quality posture.
+
+**Independent Test**: Run `/uf-init` in the Gaze repo
+(which has CI parity gate but not gatekeeping protection
+or phase boundaries). Verify all 3 are present after.
+
+**Acceptance Scenarios**:
+
+1. **Given** a repo has no gatekeeping protection
+   section, **When** `/uf-init` runs, **Then** the
+   gatekeeping protection block is added with all 8
+   protected value categories and the "stop and report"
+   instruction.
+2. **Given** a repo has no workflow phase boundaries
+   section, **When** `/uf-init` runs, **Then** the
+   phase boundary block is added mapping each pipeline
+   phase to its allowed output type.
+3. **Given** a repo has no CI parity gate, **When**
+   `/uf-init` runs, **Then** the CI parity gate block
+   is added requiring agents to replicate CI checks
+   from `.github/workflows/` before marking tasks
+   complete.
+
+---
+
+### User Story 3 — Workflow and Documentation Rules (Priority: P2)
+
+The 3 workflow rules — review council as PR
+prerequisite, website documentation sync gate, and
+spec-first development with exemptions — are present
+in every repo after running `/uf-init`.
+
+**Why this priority**: These rules enforce process
+discipline but are less immediately damaging when
+missing than the P1 quality gates. An agent that skips
+review council produces lower-quality code but doesn't
+permanently degrade thresholds.
+
+**Independent Test**: Run `/uf-init` in the Website repo
+(which has minimal behavioral guidance). Verify all 3
+workflow rules are present after.
+
+**Acceptance Scenarios**:
+
+1. **Given** a repo has no review council PR
+   prerequisite, **When** `/uf-init` runs, **Then** the
+   5-step workflow (complete → CI → review-council →
+   commit → PR) with exemptions is added.
+2. **Given** a repo has no website documentation sync
+   gate, **When** `/uf-init` runs, **Then** the gate
+   requiring website issues for user-facing changes is
+   added (with `gh issue create` template and
+   exemption list).
+3. **Given** a repo has no spec-first development
+   section, **When** `/uf-init` runs, **Then** the
+   section is added listing what requires a spec, what
+   is exempt, and the "when unsure, ask the user" rule.
+
+---
+
+### User Story 4 — Knowledge Retrieval and Core Mission (Priority: P3)
+
+The knowledge retrieval section (with Dewey tool
+selection matrix and 3-tier degradation) and core
+mission statement (3 strategic framing bullets) are
+present in every repo after running `/uf-init`.
+
+**Why this priority**: These are contextual guidance
+rather than behavioral gates. Agents work correctly
+without them but produce better results when they know
+how to use Dewey and understand the project's strategic
+framing.
+
+**Independent Test**: Run `/uf-init` in the Replicator
+repo (which has knowledge retrieval but no core
+mission). Verify the core mission is added and the
+existing knowledge retrieval is preserved.
+
+**Acceptance Scenarios**:
+
+1. **Given** a repo has no knowledge retrieval section,
+   **When** `/uf-init` runs, **Then** the section is
+   added with the Dewey tool selection matrix, fallback
+   criteria, and 3-tier degradation pattern.
+2. **Given** a repo has no core mission statement,
+   **When** `/uf-init` runs, **Then** the 3 strategic
+   framing bullets (Strategic Architecture, Outcome
+   Orientation, Intent-to-Context) are added.
+3. **Given** a repo already has both sections, **When**
+   `/uf-init` runs, **Then** neither section is
+   modified or duplicated.
+
+---
+
+### Edge Cases
+
+- What happens when `AGENTS.md` uses different section
+  headings than expected (e.g., "Constraints" instead of
+  "Behavioral Constraints")? The AI agent SHOULD check
+  for the specific detection phrases defined in
+  `data-model.md` for each block — a primary heading
+  match and a semantic fallback phrase. If either is
+  found, the block is treated as already present.
+- What happens when a guidance section exists but with
+  different wording? The AI agent SHOULD check for the
+  detection phrases (see `data-model.md` Block
+  Definitions) and skip injection if any match is found.
+  It SHOULD NOT inject a duplicate section with slightly
+  different wording.
+- What happens when `AGENTS.md` is very large (1000+
+  lines)? The AI agent SHOULD still find the correct
+  insertion points — section headings and document
+  structure guide placement.
+- What happens when the user wants to customize a
+  guidance section for their repo? The user can edit
+  the injected section after `/uf-init` runs. Running
+  `/uf-init` again will not overwrite customized
+  sections (the idempotency check detects the section
+  heading is present).
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: `/uf-init` MUST check `AGENTS.md` for
+  each of the 8 standardized guidance sections and
+  inject any that are missing.
+- **FR-002**: Each injection MUST be idempotent — if
+  the section heading (or semantic equivalent) already
+  exists, the section MUST NOT be duplicated.
+- **FR-003**: The 8 guidance sections MUST include:
+  1. Core Mission (3 strategic framing bullets)
+  2. Gatekeeping Value Protection (8 protected
+     categories + stop-and-report)
+  3. Workflow Phase Boundaries (phase-to-output mapping)
+  4. CI Parity Gate (replicate CI checks from workflow
+     files)
+  5. Review Council PR Prerequisite (5-step workflow +
+     exemptions)
+  6. Website Documentation Sync Gate (issue creation +
+     exemptions)
+  7. Spec-First Development (what requires spec + what
+     is exempt + when-unsure rule)
+  8. Knowledge Retrieval (Dewey tool matrix + 3-tier
+     degradation + fallback criteria)
+- **FR-004**: If `AGENTS.md` does not exist in the repo,
+  the guidance injection step MUST be skipped with an
+  informational message.
+- **FR-005**: The injection text for each section MUST
+  be defined inline in the `/uf-init` command file
+  instructions.
+- **FR-006**: The `/uf-init` report summary MUST include
+  a "AGENTS.md Guidance" section showing which blocks
+  were injected, which were already present, and which
+  were skipped.
+- **FR-007**: The scaffold asset copy of `uf-init.md`
+  MUST be synchronized after modification.
+- **FR-008**: All existing tests MUST continue to pass.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Running `/uf-init` in a repo with a
+  minimal `AGENTS.md` (zero guidance sections) results
+  in all 8 sections being injected — verified by
+  checking for each section heading after running.
+- **SC-002**: Running `/uf-init` twice in the same repo
+  produces identical `AGENTS.md` content (idempotent) —
+  verified by comparing file checksums before and after
+  the second run.
+- **SC-003**: Running `/uf-init` in a repo that already
+  has all 8 sections produces zero modifications —
+  verified by checking `git diff` is empty after
+  running.
+- **SC-004**: All 6 Unbound Force repos have all 8
+  guidance sections after running `/uf-init` in each —
+  verified by the cross-repo audit table showing YES
+  for all cells.
+- **SC-005**: All existing tests pass after the changes
+  — verified by running the full test suite.
+
+## Dependencies & Assumptions
+
+### Dependencies
+
+- **`/uf-init` command** (existing): The injection
+  mechanism. Already handles speckit guardrails, Dewey
+  context, and OpenSpec guardrails.
+
+### Assumptions
+
+- Each repo has an `AGENTS.md` file at the repo root.
+  If not present, the guidance step is skipped gracefully.
+- The AI agent executing `/uf-init` can read `AGENTS.md`,
+  understand its structure, and find appropriate
+  insertion points for each section based on the
+  document's existing headings.
+- The guidance text is generic enough to apply to any
+  repo in the ecosystem (no repo-specific content in
+  the injected sections). Repo-specific customization
+  is done by the user editing the injected text after
+  `/uf-init` runs.
+- The idempotency check uses section heading matching
+  (semantic, not exact string) — if a section with the
+  same concept exists under a different heading, it is
+  treated as "already present."

--- a/specs/030-agents-md-guidance/tasks.md
+++ b/specs/030-agents-md-guidance/tasks.md
@@ -1,0 +1,204 @@
+# Tasks: AGENTS.md Behavioral Guidance Injection
+
+**Input**: Design documents from `specs/030-agents-md-guidance/`
+**Prerequisites**: plan.md (required), spec.md (required for user stories), research.md, data-model.md, contracts/uf-init-guidance.md, quickstart.md
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3, US4)
+- Include exact file paths in descriptions
+
+## Scope
+
+This feature modifies exactly **2 files** — both Markdown,
+no Go code:
+
+| # | File | Change |
+|---|------|--------|
+| 1 | `.opencode/command/uf-init.md` | Add Step 9, renumber Step 9→10, extend report |
+| 2 | `internal/scaffold/assets/opencode/command/uf-init.md` | Byte-identical sync copy |
+
+---
+
+## Phase 1: Command Structure (Blocking Prerequisites)
+
+**Purpose**: Renumber existing steps and establish the new
+Step 9 skeleton before injecting guidance block content.
+
+**⚠️ CRITICAL**: All guidance block tasks depend on the
+skeleton being in place first.
+
+- [x] T001 [US1] Renumber existing "Step 9: Report Results" to "Step 10: Report Results" in `.opencode/command/uf-init.md` — update the heading `### Step 9: Report Results` to `### Step 10: Report Results`; update any internal references to "Step 9" that refer to the report
+- [x] T002 [US1] Insert new `### Step 9: AGENTS.md Behavioral Guidance` section skeleton in `.opencode/command/uf-init.md` between Step 8 (OpenSpec Command Guardrails, ends ~line 517) and the new Step 10 — include the preamble instructions: (1) check if `AGENTS.md` exists at repo root, (2) if not found report `⊘ AGENTS.md: not found (skipped)` and skip entire step, (3) if found read `AGENTS.md` and process each guidance block per the detection/injection pattern
+- [x] T003 [US1] Add idempotency detection instructions to Step 9 skeleton in `.opencode/command/uf-init.md` — for each block: search for detection phrases (heading text + semantic fallback), if found report `⊘ <block>: already present (skipped)`, if not found find correct insertion point and inject, report `✅ <block>: injected`
+
+**Checkpoint**: Step 9 skeleton is in place with the
+AGENTS.md-not-found guard and detection/injection pattern.
+Step 10 is the report. Ready for guidance block content.
+
+---
+
+## Phase 2: P1 Quality Gates (US2 — Consistent Quality Gates)
+
+**Purpose**: Inject the 3 most critical behavioral rules
+that prevent the most damaging agent behaviors.
+
+**Goal**: Gatekeeping value protection, workflow phase
+boundaries, and CI parity gate are present in every repo
+after `/uf-init`.
+
+**Independent Test**: Run `/uf-init` in the Gaze repo
+(which has CI parity gate but not gatekeeping protection
+or phase boundaries). Verify all 3 are present after.
+
+- [x] T004 [US2] Add Block 2 (Gatekeeping Value Protection) to Step 9 in `.opencode/command/uf-init.md` — detection phrases: `Gatekeeping Value Protection` heading, `MUST NOT modify values that serve as quality`; placement: inside `## Behavioral Constraints` section; inject full text from data-model.md Block 2 (8 protected categories + stop-and-report instruction)
+- [x] T005 [US2] Add Block 3 (Workflow Phase Boundaries) to Step 9 in `.opencode/command/uf-init.md` — detection phrases: `Workflow Phase Boundaries` heading, `MUST NOT cross workflow phase boundaries`; placement: inside `## Behavioral Constraints` after Gatekeeping; inject full text from data-model.md Block 3 (phase-to-output mapping + stop-and-report)
+- [x] T006 [US2] Add Block 4 (CI Parity Gate) to Step 9 in `.opencode/command/uf-init.md` — detection phrases: `CI Parity Gate` heading or bold text, `replicate the CI checks locally`; placement: inside `## Behavioral Constraints` or `## Technical Guardrails`; inject full text from data-model.md Block 4 (read workflows, execute locally, blocking error)
+
+**Checkpoint**: The 3 highest-impact behavioral controls
+are defined in Step 9. These prevent threshold tampering,
+out-of-phase code changes, and CI skipping.
+
+---
+
+## Phase 3: P2 Workflow Rules (US3 — Workflow and Documentation Rules)
+
+**Purpose**: Inject the 3 workflow/documentation rules
+that enforce process discipline.
+
+**Goal**: Review council prerequisite, website doc sync
+gate, and spec-first development are present in every
+repo after `/uf-init`.
+
+**Independent Test**: Run `/uf-init` in the Website repo
+(which has minimal behavioral guidance). Verify all 3
+workflow rules are present after.
+
+- [x] T007 [US3] Add Block 5 (Review Council PR Prerequisite) to Step 9 in `.opencode/command/uf-init.md` — detection phrases: `Review Council` + `PR Prerequisite`, `/review-council`; placement: after behavioral constraints, before build commands; inject full text from data-model.md Block 5 (5-step workflow + exemptions list)
+- [x] T008 [US3] Add Block 6 (Website Documentation Sync Gate) to Step 9 in `.opencode/command/uf-init.md` — detection phrases: `Website Documentation` + `Gate`, `gh issue create --repo`, `unbound-force/website`; placement: near documentation validation gate or spec commit gate; inject full text from data-model.md Block 6 (`gh issue create` template + exempt/required lists)
+- [x] T009 [US3] Add Block 7 (Spec-First Development) to Step 9 in `.opencode/command/uf-init.md` — detection phrases: `Spec-First Development`, `preceded by a spec workflow`; placement: after behavioral constraints, before build commands; inject full text from data-model.md Block 7 (what requires spec + what is exempt + when-unsure rule)
+
+**Checkpoint**: All 6 behavioral gate blocks (P1 + P2)
+are defined in Step 9. Process discipline rules are
+complete.
+
+---
+
+## Phase 4: P3 Contextual Guidance (US4 — Knowledge Retrieval and Core Mission)
+
+**Purpose**: Inject the 2 contextual guidance sections
+that improve agent output quality.
+
+**Goal**: Knowledge retrieval (Dewey tool matrix + 3-tier
+degradation) and core mission (3 strategic framing
+bullets) are present in every repo after `/uf-init`.
+
+**Independent Test**: Run `/uf-init` in the Replicator
+repo (which has knowledge retrieval but no core mission).
+Verify the core mission is added and the existing
+knowledge retrieval is preserved.
+
+- [x] T010 [US4] Add Block 1 (Core Mission) to Step 9 in `.opencode/command/uf-init.md` — detection phrases: `## Core Mission`, `Strategic Architecture`, `Outcome Orientation`; placement: after `## Project Overview`, before `## Behavioral Constraints`; inject full text from data-model.md Block 1 (3 strategic framing bullets)
+- [x] T011 [US4] Add Block 8 (Knowledge Retrieval) to Step 9 in `.opencode/command/uf-init.md` — detection phrases: `## Knowledge Retrieval`, `dewey_semantic_search`, `Tool Selection Matrix`; placement: after coding conventions, before testing conventions; inject full text from data-model.md Block 8 (tool selection matrix + fallback criteria + 3-tier degradation pattern)
+
+**Checkpoint**: All 8 guidance blocks are defined in
+Step 9. The full injection catalog is complete.
+
+---
+
+## Phase 5: Report Extension and Finalization (US1)
+
+**Purpose**: Extend the report template, sync the scaffold
+asset copy, and verify the build.
+
+- [x] T012 [US1] Add "AGENTS.md Guidance" section to the report template in Step 10 of `.opencode/command/uf-init.md` — insert between "OpenSpec Command Guardrails" and "Summary" sections; include 8 status lines (one per block: Core Mission, Gatekeeping Value Protection, Workflow Phase Boundaries, CI Parity Gate, Review Council PR Prerequisite, Website Documentation Sync Gate, Spec-First Development, Knowledge Retrieval) using `[status] <block>: [action]` format; update Summary counters to include AGENTS.md guidance results
+- [x] T013 [US1] Add injection order instructions to Step 9 in `.opencode/command/uf-init.md` — when multiple blocks are missing, inject in this order per data-model.md: (1) Core Mission, (2) Gatekeeping Value Protection, (3) Workflow Phase Boundaries, (4) CI Parity Gate, (5) Review Council PR Prerequisite, (6) Spec-First Development, (7) Website Documentation Sync Gate, (8) Knowledge Retrieval
+- [x] T014 [US1] Sync scaffold asset copy — copy `.opencode/command/uf-init.md` to `internal/scaffold/assets/opencode/command/uf-init.md` (must be byte-identical per contract)
+- [x] T015 [US1] Add content-presence assertions to an existing scaffold test — verify the `/uf-init` scaffold asset contains all 8 guidance block detection phrases (one per block: `Core Mission`, `Gatekeeping Value Protection`, `Workflow Phase Boundaries`, `CI Parity Gate`, `Review Council`, `Website Documentation`, `Spec-First Development`, `Knowledge Retrieval`); this catches missing or truncated blocks without new test infrastructure
+- [x] T016 [US1] Verify build and drift detection — run `go build ./...` and `go test -race -count=1 ./internal/scaffold/...` to confirm `TestScaffoldAssetDrift` passes, content-presence assertions pass, and no existing tests are broken
+
+**Checkpoint**: Implementation complete. Both files are
+modified, asset copy is synchronized, and all tests pass.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Command Structure)**: No dependencies — can
+  start immediately. BLOCKS all subsequent phases.
+- **Phase 2 (P1 Quality Gates)**: Depends on Phase 1
+  completion (Step 9 skeleton must exist).
+- **Phase 3 (P2 Workflow Rules)**: Depends on Phase 1
+  completion. Can run in parallel with Phase 2 (all tasks
+  modify the same file but different sections within
+  Step 9).
+- **Phase 4 (P3 Contextual Guidance)**: Depends on Phase 1
+  completion. Can run in parallel with Phases 2-3.
+- **Phase 5 (Report & Finalization)**: Depends on Phases
+  2-4 completion (all 8 blocks must be defined before
+  the report can reference them and the asset can be
+  synced).
+
+### Within Each Phase
+
+- Phase 1: T001 → T002 → T003 (sequential — each builds
+  on the previous)
+- Phase 2: T004, T005, T006 modify the same Step 9
+  section but are independent blocks — execute
+  sequentially to avoid edit conflicts in the same file
+- Phase 3: T007, T008, T009 — same pattern as Phase 2
+- Phase 4: T010, T011 — same pattern
+- Phase 5: T012 → T013 → T014 → T015 → T016 (sequential —
+  report before sync, sync before test, test before verify)
+
+### File Conflict Note
+
+All tasks in Phases 1-5 modify the same file
+(`.opencode/command/uf-init.md`). While the blocks are
+conceptually independent, they MUST be executed
+sequentially to avoid concurrent edit conflicts. The
+`[P]` marker is intentionally omitted from all tasks.
+
+---
+
+## Implementation Strategy
+
+### Single-File Sequential
+
+This feature modifies 1 primary file with a sync copy.
+All tasks are sequential within the primary file:
+
+1. Complete Phase 1: Skeleton → Step 9 exists
+2. Complete Phase 2: P1 blocks → 3 critical gates defined
+3. Complete Phase 3: P2 blocks → 3 workflow rules defined
+4. Complete Phase 4: P3 blocks → 2 contextual sections
+   defined
+5. Complete Phase 5: Report + sync + verify → Done
+
+### Verification
+
+After Phase 5, the implementation is verified by:
+- `TestScaffoldAssetDrift` — asset copy matches live file
+- `go build ./...` — no compilation errors
+- `go test -race -count=1 ./...` — all tests pass
+- Manual: only 2 files modified (`git diff --stat`)
+
+---
+
+## Notes
+
+- All 8 guidance block texts come from `data-model.md`
+  (the canonical content reference for this spec)
+- No Go code is modified — this is a Markdown-only change
+- No new embedded assets — `expectedAssetPaths` count
+  does not change
+- No new test files — existing `TestScaffoldAssetDrift`
+  covers the sync requirement
+- The injection order in T013 differs slightly from the
+  block numbering (Blocks 1-8) because the order is
+  optimized for document flow, not priority
+
+<!-- spec-review: passed -->


### PR DESCRIPTION
## Summary

Adds Step 9 "AGENTS.md Behavioral Guidance" to `/uf-init` that injects 8 standardized behavioral guidance sections into any repo's AGENTS.md. Ensures all Unbound Force repos have consistent quality gates, workflow rules, and context retrieval guidance.

Closes #104

### The 8 Guidance Blocks

| Priority | Block | Detection Phrase | What It Prevents |
|----------|-------|-----------------|-----------------|
| P1 | Gatekeeping Value Protection | `Gatekeeping Value Protection` | Agents modifying quality thresholds |
| P1 | Workflow Phase Boundaries | `Workflow Phase Boundaries` | Code during planning phases |
| P1 | CI Parity Gate | `CI Parity Gate` | Skipping CI checks |
| P2 | Review Council PR Prerequisite | `Review Council` + `PR Prerequisite` | PRs without review |
| P2 | Spec-First Development | `Spec-First Development` | Changes without specs |
| P2 | Website Documentation Sync Gate | `Website Documentation` + `Sync Gate` | Missing website doc issues |
| P3 | Core Mission | `Core Mission` or `Strategic Architecture` | Missing strategic framing |
| P3 | Knowledge Retrieval | `Knowledge Retrieval` | Missing Dewey usage guidance |

### How It Works

Each block has: detection phrase (for idempotency), placement guidance (where in AGENTS.md), and full canonical text. The AI agent reads AGENTS.md, checks for existing sections via semantic heading matching, and appends missing blocks. Running `/uf-init` twice produces identical results.

### Cross-Repo Audit (Before → After)

| Guidance | meta | gaze | dewey | replicator | website | containerfile |
|----------|:----:|:----:|:-----:|:----------:|:-------:|:-------------:|
| Gatekeeping | YES | NO→YES | NO→YES | NO→YES | NO→YES | NO→YES |
| Phase Boundaries | YES | NO→YES | NO→YES | NO→YES | NO→YES | NO→YES |
| CI Parity Gate | NO→YES | YES | YES | YES | NO→YES | NO→YES |
| Review Council | NO→YES | YES | YES | brief→YES | NO→YES | NO→YES |
| Website Sync | YES | NO→YES | YES | NO→YES | N/A | YES |
| Spec-First | YES | YES | YES | brief→YES | NO→YES | NO→YES |
| Knowledge Retrieval | YES | NO→YES | NO→YES | YES | YES | YES |
| Core Mission | YES | YES | YES | NO→YES | NO→YES | NO→YES |

### Files Changed

- `.opencode/command/uf-init.md` — +395 lines (Step 9 + report update)
- `internal/scaffold/assets/opencode/command/uf-init.md` — scaffold sync
- `internal/scaffold/scaffold_test.go` — +35 lines (`TestUFInitAsset_GuidanceBlockPresence`)
- Spec artifacts (8 files)