### PR TITLE
chore: remove auto-merge from /finale — PRs stay open for review

### DIFF
--- a/.opencode/command/finale.md
+++ b/.opencode/command/finale.md
@@ -1,8 +1,9 @@
 ---
 description: >
   Finalize a branch: commit, push, create PR, watch CI
-  checks, rebase-merge, and return to main. One command
-  to wrap up any feature or OpenSpec branch.
+  checks, and return to main. The PR stays open for
+  review. One command to wrap up any feature or OpenSpec
+  branch.
 ---
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->
@@ -21,9 +22,9 @@ $ARGUMENTS
 
 Automate the end-of-branch workflow. Stages all changes,
 generates a conventional commit message, pushes, creates
-a PR, watches CI checks, rebase-merges, and returns to
-`main`. Works with both Speckit (`NNN-*`) and OpenSpec
-(`opsx/*`) branches.
+a PR, watches CI checks, and returns to `main`. The PR
+stays open for human review. Works with both Speckit
+(`NNN-*`) and OpenSpec (`opsx/*`) branches.
 
 ## Usage
 
@@ -178,22 +179,11 @@ gh pr checks <number> --watch
   > 2. Re-run the checks
   > 3. Stop here and fix manually"
 
-  Ask the user how to proceed. Do NOT auto-merge a
-  PR with failing checks.
+  Ask the user how to proceed.
 
-### 7. Merge PR
+### 7. Return to Main
 
-```bash
-gh pr merge <number> --rebase --delete-branch
-```
-
-- If merge fails (e.g., merge conflict, branch
-  protection): report error and **STOP**.
-- If merge succeeds: proceed.
-
-### 8. Return to Main
-
-After merge, verify the branch switch:
+Return to main so the developer can start other work:
 
 ```bash
 git checkout main 2>/dev/null  # may already be on main
@@ -207,29 +197,33 @@ git rev-parse --abbrev-ref HEAD
 
 Should be `main`.
 
-### 9. Summary
+### 8. Summary
 
 Display a completion report:
 
 ```
 ## Finale Complete
 
-**Branch:** opsx/finale-command (deleted)
+**Branch:** opsx/finale-command (pushed)
 **Commit:** feat: add /finale slash command
-**PR:** #65 — merged via rebase
+**PR:** #65 — CI passed, ready for review
 **Checks:** passed
 **Status:** on main, up to date
+
+Next: Request reviewers on the PR, then merge after
+approval with: gh pr merge --rebase --delete-branch
 ```
 
 ## Guardrails
 
 - **NEVER run on `main`** — the command is for feature
   branches only
-- **NEVER merge with failing checks** — stop and report
+- **NEVER merge the PR** — /finale creates PRs for
+  review, not for immediate merge. Users merge manually
+  after reviewer approval.
 - **NEVER stage secret files without warning** — always
   prompt
 - **NEVER commit without user approval** of the message
-- **ALWAYS use rebase merge** — no squash or merge commit
 - **ALWAYS report the PR URL** so the user can review it
 - **If any step fails**, stop immediately with context
   and options — do not attempt to continue or recover
@@ -242,5 +236,5 @@ the OpenSpec and Speckit workflows:
 
 - Checks `git status` before any destructive operation
 - All changes are committed before any branch switch
-- The branch is deleted only via `--delete-branch` on
-  merge (remote deletion handled by GitHub)
+- The remote branch is NOT deleted — it stays open with
+  the PR until a reviewer merges

--- a/internal/scaffold/assets/opencode/command/finale.md
+++ b/internal/scaffold/assets/opencode/command/finale.md
@@ -1,8 +1,9 @@
 ---
 description: >
   Finalize a branch: commit, push, create PR, watch CI
-  checks, rebase-merge, and return to main. One command
-  to wrap up any feature or OpenSpec branch.
+  checks, and return to main. The PR stays open for
+  review. One command to wrap up any feature or OpenSpec
+  branch.
 ---
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->
@@ -21,9 +22,9 @@ $ARGUMENTS
 
 Automate the end-of-branch workflow. Stages all changes,
 generates a conventional commit message, pushes, creates
-a PR, watches CI checks, rebase-merges, and returns to
-`main`. Works with both Speckit (`NNN-*`) and OpenSpec
-(`opsx/*`) branches.
+a PR, watches CI checks, and returns to `main`. The PR
+stays open for human review. Works with both Speckit
+(`NNN-*`) and OpenSpec (`opsx/*`) branches.
 
 ## Usage
 
@@ -178,22 +179,11 @@ gh pr checks <number> --watch
   > 2. Re-run the checks
   > 3. Stop here and fix manually"
 
-  Ask the user how to proceed. Do NOT auto-merge a
-  PR with failing checks.
+  Ask the user how to proceed.
 
-### 7. Merge PR
+### 7. Return to Main
 
-```bash
-gh pr merge <number> --rebase --delete-branch
-```
-
-- If merge fails (e.g., merge conflict, branch
-  protection): report error and **STOP**.
-- If merge succeeds: proceed.
-
-### 8. Return to Main
-
-After merge, verify the branch switch:
+Return to main so the developer can start other work:
 
 ```bash
 git checkout main 2>/dev/null  # may already be on main
@@ -207,29 +197,33 @@ git rev-parse --abbrev-ref HEAD
 
 Should be `main`.
 
-### 9. Summary
+### 8. Summary
 
 Display a completion report:
 
 ```
 ## Finale Complete
 
-**Branch:** opsx/finale-command (deleted)
+**Branch:** opsx/finale-command (pushed)
 **Commit:** feat: add /finale slash command
-**PR:** #65 — merged via rebase
+**PR:** #65 — CI passed, ready for review
 **Checks:** passed
 **Status:** on main, up to date
+
+Next: Request reviewers on the PR, then merge after
+approval with: gh pr merge --rebase --delete-branch
 ```
 
 ## Guardrails
 
 - **NEVER run on `main`** — the command is for feature
   branches only
-- **NEVER merge with failing checks** — stop and report
+- **NEVER merge the PR** — /finale creates PRs for
+  review, not for immediate merge. Users merge manually
+  after reviewer approval.
 - **NEVER stage secret files without warning** — always
   prompt
 - **NEVER commit without user approval** of the message
-- **ALWAYS use rebase merge** — no squash or merge commit
 - **ALWAYS report the PR URL** so the user can review it
 - **If any step fails**, stop immediately with context
   and options — do not attempt to continue or recover
@@ -242,5 +236,5 @@ the OpenSpec and Speckit workflows:
 
 - Checks `git status` before any destructive operation
 - All changes are committed before any branch switch
-- The branch is deleted only via `--delete-branch` on
-  merge (remote deletion handled by GitHub)
+- The remote branch is NOT deleted — it stays open with
+  the PR until a reviewer merges

--- a/openspec/changes/finale-skip-merge/.openspec.yaml
+++ b/openspec/changes/finale-skip-merge/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: unbound-force
+created: 2026-04-24

--- a/openspec/changes/finale-skip-merge/design.md
+++ b/openspec/changes/finale-skip-merge/design.md
@@ -1,0 +1,51 @@
+## Context
+
+The `/finale` command is a Markdown slash command at
+`.opencode/command/finale.md` with a scaffold copy at
+`internal/scaffold/assets/opencode/command/finale.md`.
+It defines a 9-step workflow. Step 7 calls
+`gh pr merge <number> --rebase --delete-branch`.
+
+## Goals / Non-Goals
+
+### Goals
+- PRs remain open after `/finale` for human review
+- User returns to main after CI passes (ready to work
+  on other things)
+- Summary clearly states the PR is open, not merged
+
+### Non-Goals
+- Adding a separate `/merge` command (users can run
+  `gh pr merge` directly or merge via GitHub UI)
+- Changing CI check behavior (step 6 stays)
+- Changing commit or push behavior (steps 1-5 stay)
+
+## Decisions
+
+**D1: Remove step 7 entirely, keep steps 6 and 8**
+
+Step 6 (watch CI) provides immediate feedback on
+whether the PR is green before the author walks away.
+Step 8 (return to main) lets the author start other
+work. Only step 7 (merge) is removed because that's
+what should wait for reviewer approval.
+
+**D2: Update summary to say "ready for review"**
+
+The step 9 summary changes from reporting "merged via
+rebase" to "CI passed, ready for review" with a next
+step prompt to request reviewers.
+
+**D3: Remove merge-related guardrails**
+
+The guardrails "NEVER merge with failing checks" and
+"ALWAYS use rebase merge" become irrelevant since
+`/finale` no longer merges. Remove them to avoid
+confusion.
+
+## Risks / Trade-offs
+
+- **Trade-off**: Users must merge manually after review.
+  This adds one extra step but enables proper code
+  review. The `gh pr merge --rebase --delete-branch`
+  command is documented in the summary for convenience.

--- a/openspec/changes/finale-skip-merge/proposal.md
+++ b/openspec/changes/finale-skip-merge/proposal.md
@@ -1,0 +1,85 @@
+## Why
+
+The `/finale` command currently merges the PR
+automatically after CI passes. This prevents human
+reviewers from examining the PR before it lands on
+main. In a team workflow, PRs should remain open for
+review after CI passes — the author returns to main
+and waits for approval before merging.
+
+## What Changes
+
+Remove step 7 (Merge PR) from the `/finale` command.
+The command still commits, pushes, creates the PR,
+watches CI checks, and returns to main — but leaves
+the PR open for reviewers.
+
+### Before
+
+```
+commit → push → create PR → watch CI → merge → main
+```
+
+### After
+
+```
+commit → push → create PR → watch CI → main
+```
+
+The PR remains open. The user merges via GitHub UI
+or `gh pr merge` after reviewers approve.
+
+## Capabilities
+
+### New Capabilities
+- None.
+
+### Modified Capabilities
+- `/finale`: No longer merges the PR. Stops after CI
+  checks pass and returns to main. Summary reports PR
+  as "ready for review" instead of "merged via rebase".
+
+### Removed Capabilities
+- Automatic PR merge from `/finale`. Users merge
+  manually after review.
+
+## Impact
+
+- `.opencode/command/finale.md`: Remove step 7 (Merge
+  PR), update step 9 summary template, update
+  guardrails.
+- `internal/scaffold/assets/opencode/command/finale.md`:
+  Same changes (scaffold copy).
+- No Go code changes. Markdown-only.
+
+## Constitution Alignment
+
+Assessed against the Unbound Force org constitution.
+
+### I. Autonomous Collaboration
+
+**Assessment**: PASS
+
+No inter-hero communication affected. The change
+improves collaboration by enabling human review
+before merge.
+
+### II. Composability First
+
+**Assessment**: N/A
+
+No dependency changes.
+
+### III. Observable Quality
+
+**Assessment**: PASS
+
+PR review is a quality gate. Keeping PRs open for
+review strengthens the observable quality principle.
+
+### IV. Testability
+
+**Assessment**: N/A
+
+No testable code changes — Markdown command definition
+only.

--- a/openspec/changes/finale-skip-merge/specs/finale-workflow.md
+++ b/openspec/changes/finale-skip-merge/specs/finale-workflow.md
@@ -1,0 +1,49 @@
+## MODIFIED Requirements
+
+### Requirement: /finale Workflow Steps
+
+The `/finale` command MUST execute steps 1 through 6
+and step 8, skipping step 7 (Merge PR). After CI
+checks pass, the command MUST return to main without
+merging the PR.
+
+Previously: The command executed all 9 steps including
+step 7 (`gh pr merge --rebase --delete-branch`).
+
+#### Scenario: PR stays open after finale
+
+- **GIVEN** a feature branch with committed changes
+- **WHEN** the user runs `/finale`
+- **THEN** the command commits, pushes, creates a PR,
+  watches CI checks, returns to main
+- **AND** the PR remains open (not merged)
+
+#### Scenario: Summary reports ready for review
+
+- **GIVEN** `/finale` completes successfully
+- **WHEN** the summary is displayed
+- **THEN** the summary states the PR is "ready for
+  review" (not "merged via rebase")
+- **AND** includes a next step: "Request reviewers,
+  then merge after approval"
+
+### Requirement: /finale Guardrails
+
+The guardrails section MUST NOT reference merge
+behavior. The guardrails "NEVER merge with failing
+checks" and "ALWAYS use rebase merge" MUST be removed.
+
+Previously: Both guardrails were present because
+`/finale` performed the merge.
+
+## REMOVED Requirements
+
+### Requirement: Automatic PR Merge
+
+The `/finale` command no longer merges PRs. Step 7
+(Merge PR) is removed entirely. Users merge via
+GitHub UI or `gh pr merge` after reviewer approval.
+
+## ADDED Requirements
+
+None.

--- a/openspec/changes/finale-skip-merge/tasks.md
+++ b/openspec/changes/finale-skip-merge/tasks.md
@@ -1,0 +1,28 @@
+## 1. Remove Merge Step
+
+- [x] 1.1 In `.opencode/command/finale.md`, remove the entire "### 7. Merge PR" section (the `gh pr merge` step and its error handling)
+- [x] 1.2 Renumber "### 8. Return to Main" to "### 7. Return to Main"
+- [x] 1.3 Renumber "### 9. Summary" to "### 8. Summary"
+
+## 2. Update Summary Template
+
+- [x] 2.1 In the Summary section of `.opencode/command/finale.md`, change the output template from reporting "merged via rebase" to "CI passed, ready for review". Add a "Next" line: "Request reviewers on the PR, then merge after approval with `gh pr merge --rebase --delete-branch`."
+
+## 3. Update Guardrails
+
+- [x] 3.1 In the Guardrails section of `.opencode/command/finale.md`, remove "NEVER merge with failing checks" (no longer applicable)
+- [x] 3.2 Remove "ALWAYS use rebase merge" (no longer applicable)
+- [x] 3.3 Add "NEVER merge the PR — /finale creates PRs for review, not for immediate merge"
+
+## 4. Sync Scaffold Copy
+
+- [x] 4.1 Copy the updated `.opencode/command/finale.md` to `internal/scaffold/assets/opencode/command/finale.md` (scaffold asset must match live file)
+
+## 5. Validation
+
+- [x] 5.1 Verify both files are identical: `diff .opencode/command/finale.md internal/scaffold/assets/opencode/command/finale.md`
+- [x] 5.2 Run `go test -race -count=1 ./internal/scaffold/...` to verify scaffold asset count is unchanged (no new/removed files)
+- [x] 5.3 Run `go build ./...` to verify build succeeds
+
+<!-- spec-review: passed -->
+<!-- code-review: passed -->


### PR DESCRIPTION
## Summary

Remove the automatic PR merge step from the `/finale` slash command so PRs
stay open for human review before landing on main.

### Before

```
/finale: commit → push → create PR → watch CI → merge → return to main
```

The PR was merged automatically after CI passed. No opportunity for review.

### After

```
/finale: commit → push → create PR → watch CI → return to main
```

The PR stays open. The developer returns to main ready to start other work.
Reviewers examine the PR on GitHub, then merge after approval.

## What Changed

| Step | Before | After |
|------|--------|-------|
| 1-5 | Commit, push, create PR | Unchanged |
| 6 | Watch CI checks | Unchanged |
| 7 | **Merge PR** (`gh pr merge --rebase --delete-branch`) | **Removed** |
| 7 (new) | Return to main | Was step 8 — renumbered |
| 8 (new) | Summary | Was step 9 — renumbered |

### Guardrail changes

- Removed: "NEVER merge with failing checks" (no merge step exists)
- Removed: "ALWAYS use rebase merge" (no merge step exists)
- Added: "NEVER merge the PR — /finale creates PRs for review"

### Summary output change

The completion summary now reports:

```
**PR:** #65 — CI passed, ready for review

Next: Request reviewers on the PR, then merge after
approval with: gh pr merge --rebase --delete-branch
```

## How to Test

This is a Markdown-only change — no Go code, no tests to run. The `/finale`
command is interpreted by OpenCode at runtime.

### Verify the command definition

```bash
# Both files should be identical (live + scaffold copy)
diff .opencode/command/finale.md internal/scaffold/assets/opencode/command/finale.md
# Expected: no output (files match)
```

### Verify no merge step exists

```bash
grep -n "gh pr merge" .opencode/command/finale.md
# Expected: no output (merge command removed)

grep -n "### 7. Merge" .opencode/command/finale.md
# Expected: no output (section removed)
```

### Verify scaffold asset count unchanged

```bash
go test -race -count=1 -run TestRunInit ./internal/scaffold/...
# Expected: PASS (no new/removed assets)
```

### Verify build (no embedded asset issues)

```bash
go build ./...
# Expected: clean build
```

### End-to-end test (in OpenCode)

1. Create a test branch: `git checkout -b opsx/test-finale`
2. Make a trivial change and run `/finale`
3. Verify:
   - PR is created and CI checks are watched
   - After CI passes, you are returned to `main`
   - The PR is **open** on GitHub (not merged)
   - The summary says "CI passed, ready for review"

## Files Changed

- `.opencode/command/finale.md` — Removed merge step, renumbered steps 8→7 and 9→8, updated summary template and guardrails
- `internal/scaffold/assets/opencode/command/finale.md` — Identical scaffold copy
- `openspec/changes/finale-skip-merge/` — Proposal, design, specs, tasks artifacts