### PR TITLE
fix(ci): upgrade to setup-go v6.4.0 with GOTOOLCHAIN=auto and Go 1.25

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff  # v5.6.0
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
           go-version-file: go.mod
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,12 +10,14 @@ jobs:
   test:
     name: Build & Test
     runs-on: ubuntu-latest
+    env:
+      GOTOOLCHAIN: auto
     steps:
       - name: Checkout Code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Set up Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff  # v5.6.0
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
           go-version-file: 'go.mod'
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/unbound-force/unbound-force
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/charmbracelet/lipgloss v1.1.0


### PR DESCRIPTION
## Summary

- Upgrades `actions/setup-go` from v5.6.0 to v6.4.0 in both `test.yml` and `release.yml`
- Upgrades `go.mod` from Go 1.24.0 to Go 1.25.0
- Adds `GOTOOLCHAIN: auto` at the test job level for resilience against future tool version bumps

## Root Cause

Detected in [CI run #25038595224](https://github.com/unbound-force/unbound-force/actions/runs/25038595224/job/73336001676?pr=129) on PR #129.

`actions/setup-go` v6 sets `GOTOOLCHAIN=local` by default, preventing Go from auto-downloading newer toolchains. This broke `go install golangci-lint/v2@latest` because v2.11.4 requires Go >= 1.25.0, but CI was running Go 1.24.0 (from `go.mod`).

## Fix

1. **Go 1.25 upgrade** — satisfies the current golangci-lint Go requirement directly
2. **GOTOOLCHAIN=auto** — provides resilience if `@latest` tools bump their Go requirement past the `go.mod` version in the future

Supersedes #129.

## Verification

All CI-equivalent checks pass locally:

```
go build ./...     # OK
go vet ./...       # OK
golangci-lint run  # 0 issues
go test -race -count=1 ./...  # 19/19 packages OK
```