### PR TITLE
docs: propose cross-tool bridge files for Claude Code and Cursor

### DIFF
--- a/internal/scaffold/scaffold.go
+++ b/internal/scaffold/scaffold.go
@@ -217,8 +217,14 @@ func Run(opts Options) (*Result, error) {
 	// so that .gitignore is ready before sub-tools create runtime files.
 	giResult := ensureGitignore(&opts)
 
+	// Ensure cross-tool bridge files exist so Claude Code and Cursor
+	// users discover convention packs out of the box.
+	agentsResult := ensureAGENTSmdPackSection(&opts, lang)
+	claudeResult := ensureCLAUDEmd(&opts, lang)
+	cursorResult := ensureCursorrules(&opts, lang)
+
 	// Initialize sub-tools after file scaffolding, before summary.
-	subResults := append([]subToolResult{giResult}, initSubTools(&opts)...)
+	subResults := append([]subToolResult{giResult, agentsResult, claudeResult, cursorResult}, initSubTools(&opts)...)
 
 	printSummary(opts.Stdout, opts.DivisorOnly, langExplicit, langDetected, result, subResults)
 	return result, nil
@@ -751,6 +757,225 @@ func ensureGitignore(opts *Options) subToolResult {
 		name:   ".gitignore",
 		action: "configured",
 	}
+}
+
+// agentsmdPackMarker is the heading used to detect whether the
+// Convention Packs section has already been appended to AGENTS.md.
+const agentsmdPackMarker = "## Convention Packs"
+
+// ensureAGENTSmdPackSection appends a "Convention Packs" section to
+// AGENTS.md listing the deployed convention packs. Idempotent: if the
+// heading already exists, the file is not modified. Skips if AGENTS.md
+// does not exist (nothing to append to).
+// Uses opts.ReadFile/WriteFile for testability (dependency injection).
+func ensureAGENTSmdPackSection(opts *Options, lang string) subToolResult {
+	agentsPath := filepath.Join(opts.TargetDir, "AGENTS.md")
+
+	existing, readErr := opts.ReadFile(agentsPath)
+	if readErr != nil {
+		if os.IsNotExist(readErr) {
+			return subToolResult{
+				name:   "AGENTS.md pack section",
+				action: "skipped (no AGENTS.md)",
+			}
+		}
+		return subToolResult{
+			name:   "AGENTS.md pack section",
+			action: "failed",
+			detail: fmt.Sprintf("read failed: %v", readErr),
+		}
+	}
+
+	if strings.Contains(string(existing), agentsmdPackMarker) {
+		return subToolResult{
+			name:   "AGENTS.md pack section",
+			action: "already configured",
+		}
+	}
+
+	packs := collectDeployedPacks(lang)
+	var section strings.Builder
+	section.WriteString("\n" + agentsmdPackMarker + "\n\n")
+	section.WriteString("This repository uses convention packs scaffolded by\n")
+	section.WriteString("unbound-force. Agents MUST read the applicable pack(s)\n")
+	section.WriteString("before writing or reviewing code.\n\n")
+	for _, p := range packs {
+		section.WriteString("- `.opencode/uf/packs/" + p + "`\n")
+	}
+
+	content := string(existing)
+	if !strings.HasSuffix(content, "\n") {
+		content += "\n"
+	}
+	content += section.String()
+
+	if writeErr := opts.WriteFile(agentsPath, []byte(content), 0o644); writeErr != nil {
+		return subToolResult{
+			name:   "AGENTS.md pack section",
+			action: "failed",
+			detail: fmt.Sprintf("write failed: %v", writeErr),
+		}
+	}
+
+	return subToolResult{
+		name:   "AGENTS.md pack section",
+		action: "configured",
+	}
+}
+
+// claudemdMarker is the sentinel string used to detect the managed
+// block in CLAUDE.md. Same marker pattern as gitignoreMarker.
+const claudemdMarker = "# Unbound Force — managed by uf init"
+
+// ensureCLAUDEmd creates or appends a managed block to CLAUDE.md with
+// @imports for AGENTS.md and deployed convention packs. Idempotent: if
+// the marker already exists, the file is not modified.
+// Uses opts.ReadFile/WriteFile for testability (dependency injection).
+func ensureCLAUDEmd(opts *Options, lang string) subToolResult {
+	claudePath := filepath.Join(opts.TargetDir, "CLAUDE.md")
+
+	existing, readErr := opts.ReadFile(claudePath)
+	if readErr != nil && !os.IsNotExist(readErr) {
+		return subToolResult{
+			name:   "CLAUDE.md",
+			action: "failed",
+			detail: fmt.Sprintf("read failed: %v", readErr),
+		}
+	}
+
+	if readErr == nil && strings.Contains(string(existing), claudemdMarker) {
+		return subToolResult{
+			name:   "CLAUDE.md",
+			action: "already configured",
+		}
+	}
+
+	packs := collectDeployedPacks(lang)
+	var block strings.Builder
+	block.WriteString(claudemdMarker + "\n\n")
+	block.WriteString("@AGENTS.md\n\n")
+	block.WriteString("## Convention Packs\n\n")
+	for _, p := range packs {
+		block.WriteString("@.opencode/uf/packs/" + p + "\n")
+	}
+
+	var content string
+	if readErr == nil {
+		content = string(existing)
+		if len(content) > 0 && !strings.HasSuffix(content, "\n\n") {
+			if !strings.HasSuffix(content, "\n") {
+				content += "\n"
+			}
+			content += "\n"
+		}
+	}
+	content += block.String()
+
+	if writeErr := opts.WriteFile(claudePath, []byte(content), 0o644); writeErr != nil {
+		return subToolResult{
+			name:   "CLAUDE.md",
+			action: "failed",
+			detail: fmt.Sprintf("write failed: %v", writeErr),
+		}
+	}
+
+	action := "configured"
+	if readErr == nil {
+		action = "appended"
+	}
+	return subToolResult{
+		name:   "CLAUDE.md",
+		action: action,
+	}
+}
+
+// cursorrulesMarker is the sentinel string used to detect the managed
+// block in .cursorrules. Same marker pattern as claudemdMarker.
+const cursorrulesMarker = claudemdMarker
+
+// ensureCursorrules creates or appends a managed block to .cursorrules
+// with instructions to read AGENTS.md and convention packs. Idempotent:
+// if the marker already exists, the file is not modified.
+// Uses opts.ReadFile/WriteFile for testability (dependency injection).
+func ensureCursorrules(opts *Options, lang string) subToolResult {
+	rulesPath := filepath.Join(opts.TargetDir, ".cursorrules")
+
+	existing, readErr := opts.ReadFile(rulesPath)
+	if readErr != nil && !os.IsNotExist(readErr) {
+		return subToolResult{
+			name:   ".cursorrules",
+			action: "failed",
+			detail: fmt.Sprintf("read failed: %v", readErr),
+		}
+	}
+
+	if readErr == nil && strings.Contains(string(existing), cursorrulesMarker) {
+		return subToolResult{
+			name:   ".cursorrules",
+			action: "already configured",
+		}
+	}
+
+	packs := collectDeployedPacks(lang)
+	var block strings.Builder
+	block.WriteString(cursorrulesMarker + "\n\n")
+	block.WriteString("This project follows coding conventions defined in\n")
+	block.WriteString("AGENTS.md and enforced through convention packs. Before\n")
+	block.WriteString("writing or reviewing code, read the applicable convention\n")
+	block.WriteString("pack(s) from .opencode/uf/packs/ and apply all rules\n")
+	block.WriteString("marked [MUST].\n\n")
+	block.WriteString("Available packs:\n")
+	for _, p := range packs {
+		block.WriteString("- .opencode/uf/packs/" + p + "\n")
+	}
+
+	var content string
+	if readErr == nil {
+		content = string(existing)
+		if len(content) > 0 && !strings.HasSuffix(content, "\n\n") {
+			if !strings.HasSuffix(content, "\n") {
+				content += "\n"
+			}
+			content += "\n"
+		}
+	}
+	content += block.String()
+
+	if writeErr := opts.WriteFile(rulesPath, []byte(content), 0o644); writeErr != nil {
+		return subToolResult{
+			name:   ".cursorrules",
+			action: "failed",
+			detail: fmt.Sprintf("write failed: %v", writeErr),
+		}
+	}
+
+	action := "configured"
+	if readErr == nil {
+		action = "appended"
+	}
+	return subToolResult{
+		name:   ".cursorrules",
+		action: action,
+	}
+}
+
+// collectDeployedPacks returns the list of convention pack filenames
+// that would be deployed for the given resolved language. The list
+// always includes default.md, default-custom.md, severity.md,
+// content.md, and content-custom.md. Language-specific packs are
+// added when lang is not "default".
+func collectDeployedPacks(lang string) []string {
+	packs := []string{
+		"default.md",
+		"default-custom.md",
+		"severity.md",
+		"content.md",
+		"content-custom.md",
+	}
+	if lang != "" && lang != "default" {
+		packs = append(packs, lang+".md", lang+"-custom.md")
+	}
+	return packs
 }
 
 // workflowConfigContent is the default content for .uf/config.yaml.

--- a/internal/scaffold/scaffold.go
+++ b/internal/scaffold/scaffold.go
@@ -853,11 +853,20 @@ func ensureCLAUDEmd(opts *Options, lang string) subToolResult {
 	packs := collectDeployedPacks(lang)
 	var block strings.Builder
 	block.WriteString(claudemdMarker + "\n\n")
-	block.WriteString("@AGENTS.md\n\n")
+	block.WriteString("@AGENTS.md\n")
+	block.WriteString("@.opencode/agents/cobalt-crush-dev.md\n\n")
 	block.WriteString("## Convention Packs\n\n")
 	for _, p := range packs {
 		block.WriteString("@.opencode/uf/packs/" + p + "\n")
 	}
+	block.WriteString("\n## Review Agents (read on-demand)\n\n")
+	block.WriteString("When performing code review, read the applicable\n")
+	block.WriteString("Divisor agent from .opencode/agents/:\n")
+	block.WriteString("- divisor-guard.md — intent drift, constitution\n")
+	block.WriteString("- divisor-architect.md — structure, patterns, DRY\n")
+	block.WriteString("- divisor-adversary.md — security, error handling\n")
+	block.WriteString("- divisor-testing.md — test quality, assertions\n")
+	block.WriteString("- divisor-sre.md — operations, performance\n")
 
 	var content string
 	if readErr == nil {
@@ -928,6 +937,15 @@ func ensureCursorrules(opts *Options, lang string) subToolResult {
 	for _, p := range packs {
 		block.WriteString("- .opencode/uf/packs/" + p + "\n")
 	}
+	block.WriteString("\nFor engineering philosophy and coding principles, read\n")
+	block.WriteString(".opencode/agents/cobalt-crush-dev.md.\n\n")
+	block.WriteString("When reviewing code, consult the applicable reviewer\n")
+	block.WriteString("checklist from .opencode/agents/:\n")
+	block.WriteString("- divisor-guard.md — intent drift, constitution\n")
+	block.WriteString("- divisor-architect.md — structure, patterns, DRY\n")
+	block.WriteString("- divisor-adversary.md — security, error handling\n")
+	block.WriteString("- divisor-testing.md — test quality, assertions\n")
+	block.WriteString("- divisor-sre.md — operations, performance\n")
 
 	var content string
 	if readErr == nil {

--- a/internal/scaffold/scaffold_test.go
+++ b/internal/scaffold/scaffold_test.go
@@ -3895,3 +3895,421 @@ func TestUFInitAsset_GuidanceBlockPresence(t *testing.T) {
 		}
 	}
 }
+
+// --- Cross-tool bridge tests ---
+
+func TestEnsureAGENTSmdPackSection_NoAGENTSmd(t *testing.T) {
+	dir := t.TempDir()
+
+	opts := &Options{
+		TargetDir: dir,
+		ReadFile:  os.ReadFile,
+		WriteFile: os.WriteFile,
+	}
+
+	result := ensureAGENTSmdPackSection(opts, "go")
+
+	if result.action != "skipped (no AGENTS.md)" {
+		t.Errorf("expected action 'skipped (no AGENTS.md)', got %q", result.action)
+	}
+}
+
+func TestEnsureAGENTSmdPackSection_ExistingWithoutSection(t *testing.T) {
+	dir := t.TempDir()
+
+	existing := "# My Project\n\nSome content.\n"
+	agentsPath := filepath.Join(dir, "AGENTS.md")
+	if err := os.WriteFile(agentsPath, []byte(existing), 0o644); err != nil {
+		t.Fatalf("write AGENTS.md: %v", err)
+	}
+
+	opts := &Options{
+		TargetDir: dir,
+		ReadFile:  os.ReadFile,
+		WriteFile: os.WriteFile,
+	}
+
+	result := ensureAGENTSmdPackSection(opts, "go")
+
+	if result.action != "configured" {
+		t.Errorf("expected action 'configured', got %q", result.action)
+	}
+
+	content, err := os.ReadFile(agentsPath)
+	if err != nil {
+		t.Fatalf("read AGENTS.md: %v", err)
+	}
+	text := string(content)
+
+	if !strings.HasPrefix(text, existing) {
+		t.Error("existing content not preserved")
+	}
+	if !strings.Contains(text, agentsmdPackMarker) {
+		t.Error("expected Convention Packs heading")
+	}
+	if !strings.Contains(text, ".opencode/uf/packs/go.md") {
+		t.Error("expected Go pack reference")
+	}
+	if !strings.Contains(text, ".opencode/uf/packs/default.md") {
+		t.Error("expected default pack reference")
+	}
+}
+
+func TestEnsureAGENTSmdPackSection_AlreadyConfigured(t *testing.T) {
+	dir := t.TempDir()
+
+	existing := "# My Project\n\n## Convention Packs\n\nAlready here.\n"
+	agentsPath := filepath.Join(dir, "AGENTS.md")
+	if err := os.WriteFile(agentsPath, []byte(existing), 0o644); err != nil {
+		t.Fatalf("write AGENTS.md: %v", err)
+	}
+
+	opts := &Options{
+		TargetDir: dir,
+		ReadFile:  os.ReadFile,
+		WriteFile: os.WriteFile,
+	}
+
+	result := ensureAGENTSmdPackSection(opts, "go")
+
+	if result.action != "already configured" {
+		t.Errorf("expected action 'already configured', got %q", result.action)
+	}
+
+	after, err := os.ReadFile(agentsPath)
+	if err != nil {
+		t.Fatalf("read AGENTS.md: %v", err)
+	}
+	if string(after) != existing {
+		t.Error("AGENTS.md should be unchanged when section already present")
+	}
+}
+
+func TestEnsureAGENTSmdPackSection_Idempotent(t *testing.T) {
+	dir := t.TempDir()
+
+	existing := "# My Project\n"
+	agentsPath := filepath.Join(dir, "AGENTS.md")
+	if err := os.WriteFile(agentsPath, []byte(existing), 0o644); err != nil {
+		t.Fatalf("write AGENTS.md: %v", err)
+	}
+
+	opts := &Options{
+		TargetDir: dir,
+		ReadFile:  os.ReadFile,
+		WriteFile: os.WriteFile,
+	}
+
+	r1 := ensureAGENTSmdPackSection(opts, "go")
+	if r1.action != "configured" {
+		t.Errorf("first call: expected 'configured', got %q", r1.action)
+	}
+
+	content1, _ := os.ReadFile(agentsPath)
+
+	r2 := ensureAGENTSmdPackSection(opts, "go")
+	if r2.action != "already configured" {
+		t.Errorf("second call: expected 'already configured', got %q", r2.action)
+	}
+
+	content2, _ := os.ReadFile(agentsPath)
+	if !bytes.Equal(content1, content2) {
+		t.Error("content should be identical after second call")
+	}
+}
+
+func TestEnsureCLAUDEmd_FreshDir(t *testing.T) {
+	dir := t.TempDir()
+
+	opts := &Options{
+		TargetDir: dir,
+		ReadFile:  os.ReadFile,
+		WriteFile: os.WriteFile,
+	}
+
+	result := ensureCLAUDEmd(opts, "go")
+
+	if result.action != "configured" {
+		t.Errorf("expected action 'configured', got %q", result.action)
+	}
+
+	content, err := os.ReadFile(filepath.Join(dir, "CLAUDE.md"))
+	if err != nil {
+		t.Fatalf("read CLAUDE.md: %v", err)
+	}
+	text := string(content)
+
+	if !strings.Contains(text, claudemdMarker) {
+		t.Error("expected marker in CLAUDE.md")
+	}
+	if !strings.Contains(text, "@AGENTS.md") {
+		t.Error("expected @AGENTS.md import")
+	}
+	if !strings.Contains(text, "@.opencode/uf/packs/go.md") {
+		t.Error("expected Go pack @import")
+	}
+	if !strings.Contains(text, "@.opencode/uf/packs/default.md") {
+		t.Error("expected default pack @import")
+	}
+}
+
+func TestEnsureCLAUDEmd_ExistingWithoutMarker(t *testing.T) {
+	dir := t.TempDir()
+
+	existing := "# My Project Claude Config\n\nSome rules.\n"
+	claudePath := filepath.Join(dir, "CLAUDE.md")
+	if err := os.WriteFile(claudePath, []byte(existing), 0o644); err != nil {
+		t.Fatalf("write CLAUDE.md: %v", err)
+	}
+
+	opts := &Options{
+		TargetDir: dir,
+		ReadFile:  os.ReadFile,
+		WriteFile: os.WriteFile,
+	}
+
+	result := ensureCLAUDEmd(opts, "go")
+
+	if result.action != "appended" {
+		t.Errorf("expected action 'appended', got %q", result.action)
+	}
+
+	content, err := os.ReadFile(claudePath)
+	if err != nil {
+		t.Fatalf("read CLAUDE.md: %v", err)
+	}
+	text := string(content)
+
+	if !strings.HasPrefix(text, existing) {
+		t.Error("existing content not preserved")
+	}
+	if !strings.Contains(text, claudemdMarker) {
+		t.Error("expected marker appended")
+	}
+}
+
+func TestEnsureCLAUDEmd_AlreadyConfigured(t *testing.T) {
+	dir := t.TempDir()
+
+	existing := claudemdMarker + "\n\n@AGENTS.md\n"
+	claudePath := filepath.Join(dir, "CLAUDE.md")
+	if err := os.WriteFile(claudePath, []byte(existing), 0o644); err != nil {
+		t.Fatalf("write CLAUDE.md: %v", err)
+	}
+
+	opts := &Options{
+		TargetDir: dir,
+		ReadFile:  os.ReadFile,
+		WriteFile: os.WriteFile,
+	}
+
+	result := ensureCLAUDEmd(opts, "go")
+
+	if result.action != "already configured" {
+		t.Errorf("expected action 'already configured', got %q", result.action)
+	}
+
+	after, err := os.ReadFile(claudePath)
+	if err != nil {
+		t.Fatalf("read CLAUDE.md: %v", err)
+	}
+	if string(after) != existing {
+		t.Error("CLAUDE.md should be unchanged when marker already present")
+	}
+}
+
+func TestEnsureCLAUDEmd_Idempotent(t *testing.T) {
+	dir := t.TempDir()
+
+	opts := &Options{
+		TargetDir: dir,
+		ReadFile:  os.ReadFile,
+		WriteFile: os.WriteFile,
+	}
+
+	r1 := ensureCLAUDEmd(opts, "go")
+	if r1.action != "configured" {
+		t.Errorf("first call: expected 'configured', got %q", r1.action)
+	}
+
+	content1, _ := os.ReadFile(filepath.Join(dir, "CLAUDE.md"))
+
+	r2 := ensureCLAUDEmd(opts, "go")
+	if r2.action != "already configured" {
+		t.Errorf("second call: expected 'already configured', got %q", r2.action)
+	}
+
+	content2, _ := os.ReadFile(filepath.Join(dir, "CLAUDE.md"))
+	if !bytes.Equal(content1, content2) {
+		t.Error("content should be identical after second call")
+	}
+}
+
+func TestEnsureCursorrules_FreshDir(t *testing.T) {
+	dir := t.TempDir()
+
+	opts := &Options{
+		TargetDir: dir,
+		ReadFile:  os.ReadFile,
+		WriteFile: os.WriteFile,
+	}
+
+	result := ensureCursorrules(opts, "go")
+
+	if result.action != "configured" {
+		t.Errorf("expected action 'configured', got %q", result.action)
+	}
+
+	content, err := os.ReadFile(filepath.Join(dir, ".cursorrules"))
+	if err != nil {
+		t.Fatalf("read .cursorrules: %v", err)
+	}
+	text := string(content)
+
+	if !strings.Contains(text, cursorrulesMarker) {
+		t.Error("expected marker in .cursorrules")
+	}
+	if !strings.Contains(text, "AGENTS.md") {
+		t.Error("expected AGENTS.md reference")
+	}
+	if !strings.Contains(text, ".opencode/uf/packs/go.md") {
+		t.Error("expected Go pack reference")
+	}
+}
+
+func TestEnsureCursorrules_ExistingWithoutMarker(t *testing.T) {
+	dir := t.TempDir()
+
+	existing := "Use TypeScript strict mode.\n"
+	rulesPath := filepath.Join(dir, ".cursorrules")
+	if err := os.WriteFile(rulesPath, []byte(existing), 0o644); err != nil {
+		t.Fatalf("write .cursorrules: %v", err)
+	}
+
+	opts := &Options{
+		TargetDir: dir,
+		ReadFile:  os.ReadFile,
+		WriteFile: os.WriteFile,
+	}
+
+	result := ensureCursorrules(opts, "typescript")
+
+	if result.action != "appended" {
+		t.Errorf("expected action 'appended', got %q", result.action)
+	}
+
+	content, err := os.ReadFile(rulesPath)
+	if err != nil {
+		t.Fatalf("read .cursorrules: %v", err)
+	}
+	text := string(content)
+
+	if !strings.HasPrefix(text, existing) {
+		t.Error("existing content not preserved")
+	}
+	if !strings.Contains(text, ".opencode/uf/packs/typescript.md") {
+		t.Error("expected TypeScript pack reference")
+	}
+}
+
+func TestEnsureCursorrules_AlreadyConfigured(t *testing.T) {
+	dir := t.TempDir()
+
+	existing := cursorrulesMarker + "\n\nSome rules.\n"
+	rulesPath := filepath.Join(dir, ".cursorrules")
+	if err := os.WriteFile(rulesPath, []byte(existing), 0o644); err != nil {
+		t.Fatalf("write .cursorrules: %v", err)
+	}
+
+	opts := &Options{
+		TargetDir: dir,
+		ReadFile:  os.ReadFile,
+		WriteFile: os.WriteFile,
+	}
+
+	result := ensureCursorrules(opts, "go")
+
+	if result.action != "already configured" {
+		t.Errorf("expected action 'already configured', got %q", result.action)
+	}
+}
+
+func TestEnsureCursorrules_Idempotent(t *testing.T) {
+	dir := t.TempDir()
+
+	opts := &Options{
+		TargetDir: dir,
+		ReadFile:  os.ReadFile,
+		WriteFile: os.WriteFile,
+	}
+
+	r1 := ensureCursorrules(opts, "go")
+	if r1.action != "configured" {
+		t.Errorf("first call: expected 'configured', got %q", r1.action)
+	}
+
+	content1, _ := os.ReadFile(filepath.Join(dir, ".cursorrules"))
+
+	r2 := ensureCursorrules(opts, "go")
+	if r2.action != "already configured" {
+		t.Errorf("second call: expected 'already configured', got %q", r2.action)
+	}
+
+	content2, _ := os.ReadFile(filepath.Join(dir, ".cursorrules"))
+	if !bytes.Equal(content1, content2) {
+		t.Error("content should be identical after second call")
+	}
+}
+
+func TestCollectDeployedPacks_Go(t *testing.T) {
+	packs := collectDeployedPacks("go")
+
+	expected := map[string]bool{
+		"default.md":        true,
+		"default-custom.md": true,
+		"severity.md":       true,
+		"content.md":        true,
+		"content-custom.md": true,
+		"go.md":             true,
+		"go-custom.md":      true,
+	}
+
+	if len(packs) != len(expected) {
+		t.Errorf("expected %d packs, got %d: %v", len(expected), len(packs), packs)
+	}
+	for _, p := range packs {
+		if !expected[p] {
+			t.Errorf("unexpected pack %q", p)
+		}
+	}
+}
+
+func TestCollectDeployedPacks_TypeScript(t *testing.T) {
+	packs := collectDeployedPacks("typescript")
+
+	found := false
+	for _, p := range packs {
+		if p == "typescript.md" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected typescript.md in packs")
+	}
+}
+
+func TestCollectDeployedPacks_Default(t *testing.T) {
+	packs := collectDeployedPacks("default")
+
+	for _, p := range packs {
+		if p == "default.md" || p == "default-custom.md" ||
+			p == "severity.md" || p == "content.md" ||
+			p == "content-custom.md" {
+			continue
+		}
+		t.Errorf("unexpected pack %q for default lang", p)
+	}
+	if len(packs) != 5 {
+		t.Errorf("expected 5 packs for default lang, got %d", len(packs))
+	}
+}

--- a/internal/scaffold/scaffold_test.go
+++ b/internal/scaffold/scaffold_test.go
@@ -4045,11 +4045,17 @@ func TestEnsureCLAUDEmd_FreshDir(t *testing.T) {
 	if !strings.Contains(text, "@AGENTS.md") {
 		t.Error("expected @AGENTS.md import")
 	}
+	if !strings.Contains(text, "@.opencode/agents/cobalt-crush-dev.md") {
+		t.Error("expected cobalt-crush @import")
+	}
 	if !strings.Contains(text, "@.opencode/uf/packs/go.md") {
 		t.Error("expected Go pack @import")
 	}
 	if !strings.Contains(text, "@.opencode/uf/packs/default.md") {
 		t.Error("expected default pack @import")
+	}
+	if !strings.Contains(text, "divisor-guard.md") {
+		t.Error("expected Divisor review agent reference")
 	}
 }
 
@@ -4174,6 +4180,12 @@ func TestEnsureCursorrules_FreshDir(t *testing.T) {
 	}
 	if !strings.Contains(text, ".opencode/uf/packs/go.md") {
 		t.Error("expected Go pack reference")
+	}
+	if !strings.Contains(text, "cobalt-crush-dev.md") {
+		t.Error("expected cobalt-crush agent reference")
+	}
+	if !strings.Contains(text, "divisor-guard.md") {
+		t.Error("expected Divisor review agent reference")
 	}
 }
 

--- a/openspec/changes/archive/2026-04-23-cross-tool-bridge/proposal.md
+++ b/openspec/changes/archive/2026-04-23-cross-tool-bridge/proposal.md
@@ -1,0 +1,298 @@
+## Why
+
+`uf init` deploys convention packs and agent files under
+`.opencode/`, which only OpenCode auto-discovers. Teams
+where contributors use Claude Code or Cursor get no
+benefit from convention packs unless they manually find
+and reference the files. There is no bridge telling
+non-OpenCode tools where the packs live.
+
+The current `agent-agnostic-file-standard` change
+proposes moving packs to `.agents/packs/` -- but no tool
+auto-discovers that path either. The move adds migration
+cost without solving the discovery problem. The actual
+need is thin bridge files in each tool's native discovery
+location pointing to the canonical OpenCode files.
+
+Additionally, AGENTS.md lacks a "Convention Packs"
+section that would tell any LLM -- regardless of tool --
+where packs are and how to use them.
+
+## What Changes
+
+### 1. AGENTS.md "Convention Packs" section
+
+`uf init` appends a "Convention Packs" section to
+AGENTS.md (if it exists and lacks one). The section
+lists deployed packs by path and instructs agents to
+read them before writing or reviewing code.
+
+Detection: marker heading `## Convention Packs`. If
+present, skip. Same idempotent pattern as
+`ensureGitignore()`.
+
+### 2. CLAUDE.md bridge file
+
+`uf init` creates or appends to `CLAUDE.md` a managed
+block that imports AGENTS.md and each deployed convention
+pack using Claude Code's `@path` import syntax.
+
+**Generated content (example for a Go project):**
+
+```
+# Unbound Force — managed by uf init
+
+@AGENTS.md
+@.opencode/agents/cobalt-crush-dev.md
+
+## Convention Packs
+
+@.opencode/uf/packs/default.md
+@.opencode/uf/packs/severity.md
+@.opencode/uf/packs/go.md
+
+## Review Agents (read on-demand)
+
+When performing code review, read the applicable
+Divisor agent from .opencode/agents/:
+- divisor-guard.md — intent drift, constitution
+- divisor-architect.md — structure, patterns, DRY
+- divisor-adversary.md — security, error handling
+- divisor-testing.md — test quality, assertions
+- divisor-sre.md — operations, performance
+```
+
+The pack list is generated dynamically -- `uf init`
+enumerates which packs were actually deployed (based on
+`--lang` and `detectLang()`) and lists only those. This
+avoids broken `@imports` for absent packs.
+
+Detection: marker comment `# Unbound Force — managed by
+uf init`. If present, skip. If CLAUDE.md exists without
+the marker, append the block (preserving existing user
+content above).
+
+### 3. .cursorrules bridge file
+
+`uf init` creates or appends to `.cursorrules` a managed
+block that instructs Cursor's agent to read AGENTS.md
+and the applicable convention packs.
+
+**Generated content (example for a Go project):**
+
+```
+# Unbound Force — managed by uf init
+
+This project follows coding conventions defined in
+AGENTS.md and enforced through convention packs. Before
+writing or reviewing code, read the applicable convention
+pack(s) from .opencode/uf/packs/ and apply all rules
+marked [MUST].
+
+Available packs:
+- .opencode/uf/packs/default.md (language-agnostic)
+- .opencode/uf/packs/severity.md (severity definitions)
+- .opencode/uf/packs/go.md (Go-specific)
+
+For engineering philosophy and coding principles, read
+.opencode/agents/cobalt-crush-dev.md.
+
+When reviewing code, consult the applicable reviewer
+checklist from .opencode/agents/:
+- divisor-guard.md — intent drift, constitution
+- divisor-architect.md — structure, patterns, DRY
+- divisor-adversary.md — security, error handling
+- divisor-testing.md — test quality, assertions
+- divisor-sre.md — operations, performance
+```
+
+Detection: same marker pattern. Idempotent.
+
+### 4. Agent file references in bridge files
+
+Agent files under `.opencode/agents/` have two parts:
+OpenCode-specific YAML frontmatter (model, temperature,
+tool restrictions) and a universal Markdown body (role
+descriptions, review checklists, engineering philosophy).
+The frontmatter is not portable but the body content is
+valuable to any LLM.
+
+The bridge files include selective agent references:
+
+- **cobalt-crush-dev.md** is auto-loaded in CLAUDE.md
+  via `@import` (engineering philosophy applies to all
+  coding work). Listed as a reference in .cursorrules.
+- **Divisor review agents** (divisor-guard, divisor-
+  architect, divisor-adversary, divisor-testing,
+  divisor-sre) are listed as on-demand references in
+  both bridge files. The LLM reads them when performing
+  code review, not on every session start.
+
+OpenCode-specific frontmatter in agent files is harmless
+metadata that non-OpenCode tools ignore. No format
+conversion is needed.
+
+### 5. Command files excluded from bridging
+
+Command files under `.opencode/command/` are OpenCode
+execution instructions that use tool-specific features:
+`$ARGUMENTS` variable interpolation, `Task tool` for
+subagent spawning, `agent:` frontmatter delegation,
+and cross-command references (`/speckit.plan`,
+`/review-council`, etc.). They cannot be bridged via
+pointer files -- they would need full format conversion
+to each tool's native command system.
+
+The workflow concepts they encode (Speckit pipeline,
+review council methodology, OpenSpec lifecycle) are
+already documented in AGENTS.md and the Specification
+Framework section. Non-OpenCode users follow those
+workflows manually or via their tool's native
+equivalent.
+
+### 6. Convention packs stay at .opencode/uf/packs/
+
+No file move. Packs remain at their current canonical
+location. The bridge files point to them. This avoids
+migration cost for existing adopters and keeps uf
+opinionated about OpenCode as the primary tool.
+
+## Design Rationale
+
+### Why not move packs to .agents/packs/?
+
+`.agents/` is not auto-discovered by any tool (OpenCode,
+Claude Code, or Cursor). Moving packs there adds
+migration cost without improving discovery. The bridge
+approach achieves the same cross-tool visibility without
+moving files.
+
+### Why not symlinks?
+
+Claude Code supports symlinks in `.claude/rules/`, but
+`@import` in CLAUDE.md is simpler and has no cross-
+platform issues. Cursor requires `.mdc` files with
+different frontmatter -- symlinks to `.md` files would
+not be recognized. Symlinks also have Windows
+compatibility concerns (`core.symlinks`, admin
+privileges).
+
+### Why bridges instead of native format conversion?
+
+Convention packs are pure Markdown content with numbered
+MUST/SHOULD rules. Any LLM can read and follow them
+regardless of the tool that loads them. The UF-specific
+frontmatter (`pack_id`, `language`, `version`) is
+harmless metadata that non-OpenCode tools ignore. No
+format conversion is needed -- only discovery.
+
+### Stacking behavior
+
+All three tools natively stack project-level and user-
+level config files. A contributor using Claude Code gets
+both their personal `~/.claude/CLAUDE.md` AND the
+project's committed `CLAUDE.md`. The bridge files add
+project conventions without overriding personal settings.
+
+### Cursor bridge limitation
+
+The `.cursorrules` bridge is weaker than the `CLAUDE.md`
+bridge by design. Claude Code's `@path` syntax auto-
+loads referenced files into context at session start.
+Cursor loads `.cursorrules` into context but the agent
+must then choose to read the referenced pack files --
+auto-loading via `@import` is not supported. This means
+Cursor users get the instruction to read packs, but
+the packs are not guaranteed to be in context for every
+interaction. This is a known limitation of Cursor's
+rule system and cannot be solved without Cursor adding
+an import mechanism.
+
+## Capabilities
+
+### New Capabilities
+
+- `ensureCLAUDEmd()`: Creates or appends managed block
+  to CLAUDE.md with @imports for AGENTS.md, cobalt-crush
+  agent, deployed convention packs, and on-demand review
+  agent references. Idempotent via marker detection.
+- `ensureCursorrules()`: Creates or appends managed block
+  to .cursorrules with pack reference instructions and
+  agent file references. Idempotent via marker detection.
+- `ensureAGENTSmdPackSection()`: Appends Convention Packs
+  section to AGENTS.md listing deployed packs.
+  Idempotent via heading detection.
+
+### Modified Capabilities
+
+- `Run()` in `scaffold.go`: Calls the three new ensure
+  functions after existing `ensureGitignore()`, before
+  sub-tool delegation.
+- `printSummary()`: Reports bridge file status (created,
+  skipped, appended).
+
+### Removed Capabilities
+
+None.
+
+## Impact
+
+- No breaking changes. Existing `uf init` behavior is
+  unchanged for OpenCode users.
+- New files (CLAUDE.md, .cursorrules) are only created
+  if absent. Existing files get a managed block appended.
+- Bridge files should be committed to version control
+  by maintainers so new contributors get convention
+  packs out-of-box regardless of their tool choice.
+- Supersedes `agent-agnostic-file-standard` (pack move
+  abandoned) and `multi-agent-init` (bridge approach
+  replaces --packs-only flag).
+
+## Supersedes
+
+- **agent-agnostic-file-standard**: The `.agents/packs/`
+  move is abandoned. AGENTS.md deduplication (removing
+  governance rules restated from the constitution) should
+  be extracted as a separate, independent change.
+- **multi-agent-init**: The `--packs-only` flag and
+  AGENTS.md pack section are replaced by the bridge
+  approach. The "Convention Packs" section concept
+  migrates here.
+
+## Constitution Alignment
+
+Assessed against the Unbound Force org constitution.
+
+### I. Autonomous Collaboration
+
+**Assessment**: PASS
+
+Convention packs remain self-describing artifacts.
+Bridge files are thin pointers -- no runtime coupling
+between tools. Each tool discovers packs independently
+through its native mechanism.
+
+### II. Composability First
+
+**Assessment**: PASS
+
+This change directly serves composability. Convention
+packs become usable by Claude Code and Cursor without
+requiring OpenCode. Each tool benefits independently.
+The bridge files are optional -- removing them does not
+break OpenCode functionality.
+
+### III. Observable Quality
+
+**Assessment**: N/A
+
+No change to output formats or quality metrics.
+
+### IV. Testability
+
+**Assessment**: PASS
+
+Each ensure function follows the established
+ensureGitignore() pattern with injectable I/O. Tests
+verify idempotency, marker detection, dynamic pack
+enumeration, and append-without-overwrite behavior.

--- a/openspec/changes/archive/2026-04-23-cross-tool-bridge/tasks.md
+++ b/openspec/changes/archive/2026-04-23-cross-tool-bridge/tasks.md
@@ -1,0 +1,42 @@
+## Tasks
+
+### Part 1: Implement ensureAGENTSmdPackSection()
+
+- [x] Add `agentsmdPackMarker` constant (heading `## Convention Packs`)
+- [x] Implement `ensureAGENTSmdPackSection()` that appends Convention Packs section to AGENTS.md listing deployed packs -- idempotent via heading detection, uses opts.ReadFile/WriteFile
+- [x] Add `collectDeployedPacks()` helper that enumerates which pack files were deployed based on resolved language (reuse shouldDeployPack logic)
+
+### Part 2: Implement ensureCLAUDEmd()
+
+- [x] Add `claudemdMarker` constant (`# Unbound Force — managed by uf init`)
+- [x] Implement `ensureCLAUDEmd()` that creates or appends managed block to CLAUDE.md with @imports for AGENTS.md, cobalt-crush agent, deployed convention packs, and on-demand review agent references -- idempotent via marker detection, uses opts.ReadFile/WriteFile
+
+### Part 3: Implement ensureCursorrules()
+
+- [x] Add `cursorrulesMarker` constant (same marker pattern)
+- [x] Implement `ensureCursorrules()` that creates or appends managed block to .cursorrules with pack reference instructions and agent file references -- idempotent via marker detection, uses opts.ReadFile/WriteFile
+
+### Part 4: Wire into Run() and printSummary()
+
+- [x] Call ensureAGENTSmdPackSection(), ensureCLAUDEmd(), ensureCursorrules() after ensureGitignore() in Run(), append results to subResults
+- [x] Verify printSummary() handles new subToolResult entries (existing format should work)
+
+### Part 5: Agent references in bridge files
+
+- [x] Add cobalt-crush-dev.md @import and Divisor review agent on-demand list to ensureCLAUDEmd() generated content
+- [x] Add cobalt-crush-dev.md reference and Divisor review agent list to ensureCursorrules() generated content
+- [x] Update proposal.md with agent reference design rationale and command file exclusion
+
+### Part 6: Tests
+
+- [x] Add TestEnsureAGENTSmdPackSection (fresh, existing without section, existing with section, idempotent)
+- [x] Add TestEnsureCLAUDEmd (fresh, existing without marker, existing with marker, idempotent)
+- [x] Add TestEnsureCursorrules (fresh, existing without marker, existing with marker, idempotent)
+- [x] Add TestCollectDeployedPacks for different languages (go, typescript, default)
+- [x] Verify agent references in CLAUDE.md tests (cobalt-crush @import, divisor-guard reference)
+- [x] Verify agent references in .cursorrules tests (cobalt-crush reference, divisor-guard reference)
+
+### Part 7: Verification
+
+- [x] Run `go test -race -count=1 ./...` to verify all tests pass
+- [x] Run `golangci-lint run` to verify no lint issues

--- a/openspec/changes/cross-tool-bridge/proposal.md
+++ b/openspec/changes/cross-tool-bridge/proposal.md
@@ -43,12 +43,23 @@ pack using Claude Code's `@path` import syntax.
 # Unbound Force — managed by uf init
 
 @AGENTS.md
+@.opencode/agents/cobalt-crush-dev.md
 
 ## Convention Packs
 
 @.opencode/uf/packs/default.md
 @.opencode/uf/packs/severity.md
 @.opencode/uf/packs/go.md
+
+## Review Agents (read on-demand)
+
+When performing code review, read the applicable
+Divisor agent from .opencode/agents/:
+- divisor-guard.md — intent drift, constitution
+- divisor-architect.md — structure, patterns, DRY
+- divisor-adversary.md — security, error handling
+- divisor-testing.md — test quality, assertions
+- divisor-sre.md — operations, performance
 ```
 
 The pack list is generated dynamically -- `uf init`
@@ -82,11 +93,64 @@ Available packs:
 - .opencode/uf/packs/default.md (language-agnostic)
 - .opencode/uf/packs/severity.md (severity definitions)
 - .opencode/uf/packs/go.md (Go-specific)
+
+For engineering philosophy and coding principles, read
+.opencode/agents/cobalt-crush-dev.md.
+
+When reviewing code, consult the applicable reviewer
+checklist from .opencode/agents/:
+- divisor-guard.md — intent drift, constitution
+- divisor-architect.md — structure, patterns, DRY
+- divisor-adversary.md — security, error handling
+- divisor-testing.md — test quality, assertions
+- divisor-sre.md — operations, performance
 ```
 
 Detection: same marker pattern. Idempotent.
 
-### 4. Convention packs stay at .opencode/uf/packs/
+### 4. Agent file references in bridge files
+
+Agent files under `.opencode/agents/` have two parts:
+OpenCode-specific YAML frontmatter (model, temperature,
+tool restrictions) and a universal Markdown body (role
+descriptions, review checklists, engineering philosophy).
+The frontmatter is not portable but the body content is
+valuable to any LLM.
+
+The bridge files include selective agent references:
+
+- **cobalt-crush-dev.md** is auto-loaded in CLAUDE.md
+  via `@import` (engineering philosophy applies to all
+  coding work). Listed as a reference in .cursorrules.
+- **Divisor review agents** (divisor-guard, divisor-
+  architect, divisor-adversary, divisor-testing,
+  divisor-sre) are listed as on-demand references in
+  both bridge files. The LLM reads them when performing
+  code review, not on every session start.
+
+OpenCode-specific frontmatter in agent files is harmless
+metadata that non-OpenCode tools ignore. No format
+conversion is needed.
+
+### 5. Command files excluded from bridging
+
+Command files under `.opencode/command/` are OpenCode
+execution instructions that use tool-specific features:
+`$ARGUMENTS` variable interpolation, `Task tool` for
+subagent spawning, `agent:` frontmatter delegation,
+and cross-command references (`/speckit.plan`,
+`/review-council`, etc.). They cannot be bridged via
+pointer files -- they would need full format conversion
+to each tool's native command system.
+
+The workflow concepts they encode (Speckit pipeline,
+review council methodology, OpenSpec lifecycle) are
+already documented in AGENTS.md and the Specification
+Framework section. Non-OpenCode users follow those
+workflows manually or via their tool's native
+equivalent.
+
+### 6. Convention packs stay at .opencode/uf/packs/
 
 No file move. Packs remain at their current canonical
 location. The bridge files point to them. This avoids
@@ -149,11 +213,12 @@ an import mechanism.
 ### New Capabilities
 
 - `ensureCLAUDEmd()`: Creates or appends managed block
-  to CLAUDE.md with @imports for AGENTS.md and deployed
-  convention packs. Idempotent via marker detection.
+  to CLAUDE.md with @imports for AGENTS.md, cobalt-crush
+  agent, deployed convention packs, and on-demand review
+  agent references. Idempotent via marker detection.
 - `ensureCursorrules()`: Creates or appends managed block
-  to .cursorrules with pack reference instructions.
-  Idempotent via marker detection.
+  to .cursorrules with pack reference instructions and
+  agent file references. Idempotent via marker detection.
 - `ensureAGENTSmdPackSection()`: Appends Convention Packs
   section to AGENTS.md listing deployed packs.
   Idempotent via heading detection.

--- a/openspec/changes/cross-tool-bridge/proposal.md
+++ b/openspec/changes/cross-tool-bridge/proposal.md
@@ -1,0 +1,233 @@
+## Why
+
+`uf init` deploys convention packs and agent files under
+`.opencode/`, which only OpenCode auto-discovers. Teams
+where contributors use Claude Code or Cursor get no
+benefit from convention packs unless they manually find
+and reference the files. There is no bridge telling
+non-OpenCode tools where the packs live.
+
+The current `agent-agnostic-file-standard` change
+proposes moving packs to `.agents/packs/` -- but no tool
+auto-discovers that path either. The move adds migration
+cost without solving the discovery problem. The actual
+need is thin bridge files in each tool's native discovery
+location pointing to the canonical OpenCode files.
+
+Additionally, AGENTS.md lacks a "Convention Packs"
+section that would tell any LLM -- regardless of tool --
+where packs are and how to use them.
+
+## What Changes
+
+### 1. AGENTS.md "Convention Packs" section
+
+`uf init` appends a "Convention Packs" section to
+AGENTS.md (if it exists and lacks one). The section
+lists deployed packs by path and instructs agents to
+read them before writing or reviewing code.
+
+Detection: marker heading `## Convention Packs`. If
+present, skip. Same idempotent pattern as
+`ensureGitignore()`.
+
+### 2. CLAUDE.md bridge file
+
+`uf init` creates or appends to `CLAUDE.md` a managed
+block that imports AGENTS.md and each deployed convention
+pack using Claude Code's `@path` import syntax.
+
+**Generated content (example for a Go project):**
+
+```
+# Unbound Force — managed by uf init
+
+@AGENTS.md
+
+## Convention Packs
+
+@.opencode/uf/packs/default.md
+@.opencode/uf/packs/severity.md
+@.opencode/uf/packs/go.md
+```
+
+The pack list is generated dynamically -- `uf init`
+enumerates which packs were actually deployed (based on
+`--lang` and `detectLang()`) and lists only those. This
+avoids broken `@imports` for absent packs.
+
+Detection: marker comment `# Unbound Force — managed by
+uf init`. If present, skip. If CLAUDE.md exists without
+the marker, append the block (preserving existing user
+content above).
+
+### 3. .cursorrules bridge file
+
+`uf init` creates or appends to `.cursorrules` a managed
+block that instructs Cursor's agent to read AGENTS.md
+and the applicable convention packs.
+
+**Generated content (example for a Go project):**
+
+```
+# Unbound Force — managed by uf init
+
+This project follows coding conventions defined in
+AGENTS.md and enforced through convention packs. Before
+writing or reviewing code, read the applicable convention
+pack(s) from .opencode/uf/packs/ and apply all rules
+marked [MUST].
+
+Available packs:
+- .opencode/uf/packs/default.md (language-agnostic)
+- .opencode/uf/packs/severity.md (severity definitions)
+- .opencode/uf/packs/go.md (Go-specific)
+```
+
+Detection: same marker pattern. Idempotent.
+
+### 4. Convention packs stay at .opencode/uf/packs/
+
+No file move. Packs remain at their current canonical
+location. The bridge files point to them. This avoids
+migration cost for existing adopters and keeps uf
+opinionated about OpenCode as the primary tool.
+
+## Design Rationale
+
+### Why not move packs to .agents/packs/?
+
+`.agents/` is not auto-discovered by any tool (OpenCode,
+Claude Code, or Cursor). Moving packs there adds
+migration cost without improving discovery. The bridge
+approach achieves the same cross-tool visibility without
+moving files.
+
+### Why not symlinks?
+
+Claude Code supports symlinks in `.claude/rules/`, but
+`@import` in CLAUDE.md is simpler and has no cross-
+platform issues. Cursor requires `.mdc` files with
+different frontmatter -- symlinks to `.md` files would
+not be recognized. Symlinks also have Windows
+compatibility concerns (`core.symlinks`, admin
+privileges).
+
+### Why bridges instead of native format conversion?
+
+Convention packs are pure Markdown content with numbered
+MUST/SHOULD rules. Any LLM can read and follow them
+regardless of the tool that loads them. The UF-specific
+frontmatter (`pack_id`, `language`, `version`) is
+harmless metadata that non-OpenCode tools ignore. No
+format conversion is needed -- only discovery.
+
+### Stacking behavior
+
+All three tools natively stack project-level and user-
+level config files. A contributor using Claude Code gets
+both their personal `~/.claude/CLAUDE.md` AND the
+project's committed `CLAUDE.md`. The bridge files add
+project conventions without overriding personal settings.
+
+### Cursor bridge limitation
+
+The `.cursorrules` bridge is weaker than the `CLAUDE.md`
+bridge by design. Claude Code's `@path` syntax auto-
+loads referenced files into context at session start.
+Cursor loads `.cursorrules` into context but the agent
+must then choose to read the referenced pack files --
+auto-loading via `@import` is not supported. This means
+Cursor users get the instruction to read packs, but
+the packs are not guaranteed to be in context for every
+interaction. This is a known limitation of Cursor's
+rule system and cannot be solved without Cursor adding
+an import mechanism.
+
+## Capabilities
+
+### New Capabilities
+
+- `ensureCLAUDEmd()`: Creates or appends managed block
+  to CLAUDE.md with @imports for AGENTS.md and deployed
+  convention packs. Idempotent via marker detection.
+- `ensureCursorrules()`: Creates or appends managed block
+  to .cursorrules with pack reference instructions.
+  Idempotent via marker detection.
+- `ensureAGENTSmdPackSection()`: Appends Convention Packs
+  section to AGENTS.md listing deployed packs.
+  Idempotent via heading detection.
+
+### Modified Capabilities
+
+- `Run()` in `scaffold.go`: Calls the three new ensure
+  functions after existing `ensureGitignore()`, before
+  sub-tool delegation.
+- `printSummary()`: Reports bridge file status (created,
+  skipped, appended).
+
+### Removed Capabilities
+
+None.
+
+## Impact
+
+- No breaking changes. Existing `uf init` behavior is
+  unchanged for OpenCode users.
+- New files (CLAUDE.md, .cursorrules) are only created
+  if absent. Existing files get a managed block appended.
+- Bridge files should be committed to version control
+  by maintainers so new contributors get convention
+  packs out-of-box regardless of their tool choice.
+- Supersedes `agent-agnostic-file-standard` (pack move
+  abandoned) and `multi-agent-init` (bridge approach
+  replaces --packs-only flag).
+
+## Supersedes
+
+- **agent-agnostic-file-standard**: The `.agents/packs/`
+  move is abandoned. AGENTS.md deduplication (removing
+  governance rules restated from the constitution) should
+  be extracted as a separate, independent change.
+- **multi-agent-init**: The `--packs-only` flag and
+  AGENTS.md pack section are replaced by the bridge
+  approach. The "Convention Packs" section concept
+  migrates here.
+
+## Constitution Alignment
+
+Assessed against the Unbound Force org constitution.
+
+### I. Autonomous Collaboration
+
+**Assessment**: PASS
+
+Convention packs remain self-describing artifacts.
+Bridge files are thin pointers -- no runtime coupling
+between tools. Each tool discovers packs independently
+through its native mechanism.
+
+### II. Composability First
+
+**Assessment**: PASS
+
+This change directly serves composability. Convention
+packs become usable by Claude Code and Cursor without
+requiring OpenCode. Each tool benefits independently.
+The bridge files are optional -- removing them does not
+break OpenCode functionality.
+
+### III. Observable Quality
+
+**Assessment**: N/A
+
+No change to output formats or quality metrics.
+
+### IV. Testability
+
+**Assessment**: PASS
+
+Each ensure function follows the established
+ensureGitignore() pattern with injectable I/O. Tests
+verify idempotency, marker detection, dynamic pack
+enumeration, and append-without-overwrite behavior.

--- a/openspec/changes/cross-tool-bridge/tasks.md
+++ b/openspec/changes/cross-tool-bridge/tasks.md
@@ -9,26 +9,34 @@
 ### Part 2: Implement ensureCLAUDEmd()
 
 - [x] Add `claudemdMarker` constant (`# Unbound Force — managed by uf init`)
-- [x] Implement `ensureCLAUDEmd()` that creates or appends managed block to CLAUDE.md with @imports for AGENTS.md and deployed convention packs -- idempotent via marker detection, uses opts.ReadFile/WriteFile
+- [x] Implement `ensureCLAUDEmd()` that creates or appends managed block to CLAUDE.md with @imports for AGENTS.md, cobalt-crush agent, deployed convention packs, and on-demand review agent references -- idempotent via marker detection, uses opts.ReadFile/WriteFile
 
 ### Part 3: Implement ensureCursorrules()
 
 - [x] Add `cursorrulesMarker` constant (same marker pattern)
-- [x] Implement `ensureCursorrules()` that creates or appends managed block to .cursorrules with pack reference instructions -- idempotent via marker detection, uses opts.ReadFile/WriteFile
+- [x] Implement `ensureCursorrules()` that creates or appends managed block to .cursorrules with pack reference instructions and agent file references -- idempotent via marker detection, uses opts.ReadFile/WriteFile
 
 ### Part 4: Wire into Run() and printSummary()
 
 - [x] Call ensureAGENTSmdPackSection(), ensureCLAUDEmd(), ensureCursorrules() after ensureGitignore() in Run(), append results to subResults
 - [x] Verify printSummary() handles new subToolResult entries (existing format should work)
 
-### Part 5: Tests
+### Part 5: Agent references in bridge files
+
+- [x] Add cobalt-crush-dev.md @import and Divisor review agent on-demand list to ensureCLAUDEmd() generated content
+- [x] Add cobalt-crush-dev.md reference and Divisor review agent list to ensureCursorrules() generated content
+- [x] Update proposal.md with agent reference design rationale and command file exclusion
+
+### Part 6: Tests
 
 - [x] Add TestEnsureAGENTSmdPackSection (fresh, existing without section, existing with section, idempotent)
 - [x] Add TestEnsureCLAUDEmd (fresh, existing without marker, existing with marker, idempotent)
 - [x] Add TestEnsureCursorrules (fresh, existing without marker, existing with marker, idempotent)
 - [x] Add TestCollectDeployedPacks for different languages (go, typescript, default)
+- [x] Verify agent references in CLAUDE.md tests (cobalt-crush @import, divisor-guard reference)
+- [x] Verify agent references in .cursorrules tests (cobalt-crush reference, divisor-guard reference)
 
-### Part 6: Verification
+### Part 7: Verification
 
 - [x] Run `go test -race -count=1 ./...` to verify all tests pass
 - [x] Run `golangci-lint run` to verify no lint issues

--- a/openspec/changes/cross-tool-bridge/tasks.md
+++ b/openspec/changes/cross-tool-bridge/tasks.md
@@ -1,0 +1,34 @@
+## Tasks
+
+### Part 1: Implement ensureAGENTSmdPackSection()
+
+- [x] Add `agentsmdPackMarker` constant (heading `## Convention Packs`)
+- [x] Implement `ensureAGENTSmdPackSection()` that appends Convention Packs section to AGENTS.md listing deployed packs -- idempotent via heading detection, uses opts.ReadFile/WriteFile
+- [x] Add `collectDeployedPacks()` helper that enumerates which pack files were deployed based on resolved language (reuse shouldDeployPack logic)
+
+### Part 2: Implement ensureCLAUDEmd()
+
+- [x] Add `claudemdMarker` constant (`# Unbound Force — managed by uf init`)
+- [x] Implement `ensureCLAUDEmd()` that creates or appends managed block to CLAUDE.md with @imports for AGENTS.md and deployed convention packs -- idempotent via marker detection, uses opts.ReadFile/WriteFile
+
+### Part 3: Implement ensureCursorrules()
+
+- [x] Add `cursorrulesMarker` constant (same marker pattern)
+- [x] Implement `ensureCursorrules()` that creates or appends managed block to .cursorrules with pack reference instructions -- idempotent via marker detection, uses opts.ReadFile/WriteFile
+
+### Part 4: Wire into Run() and printSummary()
+
+- [x] Call ensureAGENTSmdPackSection(), ensureCLAUDEmd(), ensureCursorrules() after ensureGitignore() in Run(), append results to subResults
+- [x] Verify printSummary() handles new subToolResult entries (existing format should work)
+
+### Part 5: Tests
+
+- [x] Add TestEnsureAGENTSmdPackSection (fresh, existing without section, existing with section, idempotent)
+- [x] Add TestEnsureCLAUDEmd (fresh, existing without marker, existing with marker, idempotent)
+- [x] Add TestEnsureCursorrules (fresh, existing without marker, existing with marker, idempotent)
+- [x] Add TestCollectDeployedPacks for different languages (go, typescript, default)
+
+### Part 6: Verification
+
+- [x] Run `go test -race -count=1 ./...` to verify all tests pass
+- [x] Run `golangci-lint run` to verify no lint issues


### PR DESCRIPTION
## Summary

- Generate thin bridge files during `uf init` so Claude Code and Cursor users discover convention packs and agent content automatically
- Convention packs stay at `.opencode/uf/packs/` (no file moves)
- Agent files stay at `.opencode/agents/` (no duplication)
- Command files explicitly excluded from bridging (OpenCode-specific execution format)

## Bridge Files Generated

| File | Tool | What it does |
|------|------|--------------|
| `CLAUDE.md` | Claude Code | `@import` for AGENTS.md, cobalt-crush agent, convention packs, + on-demand Divisor review agent list |
| `.cursorrules` | Cursor | Instructions to read AGENTS.md, convention packs, cobalt-crush agent, + Divisor review agent list |
| AGENTS.md section | All tools | "Convention Packs" section listing deployed packs by path |

## Portability Analysis

| Asset Type | Portable? | Bridge Strategy |
|---|---|---|
| Convention packs (`.opencode/uf/packs/`) | Fully | `@import` (Claude) / instruction (Cursor) |
| Agent bodies (`.opencode/agents/`) | Body only | `@import` cobalt-crush; on-demand list for Divisor |
| Commands (`.opencode/command/`) | Not portable | Excluded — uses `$ARGUMENTS`, `Task tool`, cross-command refs |

## Key Design Decisions

- **No file moves**: Packs and agents remain at OpenCode paths. Bridge files are pointers.
- **No symlinks**: `@import` is simpler and cross-platform. Cursor can't use symlinks (`.mdc` format mismatch).
- **Selective agent loading**: Only cobalt-crush auto-loaded (engineering philosophy). Divisor agents listed as on-demand references to avoid context bloat.
- **Commands excluded**: 44 command files (6155 lines) are OpenCode execution logic — would need full format conversion, not bridging. Workflow concepts already documented in AGENTS.md.
- **Idempotent**: All three ensure functions use marker detection (same pattern as `ensureGitignore()`).
- **Committed by maintainers**: Bridge files provide out-of-box experience for new contributors.

## Implementation

Three new functions in `internal/scaffold/scaffold.go`:
- `ensureAGENTSmdPackSection()` — appends Convention Packs section to AGENTS.md
- `ensureCLAUDEmd()` — creates/appends CLAUDE.md with `@import` block
- `ensureCursorrules()` — creates/appends .cursorrules with instruction block

Plus `collectDeployedPacks()` helper and 16 test functions.

## Supersedes

- `agent-agnostic-file-standard` pack move (archived)
- `multi-agent-init` `--packs-only` flag (replaced by bridge approach)