### PR TITLE
fix: add inline STOP instructions to spec-phase commands (closes #109)

### DIFF
--- a/.opencode/command/opsx-propose.md
+++ b/.opencode/command/opsx-propose.md
@@ -106,6 +106,13 @@ use direct file reads of local specs and backlog items instead.
    openspec status --change "<name>"
    ```
 
+**STOP HERE. Do NOT proceed to implementation.**
+
+Your job is done. Report the results and prompt the
+user. The user will invoke a separate command
+(/opsx-apply, /cobalt-crush, or /unleash) when they
+are ready to implement.
+
 **Output**
 
 After completing all artifacts, summarize:
@@ -134,7 +141,10 @@ After completing all artifacts, summarize:
 ## Guardrails
 
 - **NEVER implement code changes** — this command
-  creates artifacts ONLY (proposal, design, specs, tasks)
+  creates artifacts ONLY (proposal, design, specs, tasks).
+  The user needs to review the plan before
+  implementation begins. Implementing without review
+  defeats the purpose of the spec-first workflow.
 - **NEVER commit, push, or create PRs** — those are
   /finale's responsibility
 - **NEVER run /opsx-apply or /cobalt-crush** — the

--- a/.opencode/command/speckit.analyze.md
+++ b/.opencode/command/speckit.analyze.md
@@ -166,6 +166,13 @@ At end of report, output a concise Next Actions block:
 
 Ask the user: "Would you like me to suggest concrete remediation edits for the top N issues?" (Do NOT apply them automatically.)
 
+**STOP HERE. Do NOT proceed to implementation.**
+
+Your job is done. Report the results and prompt the
+user. The user will invoke a separate command
+(/opsx-apply, /cobalt-crush, or /unleash) when they
+are ready to implement.
+
 ## Operating Principles
 
 ### Context Efficiency
@@ -192,6 +199,9 @@ $ARGUMENTS
 - **NEVER modify source code** — this command updates
   spec artifacts ONLY. Implementation changes belong in
   `/speckit.implement`, `/unleash`, or `/cobalt-crush`.
+  The user needs to review the plan before
+  implementation begins. Implementing without review
+  defeats the purpose of the spec-first workflow.
 - **NEVER modify test files, Go source, Markdown agents,
   convention packs, or config files** outside the
   `specs/NNN-*/` feature directory.

--- a/.opencode/command/speckit.checklist.md
+++ b/.opencode/command/speckit.checklist.md
@@ -223,6 +223,13 @@ You **MUST** consider the user input before proceeding (if not empty).
 
 To avoid clutter, use descriptive types and clean up obsolete checklists when done.
 
+**STOP HERE. Do NOT proceed to implementation.**
+
+Your job is done. Report the results and prompt the
+user. The user will invoke a separate command
+(/opsx-apply, /cobalt-crush, or /unleash) when they
+are ready to implement.
+
 ## Example Checklist Types & Sample Items
 
 **UX Requirements Quality:** `ux.md`
@@ -302,6 +309,9 @@ Sample items:
 - **NEVER modify source code** — this command updates
   spec artifacts ONLY. Implementation changes belong in
   `/speckit.implement`, `/unleash`, or `/cobalt-crush`.
+  The user needs to review the plan before
+  implementation begins. Implementing without review
+  defeats the purpose of the spec-first workflow.
 - **NEVER modify test files, Go source, Markdown agents,
   convention packs, or config files** outside the
   `specs/NNN-*/` feature directory.

--- a/.opencode/command/speckit.clarify.md
+++ b/.opencode/command/speckit.clarify.md
@@ -172,6 +172,13 @@ Execution steps:
    - If any Outstanding or Deferred remain, recommend whether to proceed to `/speckit.plan` or run `/speckit.clarify` again later post-plan.
    - Suggested next command.
 
+**STOP HERE. Do NOT proceed to implementation.**
+
+Your job is done. Report the results and prompt the
+user. The user will invoke a separate command
+(/opsx-apply, /cobalt-crush, or /unleash) when they
+are ready to implement.
+
 Behavior rules:
 
 - If no meaningful ambiguities found (or all potential questions would be low-impact), respond: "No critical ambiguities detected worth formal clarification." and suggest proceeding.
@@ -189,6 +196,9 @@ Context for prioritization: $ARGUMENTS
 - **NEVER modify source code** — this command updates
   spec artifacts ONLY. Implementation changes belong in
   `/speckit.implement`, `/unleash`, or `/cobalt-crush`.
+  The user needs to review the plan before
+  implementation begins. Implementing without review
+  defeats the purpose of the spec-first workflow.
 - **NEVER modify test files, Go source, Markdown agents,
   convention packs, or config files** outside the
   `specs/NNN-*/` feature directory.

--- a/.opencode/command/speckit.plan.md
+++ b/.opencode/command/speckit.plan.md
@@ -39,6 +39,13 @@ You **MUST** consider the user input before proceeding (if not empty).
 
 4. **Stop and report**: Command ends after Phase 2 planning. Report branch, IMPL_PLAN path, and generated artifacts.
 
+**STOP HERE. Do NOT proceed to implementation.**
+
+Your job is done. Report the results and prompt the
+user. The user will invoke a separate command
+(/opsx-apply, /cobalt-crush, or /unleash) when they
+are ready to implement.
+
 ## Phases
 
 ### Phase 0: Outline & Research
@@ -113,6 +120,9 @@ You **MUST** consider the user input before proceeding (if not empty).
 - **NEVER modify source code** — this command updates
   spec artifacts ONLY. Implementation changes belong in
   `/speckit.implement`, `/unleash`, or `/cobalt-crush`.
+  The user needs to review the plan before
+  implementation begins. Implementing without review
+  defeats the purpose of the spec-first workflow.
 - **NEVER modify test files, Go source, Markdown agents,
   convention packs, or config files** outside the
   `specs/NNN-*/` feature directory.

--- a/.opencode/command/speckit.specify.md
+++ b/.opencode/command/speckit.specify.md
@@ -219,6 +219,13 @@ Given that feature description, do this:
 
 9. Report completion with branch name, spec file path, checklist results, and readiness for the next phase (`/speckit.clarify` or `/speckit.plan`).
 
+**STOP HERE. Do NOT proceed to implementation.**
+
+Your job is done. Report the results and prompt the
+user. The user will invoke a separate command
+(/opsx-apply, /cobalt-crush, or /unleash) when they
+are ready to implement.
+
 **NOTE:** The script creates and checks out the new branch and initializes the spec file before writing.
 
 ## General Guidelines
@@ -289,6 +296,9 @@ Success criteria must be:
 - **NEVER modify source code** — this command updates
   spec artifacts ONLY. Implementation changes belong in
   `/speckit.implement`, `/unleash`, or `/cobalt-crush`.
+  The user needs to review the plan before
+  implementation begins. Implementing without review
+  defeats the purpose of the spec-first workflow.
 - **NEVER modify test files, Go source, Markdown agents,
   convention packs, or config files** outside the
   `specs/NNN-*/` feature directory.

--- a/.opencode/command/speckit.tasks.md
+++ b/.opencode/command/speckit.tasks.md
@@ -70,6 +70,13 @@ You **MUST** consider the user input before proceeding (if not empty).
    - Parallel execution examples per story
    - Implementation strategy section (MVP first, incremental delivery)
 
+**STOP HERE. Do NOT proceed to implementation.**
+
+Your job is done. Report the results and prompt the
+user. The user will invoke a separate command
+(/opsx-apply, /cobalt-crush, or /unleash) when they
+are ready to implement.
+
 6. **Report**: Output path to generated tasks.md and summary:
    - Total task count
    - Task count per user story
@@ -159,6 +166,9 @@ Every task MUST strictly follow this format:
 - **NEVER modify source code** — this command updates
   spec artifacts ONLY. Implementation changes belong in
   `/speckit.implement`, `/unleash`, or `/cobalt-crush`.
+  The user needs to review the plan before
+  implementation begins. Implementing without review
+  defeats the purpose of the spec-first workflow.
 - **NEVER modify test files, Go source, Markdown agents,
   convention packs, or config files** outside the
   `specs/NNN-*/` feature directory.

--- a/.opencode/command/speckit.testreview.md
+++ b/.opencode/command/speckit.testreview.md
@@ -116,6 +116,13 @@ At end of report, output a concise Next Actions block:
 
 Ask the user: "Would you like me to suggest concrete remediation edits for the top N issues?" (Do NOT apply them automatically.)
 
+**STOP HERE. Do NOT proceed to implementation.**
+
+Your job is done. Report the results and prompt the
+user. The user will invoke a separate command
+(/opsx-apply, /cobalt-crush, or /unleash) when they
+are ready to implement.
+
 ## Operating Principles
 
 ### Context Efficiency
@@ -132,6 +139,23 @@ Ask the user: "Would you like me to suggest concrete remediation edits for the t
 - **Prioritize Principle IV violations** (these are always CRITICAL)
 - **Missing coverage strategy is CRITICAL** — not HIGH, not MEDIUM
 - **Report zero issues gracefully** (emit success report with testability statistics)
+
+## Guardrails
+
+- **NEVER modify source code** — this command updates
+  spec artifacts ONLY. Implementation changes belong in
+  `/speckit.implement`, `/unleash`, or `/cobalt-crush`.
+  The user needs to review the plan before
+  implementation begins. Implementing without review
+  defeats the purpose of the spec-first workflow.
+- **NEVER modify test files, Go source, Markdown agents,
+  convention packs, or config files** outside the
+  `specs/NNN-*/` feature directory.
+- The ONLY files this command may write are:
+  - `FEATURE_SPEC` (the spec.md file)
+  - Files within `FEATURE_DIR` (spec artifacts:
+    plan.md, tasks.md, research.md, data-model.md,
+    quickstart.md, contracts/, checklists/)
 
 ## Context
 

--- a/.opencode/skills/openspec-propose/SKILL.md
+++ b/.opencode/skills/openspec-propose/SKILL.md
@@ -157,6 +157,13 @@ cross-repo context but are never required.
    openspec status --change "<name>"
    ```
 
+**STOP HERE. Do NOT proceed to implementation.**
+
+Your job is done. Report the results and prompt the
+user. The user will invoke a separate command
+(/opsx-apply, /cobalt-crush, or /unleash) when they
+are ready to implement.
+
 **Output**
 
 After completing all artifacts, summarize:
@@ -176,8 +183,18 @@ After completing all artifacts, summarize:
   - These guide what you write, but should never appear in the output
 
 **Guardrails**
-- Create ALL artifacts needed for implementation (as defined by schema's `apply.requires`)
+- Create ALL artifacts needed for implementation (as defined by schema's `apply.requires`).
+  The user needs to review the plan before
+  implementation begins. Implementing without review
+  defeats the purpose of the spec-first workflow.
 - Always read dependency artifacts before creating a new one
 - If context is critically unclear, ask the user - but prefer making reasonable decisions to keep momentum
 - If a change with that name already exists, ask if user wants to continue it or create a new one
 - Verify each artifact file exists after writing before proceeding to next
+- **NEVER implement code changes** — this command
+  creates artifacts ONLY. The user needs to review
+  the plan before implementation begins.
+- **NEVER commit, push, or create PRs**
+- **NEVER run /opsx-apply or /cobalt-crush**
+- After artifacts are complete, STOP and prompt the
+  user.

--- a/openspec/changes/inline-stop-instructions/.openspec.yaml
+++ b/openspec/changes/inline-stop-instructions/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: unbound-force
+created: 2026-04-18

--- a/openspec/changes/inline-stop-instructions/design.md
+++ b/openspec/changes/inline-stop-instructions/design.md
@@ -1,0 +1,71 @@
+## Context
+
+Spec-phase commands (`/opsx-propose`, `/speckit.clarify`,
+etc.) have `## Guardrails` sections at the bottom that
+say "NEVER implement." But the agent reads the workflow
+steps sequentially, completes the work, then has
+momentum to continue. The guardrails at the end are
+too late — the agent has already moved on.
+
+## Goals / Non-Goals
+
+### Goals
+
+- Add an inline STOP instruction at the exact
+  completion point of each spec-phase command
+- Add "why" reasoning to existing Guardrails sections
+- Add implementation prevention guardrails to the
+  openspec-propose skill (currently only has artifact
+  quality guardrails)
+
+### Non-Goals
+
+- No changes to `/speckit.implement` (implementation
+  IS its job)
+- No changes to `/speckit.constitution` (governance,
+  not implementation risk)
+- No changes to `/speckit.taskstoissues` (creates GH
+  issues, low risk)
+- No Go code changes
+- No scaffold asset syncs (target files are externalized)
+
+## Decisions
+
+### D1: 3-part fix per file
+
+Each file gets:
+1. **Inline STOP** — after the command's work is done
+2. **"Why" in Guardrails** — reasoning added to
+   existing guardrails
+3. **Output reinforcement** — "CRITICAL: you are DONE"
+   in the output/report section (where applicable)
+
+### D2: Inline STOP text (standardized)
+
+All files use the same STOP block:
+
+```markdown
+**STOP HERE. Do NOT proceed to implementation.**
+
+Your job is done. Report the results and prompt the
+user. The user will invoke a separate command
+(/opsx-apply, /cobalt-crush, or /unleash) when they
+are ready to implement.
+```
+
+### D3: "Why" text (standardized)
+
+All guardrails add this reasoning:
+
+```markdown
+The user needs to review the plan before
+implementation begins. Implementing without review
+defeats the purpose of the spec-first workflow.
+```
+
+### D4: Skill file gets full guardrails
+
+The openspec-propose skill currently has artifact
+quality guardrails but NOT implementation prevention
+guardrails. Add the same "NEVER implement" block that
+the command file has.

--- a/openspec/changes/inline-stop-instructions/proposal.md
+++ b/openspec/changes/inline-stop-instructions/proposal.md
@@ -1,0 +1,49 @@
+## Why
+
+AI agents repeatedly cross workflow phase boundaries
+during spec-phase commands. The agent creates artifacts
+correctly, then continues into implementation — editing
+source code, syncing scaffold assets, running tests —
+without the user reviewing the plan first. This has
+happened 3 times in the current session (issue #109).
+
+The root cause: guardrails are at the **end** of the
+command file in a separate section. By the time the
+agent reads them, it has completed artifact creation
+and is in "what next?" mode. The momentum carries it
+into implementation.
+
+The fix: add **inline STOP instructions** at the
+exact point where each command's work is done, plus
+add "why" reasoning to existing guardrails.
+
+## What Changes
+
+### Modified Capabilities
+
+- 7 speckit command files (specify, clarify, plan,
+  tasks, analyze, checklist, testreview) +
+  1 opsx-propose command + 1 openspec-propose skill:
+  Add inline STOP after the command's completion
+  point, add "why" to guardrails.
+
+### New Capabilities
+
+None.
+
+### Removed Capabilities
+
+None.
+
+## Impact
+
+- 9 Markdown files modified (~5 lines added to each)
+- No Go code changes
+- No scaffold asset syncs needed (all target files
+  are externalized or OpenSpec-owned)
+- No test changes
+
+## Constitution Alignment
+
+All N/A — behavioral instruction improvements to
+Markdown command files.

--- a/openspec/changes/inline-stop-instructions/specs/stop-instructions.md
+++ b/openspec/changes/inline-stop-instructions/specs/stop-instructions.md
@@ -1,0 +1,46 @@
+## MODIFIED Requirements
+
+### Requirement: Inline STOP in spec-phase commands
+
+Each spec-phase command MUST have an inline STOP
+instruction at the exact point where the command's
+work is complete. The STOP MUST appear before any
+output/report section, not in a separate Guardrails
+section at the end.
+
+Target files:
+1. `.opencode/command/opsx-propose.md`
+2. `.opencode/command/speckit.specify.md`
+3. `.opencode/command/speckit.clarify.md`
+4. `.opencode/command/speckit.plan.md`
+5. `.opencode/command/speckit.tasks.md`
+6. `.opencode/command/speckit.analyze.md`
+7. `.opencode/command/speckit.checklist.md`
+8. `.opencode/command/speckit.testreview.md`
+9. `.opencode/skills/openspec-propose/SKILL.md`
+
+### Acceptance Criterion
+
+Given any spec-phase command or skill file (items
+1-9 above), when the agent completes artifact
+creation, then a STOP instruction reading "STOP
+HERE. Do NOT proceed to implementation." appears
+inline before any output or report section, and the
+`## Guardrails` section includes reasoning for why
+implementation is prohibited.
+
+### Requirement: "Why" in Guardrails
+
+Each file's existing `## Guardrails` section MUST
+include reasoning for why implementation is prohibited
+(user needs to review before implementation).
+
+### Requirement: Skill guardrails
+
+`.opencode/skills/openspec-propose/SKILL.md` MUST
+include implementation prevention guardrails matching
+the command file's guardrails.
+
+## REMOVED Requirements
+
+None.

--- a/openspec/changes/inline-stop-instructions/tasks.md
+++ b/openspec/changes/inline-stop-instructions/tasks.md
@@ -1,0 +1,38 @@
+## 1. OpenSpec Propose (Command + Skill)
+
+- [x] 1.1 Add inline STOP after Step 5 artifact
+  creation loop in `.opencode/command/opsx-propose.md`
+- [x] 1.2 Add "why" reasoning to the existing
+  `## Guardrails` section in `opsx-propose.md`
+- [x] 1.3 Add implementation prevention guardrails +
+  inline STOP to
+  `.opencode/skills/openspec-propose/SKILL.md`
+
+## 2. Speckit Commands
+
+- [x] 2.1 Add inline STOP after spec is written +
+  "why" to guardrails in `speckit.specify.md`
+- [x] 2.2 Add inline STOP after clarifications
+  resolved + "why" to guardrails in `speckit.clarify.md`
+- [x] 2.3 Add inline STOP after plan.md created +
+  "why" to guardrails in `speckit.plan.md`
+- [x] 2.4 Add inline STOP after tasks.md created +
+  "why" to guardrails in `speckit.tasks.md`
+- [x] 2.5 Add inline STOP after analysis report +
+  "why" to guardrails in `speckit.analyze.md`
+- [x] 2.6 Add inline STOP after checklist created +
+  "why" to guardrails in `speckit.checklist.md`
+- [x] 2.7 Add inline STOP after testability report +
+  "why" to guardrails in `speckit.testreview.md`
+
+## 3. Verification
+
+- [x] 3.1 Verify all 9 files have inline STOP
+  (grep for "STOP HERE")
+- [x] 3.2 Verify all 9 files have "why" in guardrails
+  (grep for "review the plan before")
+- [x] 3.3 Run `go build ./...` to verify no
+  compilation issues from scaffold drift
+
+<!-- spec-review: passed -->
+<!-- code-review: passed -->


### PR DESCRIPTION
## Summary

Adds inline STOP instructions to 9 spec-phase files to prevent AI agents from crossing workflow phase boundaries into implementation after creating artifacts.

### Problem

Agents repeatedly completed artifact creation correctly, then continued into implementation — editing source code, syncing scaffold assets, running tests — without the user reviewing the plan first. This happened 3 times in a single session (issue #109).

### Root Cause

Guardrails were at the **end** of command files in a separate section. By the time the agent processed them, it had already completed artifact creation and had momentum to continue.

### Fix

**Inline STOP** blocks added at the exact completion point of each command's workflow:

```markdown
**STOP HERE. Do NOT proceed to implementation.**

Your job is done. Report the results and prompt the
user. The user will invoke a separate command
(/opsx-apply, /cobalt-crush, or /unleash) when they
are ready to implement.
```

Plus **"why" reasoning** added to all Guardrails sections:
> The user needs to review the plan before implementation begins. Implementing without review defeats the purpose of the spec-first workflow.

### Files Modified (9)

| File | Change |
|------|--------|
| `.opencode/command/opsx-propose.md` | STOP + why |
| `.opencode/skills/openspec-propose/SKILL.md` | Full implementation prevention guardrails + STOP |
| `.opencode/command/speckit.specify.md` | STOP + why |
| `.opencode/command/speckit.clarify.md` | STOP + why |
| `.opencode/command/speckit.plan.md` | STOP + why |
| `.opencode/command/speckit.tasks.md` | STOP + why |
| `.opencode/command/speckit.analyze.md` | STOP + why |
| `.opencode/command/speckit.checklist.md` | STOP + why |
| `.opencode/command/speckit.testreview.md` | STOP + why + full Guardrails section (was missing) |