### PR TITLE
feat: mount parent directory in sandbox for sibling repo access

### DIFF
--- a/cmd/unbound-force/sandbox.go
+++ b/cmd/unbound-force/sandbox.go
@@ -209,6 +209,7 @@ type sandboxStartParams struct {
 	projectDir string
 	mode       string
 	detach     bool
+	noParent   bool
 	image      string
 	memory     string
 	cpus       string
@@ -222,6 +223,7 @@ func runSandboxStart(p sandboxStartParams) error {
 		ProjectDir:  p.projectDir,
 		Mode:        p.mode,
 		Detach:      p.detach,
+		NoParent:    p.noParent,
 		Image:       p.image,
 		Memory:      p.memory,
 		CPUs:        p.cpus,
@@ -246,6 +248,7 @@ directly to the host filesystem).`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			mode, _ := cmd.Flags().GetString("mode")
 			detach, _ := cmd.Flags().GetBool("detach")
+			noParent, _ := cmd.Flags().GetBool("no-parent")
 			image, _ := cmd.Flags().GetString("image")
 			memory, _ := cmd.Flags().GetString("memory")
 			cpus, _ := cmd.Flags().GetString("cpus")
@@ -260,6 +263,7 @@ directly to the host filesystem).`,
 				projectDir: cwd,
 				mode:       mode,
 				detach:     detach,
+				noParent:   noParent,
 				image:      image,
 				memory:     memory,
 				cpus:       cpus,
@@ -282,6 +286,8 @@ directly to the host filesystem).`,
 		"Container CPU limit (default \"4\")")
 	cmd.Flags().String("backend", "auto",
 		"Backend: auto, podman, or che")
+	cmd.Flags().Bool("no-parent", false,
+		"Mount only the project directory (disable parent directory mount)")
 
 	return cmd
 }

--- a/internal/sandbox/config.go
+++ b/internal/sandbox/config.go
@@ -193,12 +193,32 @@ func googleCloudCredentialMounts(opts Options, platform PlatformConfig, gatewayA
 	return args
 }
 
-// buildVolumeMounts constructs -v flags for the project
-// directory mount. Isolated mode uses :ro (read-only),
-// direct mode uses read-write. The :Z suffix is appended
-// when SELinux is enforcing (per research.md R3).
+// useParentMount returns true if the parent directory
+// should be mounted instead of the project directory.
+// Falls back to project-only mount when NoParent is set
+// or when the parent is the filesystem root (FR-042).
+func useParentMount(opts Options) bool {
+	if opts.NoParent {
+		return false
+	}
+	parent := filepath.Dir(opts.ProjectDir)
+	return parent != "/" && parent != opts.ProjectDir
+}
+
+// buildVolumeMounts constructs -v flags for the workspace
+// mount. By default, mounts the project's parent directory
+// at /workspace so sibling repos are accessible via
+// relative paths (e.g., ../dewey). The container's workdir
+// is set to /workspace/<project-basename> by buildRunArgs.
+// When NoParent is true or the project is at the filesystem
+// root, mounts only the project directory (FR-040, FR-041,
+// FR-042). Isolated mode uses :ro, SELinux uses :Z (FR-043).
 func buildVolumeMounts(opts Options, platform PlatformConfig) []string {
-	mount := fmt.Sprintf("%s:/workspace", opts.ProjectDir)
+	mountSource := opts.ProjectDir
+	if useParentMount(opts) {
+		mountSource = filepath.Dir(opts.ProjectDir)
+	}
+	mount := fmt.Sprintf("%s:/workspace", mountSource)
 	if opts.Mode == ModeIsolated {
 		mount += ":ro"
 	}
@@ -242,6 +262,15 @@ func buildRunArgs(opts Options, platform PlatformConfig, gatewayActive bool, gat
 	// Resource limits.
 	args = append(args, "--memory", opts.Memory)
 	args = append(args, "--cpus", opts.CPUs)
+
+	// Working directory: when parent mount is active,
+	// set workdir to the project subdirectory within
+	// the parent mount (FR-040).
+	if useParentMount(opts) {
+		workdir := fmt.Sprintf("/workspace/%s",
+			filepath.Base(opts.ProjectDir))
+		args = append(args, "--workdir", workdir)
+	}
 
 	// Image name (last argument).
 	args = append(args, opts.Image)

--- a/internal/sandbox/sandbox.go
+++ b/internal/sandbox/sandbox.go
@@ -30,6 +30,14 @@ type Options struct {
 	// Yes skips confirmation prompts (for extract).
 	Yes bool
 
+	// NoParent disables parent directory mounting. When
+	// false (default), the project's parent directory is
+	// mounted at /workspace so sibling repos are
+	// accessible via relative paths (e.g., ../dewey).
+	// When true, only the project directory is mounted
+	// (pre-Spec 034 behavior).
+	NoParent bool
+
 	// Image is the container image to use.
 	// Default: "quay.io/unbound-force/opencode-dev:latest".
 	// Overridden by UF_SANDBOX_IMAGE env var or --image flag.

--- a/internal/sandbox/sandbox_test.go
+++ b/internal/sandbox/sandbox_test.go
@@ -158,9 +158,13 @@ func TestBuildRunArgs_Isolated(t *testing.T) {
 	if !strings.Contains(joined, "--cpus 4") {
 		t.Errorf("expected --cpus 4, got: %s", joined)
 	}
-	// Verify read-only mount for isolated mode.
-	if !strings.Contains(joined, "/tmp/test-project:/workspace:ro") {
-		t.Errorf("expected :ro volume mount for isolated mode, got: %s", joined)
+	// Verify parent directory mounted with :ro for isolated mode.
+	if !strings.Contains(joined, "/tmp:/workspace:ro") {
+		t.Errorf("expected parent mount /tmp:/workspace:ro, got: %s", joined)
+	}
+	// Verify workdir set to project subdirectory.
+	if !strings.Contains(joined, "--workdir /workspace/test-project") {
+		t.Errorf("expected --workdir /workspace/test-project, got: %s", joined)
 	}
 	// Verify image is last argument.
 	if args[len(args)-1] != DefaultImage {
@@ -180,12 +184,101 @@ func TestBuildRunArgs_Direct(t *testing.T) {
 
 	joined := strings.Join(args, " ")
 
-	// Verify read-write mount (no :ro) for the project directory.
-	if !strings.Contains(joined, "/tmp/test-project:/workspace") {
-		t.Errorf("expected volume mount, got: %s", joined)
+	// Verify parent directory mounted read-write (no :ro) for direct mode.
+	if !strings.Contains(joined, "/tmp:/workspace") {
+		t.Errorf("expected parent mount /tmp:/workspace, got: %s", joined)
 	}
-	if strings.Contains(joined, "/tmp/test-project:/workspace:ro") {
-		t.Errorf("expected no :ro on project mount for direct mode, got: %s", joined)
+	if strings.Contains(joined, "/tmp:/workspace:ro") {
+		t.Errorf("expected no :ro on parent mount for direct mode, got: %s", joined)
+	}
+	// Verify workdir set to project subdirectory.
+	if !strings.Contains(joined, "--workdir /workspace/test-project") {
+		t.Errorf("expected --workdir /workspace/test-project, got: %s", joined)
+	}
+}
+
+func TestBuildVolumeMounts_NoParentFlag(t *testing.T) {
+	opts := testOpts()
+	opts.Mode = ModeDirect
+	opts.NoParent = true
+
+	platform := PlatformConfig{OS: "darwin", Arch: "arm64"}
+	mounts := buildVolumeMounts(opts, platform)
+	joined := strings.Join(mounts, " ")
+
+	// With --no-parent, project dir mounted directly.
+	if !strings.Contains(joined, "/tmp/test-project:/workspace") {
+		t.Errorf("expected project-only mount, got: %s", joined)
+	}
+	// No parent mount.
+	if strings.Contains(joined, "/tmp:/workspace") {
+		t.Errorf("expected no parent mount with --no-parent, got: %s", joined)
+	}
+}
+
+func TestBuildRunArgs_NoParentNoWorkdir(t *testing.T) {
+	opts := testOpts()
+	opts.Mode = ModeDirect
+	opts.NoParent = true
+	opts.Image = DefaultImage
+	opts.Memory = DefaultMemory
+	opts.CPUs = DefaultCPUs
+
+	platform := PlatformConfig{OS: "darwin", Arch: "arm64"}
+	args := buildRunArgs(opts, platform, false, 0)
+	joined := strings.Join(args, " ")
+
+	// No --workdir when --no-parent is set.
+	if strings.Contains(joined, "--workdir") {
+		t.Errorf("expected no --workdir with --no-parent, got: %s", joined)
+	}
+}
+
+func TestBuildVolumeMounts_RootFallback(t *testing.T) {
+	opts := testOpts()
+	opts.ProjectDir = "/myproject"
+	opts.Mode = ModeDirect
+
+	platform := PlatformConfig{OS: "darwin", Arch: "arm64"}
+	mounts := buildVolumeMounts(opts, platform)
+	joined := strings.Join(mounts, " ")
+
+	// Parent of /myproject is /, should fall back to
+	// project-only mount.
+	if !strings.Contains(joined, "/myproject:/workspace") {
+		t.Errorf("expected project-only mount for root parent, got: %s", joined)
+	}
+}
+
+func TestBuildRunArgs_RootFallbackNoWorkdir(t *testing.T) {
+	opts := testOpts()
+	opts.ProjectDir = "/myproject"
+	opts.Mode = ModeDirect
+	opts.Image = DefaultImage
+	opts.Memory = DefaultMemory
+	opts.CPUs = DefaultCPUs
+
+	platform := PlatformConfig{OS: "darwin", Arch: "arm64"}
+	args := buildRunArgs(opts, platform, false, 0)
+	joined := strings.Join(args, " ")
+
+	// No --workdir when parent is root (fallback).
+	if strings.Contains(joined, "--workdir") {
+		t.Errorf("expected no --workdir for root parent fallback, got: %s", joined)
+	}
+}
+
+func TestBuildVolumeMounts_ParentMountSELinux(t *testing.T) {
+	opts := testOpts()
+	opts.Mode = ModeIsolated // SELinux + isolated = :ro,Z
+
+	platform := PlatformConfig{OS: "linux", Arch: "amd64", SELinux: true}
+	mounts := buildVolumeMounts(opts, platform)
+	joined := strings.Join(mounts, " ")
+
+	// Parent mount with isolated mode + SELinux: :ro,Z.
+	if !strings.Contains(joined, "/tmp:/workspace:ro,Z") {
+		t.Errorf("expected :ro,Z on parent mount with SELinux, got: %s", joined)
 	}
 }
 

--- a/openspec/changes/sandbox-parent-mount/.openspec.yaml
+++ b/openspec/changes/sandbox-parent-mount/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: unbound-force
+created: 2026-04-23

--- a/openspec/changes/sandbox-parent-mount/design.md
+++ b/openspec/changes/sandbox-parent-mount/design.md
@@ -1,0 +1,108 @@
+## Context
+
+The sandbox container currently mounts only the project
+directory at `/workspace`. Dewey's `sources.yaml` uses
+relative paths like `../dewey` to index sibling repos,
+but these paths don't resolve inside the container
+because the parent directory isn't mounted. This means
+Dewey runs in degraded mode inside the sandbox — only
+the local project is indexed, losing cross-repo semantic
+search.
+
+## Goals / Non-Goals
+
+### Goals
+- Dewey indexes sibling repos inside the sandbox
+- Generic solution — works for any project layout, not
+  just unbound-force
+- Backward compatible via `--no-parent` opt-out flag
+- No changes to Dewey config or `opencode.json`
+
+### Non-Goals
+- Changing Dewey's indexing behavior or sources.yaml
+- Supporting arbitrary multi-directory mounts
+- Mounting directories that aren't the immediate parent
+- Changing how `uf sandbox extract` works (patches are
+  still generated from the project subdirectory)
+
+## Decisions
+
+**D1: Mount parent at `/workspace`, set `--workdir`**
+
+Mount `filepath.Dir(ProjectDir)` at `/workspace` and
+add `--workdir /workspace/<basename>` to the podman
+args. This preserves the convention that OpenCode's
+CWD is the project root, while making the parent
+accessible at `/workspace`.
+
+Rationale: This requires zero changes to Dewey,
+OpenCode, or any tool config. Relative paths like
+`../dewey` resolve correctly because the parent is
+the mount root. The `--workdir` flag ensures OpenCode
+starts in the correct project subdirectory.
+
+**D2: Default on, `--no-parent` to opt out**
+
+The parent mount is the default behavior. Users who
+don't want sibling access (e.g., security-sensitive
+environments) can pass `--no-parent` to get the
+current project-only mount.
+
+Rationale: The common case benefits from cross-repo
+indexing. The flag name `--no-parent` clearly
+communicates what it disables. This follows the Go
+convention of `--no-*` flags for disabling defaults
+(e.g., `--no-verify` in git).
+
+**D3: Fall back to project-only for root-level projects**
+
+If `filepath.Dir(ProjectDir)` returns `/`, fall back
+to project-only mount (same as `--no-parent`). Log a
+debug message explaining why.
+
+Rationale: Mounting `/` as a container volume is
+dangerous and likely unintentional. This edge case
+is rare but should fail safely.
+
+**D4: Same read/write mode for parent mount**
+
+The parent mount uses the same mode as the project
+mount — read-write in direct mode, read-only in
+isolated mode. No separate mode for sibling repos.
+
+Rationale: Simplicity. The mode flag controls the
+entire workspace, not individual subdirectories.
+Sibling repos being writable in direct mode is an
+acceptable trade-off given the development context.
+
+**D5: `NoParent` field on `Options` struct**
+
+Add a `NoParent bool` field to the `Options` struct,
+consistent with existing boolean fields (`Detach`,
+`Yes`, `Force`). Wired from the `--no-parent` CLI flag.
+
+Rationale: Follows the established injectable options
+pattern (Constitution Principle IV — Testability).
+The field is testable without CLI parsing.
+
+## Risks / Trade-offs
+
+- **Risk**: Sibling repos are writable in direct mode.
+  A bug in a tool could modify files in a sibling repo.
+  **Mitigation**: Direct mode already trusts the
+  container with write access. Users who want isolation
+  should use isolated mode (read-only) or `--no-parent`.
+
+- **Risk**: Parent directory may contain many large
+  repos, increasing the container's visible filesystem.
+  **Mitigation**: Podman volume mounts are bind mounts —
+  they don't copy data. There is no performance or
+  storage impact from mounting a larger directory.
+
+- **Trade-off**: The `/workspace` path now refers to
+  the parent directory, not the project. Tools that
+  assume `/workspace` is the project root will break.
+  **Mitigation**: The `--workdir` flag sets the CWD
+  correctly. OpenCode and all tools that use CWD (not
+  hardcoded `/workspace`) work correctly. The sandbox
+  `extract` command uses CWD for git operations.

--- a/openspec/changes/sandbox-parent-mount/proposal.md
+++ b/openspec/changes/sandbox-parent-mount/proposal.md
@@ -1,0 +1,117 @@
+## Why
+
+When the sandbox container mounts only the project
+directory at `/workspace`, tools like Dewey that use
+relative paths (`../dewey`, `../gaze`) to index sibling
+repositories cannot access them. Dewey's `sources.yaml`
+defines disk sources as relative paths from the project
+root (e.g., `path: "../dewey"`), but inside the
+container these resolve to `/dewey` which does not exist.
+
+Mounting the project's parent directory instead gives
+the container access to the full workspace, allowing
+Dewey and any other tool to traverse sibling directories
+naturally.
+
+## What Changes
+
+### Volume mount target
+
+Currently: `ProjectDir` → `/workspace`
+```
+-v /Users/j/Projects/unbound-force/unbound-force:/workspace
+```
+
+After: `filepath.Dir(ProjectDir)` → `/workspace`
+with `--workdir /workspace/<basename>`
+```
+-v /Users/j/Projects/unbound-force:/workspace
+--workdir /workspace/unbound-force
+```
+
+### New CLI flag
+
+Add `--no-parent` flag to `uf sandbox start` that
+disables parent mounting and uses the current behavior
+(project-only mount). Default behavior is parent mount.
+
+### Edge case handling
+
+If `filepath.Dir(ProjectDir)` returns `/` (project is
+at filesystem root), fall back to project-only mount
+automatically and log a warning.
+
+## Capabilities
+
+### New Capabilities
+- `Parent directory mount`: The sandbox mounts the
+  project's parent directory at `/workspace` by
+  default, giving container tools access to sibling
+  directories via relative paths.
+- `--no-parent flag`: Opt-out flag on `uf sandbox start`
+  to disable parent mounting and use project-only mount
+  (current behavior).
+
+### Modified Capabilities
+- `buildVolumeMounts()`: Mounts parent directory
+  instead of project directory when `--no-parent` is
+  not set.
+- `buildRunArgs()`: Adds `--workdir` to set the
+  container's working directory to the project
+  subdirectory within the parent mount.
+
+### Removed Capabilities
+- None.
+
+## Impact
+
+- `internal/sandbox/config.go`: Modified
+  `buildVolumeMounts()` and `buildRunArgs()` to support
+  parent mount with workdir.
+- `internal/sandbox/sandbox.go`: Add `NoParent bool`
+  field to `Options` struct.
+- `cmd/unbound-force/sandbox.go`: Register `--no-parent`
+  flag on the `start` subcommand.
+- `internal/sandbox/sandbox_test.go`: Update mount
+  assertions, add `--no-parent` tests, add edge case
+  tests.
+
+## Constitution Alignment
+
+Assessed against the Unbound Force org constitution.
+
+### I. Autonomous Collaboration
+
+**Assessment**: PASS
+
+No inter-hero communication is affected. The mount
+change is purely a container configuration concern —
+no artifacts or protocols change.
+
+### II. Composability First
+
+**Assessment**: PASS
+
+The `--no-parent` flag preserves backward compatibility.
+Users who don't want parent mounting can opt out. The
+sandbox remains independently usable with either mount
+mode.
+
+### III. Observable Quality
+
+**Assessment**: PASS
+
+No output formats change. The sandbox status output
+continues to show the project directory. The mount
+target is an internal implementation detail.
+
+### IV. Testability
+
+**Assessment**: PASS
+
+`buildVolumeMounts()` and `buildRunArgs()` remain
+testable in isolation via injected `Options` — no
+external services needed. The `NoParent` field is a
+simple boolean that changes the mount path
+calculation. All edge cases (root directory, SELinux,
+isolated vs direct mode) are testable via unit tests.

--- a/openspec/changes/sandbox-parent-mount/specs/parent-mount.md
+++ b/openspec/changes/sandbox-parent-mount/specs/parent-mount.md
@@ -1,0 +1,106 @@
+## ADDED Requirements
+
+### Requirement: Parent Directory Mount (FR-040)
+
+The sandbox MUST mount the project's parent directory
+at `/workspace` by default, and set the container's
+working directory to `/workspace/<project-basename>`
+using the `--workdir` flag.
+
+#### Scenario: Default parent mount
+
+- **GIVEN** `ProjectDir` is
+  `/Users/j/Projects/org/myproject`
+- **WHEN** `uf sandbox start` is run without
+  `--no-parent`
+- **THEN** the container volume mount is
+  `-v /Users/j/Projects/org:/workspace`
+- **AND** the container working directory is
+  `--workdir /workspace/myproject`
+
+#### Scenario: Sibling directory accessible
+
+- **GIVEN** the parent directory contains sibling repos
+  `myproject/`, `dewey/`, `gaze/`
+- **WHEN** a tool inside the container reads
+  `../dewey/README.md`
+- **THEN** the file is accessible at
+  `/workspace/dewey/README.md`
+
+### Requirement: No-Parent Flag (FR-041)
+
+The `uf sandbox start` command MUST accept a
+`--no-parent` flag that disables parent directory
+mounting. When `--no-parent` is set, the sandbox
+MUST use the current behavior: mount `ProjectDir`
+directly at `/workspace` without `--workdir`.
+
+#### Scenario: Project-only mount with flag
+
+- **GIVEN** `ProjectDir` is
+  `/Users/j/Projects/org/myproject`
+- **WHEN** `uf sandbox start --no-parent` is run
+- **THEN** the container volume mount is
+  `-v /Users/j/Projects/org/myproject:/workspace`
+- **AND** no `--workdir` flag is set
+
+### Requirement: Root Directory Fallback (FR-042)
+
+When `filepath.Dir(ProjectDir)` returns `/` (project
+is at the filesystem root), the sandbox MUST fall back
+to project-only mounting (same as `--no-parent`) and
+SHOULD log a debug message explaining the fallback.
+
+#### Scenario: Project at filesystem root
+
+- **GIVEN** `ProjectDir` is `/myproject`
+- **WHEN** `uf sandbox start` is run
+- **THEN** the container volume mount is
+  `-v /myproject:/workspace`
+- **AND** no `--workdir` flag is set
+- **AND** the behavior matches `--no-parent`
+
+### Requirement: Mode Preservation (FR-043)
+
+The parent directory mount MUST respect the existing
+mount mode: read-only (`:ro`) in isolated mode,
+read-write in direct mode. The SELinux `:Z` flag
+MUST be applied when `platform.SELinux` is true.
+
+#### Scenario: Isolated mode with parent mount
+
+- **GIVEN** `Mode` is `isolated`
+- **WHEN** the sandbox starts with parent mount
+- **THEN** the volume mount includes `:ro`
+  (e.g., `-v /parent:/workspace:ro`)
+
+#### Scenario: Direct mode with parent mount
+
+- **GIVEN** `Mode` is `direct`
+- **WHEN** the sandbox starts with parent mount
+- **THEN** the volume mount does NOT include `:ro`
+
+#### Scenario: SELinux with parent mount
+
+- **GIVEN** `platform.SELinux` is true and `Mode`
+  is `direct`
+- **WHEN** the sandbox starts with parent mount
+- **THEN** the volume mount includes `,Z`
+  (e.g., `-v /parent:/workspace:Z`)
+
+## MODIFIED Requirements
+
+### Requirement: Volume Mount Target (FR-028 from Spec 028)
+
+The sandbox volume mount target MUST be the project's
+parent directory (not the project directory itself)
+by default. The `--workdir` flag MUST be set to
+`/workspace/<project-basename>` to maintain the
+correct working directory for OpenCode.
+
+Previously: The sandbox mounted `ProjectDir` directly
+at `/workspace` with no `--workdir` flag.
+
+## REMOVED Requirements
+
+None.

--- a/openspec/changes/sandbox-parent-mount/tasks.md
+++ b/openspec/changes/sandbox-parent-mount/tasks.md
@@ -1,0 +1,33 @@
+## 1. Options & CLI
+
+- [x] 1.1 Add `NoParent bool` field to `Options` struct in `internal/sandbox/sandbox.go`
+- [x] 1.2 Add `--no-parent` flag to the `start` subcommand in `cmd/unbound-force/sandbox.go`, wired to `opts.NoParent`
+
+## 2. Volume Mount
+
+- [x] 2.1 Update `buildVolumeMounts()` in `internal/sandbox/config.go` — when `opts.NoParent` is false (default), mount `filepath.Dir(opts.ProjectDir)` at `/workspace` instead of `opts.ProjectDir`. When `opts.NoParent` is true, use current behavior (project-only mount).
+- [x] 2.2 Add root directory fallback in `buildVolumeMounts()` — if `filepath.Dir(opts.ProjectDir)` returns `/`, fall back to project-only mount regardless of `NoParent` setting. Log at debug level.
+- [x] 2.3 Preserve `:ro` suffix for isolated mode and `,Z` suffix for SELinux on the parent mount (FR-043).
+
+## 3. Working Directory
+
+- [x] 3.1 Update `buildRunArgs()` in `internal/sandbox/config.go` — when parent mount is active (not `NoParent` and not root fallback), add `--workdir /workspace/<filepath.Base(opts.ProjectDir)>` to the podman args. Insert before the image name argument.
+
+## 4. Tests
+
+- [x] 4.1 Add `TestBuildVolumeMounts_ParentMount` in `internal/sandbox/sandbox_test.go` — verify parent directory is mounted at `/workspace` and `--workdir` is set to `/workspace/<basename>`
+- [x] 4.2 Add `TestBuildVolumeMounts_NoParentFlag` in `internal/sandbox/sandbox_test.go` — verify `--no-parent` uses project-only mount with no `--workdir`
+- [x] 4.3 Add `TestBuildVolumeMounts_RootFallback` in `internal/sandbox/sandbox_test.go` — verify `ProjectDir=/myproject` falls back to project-only mount
+- [x] 4.4 Add `TestBuildVolumeMounts_ParentMountIsolated` in `internal/sandbox/sandbox_test.go` — verify `:ro` is applied to parent mount in isolated mode
+- [x] 4.5 Add `TestBuildVolumeMounts_ParentMountSELinux` in `internal/sandbox/sandbox_test.go` — verify `,Z` is applied to parent mount when SELinux is true
+- [x] 4.6 Update existing `TestBuildRunArgs_*` tests to account for new `--workdir` argument in output
+
+## 5. Validation
+
+- [x] 5.1 Run `go test -race -count=1 ./internal/sandbox/...` — all tests pass
+- [x] 5.2 Run `go build ./...` — build succeeds
+- [x] 5.3 Run `golangci-lint run` — no lint errors
+- [x] 5.4 Verify constitution alignment: Testability (all new logic testable via `Options` injection, no external services required)
+
+<!-- spec-review: passed -->
+<!-- code-review: passed -->


### PR DESCRIPTION
## Summary

- Mount the project parent directory at /workspace by default so Dewey can access sibling repos via relative paths
- Set --workdir /workspace/<basename> to maintain correct CWD for OpenCode
- Add --no-parent flag to uf sandbox start to opt out (project-only mount)
- Fall back to project-only mount when parent is filesystem root
- 5 new tests, 2 updated tests