### PR TITLE
fix: pass WORKSPACE env var so entrypoint sets correct project CWD

### DIFF
--- a/internal/sandbox/config.go
+++ b/internal/sandbox/config.go
@@ -265,11 +265,15 @@ func buildRunArgs(opts Options, platform PlatformConfig, gatewayActive bool, gat
 
 	// Working directory: when parent mount is active,
 	// set workdir to the project subdirectory within
-	// the parent mount (FR-040).
+	// the parent mount (FR-040). Also set WORKSPACE
+	// env var so the entrypoint's cd "$WORKSPACE" goes
+	// to the project, not the parent (FR-044).
 	if useParentMount(opts) {
-		workdir := fmt.Sprintf("/workspace/%s",
+		projectSubdir := fmt.Sprintf("/workspace/%s",
 			filepath.Base(opts.ProjectDir))
-		args = append(args, "--workdir", workdir)
+		args = append(args, "--workdir", projectSubdir)
+		args = append(args, "-e",
+			fmt.Sprintf("WORKSPACE=%s", projectSubdir))
 	}
 
 	// Image name (last argument).

--- a/internal/sandbox/sandbox_test.go
+++ b/internal/sandbox/sandbox_test.go
@@ -166,6 +166,10 @@ func TestBuildRunArgs_Isolated(t *testing.T) {
 	if !strings.Contains(joined, "--workdir /workspace/test-project") {
 		t.Errorf("expected --workdir /workspace/test-project, got: %s", joined)
 	}
+	// Verify WORKSPACE env var set for entrypoint (FR-044).
+	if !strings.Contains(joined, "WORKSPACE=/workspace/test-project") {
+		t.Errorf("expected WORKSPACE=/workspace/test-project, got: %s", joined)
+	}
 	// Verify image is last argument.
 	if args[len(args)-1] != DefaultImage {
 		t.Errorf("expected image as last arg, got: %s", args[len(args)-1])
@@ -194,6 +198,10 @@ func TestBuildRunArgs_Direct(t *testing.T) {
 	// Verify workdir set to project subdirectory.
 	if !strings.Contains(joined, "--workdir /workspace/test-project") {
 		t.Errorf("expected --workdir /workspace/test-project, got: %s", joined)
+	}
+	// Verify WORKSPACE env var set for entrypoint (FR-044).
+	if !strings.Contains(joined, "WORKSPACE=/workspace/test-project") {
+		t.Errorf("expected WORKSPACE=/workspace/test-project, got: %s", joined)
 	}
 }
 
@@ -232,6 +240,10 @@ func TestBuildRunArgs_NoParentNoWorkdir(t *testing.T) {
 	if strings.Contains(joined, "--workdir") {
 		t.Errorf("expected no --workdir with --no-parent, got: %s", joined)
 	}
+	// No WORKSPACE env var when --no-parent is set (FR-044).
+	if strings.Contains(joined, "WORKSPACE=") {
+		t.Errorf("expected no WORKSPACE with --no-parent, got: %s", joined)
+	}
 }
 
 func TestBuildVolumeMounts_RootFallback(t *testing.T) {
@@ -265,6 +277,10 @@ func TestBuildRunArgs_RootFallbackNoWorkdir(t *testing.T) {
 	// No --workdir when parent is root (fallback).
 	if strings.Contains(joined, "--workdir") {
 		t.Errorf("expected no --workdir for root parent fallback, got: %s", joined)
+	}
+	// No WORKSPACE when parent is root (FR-044).
+	if strings.Contains(joined, "WORKSPACE=") {
+		t.Errorf("expected no WORKSPACE for root parent fallback, got: %s", joined)
 	}
 }
 

--- a/openspec/changes/fix-sandbox-workspace-env/.openspec.yaml
+++ b/openspec/changes/fix-sandbox-workspace-env/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: unbound-force
+created: 2026-04-24

--- a/openspec/changes/fix-sandbox-workspace-env/design.md
+++ b/openspec/changes/fix-sandbox-workspace-env/design.md
@@ -1,0 +1,47 @@
+## Context
+
+The container image's `entrypoint.sh` runs
+`cd "$WORKSPACE"` early in startup, where `WORKSPACE`
+defaults to `/workspace`. PR #119 set `--workdir` on
+the container, but the entrypoint overrides it before
+OpenCode starts. The `WORKSPACE` env var is already
+read by the entrypoint — we just need to pass it.
+
+## Goals / Non-Goals
+
+### Goals
+- OpenCode CWD matches the project directory when
+  parent mount is active
+- No container image changes required
+- Backward compatible with `--no-parent` mode
+
+### Non-Goals
+- Modifying the container image or entrypoint script
+- Changing mount behavior (already correct from PR #119)
+- Supporting custom WORKSPACE paths
+
+## Decisions
+
+**D1: Pass WORKSPACE env var, not change --workdir**
+
+The `--workdir` flag is correctly set but the
+entrypoint overrides it. Rather than fighting the
+entrypoint, work with it — pass `WORKSPACE` so the
+`cd "$WORKSPACE"` line goes to the right place. This
+requires zero image changes.
+
+**D2: Only set WORKSPACE when parent mount is active**
+
+When `--no-parent` is used (project-only mount), the
+entrypoint's default `WORKSPACE=/workspace` is
+correct — `/workspace` IS the project directory. Only
+set `WORKSPACE` explicitly when parent mount changes
+the meaning of `/workspace` to be the parent.
+
+## Risks / Trade-offs
+
+- **Risk**: Future entrypoint changes could remove the
+  `WORKSPACE` variable. **Mitigation**: The entrypoint
+  is in our own container image (`containerfile` repo)
+  and the variable is documented. Also, `--workdir`
+  remains set as a belt-and-suspenders fallback.

--- a/openspec/changes/fix-sandbox-workspace-env/proposal.md
+++ b/openspec/changes/fix-sandbox-workspace-env/proposal.md
@@ -1,0 +1,79 @@
+## Why
+
+PR #119 (`sandbox-parent-mount`) mounts the project's
+parent directory at `/workspace` and sets `--workdir
+/workspace/<basename>` so OpenCode starts in the
+correct project subdirectory. However, the container
+image's `entrypoint.sh` runs `cd "$WORKSPACE"` where
+`WORKSPACE` defaults to `/workspace`. This overrides
+the `--workdir` setting, causing OpenCode to start in
+the parent directory instead of the project.
+
+For example, when running `uf sandbox start` from
+`/Users/j/Projects/org/gcal-organizer`:
+
+- **Expected**: OpenCode CWD = `/workspace/gcal-organizer`
+- **Actual**: OpenCode CWD = `/workspace` (the parent)
+
+## What Changes
+
+Pass `-e WORKSPACE=/workspace/<basename>` in
+`buildRunArgs()` when parent mount is active. The
+container's `entrypoint.sh` already reads the
+`WORKSPACE` environment variable and `cd`s to it,
+so no image changes are needed.
+
+## Capabilities
+
+### New Capabilities
+- None.
+
+### Modified Capabilities
+- `buildRunArgs()`: When parent mount is active, passes
+  `-e WORKSPACE=/workspace/<basename>` to the container
+  so the entrypoint `cd`s to the correct project
+  subdirectory.
+
+### Removed Capabilities
+- None.
+
+## Impact
+
+- `internal/sandbox/config.go`: Add one `-e` flag pair
+  to `buildRunArgs()` when `useParentMount()` is true.
+- `internal/sandbox/sandbox_test.go`: Update existing
+  parent-mount tests to verify `WORKSPACE` env var,
+  add test for `--no-parent` case (no `WORKSPACE`).
+
+## Constitution Alignment
+
+Assessed against the Unbound Force org constitution.
+
+### I. Autonomous Collaboration
+
+**Assessment**: PASS
+
+No inter-hero communication affected. This is a
+container configuration fix.
+
+### II. Composability First
+
+**Assessment**: PASS
+
+The sandbox remains independently usable. The fix is
+backward compatible — `--no-parent` mode does not set
+`WORKSPACE` (entrypoint uses its default `/workspace`).
+
+### III. Observable Quality
+
+**Assessment**: PASS
+
+No output format changes.
+
+### IV. Testability
+
+**Assessment**: PASS
+
+The change is testable via `buildRunArgs()` output
+inspection — same pattern as existing tests. No
+external services required.

--- a/openspec/changes/fix-sandbox-workspace-env/specs/workspace-env.md
+++ b/openspec/changes/fix-sandbox-workspace-env/specs/workspace-env.md
@@ -1,0 +1,40 @@
+## ADDED Requirements
+
+### Requirement: WORKSPACE Environment Variable (FR-044)
+
+When parent mount is active, `buildRunArgs()` MUST pass
+`-e WORKSPACE=/workspace/<project-basename>` to the
+container so the entrypoint's `cd "$WORKSPACE"` sets
+the correct working directory for OpenCode.
+
+#### Scenario: Parent mount sets WORKSPACE
+
+- **GIVEN** `ProjectDir` is
+  `/Users/j/Projects/org/myproject`
+- **AND** `NoParent` is false
+- **WHEN** `buildRunArgs()` constructs the podman args
+- **THEN** the args include
+  `-e WORKSPACE=/workspace/myproject`
+
+#### Scenario: No-parent mode omits WORKSPACE
+
+- **GIVEN** `NoParent` is true
+- **WHEN** `buildRunArgs()` constructs the podman args
+- **THEN** the args do NOT include `-e WORKSPACE=...`
+  (entrypoint uses its default `/workspace`)
+
+#### Scenario: Root fallback omits WORKSPACE
+
+- **GIVEN** `ProjectDir` is `/myproject`
+  (parent is `/`)
+- **WHEN** `buildRunArgs()` constructs the podman args
+- **THEN** the args do NOT include `-e WORKSPACE=...`
+  (parent mount is not active due to root fallback)
+
+## MODIFIED Requirements
+
+None.
+
+## REMOVED Requirements
+
+None.

--- a/openspec/changes/fix-sandbox-workspace-env/tasks.md
+++ b/openspec/changes/fix-sandbox-workspace-env/tasks.md
@@ -1,0 +1,19 @@
+## 1. Fix
+
+- [x] 1.1 In `buildRunArgs()` in `internal/sandbox/config.go`, add `-e WORKSPACE=/workspace/<filepath.Base(opts.ProjectDir)>` when `useParentMount(opts)` is true. Place it next to the existing `--workdir` block.
+
+## 2. Tests
+
+- [x] 2.1 Update `TestBuildRunArgs_Isolated` in `internal/sandbox/sandbox_test.go` — verify args contain `WORKSPACE=/workspace/test-project`
+- [x] 2.2 Update `TestBuildRunArgs_Direct` in `internal/sandbox/sandbox_test.go` — verify args contain `WORKSPACE=/workspace/test-project`
+- [x] 2.3 Add `TestBuildRunArgs_NoParentNoWorkspace` in `internal/sandbox/sandbox_test.go` — verify args do NOT contain `WORKSPACE=` when `NoParent` is true
+- [x] 2.4 Add `TestBuildRunArgs_RootFallbackNoWorkspace` in `internal/sandbox/sandbox_test.go` — verify args do NOT contain `WORKSPACE=` when `ProjectDir=/myproject` (root fallback)
+
+## 3. Validation
+
+- [x] 3.1 Run `go test -race -count=1 ./internal/sandbox/...` — all tests pass
+- [x] 3.2 Run `go build ./...` — build succeeds
+- [x] 3.3 Run `golangci-lint run` — no lint errors
+
+<!-- spec-review: passed -->
+<!-- code-review: passed -->


### PR DESCRIPTION
## Summary

Fixes a defect from PR #119 (sandbox-parent-mount) where OpenCode inside the
sandbox started in the parent directory (`/workspace`) instead of the project
subdirectory (`/workspace/<project-name>`).

### Root Cause

PR #119 correctly sets `--workdir /workspace/<basename>` on the container, but
the container image's `entrypoint.sh` runs `cd "$WORKSPACE"` where `WORKSPACE`
defaults to `/workspace`. This overrides the `--workdir` setting before OpenCode
starts.

### Fix

Pass `-e WORKSPACE=/workspace/<basename>` alongside `--workdir` when parent
mount is active. The entrypoint already reads the `WORKSPACE` environment
variable, so no container image changes are needed.

| Scenario | WORKSPACE env var | Entrypoint cd target |
|----------|------------------|---------------------|
| Parent mount (default) | `/workspace/<basename>` | Project subdirectory |
| `--no-parent` | Not set (entrypoint default) | `/workspace` (correct — project is the mount root) |
| Root fallback | Not set | `/workspace` (correct — project-only mount) |

## How to Test

### Automated tests

```bash
go test -race -count=1 ./internal/sandbox/...
```

4 test assertions added/updated:
- `TestBuildRunArgs_Isolated` — verifies `WORKSPACE=/workspace/test-project` present
- `TestBuildRunArgs_Direct` — verifies `WORKSPACE=/workspace/test-project` present
- `TestBuildRunArgs_NoParentNoWorkdir` — verifies no `WORKSPACE=` with `--no-parent`
- `TestBuildRunArgs_RootFallbackNoWorkdir` — verifies no `WORKSPACE=` when parent is `/`

### Manual test (macOS with Podman)

```bash
# 1. Build and install
make install

# 2. Navigate to any project
cd /path/to/your/project

# 3. Start sandbox
uf sandbox stop   # if running
uf sandbox start --mode direct

# 4. Inside the sandbox OpenCode session, verify CWD:
#    Ask: "what is the cwd"
#    Expected: /workspace/<your-project-name>
#    NOT: /workspace (the parent)

# 5. Verify with shell
podman exec uf-sandbox env | grep WORKSPACE
# Expected: WORKSPACE=/workspace/<your-project-name>
```

### Verify --no-parent is unaffected

```bash
uf sandbox stop
uf sandbox start --mode direct --no-parent

# Inside sandbox:
#    Ask: "what is the cwd"
#    Expected: /workspace (project is the mount root)

podman exec uf-sandbox env | grep WORKSPACE
# Expected: no output (WORKSPACE not set, entrypoint uses default)
```

## Files Changed

- `internal/sandbox/config.go` — Added `-e WORKSPACE=...` to `buildRunArgs()` when `useParentMount()` is true (+5 lines)
- `internal/sandbox/sandbox_test.go` — 4 new test assertions across 4 existing test functions (+16 lines)
- `openspec/changes/fix-sandbox-workspace-env/` — Proposal, design, specs, tasks artifacts