### PR TITLE
chore: add branch protection instructions and doctor check

### DIFF
--- a/.opencode/command/agent-brief.md
+++ b/.opencode/command/agent-brief.md
@@ -182,7 +182,11 @@ comment explaining what to fill and why it matters:
 ## Git & Workflow
 <!-- TODO: Commit format, branching strategy, PR requirements.
      Example: "Conventional commits (type: description), feature
-     branches from main, 1 approving review required." -->
+     branches from main, 1 approving review required."
+     IMPORTANT: Include an explicit branch protection rule
+     stating agents MUST NOT commit directly to main. All
+     changes -- including docs, chores, and archives -- must
+     go through a feature branch and pull request. -->
 ```
 
 **Behavioral Constraints**:
@@ -191,6 +195,7 @@ comment explaining what to fill and why it matters:
 <!-- TODO: Things agents must NEVER do. Negative instructions are
      often more impactful than positive ones.
      Examples:
+     - "Never commit directly to main -- always use a feature branch."
      - "Never modify coverage thresholds to make tests pass."
      - "Never commit .env files or credentials."
      - "Never use os.Exit() in library code." -->
@@ -253,6 +258,12 @@ Record which sections are found and which are missing.
    constitution governs both frameworks. Look for co-occurrence
    of "constitution" with "both"/"all"/"regardless"/"openspec"
    within the spec framework or constitution section.
+7. **Branch protection**: Check if AGENTS.md contains explicit
+   instructions prohibiting direct commits to `main`. Look for
+   co-occurrence of "main" with "MUST NOT"/"never"/"prohibited"
+   in a branching, workflow, or constraints section. Flag if
+   absent -- agents without this instruction may commit directly
+   to the default branch.
 
 #### 4c: Scoring
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,6 +114,30 @@ Use `/review-council` before pushing to validate your
 own work. Use `/review-pr` after creating a PR to
 review any PR (yours or others').
 
+### Branch Protection
+
+Agents MUST NOT commit directly to `main`. All changes
+-- including documentation, archival, chores, and CI
+fixes -- MUST be committed on a feature branch and
+submitted via pull request.
+
+Before running `git commit`, verify the current branch:
+
+```bash
+git branch --show-current
+```
+
+If on `main`, create a branch first:
+
+```bash
+git checkout -b <type>/<short-description>
+```
+
+A direct commit to `main` is a process violation. If it
+occurs, immediately move the commit to a branch (via
+`git branch <name>` + `git reset`), restore `main`, and
+submit a PR instead.
+
 ## Constitution (Highest Authority)
 
 The org constitution at `.specify/memory/constitution.md` defines four core principles that govern all hero repositories:

--- a/internal/doctor/checks.go
+++ b/internal/doctor/checks.go
@@ -1305,6 +1305,37 @@ func hasSpecNumberedDirs(specsDir string) bool {
 	return false
 }
 
+// checkBridgeFile checks whether a bridge file exists and
+// references AGENTS.md. The verb parameter describes the
+// relationship (e.g., "imports" for CLAUDE.md, "references"
+// for .cursorrules).
+func checkBridgeFile(opts *Options, filename, verb string) CheckResult {
+	name := "Bridge: " + filename
+	path := filepath.Join(opts.TargetDir, filename)
+	content, err := opts.ReadFile(path)
+	if err != nil {
+		return CheckResult{
+			Name:        name,
+			Severity:    Warn,
+			Message:     "not found",
+			InstallHint: "Run: /agent-brief in OpenCode",
+		}
+	}
+	if strings.Contains(string(content), "AGENTS.md") {
+		return CheckResult{
+			Name:     name,
+			Severity: Pass,
+			Message:  verb + " AGENTS.md",
+		}
+	}
+	return CheckResult{
+		Name:        name,
+		Severity:    Warn,
+		Message:     "exists but does not reference AGENTS.md",
+		InstallHint: "Run: /agent-brief in OpenCode",
+	}
+}
+
 // checkAgentContext validates AGENTS.md content quality with a
 // context-sensitive section taxonomy. Checks file existence,
 // Tier 1 section headers, build code blocks, line count,
@@ -1434,59 +1465,11 @@ func checkAgentContext(opts *Options) CheckGroup {
 		}
 	}
 
-	// Check #11: CLAUDE.md bridge.
-	claudePath := filepath.Join(opts.TargetDir, "CLAUDE.md")
-	claudeContent, claudeErr := opts.ReadFile(claudePath)
-	if claudeErr == nil {
-		if strings.Contains(string(claudeContent), "AGENTS.md") {
-			group.Results = append(group.Results, CheckResult{
-				Name:     "Bridge: CLAUDE.md",
-				Severity: Pass,
-				Message:  "imports AGENTS.md",
-			})
-		} else {
-			group.Results = append(group.Results, CheckResult{
-				Name:        "Bridge: CLAUDE.md",
-				Severity:    Warn,
-				Message:     "exists but does not reference AGENTS.md",
-				InstallHint: "Run: /agent-brief in OpenCode",
-			})
-		}
-	} else {
-		group.Results = append(group.Results, CheckResult{
-			Name:        "Bridge: CLAUDE.md",
-			Severity:    Warn,
-			Message:     "not found",
-			InstallHint: "Run: /agent-brief in OpenCode",
-		})
-	}
-
-	// Check #12: .cursorrules bridge.
-	cursorPath := filepath.Join(opts.TargetDir, ".cursorrules")
-	cursorContent, cursorErr := opts.ReadFile(cursorPath)
-	if cursorErr == nil {
-		if strings.Contains(string(cursorContent), "AGENTS.md") {
-			group.Results = append(group.Results, CheckResult{
-				Name:     "Bridge: .cursorrules",
-				Severity: Pass,
-				Message:  "references AGENTS.md",
-			})
-		} else {
-			group.Results = append(group.Results, CheckResult{
-				Name:        "Bridge: .cursorrules",
-				Severity:    Warn,
-				Message:     "exists but does not reference AGENTS.md",
-				InstallHint: "Run: /agent-brief in OpenCode",
-			})
-		}
-	} else {
-		group.Results = append(group.Results, CheckResult{
-			Name:        "Bridge: .cursorrules",
-			Severity:    Warn,
-			Message:     "not found",
-			InstallHint: "Run: /agent-brief in OpenCode",
-		})
-	}
+	// Checks #11-12: bridge files.
+	group.Results = append(group.Results,
+		checkBridgeFile(opts, "CLAUDE.md", "imports"),
+		checkBridgeFile(opts, ".cursorrules", "references"),
+	)
 
 	// Check #13: Branch protection instructions.
 	if branchProtectionPattern.Match(content) {

--- a/internal/doctor/checks.go
+++ b/internal/doctor/checks.go
@@ -1228,6 +1228,13 @@ var (
 	// specFrameworkPattern matches spec framework references.
 	specFrameworkPattern = regexp.MustCompile(
 		`(?i)(speckit|openspec|spec\s*(ification)?\s*framework)`)
+	// branchProtectionPattern matches instructions prohibiting
+	// direct commits to main. Covers patterns like
+	// "MUST NOT commit directly to main",
+	// "never commit to main", "prohibited...main".
+	branchProtectionPattern = regexp.MustCompile(
+		`(?i)(must\s+not|never|prohibited).*commit.*main|` +
+			`(?i)commit.*main.*(must\s+not|never|prohibited)`)
 )
 
 // detectAGENTSmdSections scans AGENTS.md content and returns
@@ -1478,6 +1485,22 @@ func checkAgentContext(opts *Options) CheckGroup {
 			Severity:    Warn,
 			Message:     "not found",
 			InstallHint: "Run: /agent-brief in OpenCode",
+		})
+	}
+
+	// Check #13: Branch protection instructions.
+	if branchProtectionPattern.Match(content) {
+		group.Results = append(group.Results, CheckResult{
+			Name:     "Branch protection",
+			Severity: Pass,
+			Message:  "direct-to-main prohibition found",
+		})
+	} else {
+		group.Results = append(group.Results, CheckResult{
+			Name:        "Branch protection",
+			Severity:    Warn,
+			Message:     "no explicit prohibition of direct commits to main",
+			InstallHint: "Add a Branch Protection section to AGENTS.md",
 		})
 	}
 

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -3070,6 +3070,10 @@ Conventional commits, feature branches.
 
 Never modify coverage thresholds.
 
+### Branch Protection
+
+Agents MUST NOT commit directly to main.
+
 ## Constitution (Highest Authority)
 
 The org constitution at .specify/memory/constitution.md
@@ -3518,7 +3522,7 @@ func TestCheckAgentContext_FullPass(t *testing.T) {
 		t.Errorf("group name = %q, want Agent Context", group.Name)
 	}
 
-	// All 12 checks should be present and passing.
+	// All 13 checks should be present and passing.
 	for _, r := range group.Results {
 		if r.Severity != Pass {
 			t.Errorf("check %q: severity = %v, want Pass (message: %s)",
@@ -3528,11 +3532,73 @@ func TestCheckAgentContext_FullPass(t *testing.T) {
 
 	// Verify expected check count: 1 (existence) + 5 (tier1) +
 	// 1 (code blocks) + 1 (line count) + 1 (constitution) +
-	// 1 (spec framework) + 2 (bridges) = 12.
-	if len(group.Results) != 12 {
-		t.Errorf("expected 12 check results, got %d", len(group.Results))
+	// 1 (spec framework) + 2 (bridges) + 1 (branch protection)
+	// = 13.
+	if len(group.Results) != 13 {
+		t.Errorf("expected 13 check results, got %d", len(group.Results))
 		for _, r := range group.Results {
 			t.Logf("  %s: %v — %s", r.Name, r.Severity, r.Message)
 		}
 	}
+}
+
+func TestCheckAgentContext_BranchProtection(t *testing.T) {
+	t.Run("found when prohibition present", func(t *testing.T) {
+		dir := t.TempDir()
+		content := "## Overview\n\n### Branch Protection\n\nAgents MUST NOT commit directly to main.\n"
+		createFile(t, dir, "AGENTS.md", content)
+
+		opts := &Options{TargetDir: dir, ReadFile: os.ReadFile}
+		group := checkAgentContext(opts)
+
+		found := false
+		for _, r := range group.Results {
+			if r.Name == "Branch protection" {
+				found = true
+				if r.Severity != Pass {
+					t.Errorf("severity = %v, want Pass", r.Severity)
+				}
+			}
+		}
+		if !found {
+			t.Error("Branch protection check not found in results")
+		}
+	})
+
+	t.Run("warning when missing", func(t *testing.T) {
+		dir := t.TempDir()
+		content := "## Overview\n\nJust a project.\n"
+		createFile(t, dir, "AGENTS.md", content)
+
+		opts := &Options{TargetDir: dir, ReadFile: os.ReadFile}
+		group := checkAgentContext(opts)
+
+		found := false
+		for _, r := range group.Results {
+			if r.Name == "Branch protection" {
+				found = true
+				if r.Severity != Warn {
+					t.Errorf("severity = %v, want Warn", r.Severity)
+				}
+			}
+		}
+		if !found {
+			t.Error("Branch protection check not found in results")
+		}
+	})
+
+	t.Run("detects never-commit variant", func(t *testing.T) {
+		dir := t.TempDir()
+		content := "## Overview\n\nNever commit directly to main.\n"
+		createFile(t, dir, "AGENTS.md", content)
+
+		opts := &Options{TargetDir: dir, ReadFile: os.ReadFile}
+		group := checkAgentContext(opts)
+
+		for _, r := range group.Results {
+			if r.Name == "Branch protection" && r.Severity != Pass {
+				t.Errorf("severity = %v, want Pass for 'never commit' variant", r.Severity)
+			}
+		}
+	})
 }

--- a/internal/scaffold/assets/opencode/command/agent-brief.md
+++ b/internal/scaffold/assets/opencode/command/agent-brief.md
@@ -182,7 +182,11 @@ comment explaining what to fill and why it matters:
 ## Git & Workflow
 <!-- TODO: Commit format, branching strategy, PR requirements.
      Example: "Conventional commits (type: description), feature
-     branches from main, 1 approving review required." -->
+     branches from main, 1 approving review required."
+     IMPORTANT: Include an explicit branch protection rule
+     stating agents MUST NOT commit directly to main. All
+     changes -- including docs, chores, and archives -- must
+     go through a feature branch and pull request. -->
 ```
 
 **Behavioral Constraints**:
@@ -191,6 +195,7 @@ comment explaining what to fill and why it matters:
 <!-- TODO: Things agents must NEVER do. Negative instructions are
      often more impactful than positive ones.
      Examples:
+     - "Never commit directly to main -- always use a feature branch."
      - "Never modify coverage thresholds to make tests pass."
      - "Never commit .env files or credentials."
      - "Never use os.Exit() in library code." -->
@@ -253,6 +258,12 @@ Record which sections are found and which are missing.
    constitution governs both frameworks. Look for co-occurrence
    of "constitution" with "both"/"all"/"regardless"/"openspec"
    within the spec framework or constitution section.
+7. **Branch protection**: Check if AGENTS.md contains explicit
+   instructions prohibiting direct commits to `main`. Look for
+   co-occurrence of "main" with "MUST NOT"/"never"/"prohibited"
+   in a branching, workflow, or constraints section. Flag if
+   absent -- agents without this instruction may commit directly
+   to the default branch.
 
 #### 4c: Scoring
 


### PR DESCRIPTION
## Summary

- Adds explicit "never commit to main" instructions to `AGENTS.md` and `~/.config/opencode/commit.md`
- Adds branch protection detection to `/agent-brief` audit mode and `uf doctor`

## Changes

### AGENTS.md -- new Behavioral Constraint

New "Branch Protection" subsection alongside the existing gatekeeping, phase boundary, and CI parity constraints. Includes the `git branch --show-current` verification command and a recovery procedure if a direct-to-main commit occurs.

### `/agent-brief` command updates

- **Audit mode (Step 4b)**: New check #7 detects branch protection instructions by matching prohibition keywords ("MUST NOT", "never", "prohibited") near "commit" and "main"
- **Create mode (Step 3c)**: Git & Workflow and Behavioral Constraints Tier 2 stubs now mention branch protection as a recommended inclusion

### `uf doctor` -- new Agent Context check

- Check #13: warns when AGENTS.md lacks explicit direct-to-main prohibition
- Package-level compiled regex `branchProtectionPattern` matches common prohibition variants
- 3 new test functions (`TestCheckAgentContext_BranchProtection` with 3 subtests)
- `TestCheckAgentContext_FullPass` count updated 12 -> 13
- `completeAGENTSmd()` helper updated with branch protection content

### Local-only (not in this PR)

- `~/.config/opencode/commit.md`: Global "Branch Protection" section applying to all repositories

## Verification

All CI-equivalent checks pass locally:

```
go build ./...     # OK
go vet ./...       # OK
golangci-lint run  # 0 issues
go test -race -count=1 ./...  # 19/19 packages OK
```