### PR TITLE
fix: sync 17 stale scaffold assets and fix Ollama test GOOS mismatch

### DIFF
--- a/internal/scaffold/assets/opencode/command/cobalt-crush.md
+++ b/internal/scaffold/assets/opencode/command/cobalt-crush.md
@@ -7,6 +7,7 @@ description: >
 ---
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->
+<!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vv0.6.1 -->
 
 # Command: /cobalt-crush

--- a/internal/scaffold/assets/opencode/command/constitution-check.md
+++ b/internal/scaffold/assets/opencode/command/constitution-check.md
@@ -4,6 +4,7 @@ agent: constitution-check
 ---
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->
+<!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vv0.6.1 -->
 <!-- scaffolded by uf vdev -->
 

--- a/internal/scaffold/assets/opencode/command/finale.md
+++ b/internal/scaffold/assets/opencode/command/finale.md
@@ -6,6 +6,7 @@ description: >
 ---
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->
+<!-- scaffolded by uf vdev -->
 
 # Command: /finale
 

--- a/internal/scaffold/assets/opencode/command/review-council.md
+++ b/internal/scaffold/assets/opencode/command/review-council.md
@@ -3,6 +3,7 @@ description: Run the reviewer governance council to audit codebase or spec compl
 ---
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->
+<!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vv0.6.1 -->
 # Command: /review-council
 

--- a/internal/scaffold/assets/opencode/command/uf-init.md
+++ b/internal/scaffold/assets/opencode/command/uf-init.md
@@ -7,6 +7,7 @@ description: >
 ---
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->
+<!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vv0.6.1 -->
 
 # Command: /uf-init

--- a/internal/scaffold/assets/opencode/command/unleash.md
+++ b/internal/scaffold/assets/opencode/command/unleash.md
@@ -9,6 +9,7 @@ description: >
 ---
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->
+<!-- scaffolded by uf vdev -->
 
 # Command: /unleash
 

--- a/internal/scaffold/assets/opencode/skill/speckit-workflow/SKILL.md
+++ b/internal/scaffold/assets/opencode/skill/speckit-workflow/SKILL.md
@@ -8,6 +8,7 @@ tags:
 ---
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->
+<!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vv0.6.1 -->
 
 # Speckit Workflow — Swarm Skill

--- a/internal/scaffold/assets/opencode/uf/packs/content.md
+++ b/internal/scaffold/assets/opencode/uf/packs/content.md
@@ -4,6 +4,7 @@ language: Any
 version: 1.0.0
 ---
 <!-- scaffolded by uf vdev -->
+<!-- scaffolded by uf vdev -->
 
 # Convention Pack: Content (Documentation, Blog, PR/Comms)
 

--- a/internal/scaffold/assets/opencode/uf/packs/default.md
+++ b/internal/scaffold/assets/opencode/uf/packs/default.md
@@ -5,6 +5,7 @@ version: 1.0.0
 ---
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->
+<!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vv0.6.1 -->
 
 # Convention Pack: Default (Language-Agnostic)

--- a/internal/scaffold/assets/opencode/uf/packs/go.md
+++ b/internal/scaffold/assets/opencode/uf/packs/go.md
@@ -5,6 +5,7 @@ version: 1.0.0
 ---
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->
+<!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vv0.6.1 -->
 
 # Convention Pack: Go

--- a/internal/scaffold/assets/opencode/uf/packs/severity.md
+++ b/internal/scaffold/assets/opencode/uf/packs/severity.md
@@ -2,6 +2,7 @@
 description: "Shared severity level definitions for all Divisor Council personas."
 ---
 <!-- scaffolded by uf vdev -->
+<!-- scaffolded by uf vdev -->
 
 # Severity Convention Pack
 

--- a/internal/scaffold/assets/opencode/uf/packs/typescript.md
+++ b/internal/scaffold/assets/opencode/uf/packs/typescript.md
@@ -5,6 +5,7 @@ version: 1.0.0
 ---
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->
+<!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vv0.6.1 -->
 
 # Convention Pack: TypeScript

--- a/internal/scaffold/assets/openspec/schemas/unbound-force/schema.yaml
+++ b/internal/scaffold/assets/openspec/schemas/unbound-force/schema.yaml
@@ -68,3 +68,4 @@ apply:
 # scaffolded by uf vv0.6.1
 # scaffolded by uf vdev
 # scaffolded by uf vdev
+# scaffolded by uf vdev

--- a/internal/scaffold/assets/openspec/schemas/unbound-force/templates/design.md
+++ b/internal/scaffold/assets/openspec/schemas/unbound-force/templates/design.md
@@ -20,3 +20,4 @@
 <!-- scaffolded by uf vv0.6.1 -->
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->
+<!-- scaffolded by uf vdev -->

--- a/internal/scaffold/assets/openspec/schemas/unbound-force/templates/proposal.md
+++ b/internal/scaffold/assets/openspec/schemas/unbound-force/templates/proposal.md
@@ -57,3 +57,4 @@ Are components testable in isolation? -->
 <!-- scaffolded by uf vv0.6.1 -->
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->
+<!-- scaffolded by uf vdev -->

--- a/internal/scaffold/assets/openspec/schemas/unbound-force/templates/spec.md
+++ b/internal/scaffold/assets/openspec/schemas/unbound-force/templates/spec.md
@@ -23,3 +23,4 @@
 <!-- scaffolded by uf vv0.6.1 -->
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->
+<!-- scaffolded by uf vdev -->

--- a/internal/scaffold/assets/openspec/schemas/unbound-force/templates/tasks.md
+++ b/internal/scaffold/assets/openspec/schemas/unbound-force/templates/tasks.md
@@ -9,3 +9,4 @@
 <!-- scaffolded by uf vv0.6.1 -->
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->
+<!-- scaffolded by uf vdev -->

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -1413,6 +1413,7 @@ func TestSetupRun_OllamaInstall(t *testing.T) {
 	var buf bytes.Buffer
 	opts := Options{
 		TargetDir: dir,
+		GOOS:      runtime.GOOS,
 		Stdout:    &buf,
 		Stderr:    &buf,
 		LookPath: stubLookPath(map[string]string{

--- a/openspec/changes/fix-test-failures/.openspec.yaml
+++ b/openspec/changes/fix-test-failures/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: unbound-force
+created: 2026-04-18

--- a/openspec/changes/fix-test-failures/design.md
+++ b/openspec/changes/fix-test-failures/design.md
@@ -1,0 +1,25 @@
+## Context
+
+Scaffold drift accumulates when canonical files under
+`.opencode/` and `openspec/` are modified but their
+copies under `internal/scaffold/assets/` are not synced.
+The TestEmbeddedAssets_MatchSource regression test
+catches this.
+
+The Ollama test uses `opts.GOOS` to determine the
+expected brew command but never sets it. The `defaults()`
+function in `Run()` sets `GOOS = runtime.GOOS`, but
+in the test the Options struct is constructed directly
+without calling `defaults()`.
+
+## Decisions
+
+### D1: Sync all 17 files
+
+Mechanical copy from canonical source to scaffold asset.
+
+### D2: Set GOOS in test
+
+Add `GOOS: runtime.GOOS` to the test's Options struct
+so the test expectation matches the runtime behavior
+on both macOS and Linux.

--- a/openspec/changes/fix-test-failures/proposal.md
+++ b/openspec/changes/fix-test-failures/proposal.md
@@ -1,0 +1,23 @@
+## Why
+
+Two test failures block CI and prevent Gaze from
+running quality analysis:
+
+1. **TestEmbeddedAssets_MatchSource** — 17 scaffold
+   asset files are stale. Source files were updated
+   but never copied to `internal/scaffold/assets/`.
+2. **TestSetupRun_OllamaInstall** — test doesn't set
+   `opts.GOOS`, causing a mismatch between the test
+   expectation (Linux default) and the actual runtime
+   behavior (macOS uses cask).
+
+## What Changes
+
+- Sync 17 stale scaffold assets
+- Fix Ollama test to set `opts.GOOS = runtime.GOOS`
+
+## Impact
+
+- 17 scaffold asset copies (file sync, no content change)
+- 1 test fix (1 line added)
+- No logic changes

--- a/openspec/changes/fix-test-failures/specs/fixes.md
+++ b/openspec/changes/fix-test-failures/specs/fixes.md
@@ -1,0 +1,12 @@
+## MODIFIED Requirements
+
+### Requirement: Scaffold asset sync
+
+17 stale scaffold assets MUST be synced from their
+canonical sources.
+
+### Requirement: Ollama test GOOS
+
+TestSetupRun_OllamaInstall MUST set opts.GOOS to
+runtime.GOOS so the expected brew command matches
+the actual runtime behavior.

--- a/openspec/changes/fix-test-failures/tasks.md
+++ b/openspec/changes/fix-test-failures/tasks.md
@@ -1,0 +1,18 @@
+## 1. Scaffold Asset Sync
+
+- [x] 1.1 Sync 17 stale scaffold assets from canonical
+  sources to internal/scaffold/assets/
+
+## 2. Ollama Test Fix
+
+- [x] 2.1 Add GOOS: runtime.GOOS to the Options struct
+  in TestSetupRun_OllamaInstall in
+  internal/setup/setup_test.go
+
+## 3. Verification
+
+- [x] 3.1 Run go test -race -count=1 ./... and verify
+  all packages pass
+
+<!-- spec-review: passed -->
+<!-- code-review: passed -->


### PR DESCRIPTION
## Summary

Fixes 2 test failures blocking CI and Gaze quality analysis.

### Fix 1: Scaffold Drift (TestEmbeddedAssets_MatchSource)

17 scaffold asset files were stale — canonical files under `.opencode/` and `openspec/` were updated by recent changes but copies under `internal/scaffold/assets/` were not synced.

Files synced: 6 commands, 1 skill, 5 packs, 5 openspec templates.

### Fix 2: Ollama Test (TestSetupRun_OllamaInstall)

The test constructed an `Options` struct without setting `GOOS`, which defaults to empty string. The `defaults()` function called by `Run()` sets `GOOS = runtime.GOOS`, causing a mismatch — on macOS, `Run()` uses the cask path (`brew install --cask ollama-app`) while the test expected the formula path (`brew install ollama`).

Fix: Added `GOOS: runtime.GOOS` to the test's Options struct.

### Impact

- Unblocks CI pipeline
- Unblocks Gaze quality analysis (`gaze crap` runs `go test` internally)
- No logic changes — only file syncs and 1 test fix