### PR TITLE
fix: recommend /unleash as primary implementation command in all handoff prompts

### DIFF
--- a/.opencode/command/cobalt-crush.md
+++ b/.opencode/command/cobalt-crush.md
@@ -3,7 +3,7 @@ description: >
   Invoke the Cobalt-Crush developer persona for implementation tasks.
   With arguments: delegates to the cobalt-crush-dev agent. Without
   arguments: detects active workflow and runs /speckit.implement or
-  /opsx:apply.
+  /opsx-apply.
 ---
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->
@@ -90,9 +90,11 @@ implementation command to the `cobalt-crush-dev` agent:
    > No active implementation context detected. Which workflow
    > should I execute?
    >
+   > - `/unleash` — Autonomous pipeline (parallel swarm,
+   >   recommended for multi-task changes)
    > - `/speckit.implement` — Strategic spec implementation
    >   (requires a feature branch with `specs/NNN-*/tasks.md`)
-   > - `/opsx:apply` — Tactical change implementation
+   > - `/opsx-apply` — Tactical change implementation
    >   (requires an active change in `openspec/changes/`)
 
 ## Branch Safety Guardrails

--- a/.opencode/command/opsx-explore.md
+++ b/.opencode/command/opsx-explore.md
@@ -149,7 +149,7 @@ If the user mentions a change or you detect one is relevant:
 
 There's no required ending. Discovery might:
 
-- **Flow into a proposal**: "Ready to start? I can create a change proposal."
+- **Flow into a proposal**: "Ready to start? I can create a change proposal. After that, run `/unleash` for autonomous execution or `/opsx-apply` for sequential implementation."
 - **Result in artifact updates**: "Updated design.md with these decisions"
 - **Just provide clarity**: User has what they need, moves on
 - **Continue later**: "We can pick this up anytime"

--- a/.opencode/command/opsx-propose.md
+++ b/.opencode/command/opsx-propose.md
@@ -9,7 +9,7 @@ I'll create a change with artifacts:
 - design.md (how)
 - tasks.md (implementation steps)
 
-When ready to implement, run /opsx-apply
+When ready to implement, run /unleash (autonomous) or /opsx-apply (sequential)
 
 ---
 
@@ -110,7 +110,7 @@ use direct file reads of local specs and backlog items instead.
 
 Your job is done. Report the results and prompt the
 user. The user will invoke a separate command
-(/opsx-apply, /cobalt-crush, or /unleash) when they
+(/unleash, /cobalt-crush, or /opsx-apply) when they
 are ready to implement.
 
 **Output**
@@ -119,7 +119,7 @@ After completing all artifacts, summarize:
 - Change name and location
 - List of artifacts created with brief descriptions
 - What's ready: "All artifacts created! Ready for implementation."
-- Prompt: "Run `/opsx-apply` to start implementing."
+- Prompt: "Run `/unleash` for autonomous pipeline execution, `/opsx-apply` for sequential implementation, or `/cobalt-crush` for direct coding. `/unleash` is recommended when the change has multiple independent task groups."
 
 **Artifact Creation Guidelines**
 
@@ -147,7 +147,7 @@ After completing all artifacts, summarize:
   defeats the purpose of the spec-first workflow.
 - **NEVER commit, push, or create PRs** — those are
   /finale's responsibility
-- **NEVER run /opsx-apply or /cobalt-crush** — the
-  user decides when to implement
+- **NEVER run /unleash, /opsx-apply, or /cobalt-crush**
+  — the user decides when to implement
 - After artifacts are complete, STOP and prompt the
-  user to run /opsx-apply or /cobalt-crush
+  user to run /unleash, /opsx-apply, or /cobalt-crush

--- a/.opencode/command/speckit.analyze.md
+++ b/.opencode/command/speckit.analyze.md
@@ -170,7 +170,7 @@ Ask the user: "Would you like me to suggest concrete remediation edits for the t
 
 Your job is done. Report the results and prompt the
 user. The user will invoke a separate command
-(/opsx-apply, /cobalt-crush, or /unleash) when they
+(/unleash, /cobalt-crush, or /opsx-apply) when they
 are ready to implement.
 
 ## Operating Principles

--- a/.opencode/command/speckit.checklist.md
+++ b/.opencode/command/speckit.checklist.md
@@ -227,7 +227,7 @@ To avoid clutter, use descriptive types and clean up obsolete checklists when do
 
 Your job is done. Report the results and prompt the
 user. The user will invoke a separate command
-(/opsx-apply, /cobalt-crush, or /unleash) when they
+(/unleash, /cobalt-crush, or /opsx-apply) when they
 are ready to implement.
 
 ## Example Checklist Types & Sample Items

--- a/.opencode/command/speckit.clarify.md
+++ b/.opencode/command/speckit.clarify.md
@@ -176,7 +176,7 @@ Execution steps:
 
 Your job is done. Report the results and prompt the
 user. The user will invoke a separate command
-(/opsx-apply, /cobalt-crush, or /unleash) when they
+(/unleash, /cobalt-crush, or /opsx-apply) when they
 are ready to implement.
 
 Behavior rules:

--- a/.opencode/command/speckit.plan.md
+++ b/.opencode/command/speckit.plan.md
@@ -43,7 +43,7 @@ You **MUST** consider the user input before proceeding (if not empty).
 
 Your job is done. Report the results and prompt the
 user. The user will invoke a separate command
-(/opsx-apply, /cobalt-crush, or /unleash) when they
+(/unleash, /cobalt-crush, or /opsx-apply) when they
 are ready to implement.
 
 ## Phases

--- a/.opencode/command/speckit.specify.md
+++ b/.opencode/command/speckit.specify.md
@@ -223,7 +223,7 @@ Given that feature description, do this:
 
 Your job is done. Report the results and prompt the
 user. The user will invoke a separate command
-(/opsx-apply, /cobalt-crush, or /unleash) when they
+(/unleash, /cobalt-crush, or /opsx-apply) when they
 are ready to implement.
 
 **NOTE:** The script creates and checks out the new branch and initializes the spec file before writing.

--- a/.opencode/command/speckit.tasks.md
+++ b/.opencode/command/speckit.tasks.md
@@ -74,7 +74,7 @@ You **MUST** consider the user input before proceeding (if not empty).
 
 Your job is done. Report the results and prompt the
 user. The user will invoke a separate command
-(/opsx-apply, /cobalt-crush, or /unleash) when they
+(/unleash, /cobalt-crush, or /opsx-apply) when they
 are ready to implement.
 
 6. **Report**: Output path to generated tasks.md and summary:

--- a/.opencode/command/speckit.testreview.md
+++ b/.opencode/command/speckit.testreview.md
@@ -120,7 +120,7 @@ Ask the user: "Would you like me to suggest concrete remediation edits for the t
 
 Your job is done. Report the results and prompt the
 user. The user will invoke a separate command
-(/opsx-apply, /cobalt-crush, or /unleash) when they
+(/unleash, /cobalt-crush, or /opsx-apply) when they
 are ready to implement.
 
 ## Operating Principles

--- a/.opencode/command/uf-init.md
+++ b/.opencode/command/uf-init.md
@@ -511,10 +511,10 @@ The guardrails block to append:
   tasks)
 - **NEVER commit, push, or create PRs** — those are
   /finale's responsibility
-- **NEVER run /opsx-apply or /cobalt-crush** — the
-  user decides when to implement
+- **NEVER run /unleash, /opsx-apply, or /cobalt-crush**
+  — the user decides when to implement
 - After artifacts are complete, STOP and prompt the
-  user to run /opsx-apply or /cobalt-crush
+  user to run /unleash, /opsx-apply, or /cobalt-crush
 ```
 
 ### Step 9: AGENTS.md Behavioral Guidance
@@ -979,6 +979,8 @@ Finally, remind the user:
 
 After customizations are applied:
 
+- Run `/unleash` for autonomous pipeline execution
+  (parallel swarm, recommended for multi-task changes)
 - Run `/cobalt-crush` to start implementing — it
   auto-detects your active workflow (Speckit or OpenSpec)
   and delegates to the correct implementation command.

--- a/.opencode/skill/speckit-workflow/SKILL.md
+++ b/.opencode/skill/speckit-workflow/SKILL.md
@@ -139,3 +139,13 @@ hero routing and workflow stage context:
 skills_use({ name: "unbound-force-heroes" })
 skills_use({ name: "speckit-workflow" })
 ```
+
+## Entry Point
+
+The `/unleash` command is the primary way to trigger
+autonomous pipeline execution using this skill. It
+orchestrates the full Speckit pipeline (clarify, plan,
+tasks, spec review, implement, code review,
+retrospective, demo) and uses the task format described
+above for the implementation phase. `/unleash` also
+supports OpenSpec (`opsx/*`) branches.

--- a/.opencode/skills/openspec-propose/SKILL.md
+++ b/.opencode/skills/openspec-propose/SKILL.md
@@ -16,7 +16,7 @@ I'll create a change with artifacts:
 - design.md (how)
 - tasks.md (implementation steps)
 
-When ready to implement, run /opsx-apply
+When ready to implement, run /unleash (autonomous) or /opsx-apply (sequential)
 
 ---
 
@@ -161,7 +161,7 @@ cross-repo context but are never required.
 
 Your job is done. Report the results and prompt the
 user. The user will invoke a separate command
-(/opsx-apply, /cobalt-crush, or /unleash) when they
+(/unleash, /cobalt-crush, or /opsx-apply) when they
 are ready to implement.
 
 **Output**
@@ -170,7 +170,7 @@ After completing all artifacts, summarize:
 - Change name and location
 - List of artifacts created with brief descriptions
 - What's ready: "All artifacts created! Ready for implementation."
-- Prompt: "Run `/opsx-apply` or ask me to implement to start working on the tasks."
+- Prompt: "Run `/unleash` for autonomous pipeline execution, `/opsx-apply` for sequential implementation, or `/cobalt-crush` for direct coding. `/unleash` is recommended when the change has multiple independent task groups."
 
 **Artifact Creation Guidelines**
 
@@ -195,6 +195,6 @@ After completing all artifacts, summarize:
   creates artifacts ONLY. The user needs to review
   the plan before implementation begins.
 - **NEVER commit, push, or create PRs**
-- **NEVER run /opsx-apply or /cobalt-crush**
+- **NEVER run /unleash, /opsx-apply, or /cobalt-crush**
 - After artifacts are complete, STOP and prompt the
   user.

--- a/internal/scaffold/assets/opencode/command/cobalt-crush.md
+++ b/internal/scaffold/assets/opencode/command/cobalt-crush.md
@@ -3,7 +3,7 @@ description: >
   Invoke the Cobalt-Crush developer persona for implementation tasks.
   With arguments: delegates to the cobalt-crush-dev agent. Without
   arguments: detects active workflow and runs /speckit.implement or
-  /opsx:apply.
+  /opsx-apply.
 ---
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->
@@ -90,9 +90,11 @@ implementation command to the `cobalt-crush-dev` agent:
    > No active implementation context detected. Which workflow
    > should I execute?
    >
+   > - `/unleash` — Autonomous pipeline (parallel swarm,
+   >   recommended for multi-task changes)
    > - `/speckit.implement` — Strategic spec implementation
    >   (requires a feature branch with `specs/NNN-*/tasks.md`)
-   > - `/opsx:apply` — Tactical change implementation
+   > - `/opsx-apply` — Tactical change implementation
    >   (requires an active change in `openspec/changes/`)
 
 ## Branch Safety Guardrails

--- a/internal/scaffold/assets/opencode/command/uf-init.md
+++ b/internal/scaffold/assets/opencode/command/uf-init.md
@@ -511,10 +511,10 @@ The guardrails block to append:
   tasks)
 - **NEVER commit, push, or create PRs** — those are
   /finale's responsibility
-- **NEVER run /opsx-apply or /cobalt-crush** — the
-  user decides when to implement
+- **NEVER run /unleash, /opsx-apply, or /cobalt-crush**
+  — the user decides when to implement
 - After artifacts are complete, STOP and prompt the
-  user to run /opsx-apply or /cobalt-crush
+  user to run /unleash, /opsx-apply, or /cobalt-crush
 ```
 
 ### Step 9: AGENTS.md Behavioral Guidance
@@ -979,6 +979,8 @@ Finally, remind the user:
 
 After customizations are applied:
 
+- Run `/unleash` for autonomous pipeline execution
+  (parallel swarm, recommended for multi-task changes)
 - Run `/cobalt-crush` to start implementing — it
   auto-detects your active workflow (Speckit or OpenSpec)
   and delegates to the correct implementation command.

--- a/internal/scaffold/assets/opencode/skill/speckit-workflow/SKILL.md
+++ b/internal/scaffold/assets/opencode/skill/speckit-workflow/SKILL.md
@@ -139,3 +139,13 @@ hero routing and workflow stage context:
 skills_use({ name: "unbound-force-heroes" })
 skills_use({ name: "speckit-workflow" })
 ```
+
+## Entry Point
+
+The `/unleash` command is the primary way to trigger
+autonomous pipeline execution using this skill. It
+orchestrates the full Speckit pipeline (clarify, plan,
+tasks, spec review, implement, code review,
+retrospective, demo) and uses the task format described
+above for the implementation phase. `/unleash` also
+supports OpenSpec (`opsx/*`) branches.

--- a/openspec/changes/unleash-handoff-fix/.openspec.yaml
+++ b/openspec/changes/unleash-handoff-fix/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: unbound-force
+created: 2026-04-19

--- a/openspec/changes/unleash-handoff-fix/design.md
+++ b/openspec/changes/unleash-handoff-fix/design.md
@@ -1,0 +1,92 @@
+## Context
+
+After `/unleash` was implemented (Spec 018) and extended
+to support OpenSpec branches (Spec 031), it became the
+primary autonomous pipeline. However, the handoff
+prompts in spec-phase commands and skills were not
+updated consistently. Some omit `/unleash` entirely,
+others list it last (alphabetical ordering rather than
+priority ordering).
+
+The canonical implementation command priority is:
+
+1. `/unleash` — autonomous pipeline with parallel swarm
+   workers (recommended for multi-task changes)
+2. `/cobalt-crush` — developer agent, auto-detects
+   workflow context (good for single-agent work)
+3. `/opsx-apply` — sequential single-agent (OpenSpec)
+4. `/speckit.implement` — sequential single-agent
+   (Speckit)
+
+## Goals / Non-Goals
+
+### Goals
+
+- Every spec-phase STOP block lists `/unleash` first
+- Every output prompt recommends `/unleash` as primary
+- Every guardrails "NEVER run" list includes `/unleash`
+- The `/cobalt-crush` fallback prompt includes `/unleash`
+- The `uf-init.md` template propagates correct text
+- Fix the `/opsx:apply` typo in `cobalt-crush.md`
+
+### Non-Goals
+
+- Changing Go source code or test files
+- Modifying agent persona files (divisor-*, cobalt-crush-dev, etc.)
+- Modifying convention packs
+- Fixing stale Hivemind references (separate issue)
+- Fixing the self-referential guardrails in `speckit.implement.md`
+  (that's a different bug — the guardrails say "NEVER modify
+  source code" on the command that IS supposed to modify source
+  code; needs its own investigation)
+
+## Decisions
+
+**D1: Canonical ordering** — All command lists use the
+order `/unleash`, `/cobalt-crush`, `/opsx-apply`. This
+puts the most autonomous option first and the most
+manual last.
+
+**D2: Scaffold asset sync required for 3 files** — Most
+of the affected command files are NOT embedded scaffold
+assets (the spec-phase `speckit.*.md` commands were
+externalized in Spec 027). However, 3 of the 13 target
+files ARE embedded assets that require sync:
+- `.opencode/command/cobalt-crush.md` →
+  `internal/scaffold/assets/opencode/command/cobalt-crush.md`
+- `.opencode/command/uf-init.md` →
+  `internal/scaffold/assets/opencode/command/uf-init.md`
+- `.opencode/skill/speckit-workflow/SKILL.md` →
+  `internal/scaffold/assets/opencode/skill/speckit-workflow/SKILL.md`
+
+These must be synced after editing the live files, or
+the `TestScaffoldOutput_*` drift detection tests will
+fail CI.
+
+**D3: `uf-init.md` template must match** — The
+`uf-init.md` command contains a guardrails template
+block that gets injected into `opsx-propose.md` during
+`/uf-init`. This template must be updated to match the
+corrected text, otherwise fresh `/uf-init` runs would
+re-inject the old text.
+
+**D4: `speckit-workflow/SKILL.md` gets an entry point
+section** — This skill describes how Swarm coordinators
+work with Speckit tasks but never mentions `/unleash` as
+the trigger command. Adding a brief Entry Point section
+connects the skill to the command.
+
+## Risks / Trade-offs
+
+- **Risk**: Agents may over-recommend `/unleash` for
+  trivial 1-2 task changes where `/opsx-apply` would be
+  faster. **Mitigation**: The handoff text says
+  "recommended for multi-task changes" — agents should
+  use judgment.
+
+- **Trade-off**: Listing `/unleash` first in STOP blocks
+  could confuse users who don't have Replicator installed
+  (Swarm worktrees unavailable). **Mitigation**:
+  `/unleash` gracefully degrades to sequential execution
+  when Swarm is unavailable, so it still works — just
+  without parallelism.

--- a/openspec/changes/unleash-handoff-fix/proposal.md
+++ b/openspec/changes/unleash-handoff-fix/proposal.md
@@ -1,0 +1,105 @@
+## Why
+
+When spec-phase commands (`/opsx-propose`, `/speckit.plan`,
+etc.) finish creating artifacts, they prompt the user with
+a "next step" handoff message. Currently, these handoffs
+either omit `/unleash` entirely or list it last after
+`/opsx-apply` and `/cobalt-crush`. This causes agents to
+recommend single-agent sequential implementation even when
+the change has many independent task groups that would
+benefit from parallel swarm execution.
+
+The `/unleash` command is the primary autonomous pipeline
+and should be the first recommendation for multi-task
+changes. A user reported this exact issue: after running
+`/opsx-propose` on a 22-task change, the agent suggested
+only `/opsx-apply` instead of `/unleash`.
+
+## What Changes
+
+Update all implementation handoff prompts, STOP blocks,
+and guardrails across 13 files to consistently recommend
+`/unleash` as the primary implementation option.
+
+## Capabilities
+
+### New Capabilities
+
+- None — no new functionality is added.
+
+### Modified Capabilities
+
+- `Handoff prompts`: All spec-phase command STOP blocks
+  and output prompts now list `/unleash` first, followed
+  by `/cobalt-crush` and `/opsx-apply`.
+- `Guardrails`: All "NEVER run" lists in spec-phase
+  commands now include `/unleash` alongside `/opsx-apply`
+  and `/cobalt-crush`.
+- `Fallback routing`: The `/cobalt-crush` command's
+  no-context fallback prompt now includes `/unleash` as
+  the first option.
+
+### Removed Capabilities
+
+- None.
+
+## Impact
+
+- 13 Markdown files modified (commands, skills)
+- No Go source code changes
+- No test changes
+- No convention pack changes
+- No agent persona changes (only command/skill files)
+
+Files affected:
+- `.opencode/command/opsx-propose.md`
+- `.opencode/command/cobalt-crush.md`
+- `.opencode/command/opsx-explore.md`
+- `.opencode/command/uf-init.md`
+- `.opencode/command/speckit.specify.md`
+- `.opencode/command/speckit.clarify.md`
+- `.opencode/command/speckit.plan.md`
+- `.opencode/command/speckit.tasks.md`
+- `.opencode/command/speckit.analyze.md`
+- `.opencode/command/speckit.checklist.md`
+- `.opencode/command/speckit.testreview.md`
+- `.opencode/skills/openspec-propose/SKILL.md`
+- `.opencode/skill/speckit-workflow/SKILL.md`
+
+## Constitution Alignment
+
+Assessed against the Unbound Force org constitution.
+
+### I. Autonomous Collaboration
+
+**Assessment**: N/A
+
+This change modifies prompt text only. It does not
+affect artifact-based communication between heroes or
+inter-hero data formats.
+
+### II. Composability First
+
+**Assessment**: PASS
+
+The change adds `/unleash` as an option alongside
+existing commands. No mandatory dependencies are
+introduced — users can still choose `/opsx-apply` or
+`/cobalt-crush` for sequential execution.
+
+### III. Observable Quality
+
+**Assessment**: N/A
+
+No machine-parseable output or provenance metadata is
+affected. This is a prompt text change only.
+
+### IV. Testability
+
+**Assessment**: N/A
+
+No testable components are modified. The change affects
+natural language prompts, not executable code. The
+existing `TestScaffoldOutput_*` regression tests in
+`scaffold_test.go` will catch any scaffold asset drift
+if the command files are also embedded assets.

--- a/openspec/changes/unleash-handoff-fix/specs/handoff-prompts.md
+++ b/openspec/changes/unleash-handoff-fix/specs/handoff-prompts.md
@@ -1,0 +1,79 @@
+## ADDED Requirements
+
+### Requirement: Canonical Command Ordering
+
+All implementation handoff prompts MUST list commands
+in priority order: `/unleash`, `/cobalt-crush`,
+`/opsx-apply` (or `/speckit.implement` where
+applicable).
+
+#### Scenario: Agent recommends implementation after proposal
+
+- **GIVEN** a spec-phase command completes artifact
+  creation
+- **WHEN** the agent presents the "next steps" prompt
+- **THEN** `/unleash` MUST be listed first, with a note
+  that it is recommended for multi-task changes
+
+#### Scenario: Cobalt-Crush fallback with no context
+
+- **GIVEN** `/cobalt-crush` is invoked with no active
+  workflow detected
+- **WHEN** the agent presents the fallback menu
+- **THEN** `/unleash` MUST appear as the first option
+  before `/speckit.implement` and `/opsx-apply`
+
+### Requirement: Speckit Workflow Entry Point
+
+The `speckit-workflow` skill MUST include an Entry Point
+section that identifies `/unleash` as the primary
+command for triggering autonomous pipeline execution.
+
+#### Scenario: Swarm coordinator reads speckit-workflow skill
+
+- **GIVEN** a Swarm coordinator loads the
+  `speckit-workflow` skill
+- **WHEN** the coordinator looks for how to start
+  execution
+- **THEN** the skill MUST reference `/unleash` as the
+  entry point command
+
+## MODIFIED Requirements
+
+### Requirement: Guardrails NEVER-Run Lists
+
+All spec-phase command guardrails that list commands
+agents MUST NOT run now include `/unleash` alongside
+`/opsx-apply` and `/cobalt-crush`.
+
+Previously: Guardrails listed only `/opsx-apply` and
+`/cobalt-crush` in "NEVER run" lists, omitting
+`/unleash`.
+
+#### Scenario: Agent reads guardrails during opsx-propose
+
+- **GIVEN** an agent is executing `/opsx-propose`
+- **WHEN** it reads the Guardrails section
+- **THEN** the NEVER-run list MUST include `/unleash`,
+  `/opsx-apply`, and `/cobalt-crush`
+
+### Requirement: uf-init Template Consistency
+
+The guardrails template injected by `/uf-init` into
+`opsx-propose.md` MUST match the corrected text with
+`/unleash` included.
+
+Previously: The template in `uf-init.md` Step 8 listed
+only `/opsx-apply` and `/cobalt-crush`.
+
+#### Scenario: Fresh uf-init injects guardrails
+
+- **GIVEN** a user runs `/uf-init` on a repo
+- **WHEN** Step 8 injects guardrails into
+  `opsx-propose.md`
+- **THEN** the injected text MUST list `/unleash` in
+  both the NEVER-run list and the user prompt
+
+## REMOVED Requirements
+
+None.

--- a/openspec/changes/unleash-handoff-fix/tasks.md
+++ b/openspec/changes/unleash-handoff-fix/tasks.md
@@ -1,0 +1,50 @@
+## 1. OpenSpec Propose — Fix Missing `/unleash`
+
+- [x] 1.1 Update `.opencode/command/opsx-propose.md` line 12: change intro from `run /opsx-apply` to `run /unleash (autonomous) or /opsx-apply (sequential)`
+- [x] 1.2 Update `.opencode/command/opsx-propose.md` line ~122: change output prompt to list `/unleash` first: `"Run '/unleash' for autonomous pipeline execution, '/opsx-apply' for sequential implementation, or '/cobalt-crush' for direct coding."`
+- [x] 1.3 Update `.opencode/command/opsx-propose.md` lines ~150-153: add `/unleash` to NEVER-run guardrail and user prompt
+- [x] 1.4 Update `.opencode/skills/openspec-propose/SKILL.md` line 19: change intro from `run /opsx-apply` to `run /unleash (autonomous) or /opsx-apply (sequential)`
+- [x] 1.5 Update `.opencode/skills/openspec-propose/SKILL.md` line ~173: change output prompt to list `/unleash` first
+- [x] 1.6 Update `.opencode/skills/openspec-propose/SKILL.md` line ~198: add `/unleash` to NEVER-run guardrail
+
+## 2. Cobalt-Crush Command — Fix Fallback and Typo
+
+- [x] 2.1 Update `.opencode/command/cobalt-crush.md` lines ~88-97: add `/unleash` as first option in the no-context fallback prompt
+- [x] 2.2 Fix typo in `.opencode/command/cobalt-crush.md`: change `/opsx:apply` to `/opsx-apply` (2 occurrences)
+
+## 3. uf-init Command — Fix Template and Next Steps
+
+- [x] 3.1 Update `.opencode/command/uf-init.md` lines ~503-518: add `/unleash` to the OpenSpec guardrails template block (NEVER-run list and user prompt)
+- [x] 3.2 Update `.opencode/command/uf-init.md` lines ~980-985: add `/unleash` to Next Steps section as primary recommendation
+
+## 4. Speckit Spec-Phase Commands — Reorder STOP Blocks
+
+- [x] 4.1 Update `.opencode/command/speckit.specify.md`: reorder STOP block from `(/opsx-apply, /cobalt-crush, or /unleash)` to `(/unleash, /cobalt-crush, or /opsx-apply)`
+- [x] 4.2 Update `.opencode/command/speckit.clarify.md`: same reorder
+- [x] 4.3 Update `.opencode/command/speckit.plan.md`: same reorder
+- [x] 4.4 Update `.opencode/command/speckit.tasks.md`: same reorder
+- [x] 4.5 Update `.opencode/command/speckit.analyze.md`: same reorder
+- [x] 4.6 Update `.opencode/command/speckit.checklist.md`: same reorder
+- [x] 4.7 Update `.opencode/command/speckit.testreview.md`: same reorder
+
+## 5. Explore Command — Add `/unleash` to Proposal Flow
+
+- [x] 5.1 Update `.opencode/command/opsx-explore.md` lines ~148-157: add `/unleash` mention to the "Flow into a proposal" ending bullet
+
+## 6. Speckit Workflow Skill — Add Entry Point
+
+- [x] 6.1 Add Entry Point section to `.opencode/skill/speckit-workflow/SKILL.md` identifying `/unleash` as the primary command
+
+## 7. Scaffold Asset Sync
+
+- [x] 7.1 Copy `.opencode/command/cobalt-crush.md` to `internal/scaffold/assets/opencode/command/cobalt-crush.md`
+- [x] 7.2 Copy `.opencode/command/uf-init.md` to `internal/scaffold/assets/opencode/command/uf-init.md`
+- [x] 7.3 Copy `.opencode/skill/speckit-workflow/SKILL.md` to `internal/scaffold/assets/opencode/skill/speckit-workflow/SKILL.md`
+
+## 8. Verification
+
+- [x] 8.1 Grep all modified files for remaining instances of `(/opsx-apply, /cobalt-crush, or /unleash)` — should be zero (all reordered)
+- [x] 8.2 Grep all `.opencode/command/` and `.opencode/skills/` files for "Run `/opsx-apply`" without `/unleash` — should be zero
+- [x] 8.3 Run `go test ./internal/scaffold/...` to verify scaffold drift tests pass
+<!-- spec-review: passed -->
+<!-- code-review: passed -->


### PR DESCRIPTION
## Summary

- Updated all implementation handoff prompts across 13 command/skill files to consistently recommend `/unleash` as the primary implementation option
- Reordered STOP blocks in 7 speckit spec-phase commands from `(/opsx-apply, /cobalt-crush, or /unleash)` to `(/unleash, /cobalt-crush, or /opsx-apply)`
- Updated `opsx-propose` command and skill with `/unleash` in output prompts and guardrails
- Added `/unleash` to `cobalt-crush` no-context fallback and `uf-init` Next Steps
- Added Entry Point section to `speckit-workflow` skill
- Fixed `/opsx:apply` typo in `cobalt-crush.md`
- Synced 3 scaffold asset copies to prevent drift test failures
- All 25 tasks completed, verification grep checks pass, scaffold tests pass

## Motivation

A user reported that after running `/opsx-propose` on a 22-task change, the agent suggested only `/opsx-apply` instead of `/unleash`. The root cause was that handoff prompts either omitted `/unleash` entirely or listed it last.