### PR TITLE
feat(agents): enforce spec paths in AGENTS.md Recent Changes entries

### DIFF
--- a/.opencode/agents/divisor-curator.md
+++ b/.opencode/agents/divisor-curator.md
@@ -100,6 +100,7 @@ Classify files as user-facing or internal based on path patterns:
 - Does this change modify user-facing behavior (CLI commands, agent capabilities, installation steps, workflows)?
 - If yes:
   - Was `AGENTS.md` updated (Recent Changes, Project Structure, Active Technologies as applicable)?
+  - Do Recent Changes entries include `Spec:` paths to canonical specs under `openspec/specs/`?
   - Was `README.md` updated if project description or install steps changed?
 - If documentation updates were needed but missing, flag as MEDIUM.
 - Skip for internal-only changes (refactoring, test-only, CI-only).

--- a/.opencode/agents/divisor-guard.md
+++ b/.opencode/agents/divisor-guard.md
@@ -99,6 +99,7 @@ Evaluate all recent changes (staged, unstaged, and untracked files). Use `git di
 - Does this change modify user-facing behavior, CLI commands, agent capabilities, or workflows?
 - If yes:
   - Was AGENTS.md updated (Recent Changes, Project Structure, Active Technologies as applicable)?
+  - Do Recent Changes entries include `Spec:` paths to canonical specs under `openspec/specs/`?
   - Was README.md updated if project description or install steps changed?
 - If documentation updates were needed but missing, flag as MEDIUM.
 - Skip for internal-only changes (refactoring, test-only, CI-only).

--- a/.opencode/agents/divisor-scribe.md
+++ b/.opencode/agents/divisor-scribe.md
@@ -64,8 +64,12 @@ When asked to update AGENTS.md:
 1. Read the full current AGENTS.md
 2. Identify what sections need updating (Project Structure, Active Technologies, Recent Changes, etc.)
 3. Follow the existing format precisely — match indentation, table alignment, bullet style
-4. Recent Changes entries MUST follow the established pattern: spec number, colon, summary of changes with file counts and task counts
-5. Verify all file paths, line references, and counts against the actual codebase
+4. Recent Changes entries MUST follow this format:
+   - Line 1: `- <change-name>: <summary of what changed>`
+   - Line 2+: `  - Spec: \`openspec/specs/<capability>/spec.md\`` (one per capability)
+   - Every entry MUST include at least one Spec path pointing to the canonical spec under `openspec/specs/`. This applies to both OpenSpec and SpecKit workflows.
+   - If the change has no spec (e.g., pure chore/infra), use `  - Spec: _(none — <reason>)_`
+5. Verify all file paths, line references, and spec paths against the actual codebase
 
 ### 3. Spec Descriptions
 

--- a/internal/scaffold/assets/opencode/agents/divisor-curator.md
+++ b/internal/scaffold/assets/opencode/agents/divisor-curator.md
@@ -100,6 +100,7 @@ Classify files as user-facing or internal based on path patterns:
 - Does this change modify user-facing behavior (CLI commands, agent capabilities, installation steps, workflows)?
 - If yes:
   - Was `AGENTS.md` updated (Recent Changes, Project Structure, Active Technologies as applicable)?
+  - Do Recent Changes entries include `Spec:` paths to canonical specs under `openspec/specs/`?
   - Was `README.md` updated if project description or install steps changed?
 - If documentation updates were needed but missing, flag as MEDIUM.
 - Skip for internal-only changes (refactoring, test-only, CI-only).

--- a/internal/scaffold/assets/opencode/agents/divisor-guard.md
+++ b/internal/scaffold/assets/opencode/agents/divisor-guard.md
@@ -99,6 +99,7 @@ Evaluate all recent changes (staged, unstaged, and untracked files). Use `git di
 - Does this change modify user-facing behavior, CLI commands, agent capabilities, or workflows?
 - If yes:
   - Was AGENTS.md updated (Recent Changes, Project Structure, Active Technologies as applicable)?
+  - Do Recent Changes entries include `Spec:` paths to canonical specs under `openspec/specs/`?
   - Was README.md updated if project description or install steps changed?
 - If documentation updates were needed but missing, flag as MEDIUM.
 - Skip for internal-only changes (refactoring, test-only, CI-only).

--- a/internal/scaffold/assets/opencode/agents/divisor-scribe.md
+++ b/internal/scaffold/assets/opencode/agents/divisor-scribe.md
@@ -64,8 +64,12 @@ When asked to update AGENTS.md:
 1. Read the full current AGENTS.md
 2. Identify what sections need updating (Project Structure, Active Technologies, Recent Changes, etc.)
 3. Follow the existing format precisely — match indentation, table alignment, bullet style
-4. Recent Changes entries MUST follow the established pattern: spec number, colon, summary of changes with file counts and task counts
-5. Verify all file paths, line references, and counts against the actual codebase
+4. Recent Changes entries MUST follow this format:
+   - Line 1: `- <change-name>: <summary of what changed>`
+   - Line 2+: `  - Spec: \`openspec/specs/<capability>/spec.md\`` (one per capability)
+   - Every entry MUST include at least one Spec path pointing to the canonical spec under `openspec/specs/`. This applies to both OpenSpec and SpecKit workflows.
+   - If the change has no spec (e.g., pure chore/infra), use `  - Spec: _(none — <reason>)_`
+5. Verify all file paths, line references, and spec paths against the actual codebase
 
 ### 3. Spec Descriptions
 


### PR DESCRIPTION
## Summary

- Update divisor-scribe AGENTS.md format instructions to require `Spec:` paths pointing to canonical specs under `openspec/specs/` for every Recent Changes entry
- Add spec path verification check to divisor-guard and divisor-curator review checklists
- Applies to both OpenSpec and SpecKit workflows; chore/infra changes without specs use a `_(none — <reason>)_` marker

## Motivation

AGENTS.md Recent Changes entries currently provide a summary but no link to the underlying specification. Since projects use spec-driven development, agents reviewing PRs or proposing changes need to follow references from Recent Changes to canonical specs for detailed requirements context. This change enforces that link at three points:

1. **Scribe** (format authority): defines the exact format with `Spec:` paths
2. **Guard** (review gate): verifies spec paths are present
3. **Curator** (review gate): verifies spec paths are present

## Example

```markdown
## Recent Changes

- migrate-gemara-sdk: Migrated from ossf/gemara to go-gemara v0.3.0
  - Spec: `openspec/specs/gemara-evidence-attributes/spec.md`
```