### PR TITLE
fix: make scaffold marker insertion idempotent and fix double-v prefix

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -15,7 +15,7 @@ builds:
       - arm64
     ldflags:
       - -s -w
-      - -X main.version={{.Tag}}
+      - -X main.version={{.Version}}
       - -X main.commit={{.Commit}}
       - -X main.date={{.CommitDate}}
   - id: mxf
@@ -32,7 +32,7 @@ builds:
       - arm64
     ldflags:
       - -s -w
-      - -X main.version={{.Tag}}
+      - -X main.version={{.Version}}
       - -X main.commit={{.Commit}}
       - -X main.date={{.CommitDate}}
 

--- a/.opencode/command/cobalt-crush.md
+++ b/.opencode/command/cobalt-crush.md
@@ -6,11 +6,6 @@ description: >
   /opsx-apply.
 ---
 <!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vv0.6.1 -->
 
 # Command: /cobalt-crush
 

--- a/.opencode/command/constitution-check.md
+++ b/.opencode/command/constitution-check.md
@@ -3,12 +3,6 @@ description: "Check a hero constitution's alignment with the Unbound Force org c
 agent: constitution-check
 ---
 <!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vv0.6.1 -->
-<!-- scaffolded by uf vdev -->
 
 # Command: /constitution-check
 

--- a/.opencode/command/finale.md
+++ b/.opencode/command/finale.md
@@ -6,10 +6,6 @@ description: >
   branch.
 ---
 <!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
 
 # Command: /finale
 

--- a/.opencode/command/review-council.md
+++ b/.opencode/command/review-council.md
@@ -2,11 +2,6 @@
 description: Run the reviewer governance council to audit codebase or spec compliance.
 ---
 <!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vv0.6.1 -->
 # Command: /review-council
 
 ## User Input

--- a/.opencode/command/speckit.analyze.md
+++ b/.opencode/command/speckit.analyze.md
@@ -2,9 +2,6 @@
 description: Perform a non-destructive cross-artifact consistency and quality analysis across spec.md, plan.md, and tasks.md after task generation.
 ---
 <!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vv0.6.1 -->
-<!-- scaffolded by uf vdev -->
 
 ## User Input
 

--- a/.opencode/command/speckit.checklist.md
+++ b/.opencode/command/speckit.checklist.md
@@ -2,9 +2,6 @@
 description: Generate a custom checklist for the current feature based on user requirements.
 ---
 <!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vv0.6.1 -->
-<!-- scaffolded by uf vdev -->
 
 ## Checklist Purpose: "Unit Tests for English"
 

--- a/.opencode/command/speckit.clarify.md
+++ b/.opencode/command/speckit.clarify.md
@@ -6,9 +6,6 @@ handoffs:
     prompt: Create a plan for the spec. I am building with...
 ---
 <!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vv0.6.1 -->
-<!-- scaffolded by uf vdev -->
 
 ## User Input
 

--- a/.opencode/command/speckit.constitution.md
+++ b/.opencode/command/speckit.constitution.md
@@ -6,9 +6,6 @@ handoffs:
     prompt: Implement the feature specification based on the updated constitution. I want to build...
 ---
 <!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vv0.6.1 -->
-<!-- scaffolded by uf vdev -->
 
 ## User Input
 

--- a/.opencode/command/speckit.implement.md
+++ b/.opencode/command/speckit.implement.md
@@ -2,9 +2,6 @@
 description: Execute the implementation plan by processing and executing all tasks defined in tasks.md
 ---
 <!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vv0.6.1 -->
-<!-- scaffolded by uf vdev -->
 
 ## User Input
 

--- a/.opencode/command/speckit.plan.md
+++ b/.opencode/command/speckit.plan.md
@@ -10,9 +10,6 @@ handoffs:
     prompt: Create a checklist for the following domain...
 ---
 <!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vv0.6.1 -->
-<!-- scaffolded by uf vdev -->
 
 ## User Input
 

--- a/.opencode/command/speckit.specify.md
+++ b/.opencode/command/speckit.specify.md
@@ -10,9 +10,6 @@ handoffs:
     send: true
 ---
 <!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vv0.6.1 -->
-<!-- scaffolded by uf vdev -->
 
 ## User Input
 

--- a/.opencode/command/speckit.tasks.md
+++ b/.opencode/command/speckit.tasks.md
@@ -11,9 +11,6 @@ handoffs:
     send: true
 ---
 <!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vv0.6.1 -->
-<!-- scaffolded by uf vdev -->
 
 ## User Input
 

--- a/.opencode/command/speckit.taskstoissues.md
+++ b/.opencode/command/speckit.taskstoissues.md
@@ -3,9 +3,6 @@ description: Convert existing tasks into actionable, dependency-ordered GitHub i
 tools: ['github/github-mcp-server/issue_write']
 ---
 <!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vv0.6.1 -->
-<!-- scaffolded by uf vdev -->
 
 ## User Input
 

--- a/.opencode/command/uf-init.md
+++ b/.opencode/command/uf-init.md
@@ -6,11 +6,6 @@ description: >
   updating the OpenSpec CLI.
 ---
 <!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vv0.6.1 -->
 
 # Command: /uf-init
 

--- a/.opencode/command/unleash.md
+++ b/.opencode/command/unleash.md
@@ -8,10 +8,6 @@ description: >
   needs human judgment.
 ---
 <!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
 
 # Command: /unleash
 

--- a/.opencode/skill/speckit-workflow/SKILL.md
+++ b/.opencode/skill/speckit-workflow/SKILL.md
@@ -7,11 +7,6 @@ tags:
   - decomposition
 ---
 <!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vv0.6.1 -->
 
 # Speckit Workflow — Swarm Skill
 

--- a/.opencode/uf/packs/content.md
+++ b/.opencode/uf/packs/content.md
@@ -4,9 +4,6 @@ language: Any
 version: 1.0.0
 ---
 <!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
 
 # Convention Pack: Content (Documentation, Blog, PR/Comms)
 

--- a/.opencode/uf/packs/default.md
+++ b/.opencode/uf/packs/default.md
@@ -4,11 +4,6 @@ language: Any
 version: 1.0.0
 ---
 <!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vv0.6.1 -->
 
 # Convention Pack: Default (Language-Agnostic)
 

--- a/.opencode/uf/packs/go.md
+++ b/.opencode/uf/packs/go.md
@@ -4,11 +4,6 @@ language: Go
 version: 1.0.0
 ---
 <!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vv0.6.1 -->
 
 # Convention Pack: Go
 

--- a/.opencode/uf/packs/severity.md
+++ b/.opencode/uf/packs/severity.md
@@ -2,9 +2,6 @@
 description: "Shared severity level definitions for all Divisor Council personas."
 ---
 <!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
 
 # Severity Convention Pack
 

--- a/.opencode/uf/packs/typescript.md
+++ b/.opencode/uf/packs/typescript.md
@@ -4,11 +4,6 @@ language: TypeScript
 version: 1.0.0
 ---
 <!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vv0.6.1 -->
 
 # Convention Pack: TypeScript
 

--- a/internal/scaffold/assets/opencode/command/cobalt-crush.md
+++ b/internal/scaffold/assets/opencode/command/cobalt-crush.md
@@ -6,11 +6,6 @@ description: >
   /opsx-apply.
 ---
 <!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vv0.6.1 -->
 
 # Command: /cobalt-crush
 

--- a/internal/scaffold/assets/opencode/command/constitution-check.md
+++ b/internal/scaffold/assets/opencode/command/constitution-check.md
@@ -3,12 +3,6 @@ description: "Check a hero constitution's alignment with the Unbound Force org c
 agent: constitution-check
 ---
 <!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vv0.6.1 -->
-<!-- scaffolded by uf vdev -->
 
 # Command: /constitution-check
 

--- a/internal/scaffold/assets/opencode/command/finale.md
+++ b/internal/scaffold/assets/opencode/command/finale.md
@@ -6,10 +6,6 @@ description: >
   branch.
 ---
 <!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
 
 # Command: /finale
 

--- a/internal/scaffold/assets/opencode/command/review-council.md
+++ b/internal/scaffold/assets/opencode/command/review-council.md
@@ -2,11 +2,6 @@
 description: Run the reviewer governance council to audit codebase or spec compliance.
 ---
 <!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vv0.6.1 -->
 # Command: /review-council
 
 ## User Input

--- a/internal/scaffold/assets/opencode/command/uf-init.md
+++ b/internal/scaffold/assets/opencode/command/uf-init.md
@@ -6,11 +6,6 @@ description: >
   updating the OpenSpec CLI.
 ---
 <!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vv0.6.1 -->
 
 # Command: /uf-init
 

--- a/internal/scaffold/assets/opencode/command/unleash.md
+++ b/internal/scaffold/assets/opencode/command/unleash.md
@@ -8,10 +8,6 @@ description: >
   needs human judgment.
 ---
 <!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
 
 # Command: /unleash
 

--- a/internal/scaffold/assets/opencode/skill/speckit-workflow/SKILL.md
+++ b/internal/scaffold/assets/opencode/skill/speckit-workflow/SKILL.md
@@ -7,11 +7,6 @@ tags:
   - decomposition
 ---
 <!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vv0.6.1 -->
 
 # Speckit Workflow — Swarm Skill
 

--- a/internal/scaffold/assets/opencode/uf/packs/content.md
+++ b/internal/scaffold/assets/opencode/uf/packs/content.md
@@ -4,9 +4,6 @@ language: Any
 version: 1.0.0
 ---
 <!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
 
 # Convention Pack: Content (Documentation, Blog, PR/Comms)
 

--- a/internal/scaffold/assets/opencode/uf/packs/default.md
+++ b/internal/scaffold/assets/opencode/uf/packs/default.md
@@ -4,11 +4,6 @@ language: Any
 version: 1.0.0
 ---
 <!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vv0.6.1 -->
 
 # Convention Pack: Default (Language-Agnostic)
 

--- a/internal/scaffold/assets/opencode/uf/packs/go.md
+++ b/internal/scaffold/assets/opencode/uf/packs/go.md
@@ -4,11 +4,6 @@ language: Go
 version: 1.0.0
 ---
 <!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vv0.6.1 -->
 
 # Convention Pack: Go
 

--- a/internal/scaffold/assets/opencode/uf/packs/severity.md
+++ b/internal/scaffold/assets/opencode/uf/packs/severity.md
@@ -2,9 +2,6 @@
 description: "Shared severity level definitions for all Divisor Council personas."
 ---
 <!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
 
 # Severity Convention Pack
 

--- a/internal/scaffold/assets/opencode/uf/packs/typescript.md
+++ b/internal/scaffold/assets/opencode/uf/packs/typescript.md
@@ -4,11 +4,6 @@ language: TypeScript
 version: 1.0.0
 ---
 <!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vv0.6.1 -->
 
 # Convention Pack: TypeScript
 

--- a/internal/scaffold/assets/openspec/schemas/unbound-force/templates/design.md
+++ b/internal/scaffold/assets/openspec/schemas/unbound-force/templates/design.md
@@ -17,9 +17,4 @@
 ## Risks / Trade-offs
 
 <!-- Known risks and accepted trade-offs -->
-<!-- scaffolded by uf vv0.6.1 -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->

--- a/internal/scaffold/assets/openspec/schemas/unbound-force/templates/proposal.md
+++ b/internal/scaffold/assets/openspec/schemas/unbound-force/templates/proposal.md
@@ -54,9 +54,4 @@ output? Does it maintain provenance metadata? -->
 
 <!-- Does this change verify observable side effects?
 Are components testable in isolation? -->
-<!-- scaffolded by uf vv0.6.1 -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->

--- a/internal/scaffold/assets/openspec/schemas/unbound-force/templates/spec.md
+++ b/internal/scaffold/assets/openspec/schemas/unbound-force/templates/spec.md
@@ -20,9 +20,4 @@
 ### Requirement: <!-- name -->
 
 <!-- reason for removal -->
-<!-- scaffolded by uf vv0.6.1 -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->

--- a/internal/scaffold/assets/openspec/schemas/unbound-force/templates/tasks.md
+++ b/internal/scaffold/assets/openspec/schemas/unbound-force/templates/tasks.md
@@ -6,9 +6,4 @@
 ## 2. <!-- Task Group -->
 
 - [ ] 2.1 <!-- task description -->
-<!-- scaffolded by uf vv0.6.1 -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->

--- a/internal/scaffold/scaffold.go
+++ b/internal/scaffold/scaffold.go
@@ -386,12 +386,34 @@ func versionMarker(version string, ext string) string {
 	}
 }
 
+// stripExistingMarkers removes all scaffold provenance marker
+// lines from content, regardless of version or comment format.
+// Marker lines are identified by the prefixes
+// "<!-- scaffolded by uf " (HTML comment) and
+// "# scaffolded by uf " (hash comment).
+func stripExistingMarkers(s string) string {
+	var kept []string
+	for _, line := range strings.Split(s, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "<!-- scaffolded by uf ") ||
+			strings.HasPrefix(trimmed, "# scaffolded by uf ") {
+			continue
+		}
+		kept = append(kept, line)
+	}
+	return strings.Join(kept, "\n")
+}
+
 // insertMarkerAfterFrontmatter inserts the version marker after
 // YAML frontmatter (if present) or appends it at the end.
 // Frontmatter is delimited by "---\n" at the start and a
 // matching "---\n" line.
+//
+// The function is idempotent: existing scaffold markers are
+// stripped before the new marker is inserted, so the output
+// always contains exactly one marker regardless of input state.
 func insertMarkerAfterFrontmatter(content []byte, marker string) []byte {
-	s := string(content)
+	s := stripExistingMarkers(string(content))
 
 	// Check for YAML frontmatter: must start with "---\n"
 	if !strings.HasPrefix(s, "---\n") {

--- a/internal/scaffold/scaffold_test.go
+++ b/internal/scaffold/scaffold_test.go
@@ -75,6 +75,43 @@ func TestEmbeddedAssets_MatchSource(t *testing.T) {
 	}
 }
 
+// TestEmbeddedAssets_SingleMarker verifies that no embedded
+// Markdown asset contains more than one scaffold provenance
+// marker line. This prevents marker accumulation through the
+// asset-sync feedback loop.
+func TestEmbeddedAssets_SingleMarker(t *testing.T) {
+	paths, err := assetPaths()
+	if err != nil {
+		t.Fatalf("get asset paths: %v", err)
+	}
+
+	for _, relPath := range paths {
+		if filepath.Ext(relPath) != ".md" {
+			continue
+		}
+
+		content, err := assetContent(relPath)
+		if err != nil {
+			t.Errorf("read embedded %s: %v", relPath, err)
+			continue
+		}
+
+		count := 0
+		for _, line := range strings.Split(string(content), "\n") {
+			trimmed := strings.TrimSpace(line)
+			if strings.HasPrefix(trimmed, "<!-- scaffolded by uf ") ||
+				strings.HasPrefix(trimmed, "# scaffolded by uf ") {
+				count++
+			}
+		}
+
+		if count > 1 {
+			t.Errorf("embedded asset %s contains %d scaffold markers (expected at most 1)",
+				relPath, count)
+		}
+	}
+}
+
 // mapAssetToSource converts an embedded asset relative path to
 // the canonical source path at the repo root. Delegates to
 // mapAssetPath to avoid duplicating the prefix mapping logic.
@@ -672,13 +709,24 @@ func TestInsertMarkerAfterFrontmatter(t *testing.T) {
 			expected: "---\nkey: value\n---\n" + hashMarker + "\nmore: yaml\n",
 		},
 		{
-			name:   "double insert on repeat call",
+			name:   "idempotent on repeat call",
 			input:  "# Hello\n" + mdMarker + "\n",
 			marker: mdMarker,
-			// insertMarkerAfterFrontmatter is not idempotent by design.
-			// Run() achieves idempotency via the bytes.Equal check for
-			// tool-owned files. This test documents the raw function behavior.
-			expected: "# Hello\n" + mdMarker + "\n" + mdMarker + "\n",
+			// insertMarkerAfterFrontmatter is idempotent: existing
+			// markers are stripped before the new one is inserted.
+			expected: "# Hello\n" + mdMarker + "\n",
+		},
+		{
+			name:     "strips multiple existing markers",
+			input:    "---\ntitle: Test\n---\n<!-- scaffolded by uf vdev -->\n<!-- scaffolded by uf vdev -->\n<!-- scaffolded by uf vv0.6.1 -->\n# Content\n",
+			marker:   mdMarker,
+			expected: "---\ntitle: Test\n---\n" + mdMarker + "\n# Content\n",
+		},
+		{
+			name:     "replaces old version with new",
+			input:    "---\ntitle: Test\n---\n<!-- scaffolded by uf v0.5.0 -->\n# Content\n",
+			marker:   mdMarker,
+			expected: "---\ntitle: Test\n---\n" + mdMarker + "\n# Content\n",
 		},
 	}
 
@@ -687,6 +735,69 @@ func TestInsertMarkerAfterFrontmatter(t *testing.T) {
 			got := insertMarkerAfterFrontmatter([]byte(tt.input), tt.marker)
 			if string(got) != tt.expected {
 				t.Errorf("got:\n%s\nexpected:\n%s", string(got), tt.expected)
+			}
+		})
+	}
+}
+
+func TestStripExistingMarkers(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "no markers",
+			input:    "# Hello\n\nSome content.\n",
+			expected: "# Hello\n\nSome content.\n",
+		},
+		{
+			name:     "single HTML marker",
+			input:    "# Hello\n<!-- scaffolded by uf vdev -->\nContent\n",
+			expected: "# Hello\nContent\n",
+		},
+		{
+			name:     "multiple HTML markers",
+			input:    "<!-- scaffolded by uf vdev -->\n<!-- scaffolded by uf vdev -->\n<!-- scaffolded by uf vv0.6.1 -->\nContent\n",
+			expected: "Content\n",
+		},
+		{
+			name:     "single hash marker",
+			input:    "#!/bin/bash\n# scaffolded by uf vdev\nset -e\n",
+			expected: "#!/bin/bash\nset -e\n",
+		},
+		{
+			name:     "mixed HTML and hash markers",
+			input:    "<!-- scaffolded by uf v1.0.0 -->\n# scaffolded by uf v2.0.0\nContent\n",
+			expected: "Content\n",
+		},
+		{
+			name:     "frontmatter preserved",
+			input:    "---\ntitle: Test\n---\n<!-- scaffolded by uf vdev -->\n# Content\n",
+			expected: "---\ntitle: Test\n---\n# Content\n",
+		},
+		{
+			name:     "empty input",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "content only no markers",
+			input:    "line1\nline2\nline3\n",
+			expected: "line1\nline2\nline3\n",
+		},
+		{
+			name:     "marker-like content preserved",
+			input:    "<!-- scaffolded by someone else -->\nContent\n",
+			expected: "<!-- scaffolded by someone else -->\nContent\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := stripExistingMarkers(tt.input)
+			if got != tt.expected {
+				t.Errorf("got:\n%q\nexpected:\n%q", got, tt.expected)
 			}
 		})
 	}

--- a/openspec/changes/archive/2026-04-28-idempotent-scaffold-markers/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-28-idempotent-scaffold-markers/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: unbound-force
+created: 2026-04-27

--- a/openspec/changes/archive/2026-04-28-idempotent-scaffold-markers/design.md
+++ b/openspec/changes/archive/2026-04-28-idempotent-scaffold-markers/design.md
@@ -1,0 +1,116 @@
+## Context
+
+`insertMarkerAfterFrontmatter` (scaffold.go:393) inserts a
+provenance marker after YAML frontmatter or at the end of a
+file. It is a pure function but not idempotent -- repeated
+calls accumulate markers. The `Run()` function relies on
+`bytes.Equal` to skip unchanged tool-owned files, but this
+defense fails when markers are already baked into the embedded
+assets (which happens through the asset-sync feedback loop in
+this repo).
+
+Separately, `versionMarker()` formats `"v%s"` and GoReleaser
+injects `{{.Tag}}` (already `v`-prefixed), producing `vv0.6.1`.
+
+## Goals / Non-Goals
+
+### Goals
+- Make `insertMarkerAfterFrontmatter` idempotent: any input
+  produces output with exactly one marker, regardless of how
+  many markers the input already contains.
+- Fix the double-v version prefix in release builds.
+- Clean all existing files to exactly one marker each.
+- Add regression tests preventing future accumulation.
+
+### Non-Goals
+- Changing the marker format or moving to a different
+  provenance mechanism.
+- Making markers user-configurable.
+- Changing the drift detection test architecture (approach A
+  keeps byte-identical comparison).
+
+## Decisions
+
+### D1: Strip-then-insert (Approach A)
+
+Add `stripExistingMarkers(s string) string` that removes all
+lines matching the marker patterns:
+- `<!-- scaffolded by uf ... -->`
+- `# scaffolded by uf ...`
+
+Call it at the top of `insertMarkerAfterFrontmatter` before
+the existing insertion logic runs. This is the minimal change
+that breaks the accumulation cycle.
+
+**Rationale**: Approach A was chosen over Approach B
+(marker-free assets with marker-aware drift test) because it
+requires no changes to the drift detection architecture. The
+function becomes self-correcting -- even if markers somehow
+leak into assets, the output is always clean.
+
+### D2: Fix version at GoReleaser level
+
+Change `.goreleaser.yaml` ldflags from `{{.Tag}}` to
+`{{.Version}}`. GoReleaser's `.Version` is the semver without
+the `v` prefix (e.g., `0.6.1`). The `v` prefix in
+`versionMarker`'s format string (`"v%s"`) then produces the
+correct `v0.6.1`.
+
+**Rationale**: Fixing at the injection point rather than in
+`versionMarker()` avoids needing to handle the `dev` case
+(which has no `v` prefix). The `version` variable throughout
+the codebase remains a clean semver without prefix, and
+display functions add `v` where appropriate.
+
+### D3: Assets keep exactly one marker
+
+Both embedded assets and their canonical live counterparts
+retain exactly one `<!-- scaffolded by uf vdev -->` marker.
+The drift test (`TestEmbeddedAssets_MatchSource`) continues
+to pass with no changes because both sides are byte-identical.
+
+When `uf init` runs:
+1. Read asset (1 marker: `vdev`)
+2. Strip existing markers, insert new marker (1 marker: `vX`)
+3. If version matches existing file, `bytes.Equal` succeeds,
+   file skipped. If version changed, content differs, file
+   updated.
+
+### D4: Marker pattern matching uses string prefix
+
+`stripExistingMarkers` uses `strings.HasPrefix` on trimmed
+lines rather than regex. The marker patterns are fixed and
+well-known -- regex would add complexity without benefit.
+
+Two patterns matched:
+- `<!-- scaffolded by uf ` (HTML comment, Markdown files)
+- `# scaffolded by uf ` (hash comment, YAML/shell files)
+
+**Rationale**: Aligns with Observable Quality (constitution
+III) -- the function's behavior is predictable and
+inspectable without needing to reason about regex edge cases.
+
+## Risks / Trade-offs
+
+### R1: Blank line accumulation after stripping
+
+When markers are stripped from between frontmatter and
+content, the resulting blank lines could accumulate. The
+existing insertion logic places the marker immediately after
+the frontmatter closing `---\n`, so no extra blank lines are
+introduced. Stripped marker lines leave no trace (the
+line-by-line filter drops them entirely).
+
+**Mitigation**: The strip function removes whole lines
+including their trailing newline. No blank-line ghosts remain.
+
+### R2: Non-embedded speckit commands
+
+Nine speckit command files (`.opencode/command/speckit.*.md`)
+carry stale markers from when they were embedded assets. They
+are listed in `knownNonEmbeddedFiles` and `uf init` no longer
+manages them. They need a one-time manual cleanup but will
+not accumulate new markers going forward.
+
+**Mitigation**: Include these 9 files in the cleanup task.
+No code change needed since `uf init` already ignores them.

--- a/openspec/changes/archive/2026-04-28-idempotent-scaffold-markers/proposal.md
+++ b/openspec/changes/archive/2026-04-28-idempotent-scaffold-markers/proposal.md
@@ -1,0 +1,98 @@
+## Why
+
+The scaffold engine's `insertMarkerAfterFrontmatter` function
+appends a provenance marker (`<!-- scaffolded by uf vX.Y.Z -->`)
+every time it processes a file, without checking whether one
+already exists. Combined with the asset-to-canonical sync cycle
+in this repo (drift test enforces byte-identical copies), markers
+accumulate with each `uf init` run. Currently 21 live files and
+12 embedded assets carry 3-6 duplicate markers each.
+
+A secondary bug compounds the issue: GoReleaser injects
+`{{.Tag}}` (which includes a `v` prefix, e.g., `v0.6.1`) into
+the `version` variable, and `versionMarker()` adds another `v`
+prefix via its `"v%s"` format string, producing `vv0.6.1`.
+
+## What Changes
+
+Make `insertMarkerAfterFrontmatter` idempotent by stripping
+existing markers before inserting the new one. Fix the double-v
+version prefix. Clean up all existing files.
+
+## Capabilities
+
+### New Capabilities
+- `stripExistingMarkers`: Helper function that removes all
+  scaffold provenance marker lines from content, regardless
+  of version or comment format (HTML or hash).
+
+### Modified Capabilities
+- `insertMarkerAfterFrontmatter`: Now calls
+  `stripExistingMarkers` before inserting, ensuring output
+  always contains exactly one marker.
+- `versionMarker`: No code change to this function; the
+  double-v is fixed at the GoReleaser ldflags level by
+  switching from `{{.Tag}}` to `{{.Version}}`.
+
+### Removed Capabilities
+- None.
+
+## Impact
+
+- **internal/scaffold/scaffold.go**: New
+  `stripExistingMarkers` function; modified
+  `insertMarkerAfterFrontmatter` call site.
+- **internal/scaffold/scaffold_test.go**: Updated "double
+  insert" test expectation (now idempotent). New tests for
+  `stripExistingMarkers` and embedded asset marker count
+  regression.
+- **.goreleaser.yaml**: Two ldflags lines changed
+  (`{{.Tag}}` to `{{.Version}}`).
+- **30 Markdown files**: Mechanical cleanup -- strip
+  duplicate markers to exactly one per file. Affects
+  `.opencode/command/`, `.opencode/uf/packs/`,
+  `.opencode/skill/`, and their embedded asset copies
+  under `internal/scaffold/assets/`.
+
+## Constitution Alignment
+
+Assessed against the Unbound Force org constitution.
+
+### I. Autonomous Collaboration
+
+**Assessment**: N/A
+
+This change is internal to the scaffold engine. It does not
+affect inter-hero artifact communication or self-describing
+outputs. Provenance markers are deployment metadata, not
+inter-hero artifacts.
+
+### II. Composability First
+
+**Assessment**: PASS
+
+The fix is entirely within the scaffold engine. No new
+dependencies are introduced. Standalone functionality is
+preserved -- `uf init` continues to work identically from
+the user's perspective, just without accumulating garbage
+markers.
+
+### III. Observable Quality
+
+**Assessment**: PASS
+
+Provenance markers are a form of observable quality metadata.
+This change ensures they are correct (single marker, accurate
+version) rather than noisy (multiple markers, malformed
+version). Machine parseability improves because consumers of
+these markers can rely on exactly one per file.
+
+### IV. Testability
+
+**Assessment**: PASS
+
+`stripExistingMarkers` is a pure function (string in, string
+out) -- trivially testable in isolation. The modified
+`insertMarkerAfterFrontmatter` remains a pure function. New
+tests cover idempotency, marker stripping, and embedded asset
+regression. No external services or shared state required.

--- a/openspec/changes/archive/2026-04-28-idempotent-scaffold-markers/specs/scaffold/marker-idempotency.md
+++ b/openspec/changes/archive/2026-04-28-idempotent-scaffold-markers/specs/scaffold/marker-idempotency.md
@@ -1,0 +1,94 @@
+## ADDED Requirements
+
+### Requirement: Idempotent marker insertion
+
+`insertMarkerAfterFrontmatter` MUST produce output
+containing exactly one provenance marker line, regardless
+of how many marker lines the input content contains.
+
+The function MUST strip all existing marker lines before
+inserting the new one. Marker lines are identified by the
+prefixes `<!-- scaffolded by uf ` (HTML comment) and
+`# scaffolded by uf ` (hash comment).
+
+#### Scenario: Input with no existing markers
+
+- **GIVEN** content with no scaffold provenance markers
+- **WHEN** `insertMarkerAfterFrontmatter` is called
+- **THEN** the output contains exactly one marker line
+  after the YAML frontmatter closing delimiter (or at end
+  of file if no frontmatter)
+
+#### Scenario: Input with one existing marker
+
+- **GIVEN** content with one scaffold provenance marker
+- **WHEN** `insertMarkerAfterFrontmatter` is called
+- **THEN** the output contains exactly one marker line
+  (the old one is replaced)
+
+#### Scenario: Input with multiple existing markers
+
+- **GIVEN** content with three or more scaffold markers
+- **WHEN** `insertMarkerAfterFrontmatter` is called
+- **THEN** the output contains exactly one marker line
+  and all original content (non-marker lines) is preserved
+
+#### Scenario: Repeated calls produce stable output
+
+- **GIVEN** content that has already been processed by
+  `insertMarkerAfterFrontmatter`
+- **WHEN** `insertMarkerAfterFrontmatter` is called again
+  with the same version marker
+- **THEN** the output is byte-identical to the input
+
+### Requirement: Version marker correctness
+
+`versionMarker` MUST produce markers with a single `v`
+prefix followed by the semantic version (e.g.,
+`v0.6.1`). Release builds MUST NOT produce double-v
+prefixes (e.g., `vv0.6.1`).
+
+#### Scenario: Release build version marker
+
+- **GIVEN** GoReleaser injects the version via ldflags
+- **WHEN** `versionMarker` formats the provenance marker
+- **THEN** the marker reads `<!-- scaffolded by uf vX.Y.Z -->`
+  with exactly one `v` prefix
+
+#### Scenario: Development build version marker
+
+- **GIVEN** the version variable defaults to `"dev"`
+- **WHEN** `versionMarker` formats the provenance marker
+- **THEN** the marker reads `<!-- scaffolded by uf vdev -->`
+
+### Requirement: Embedded asset marker regression guard
+
+Automated tests MUST verify that no embedded asset under
+`internal/scaffold/assets/` contains more than one
+scaffold provenance marker line.
+
+#### Scenario: Drift test catches marker accumulation
+
+- **GIVEN** an embedded asset file is modified to contain
+  two or more scaffold marker lines
+- **WHEN** the test suite runs
+- **THEN** the test fails with a message identifying the
+  file and the number of markers found
+
+## MODIFIED Requirements
+
+### Requirement: Tool-owned file update semantics
+
+Previously: `Run()` achieves idempotency via the
+`bytes.Equal` check for tool-owned files, compensating
+for the non-idempotent `insertMarkerAfterFrontmatter`.
+
+Now: `insertMarkerAfterFrontmatter` is itself idempotent.
+The `bytes.Equal` check in `Run()` remains as a
+performance optimization (avoids unnecessary disk writes)
+but is no longer the sole defense against marker
+accumulation.
+
+## REMOVED Requirements
+
+None.

--- a/openspec/changes/archive/2026-04-28-idempotent-scaffold-markers/tasks.md
+++ b/openspec/changes/archive/2026-04-28-idempotent-scaffold-markers/tasks.md
@@ -1,0 +1,80 @@
+## 1. Idempotent marker insertion
+
+- [x] 1.1 Add `stripExistingMarkers(s string) string` to
+  `internal/scaffold/scaffold.go`. The function removes all
+  lines whose trimmed content starts with
+  `<!-- scaffolded by uf ` or `# scaffolded by uf `.
+  Preserves all other lines including blank lines.
+- [x] 1.2 Modify `insertMarkerAfterFrontmatter` to call
+  `stripExistingMarkers` on its input string before
+  proceeding with the existing frontmatter detection and
+  marker insertion logic.
+
+## 2. Fix double-v version prefix
+
+- [x] 2.1 In `.goreleaser.yaml`, change the `unbound-force`
+  build ldflags from `-X main.version={{.Tag}}` to
+  `-X main.version={{.Version}}` (line 18).
+- [x] 2.2 In `.goreleaser.yaml`, change the `mxf` build
+  ldflags from `-X main.version={{.Tag}}` to
+  `-X main.version={{.Version}}` (line 35).
+
+## 3. Clean up embedded assets
+
+Strip duplicate markers from all files under
+`internal/scaffold/assets/` so each has exactly one
+`<!-- scaffolded by uf vdev -->` line after frontmatter.
+
+- [x] 3.1 Clean `internal/scaffold/assets/opencode/command/`
+  (6 files: cobalt-crush.md, constitution-check.md,
+  finale.md, review-council.md, uf-init.md, unleash.md)
+- [x] 3.2 Clean `internal/scaffold/assets/opencode/uf/packs/`
+  (5 files: content.md, default.md, go.md, severity.md,
+  typescript.md)
+- [x] 3.3 Clean
+  `internal/scaffold/assets/opencode/skill/speckit-workflow/SKILL.md`
+
+## 4. Clean up live files
+
+Strip duplicate markers from all live files so each has
+exactly one `<!-- scaffolded by uf vdev -->` line after
+frontmatter.
+
+- [x] 4.1 Clean `.opencode/command/` embedded counterparts
+  (6 files matching task 3.1)
+- [x] 4.2 Clean `.opencode/uf/packs/` files
+  (5 files matching task 3.2)
+- [x] 4.3 Clean `.opencode/skill/speckit-workflow/SKILL.md`
+- [x] 4.4 Clean non-embedded speckit commands
+  (9 files: speckit.analyze.md, speckit.checklist.md,
+  speckit.clarify.md, speckit.constitution.md,
+  speckit.implement.md, speckit.plan.md, speckit.specify.md,
+  speckit.tasks.md, speckit.taskstoissues.md)
+
+## 5. Update tests
+
+- [x] 5.1 Add `TestStripExistingMarkers` to
+  `scaffold_test.go` covering: no markers, single marker,
+  multiple markers, mixed HTML/hash markers, content
+  preservation, frontmatter preservation.
+- [x] 5.2 Update the `"double insert on repeat call"` test
+  case in `TestInsertMarkerAfterFrontmatter`. Change
+  expected output from double-marker to single-marker
+  (function is now idempotent).
+- [x] 5.3 Add `TestEmbeddedAssets_SingleMarker` regression
+  test: walk all embedded `.md` assets and assert each
+  contains at most one line matching the scaffold marker
+  pattern.
+
+## 6. Verification
+
+- [x] 6.1 Run `go test -race -count=1 ./...` and confirm
+  all tests pass (including drift detection).
+- [x] 6.2 Run `go vet ./...` and confirm no issues.
+- [x] 6.3 Run `golangci-lint run` and confirm no issues.
+- [x] 6.4 Verify no file in the repo contains more than one
+  scaffold marker line (grep check).
+- [x] 6.5 Constitution alignment: Observable Quality (III)
+  -- provenance markers are correct (single, accurate
+  version); Testability (IV) -- new pure functions have
+  isolation tests.

--- a/openspec/changes/idempotent-scaffold-markers/.openspec.yaml
+++ b/openspec/changes/idempotent-scaffold-markers/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: unbound-force
+created: 2026-04-27

--- a/openspec/changes/idempotent-scaffold-markers/design.md
+++ b/openspec/changes/idempotent-scaffold-markers/design.md
@@ -1,0 +1,116 @@
+## Context
+
+`insertMarkerAfterFrontmatter` (scaffold.go:393) inserts a
+provenance marker after YAML frontmatter or at the end of a
+file. It is a pure function but not idempotent -- repeated
+calls accumulate markers. The `Run()` function relies on
+`bytes.Equal` to skip unchanged tool-owned files, but this
+defense fails when markers are already baked into the embedded
+assets (which happens through the asset-sync feedback loop in
+this repo).
+
+Separately, `versionMarker()` formats `"v%s"` and GoReleaser
+injects `{{.Tag}}` (already `v`-prefixed), producing `vv0.6.1`.
+
+## Goals / Non-Goals
+
+### Goals
+- Make `insertMarkerAfterFrontmatter` idempotent: any input
+  produces output with exactly one marker, regardless of how
+  many markers the input already contains.
+- Fix the double-v version prefix in release builds.
+- Clean all existing files to exactly one marker each.
+- Add regression tests preventing future accumulation.
+
+### Non-Goals
+- Changing the marker format or moving to a different
+  provenance mechanism.
+- Making markers user-configurable.
+- Changing the drift detection test architecture (approach A
+  keeps byte-identical comparison).
+
+## Decisions
+
+### D1: Strip-then-insert (Approach A)
+
+Add `stripExistingMarkers(s string) string` that removes all
+lines matching the marker patterns:
+- `<!-- scaffolded by uf ... -->`
+- `# scaffolded by uf ...`
+
+Call it at the top of `insertMarkerAfterFrontmatter` before
+the existing insertion logic runs. This is the minimal change
+that breaks the accumulation cycle.
+
+**Rationale**: Approach A was chosen over Approach B
+(marker-free assets with marker-aware drift test) because it
+requires no changes to the drift detection architecture. The
+function becomes self-correcting -- even if markers somehow
+leak into assets, the output is always clean.
+
+### D2: Fix version at GoReleaser level
+
+Change `.goreleaser.yaml` ldflags from `{{.Tag}}` to
+`{{.Version}}`. GoReleaser's `.Version` is the semver without
+the `v` prefix (e.g., `0.6.1`). The `v` prefix in
+`versionMarker`'s format string (`"v%s"`) then produces the
+correct `v0.6.1`.
+
+**Rationale**: Fixing at the injection point rather than in
+`versionMarker()` avoids needing to handle the `dev` case
+(which has no `v` prefix). The `version` variable throughout
+the codebase remains a clean semver without prefix, and
+display functions add `v` where appropriate.
+
+### D3: Assets keep exactly one marker
+
+Both embedded assets and their canonical live counterparts
+retain exactly one `<!-- scaffolded by uf vdev -->` marker.
+The drift test (`TestEmbeddedAssets_MatchSource`) continues
+to pass with no changes because both sides are byte-identical.
+
+When `uf init` runs:
+1. Read asset (1 marker: `vdev`)
+2. Strip existing markers, insert new marker (1 marker: `vX`)
+3. If version matches existing file, `bytes.Equal` succeeds,
+   file skipped. If version changed, content differs, file
+   updated.
+
+### D4: Marker pattern matching uses string prefix
+
+`stripExistingMarkers` uses `strings.HasPrefix` on trimmed
+lines rather than regex. The marker patterns are fixed and
+well-known -- regex would add complexity without benefit.
+
+Two patterns matched:
+- `<!-- scaffolded by uf ` (HTML comment, Markdown files)
+- `# scaffolded by uf ` (hash comment, YAML/shell files)
+
+**Rationale**: Aligns with Observable Quality (constitution
+III) -- the function's behavior is predictable and
+inspectable without needing to reason about regex edge cases.
+
+## Risks / Trade-offs
+
+### R1: Blank line accumulation after stripping
+
+When markers are stripped from between frontmatter and
+content, the resulting blank lines could accumulate. The
+existing insertion logic places the marker immediately after
+the frontmatter closing `---\n`, so no extra blank lines are
+introduced. Stripped marker lines leave no trace (the
+line-by-line filter drops them entirely).
+
+**Mitigation**: The strip function removes whole lines
+including their trailing newline. No blank-line ghosts remain.
+
+### R2: Non-embedded speckit commands
+
+Nine speckit command files (`.opencode/command/speckit.*.md`)
+carry stale markers from when they were embedded assets. They
+are listed in `knownNonEmbeddedFiles` and `uf init` no longer
+manages them. They need a one-time manual cleanup but will
+not accumulate new markers going forward.
+
+**Mitigation**: Include these 9 files in the cleanup task.
+No code change needed since `uf init` already ignores them.

--- a/openspec/changes/idempotent-scaffold-markers/proposal.md
+++ b/openspec/changes/idempotent-scaffold-markers/proposal.md
@@ -1,0 +1,98 @@
+## Why
+
+The scaffold engine's `insertMarkerAfterFrontmatter` function
+appends a provenance marker (`<!-- scaffolded by uf vX.Y.Z -->`)
+every time it processes a file, without checking whether one
+already exists. Combined with the asset-to-canonical sync cycle
+in this repo (drift test enforces byte-identical copies), markers
+accumulate with each `uf init` run. Currently 21 live files and
+12 embedded assets carry 3-6 duplicate markers each.
+
+A secondary bug compounds the issue: GoReleaser injects
+`{{.Tag}}` (which includes a `v` prefix, e.g., `v0.6.1`) into
+the `version` variable, and `versionMarker()` adds another `v`
+prefix via its `"v%s"` format string, producing `vv0.6.1`.
+
+## What Changes
+
+Make `insertMarkerAfterFrontmatter` idempotent by stripping
+existing markers before inserting the new one. Fix the double-v
+version prefix. Clean up all existing files.
+
+## Capabilities
+
+### New Capabilities
+- `stripExistingMarkers`: Helper function that removes all
+  scaffold provenance marker lines from content, regardless
+  of version or comment format (HTML or hash).
+
+### Modified Capabilities
+- `insertMarkerAfterFrontmatter`: Now calls
+  `stripExistingMarkers` before inserting, ensuring output
+  always contains exactly one marker.
+- `versionMarker`: No code change to this function; the
+  double-v is fixed at the GoReleaser ldflags level by
+  switching from `{{.Tag}}` to `{{.Version}}`.
+
+### Removed Capabilities
+- None.
+
+## Impact
+
+- **internal/scaffold/scaffold.go**: New
+  `stripExistingMarkers` function; modified
+  `insertMarkerAfterFrontmatter` call site.
+- **internal/scaffold/scaffold_test.go**: Updated "double
+  insert" test expectation (now idempotent). New tests for
+  `stripExistingMarkers` and embedded asset marker count
+  regression.
+- **.goreleaser.yaml**: Two ldflags lines changed
+  (`{{.Tag}}` to `{{.Version}}`).
+- **30 Markdown files**: Mechanical cleanup -- strip
+  duplicate markers to exactly one per file. Affects
+  `.opencode/command/`, `.opencode/uf/packs/`,
+  `.opencode/skill/`, and their embedded asset copies
+  under `internal/scaffold/assets/`.
+
+## Constitution Alignment
+
+Assessed against the Unbound Force org constitution.
+
+### I. Autonomous Collaboration
+
+**Assessment**: N/A
+
+This change is internal to the scaffold engine. It does not
+affect inter-hero artifact communication or self-describing
+outputs. Provenance markers are deployment metadata, not
+inter-hero artifacts.
+
+### II. Composability First
+
+**Assessment**: PASS
+
+The fix is entirely within the scaffold engine. No new
+dependencies are introduced. Standalone functionality is
+preserved -- `uf init` continues to work identically from
+the user's perspective, just without accumulating garbage
+markers.
+
+### III. Observable Quality
+
+**Assessment**: PASS
+
+Provenance markers are a form of observable quality metadata.
+This change ensures they are correct (single marker, accurate
+version) rather than noisy (multiple markers, malformed
+version). Machine parseability improves because consumers of
+these markers can rely on exactly one per file.
+
+### IV. Testability
+
+**Assessment**: PASS
+
+`stripExistingMarkers` is a pure function (string in, string
+out) -- trivially testable in isolation. The modified
+`insertMarkerAfterFrontmatter` remains a pure function. New
+tests cover idempotency, marker stripping, and embedded asset
+regression. No external services or shared state required.

--- a/openspec/changes/idempotent-scaffold-markers/specs/scaffold/marker-idempotency.md
+++ b/openspec/changes/idempotent-scaffold-markers/specs/scaffold/marker-idempotency.md
@@ -1,0 +1,94 @@
+## ADDED Requirements
+
+### Requirement: Idempotent marker insertion
+
+`insertMarkerAfterFrontmatter` MUST produce output
+containing exactly one provenance marker line, regardless
+of how many marker lines the input content contains.
+
+The function MUST strip all existing marker lines before
+inserting the new one. Marker lines are identified by the
+prefixes `<!-- scaffolded by uf ` (HTML comment) and
+`# scaffolded by uf ` (hash comment).
+
+#### Scenario: Input with no existing markers
+
+- **GIVEN** content with no scaffold provenance markers
+- **WHEN** `insertMarkerAfterFrontmatter` is called
+- **THEN** the output contains exactly one marker line
+  after the YAML frontmatter closing delimiter (or at end
+  of file if no frontmatter)
+
+#### Scenario: Input with one existing marker
+
+- **GIVEN** content with one scaffold provenance marker
+- **WHEN** `insertMarkerAfterFrontmatter` is called
+- **THEN** the output contains exactly one marker line
+  (the old one is replaced)
+
+#### Scenario: Input with multiple existing markers
+
+- **GIVEN** content with three or more scaffold markers
+- **WHEN** `insertMarkerAfterFrontmatter` is called
+- **THEN** the output contains exactly one marker line
+  and all original content (non-marker lines) is preserved
+
+#### Scenario: Repeated calls produce stable output
+
+- **GIVEN** content that has already been processed by
+  `insertMarkerAfterFrontmatter`
+- **WHEN** `insertMarkerAfterFrontmatter` is called again
+  with the same version marker
+- **THEN** the output is byte-identical to the input
+
+### Requirement: Version marker correctness
+
+`versionMarker` MUST produce markers with a single `v`
+prefix followed by the semantic version (e.g.,
+`v0.6.1`). Release builds MUST NOT produce double-v
+prefixes (e.g., `vv0.6.1`).
+
+#### Scenario: Release build version marker
+
+- **GIVEN** GoReleaser injects the version via ldflags
+- **WHEN** `versionMarker` formats the provenance marker
+- **THEN** the marker reads `<!-- scaffolded by uf vX.Y.Z -->`
+  with exactly one `v` prefix
+
+#### Scenario: Development build version marker
+
+- **GIVEN** the version variable defaults to `"dev"`
+- **WHEN** `versionMarker` formats the provenance marker
+- **THEN** the marker reads `<!-- scaffolded by uf vdev -->`
+
+### Requirement: Embedded asset marker regression guard
+
+Automated tests MUST verify that no embedded asset under
+`internal/scaffold/assets/` contains more than one
+scaffold provenance marker line.
+
+#### Scenario: Drift test catches marker accumulation
+
+- **GIVEN** an embedded asset file is modified to contain
+  two or more scaffold marker lines
+- **WHEN** the test suite runs
+- **THEN** the test fails with a message identifying the
+  file and the number of markers found
+
+## MODIFIED Requirements
+
+### Requirement: Tool-owned file update semantics
+
+Previously: `Run()` achieves idempotency via the
+`bytes.Equal` check for tool-owned files, compensating
+for the non-idempotent `insertMarkerAfterFrontmatter`.
+
+Now: `insertMarkerAfterFrontmatter` is itself idempotent.
+The `bytes.Equal` check in `Run()` remains as a
+performance optimization (avoids unnecessary disk writes)
+but is no longer the sole defense against marker
+accumulation.
+
+## REMOVED Requirements
+
+None.

--- a/openspec/changes/idempotent-scaffold-markers/tasks.md
+++ b/openspec/changes/idempotent-scaffold-markers/tasks.md
@@ -1,0 +1,80 @@
+## 1. Idempotent marker insertion
+
+- [ ] 1.1 Add `stripExistingMarkers(s string) string` to
+  `internal/scaffold/scaffold.go`. The function removes all
+  lines whose trimmed content starts with
+  `<!-- scaffolded by uf ` or `# scaffolded by uf `.
+  Preserves all other lines including blank lines.
+- [ ] 1.2 Modify `insertMarkerAfterFrontmatter` to call
+  `stripExistingMarkers` on its input string before
+  proceeding with the existing frontmatter detection and
+  marker insertion logic.
+
+## 2. Fix double-v version prefix
+
+- [ ] 2.1 In `.goreleaser.yaml`, change the `unbound-force`
+  build ldflags from `-X main.version={{.Tag}}` to
+  `-X main.version={{.Version}}` (line 18).
+- [ ] 2.2 In `.goreleaser.yaml`, change the `mxf` build
+  ldflags from `-X main.version={{.Tag}}` to
+  `-X main.version={{.Version}}` (line 35).
+
+## 3. Clean up embedded assets
+
+Strip duplicate markers from all files under
+`internal/scaffold/assets/` so each has exactly one
+`<!-- scaffolded by uf vdev -->` line after frontmatter.
+
+- [ ] 3.1 Clean `internal/scaffold/assets/opencode/command/`
+  (6 files: cobalt-crush.md, constitution-check.md,
+  finale.md, review-council.md, uf-init.md, unleash.md)
+- [ ] 3.2 Clean `internal/scaffold/assets/opencode/uf/packs/`
+  (5 files: content.md, default.md, go.md, severity.md,
+  typescript.md)
+- [ ] 3.3 Clean
+  `internal/scaffold/assets/opencode/skill/speckit-workflow/SKILL.md`
+
+## 4. Clean up live files
+
+Strip duplicate markers from all live files so each has
+exactly one `<!-- scaffolded by uf vdev -->` line after
+frontmatter.
+
+- [ ] 4.1 Clean `.opencode/command/` embedded counterparts
+  (6 files matching task 3.1)
+- [ ] 4.2 Clean `.opencode/uf/packs/` files
+  (5 files matching task 3.2)
+- [ ] 4.3 Clean `.opencode/skill/speckit-workflow/SKILL.md`
+- [ ] 4.4 Clean non-embedded speckit commands
+  (9 files: speckit.analyze.md, speckit.checklist.md,
+  speckit.clarify.md, speckit.constitution.md,
+  speckit.implement.md, speckit.plan.md, speckit.specify.md,
+  speckit.tasks.md, speckit.taskstoissues.md)
+
+## 5. Update tests
+
+- [ ] 5.1 Add `TestStripExistingMarkers` to
+  `scaffold_test.go` covering: no markers, single marker,
+  multiple markers, mixed HTML/hash markers, content
+  preservation, frontmatter preservation.
+- [ ] 5.2 Update the `"double insert on repeat call"` test
+  case in `TestInsertMarkerAfterFrontmatter`. Change
+  expected output from double-marker to single-marker
+  (function is now idempotent).
+- [ ] 5.3 Add `TestEmbeddedAssets_SingleMarker` regression
+  test: walk all embedded `.md` assets and assert each
+  contains at most one line matching the scaffold marker
+  pattern.
+
+## 6. Verification
+
+- [ ] 6.1 Run `go test -race -count=1 ./...` and confirm
+  all tests pass (including drift detection).
+- [ ] 6.2 Run `go vet ./...` and confirm no issues.
+- [ ] 6.3 Run `golangci-lint run` and confirm no issues.
+- [ ] 6.4 Verify no file in the repo contains more than one
+  scaffold marker line (grep check).
+- [ ] 6.5 Constitution alignment: Observable Quality (III)
+  -- provenance markers are correct (single, accurate
+  version); Testability (IV) -- new pure functions have
+  isolation tests.

--- a/openspec/changes/idempotent-scaffold-markers/tasks.md
+++ b/openspec/changes/idempotent-scaffold-markers/tasks.md
@@ -1,21 +1,21 @@
 ## 1. Idempotent marker insertion
 
-- [ ] 1.1 Add `stripExistingMarkers(s string) string` to
+- [x] 1.1 Add `stripExistingMarkers(s string) string` to
   `internal/scaffold/scaffold.go`. The function removes all
   lines whose trimmed content starts with
   `<!-- scaffolded by uf ` or `# scaffolded by uf `.
   Preserves all other lines including blank lines.
-- [ ] 1.2 Modify `insertMarkerAfterFrontmatter` to call
+- [x] 1.2 Modify `insertMarkerAfterFrontmatter` to call
   `stripExistingMarkers` on its input string before
   proceeding with the existing frontmatter detection and
   marker insertion logic.
 
 ## 2. Fix double-v version prefix
 
-- [ ] 2.1 In `.goreleaser.yaml`, change the `unbound-force`
+- [x] 2.1 In `.goreleaser.yaml`, change the `unbound-force`
   build ldflags from `-X main.version={{.Tag}}` to
   `-X main.version={{.Version}}` (line 18).
-- [ ] 2.2 In `.goreleaser.yaml`, change the `mxf` build
+- [x] 2.2 In `.goreleaser.yaml`, change the `mxf` build
   ldflags from `-X main.version={{.Tag}}` to
   `-X main.version={{.Version}}` (line 35).
 
@@ -25,13 +25,13 @@ Strip duplicate markers from all files under
 `internal/scaffold/assets/` so each has exactly one
 `<!-- scaffolded by uf vdev -->` line after frontmatter.
 
-- [ ] 3.1 Clean `internal/scaffold/assets/opencode/command/`
+- [x] 3.1 Clean `internal/scaffold/assets/opencode/command/`
   (6 files: cobalt-crush.md, constitution-check.md,
   finale.md, review-council.md, uf-init.md, unleash.md)
-- [ ] 3.2 Clean `internal/scaffold/assets/opencode/uf/packs/`
+- [x] 3.2 Clean `internal/scaffold/assets/opencode/uf/packs/`
   (5 files: content.md, default.md, go.md, severity.md,
   typescript.md)
-- [ ] 3.3 Clean
+- [x] 3.3 Clean
   `internal/scaffold/assets/opencode/skill/speckit-workflow/SKILL.md`
 
 ## 4. Clean up live files
@@ -40,12 +40,12 @@ Strip duplicate markers from all live files so each has
 exactly one `<!-- scaffolded by uf vdev -->` line after
 frontmatter.
 
-- [ ] 4.1 Clean `.opencode/command/` embedded counterparts
+- [x] 4.1 Clean `.opencode/command/` embedded counterparts
   (6 files matching task 3.1)
-- [ ] 4.2 Clean `.opencode/uf/packs/` files
+- [x] 4.2 Clean `.opencode/uf/packs/` files
   (5 files matching task 3.2)
-- [ ] 4.3 Clean `.opencode/skill/speckit-workflow/SKILL.md`
-- [ ] 4.4 Clean non-embedded speckit commands
+- [x] 4.3 Clean `.opencode/skill/speckit-workflow/SKILL.md`
+- [x] 4.4 Clean non-embedded speckit commands
   (9 files: speckit.analyze.md, speckit.checklist.md,
   speckit.clarify.md, speckit.constitution.md,
   speckit.implement.md, speckit.plan.md, speckit.specify.md,
@@ -53,28 +53,28 @@ frontmatter.
 
 ## 5. Update tests
 
-- [ ] 5.1 Add `TestStripExistingMarkers` to
+- [x] 5.1 Add `TestStripExistingMarkers` to
   `scaffold_test.go` covering: no markers, single marker,
   multiple markers, mixed HTML/hash markers, content
   preservation, frontmatter preservation.
-- [ ] 5.2 Update the `"double insert on repeat call"` test
+- [x] 5.2 Update the `"double insert on repeat call"` test
   case in `TestInsertMarkerAfterFrontmatter`. Change
   expected output from double-marker to single-marker
   (function is now idempotent).
-- [ ] 5.3 Add `TestEmbeddedAssets_SingleMarker` regression
+- [x] 5.3 Add `TestEmbeddedAssets_SingleMarker` regression
   test: walk all embedded `.md` assets and assert each
   contains at most one line matching the scaffold marker
   pattern.
 
 ## 6. Verification
 
-- [ ] 6.1 Run `go test -race -count=1 ./...` and confirm
+- [x] 6.1 Run `go test -race -count=1 ./...` and confirm
   all tests pass (including drift detection).
-- [ ] 6.2 Run `go vet ./...` and confirm no issues.
-- [ ] 6.3 Run `golangci-lint run` and confirm no issues.
-- [ ] 6.4 Verify no file in the repo contains more than one
+- [x] 6.2 Run `go vet ./...` and confirm no issues.
+- [x] 6.3 Run `golangci-lint run` and confirm no issues.
+- [x] 6.4 Verify no file in the repo contains more than one
   scaffold marker line (grep check).
-- [ ] 6.5 Constitution alignment: Observable Quality (III)
+- [x] 6.5 Constitution alignment: Observable Quality (III)
   -- provenance markers are correct (single, accurate
   version); Testability (IV) -- new pure functions have
   isolation tests.

--- a/openspec/schemas/unbound-force/templates/design.md
+++ b/openspec/schemas/unbound-force/templates/design.md
@@ -17,9 +17,4 @@
 ## Risks / Trade-offs
 
 <!-- Known risks and accepted trade-offs -->
-<!-- scaffolded by uf vv0.6.1 -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->

--- a/openspec/schemas/unbound-force/templates/proposal.md
+++ b/openspec/schemas/unbound-force/templates/proposal.md
@@ -54,9 +54,4 @@ output? Does it maintain provenance metadata? -->
 
 <!-- Does this change verify observable side effects?
 Are components testable in isolation? -->
-<!-- scaffolded by uf vv0.6.1 -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->

--- a/openspec/schemas/unbound-force/templates/spec.md
+++ b/openspec/schemas/unbound-force/templates/spec.md
@@ -20,9 +20,4 @@
 ### Requirement: <!-- name -->
 
 <!-- reason for removal -->
-<!-- scaffolded by uf vv0.6.1 -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->

--- a/openspec/schemas/unbound-force/templates/tasks.md
+++ b/openspec/schemas/unbound-force/templates/tasks.md
@@ -6,9 +6,4 @@
 ## 2. <!-- Task Group -->
 
 - [ ] 2.1 <!-- task description -->
-<!-- scaffolded by uf vv0.6.1 -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
-<!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->


### PR DESCRIPTION
## Summary

- Make `insertMarkerAfterFrontmatter` idempotent by stripping existing markers before inserting — breaks the accumulation cycle that produced 3-6 duplicate `<!-- scaffolded by uf vdev -->` lines per file
- Fix double-v version prefix (`vv0.6.1`) by changing GoReleaser ldflags from `{{.Tag}}` to `{{.Version}}`
- Clean 37 files (embedded assets, live commands, packs, OpenSpec templates) to exactly 1 marker each

## Changes

**Go logic** (`internal/scaffold/scaffold.go`):
- New `stripExistingMarkers()` helper removes all lines matching the marker pattern
- `insertMarkerAfterFrontmatter` calls it before inserting, making the function idempotent

**GoReleaser** (`.goreleaser.yaml`):
- Both `unbound-force` and `mxf` builds: `{{.Tag}}` → `{{.Version}}` in ldflags

**Marker cleanup** (37 Markdown files):
- Embedded assets, live commands, convention packs, skill, OpenSpec templates — all reduced to exactly 1 marker

**Tests** (`internal/scaffold/scaffold_test.go`):
- `TestStripExistingMarkers` — 9 cases (no markers, single, multiple, mixed formats, frontmatter preservation)
- `TestEmbeddedAssets_SingleMarker` — regression guard preventing future accumulation
- Updated idempotency test expectations (3 new cases)

## Verification

- `go test -race -count=1 ./...` — 19/19 packages pass
- `go vet ./...` — clean
- `golangci-lint run` — 0 issues
- Grep check — no production file has more than 1 marker