### PR TITLE
feat: add /review-pr scaffold command for GitHub PR review

### DIFF
--- a/.opencode/command/review-pr.md
+++ b/.opencode/command/review-pr.md
@@ -1,0 +1,419 @@
+---
+description: "Review a pull request for alignment, security, and constitution compliance"
+---
+
+# Review Pull Request
+
+You are a token-efficient code reviewer. The user will provide a PR number or you will auto-detect it from the current branch. Delegate deterministic checks to local tools and CI results first, then apply AI judgment only where tools cannot reach: intent alignment, security patterns, and architectural concerns.
+
+## Arguments
+
+- **PR number** (optional): The pull request number to review (e.g., `42`). If omitted, the command auto-detects the open PR for the current branch.
+
+## Execution Steps
+
+### 0. Prerequisites
+
+Verify the `gh` CLI is available and authenticated before proceeding:
+
+```bash
+which gh
+```
+
+If `gh` is not found: **STOP** with error:
+> "`gh` CLI is not installed. Install it from https://cli.github.com/ or via your package manager."
+
+If `gh` is found, verify authentication:
+
+```bash
+gh auth status
+```
+
+If not authenticated: **STOP** with error:
+> "`gh` is installed but not authenticated. Run `gh auth login` to authenticate."
+
+### 1. Resolve PR Number
+
+**If a PR number was provided**: use it directly as `<PR_NUMBER>`.
+
+**If no PR number was provided**: auto-detect from the current branch:
+
+```bash
+gh pr view --json number --jq '.number'
+```
+
+If no open PR exists for the current branch: **STOP** with error:
+> "No open PR found for branch '`<branch>`'. Provide a PR number: `/review-pr 42`"
+
+### 2. Fetch PR Metadata (Minimal)
+
+Retrieve PR metadata first — avoid loading the full diff until needed:
+
+```bash
+gh pr view <PR_NUMBER> --json title,body,files,additions,deletions,baseRefName,headRefName,labels,milestone,commits
+```
+
+Record the PR title, description, branch name, base branch, and changed file list. **Do NOT fetch the full diff yet** — later steps determine which files need AI analysis.
+
+### 3. Fetch CI Check Results
+
+Retrieve the CI/CD check suite status for the PR:
+
+```bash
+gh pr checks <PR_NUMBER> --json name,state,description,link
+```
+
+Categorize each check as:
+- **PASS**: Check succeeded
+- **FAIL**: Check failed
+- **PENDING**: Check still running
+- **SKIPPED**: Check was skipped
+
+If checks are still PENDING, inform the user and ask whether to wait or proceed with the available results.
+
+**If all checks pass**: Record this and move to Step 4. No CI triage needed.
+
+**If any checks fail**: Proceed to Step 3a for causality determination.
+
+#### 3a. CI Failure Causality Determination
+
+For each failing check, determine whether the failure is caused by the PR's changes or is a pre-existing issue on the base branch.
+
+**Method**: Check if the same test/check also fails on the base branch:
+
+```bash
+# Get the base branch name (from Step 2 metadata, e.g., "main")
+BASE_BRANCH="<baseRefName from Step 2>"
+
+# Check the latest CI status on the base branch
+# Use --jq with $ENVIRON or --arg to avoid injection from check names containing quotes
+gh api repos/{owner}/{repo}/commits/${BASE_BRANCH}/check-runs \
+  --jq --arg name "<FAILING_CHECK_NAME>" '.check_runs[] | select(.name == $name) | {name, conclusion}'
+```
+
+**Classification**:
+
+| Base branch status | PR check status | Classification |
+|--------------------|-----------------|----------------|
+| Pass | Fail | **PR-caused** — the PR introduced the failure |
+| Fail | Fail | **Pre-existing** — failure exists independently of the PR |
+| No data | Fail | **Unknown** — treat as PR-caused (conservative) |
+
+Record the classification for each failing check. This feeds into Step 7 (AI review) and Step 9 (fix-branch).
+
+### 4. Run Local Deterministic Tools (Pre-flight)
+
+Run the project's own tools as a rapid pre-flight check. **If CI already ran and passed the same checks, skip re-running them locally** to save time.
+
+**Detection**: Check which tools are available by looking for their configuration files:
+
+```bash
+test -f Makefile && echo "MAKEFILE=yes"
+test -f .golangci.yml && echo "GO_LINT=yes"
+test -f ruff.toml -o -f pyproject.toml && echo "PYTHON_LINT=yes"
+test -f .yamllint.yml && echo "YAML_LINT=yes"
+test -f .pre-commit-config.yaml && echo "PRECOMMIT=yes"
+```
+
+**Execution** (run only what is detected, skip if CI already covers it):
+
+| Tool detected | Command to run | What it checks |
+|---------------|----------------|----------------|
+| Makefile | `make lint` (or `make check`) | Project-defined lint/format/vet |
+| `.golangci.yml` | `golangci-lint run ./...` | Go lint rules |
+| `ruff.toml` / `pyproject.toml` | `ruff check .` | Python lint rules |
+| `.yamllint.yml` | `yamllint .` | YAML lint rules |
+| `.pre-commit-config.yaml` | `pre-commit run --all-files` | Pre-commit hooks |
+| `go.mod` | `go test ./...` | Go tests |
+| `pyproject.toml` / `setup.py` | `pytest` or `python -m pytest` | Python tests |
+
+**Record results**: Capture tool exit codes and output. If tools pass, skip those categories in the AI review entirely. If tools fail, include the failure output as context.
+
+**If no tools are detected**: Note this and proceed to AI-based review for all categories.
+
+### 5. Fetch Diff (Scoped)
+
+Now fetch the diff, being token-conscious:
+
+```bash
+gh pr diff <PR_NUMBER>
+```
+
+**Large diff handling**:
+- If the diff exceeds 500 lines, process file-by-file instead of loading the entire diff
+- Skip binary files, lock files (`package-lock.json`, `go.sum`, `yarn.lock`, `bun.lock`), and auto-generated files (`*.pb.go`, `vendor/` contents)
+- For very large PRs (2000+ lines changed or 50+ files), warn the user and ask whether to review all files or focus on specific ones
+
+### 6. Locate Associated Specification
+
+Search for a specification that matches this PR across all spec directories:
+
+- Check if the PR branch name matches a spec directory:
+  - `specs/<branch-name>/spec.md` (Speckit output)
+  - `openspec/specs/<branch-name>/spec.md` (OpenSpec specs)
+  - `openspec/changes/<branch-name>/proposal.md` (OpenSpec changes)
+- Check if the PR description references a spec
+- If a Speckit spec is found, read only the **Functional Requirements** and **User Stories** sections (not the entire spec) to minimize token usage
+- If an OpenSpec proposal is found, read only the **Capabilities** and **Impact** sections
+- If no spec is found in any directory, note this and use the PR title and description as the intent source
+
+### 7. Load Convention Packs (Optional)
+
+Check if convention packs are available for enhanced review precision:
+
+```bash
+test -d .opencode/uf/packs && echo "PACKS=yes"
+```
+
+**If packs are available**:
+1. Always read `.opencode/uf/packs/default.md` (language-agnostic rules)
+2. Detect language and load the appropriate pack:
+   - `go.mod` exists → read `.opencode/uf/packs/go.md`
+   - `tsconfig.json` or `package.json` exists → read `.opencode/uf/packs/typescript.md`
+3. Read corresponding `-custom.md` files if they exist (e.g., `go-custom.md`)
+4. Read `.opencode/uf/packs/severity.md` if it exists — use its severity definitions instead of the inline fallback in Step 8
+5. Do NOT load `content.md` or `content-custom.md` — these contain writing standards for documentation agents, not code quality rules
+
+Use pack rules (CS-001, AP-001, SC-001, TC-001, DR-001, etc.) alongside the constitution for more specific, actionable findings. Reference the specific rule ID in each finding.
+
+**If packs are NOT available**: proceed without them. Use the constitution and inline severity definitions only. No error or warning needed.
+
+### 8. AI Review (Judgment-Based Only)
+
+Focus AI analysis exclusively on what deterministic tools and CI cannot check. Skip any category where local tools or CI already passed.
+
+#### 8a. Alignment Check
+
+Compare the PR intent (title + description + linked spec) against the actual code changes:
+
+- **Scope alignment**: Do the changed files match what the spec/description says should change? Flag files modified outside the stated scope.
+- **Requirement coverage**: For each requirement in the spec (if found), verify the code changes address it. Flag uncovered requirements.
+- **Completeness**: Are there partial implementations that could leave the system in an inconsistent state?
+- **Drift detection**: Does the code do anything NOT described in the intent/spec? Flag undocumented behavioral changes.
+
+#### 8b. Security Review
+
+Examine the diff for security vulnerabilities that linters cannot catch:
+
+- **Input sanitization**: Are external inputs (user input, API parameters, file paths, environment variables, command arguments) validated before use in:
+  - SQL queries (injection risk)
+  - Shell commands (command injection)
+  - File paths (path traversal)
+  - HTML/template output (XSS)
+  - YAML/JSON parsing (deserialization attacks)
+- **Unexpected workflows**: Can the code be executed in an unintended order or context?
+  - Missing authentication/authorization checks
+  - Race conditions or TOCTOU vulnerabilities
+  - State machine violations (skipping steps)
+  - Error handling that exposes sensitive information
+- **Privilege escalation**: Does the code grant permissions or elevate privileges without proper validation?
+- **Secrets and credentials**: Are there hardcoded secrets, tokens, or API keys? Are secrets logged or exposed in error messages?
+- **Dependency risks**: Are new dependencies well-maintained and from trusted sources?
+
+#### 8c. Constitution Compliance (AI-only items)
+
+Read `.specify/memory/constitution.md` if it exists. Extract all principles and their MUST/SHOULD rules. For each principle, check whether the PR's changes comply. **Only check items that local tools and CI did NOT already verify.**
+
+If no constitution file exists, note this and review against general software engineering best practices. Do NOT hardcode specific principle names or numbers — each project defines its own constitution.
+
+**Skip if already covered by local tools or CI**: naming conventions, line length, lint issues, formatting, file headers.
+
+#### 8d. CI Failure Analysis
+
+For each CI failure classified in Step 3a, provide analysis:
+
+**PR-caused failures**: Include as HIGH or CRITICAL findings:
+- Which check failed and what the error output says
+- Which PR change likely caused the failure (map failing test to changed file/function)
+- Suggested fix or direction
+
+**Pre-existing failures**: Report separately with clear labeling:
+- Confirm the failure also exists on the base branch
+- Brief root cause analysis if determinable from the error output
+- Note that this will be addressed in Step 9 (fix-branch offer)
+
+### 9. Output Format
+
+Present findings in this structured format:
+
+```markdown
+## PR Review: #<NUMBER> — <TITLE>
+
+### CI Status
+| Check | Status | Classification |
+|-------|--------|----------------|
+| <name> | PASS/FAIL | PR-caused / Pre-existing / N/A |
+
+### Local Tool Results
+<Table showing which tools ran, pass/fail status, and summary of failures if any>
+
+### Summary
+<1-2 sentence overview of what the PR does and overall assessment>
+
+### Alignment
+- <Finding with severity>
+
+### Security
+- <Finding with severity>
+
+### Constitution Compliance
+- <Finding with severity>
+
+### CI Failures (PR-caused)
+- <Finding with severity — only if PR-caused failures exist>
+
+### CI Failures (Pre-existing)
+- <Description — only if pre-existing failures exist>
+- Note: These failures exist independently of this PR. See fix-branch offer below.
+
+### Verdict
+**<APPROVE / REQUEST CHANGES / COMMENT>**
+
+<Brief justification. Pre-existing CI failures do NOT block the PR verdict.>
+```
+
+**Severity levels** (use `.opencode/uf/packs/severity.md` definitions if loaded in Step 7, otherwise use these defaults):
+- **CRITICAL**: Must be fixed before merge (security vulnerabilities, data loss risks)
+- **HIGH**: Should be fixed before merge (spec violations, missing tests for critical paths, PR-caused CI failures)
+- **MEDIUM**: Recommended to fix (code quality, minor compliance issues)
+- **LOW**: Optional improvements (style, naming suggestions)
+
+If no issues are found in a category, state "No issues found."
+
+### 10. Offer Fix-Branch for Pre-existing CI Failures
+
+If Step 3a identified any **pre-existing** CI failures, offer to create a fix branch:
+
+```
+I identified <N> pre-existing CI failure(s) that are NOT caused by this PR:
+- <check name>: <brief description of failure>
+
+These failures also occur on the base branch (<BASE_BRANCH>).
+
+Would you like me to create a fix branch with a proposed resolution?
+I will create the branch and commit locally — you can review the changes and file a PR when ready.
+```
+
+**If the user agrees**:
+
+1. **Verify clean working tree**:
+   ```bash
+   git status --porcelain
+   ```
+   If the output is not empty: **STOP** branch creation with message:
+   > "Working tree has uncommitted changes. Commit or stash them before creating a fix branch."
+   Switch back to the PR branch and continue to Step 11.
+
+2. **Check for branch name collision**:
+   ```bash
+   git branch --list "fix/pr-<PR_NUMBER>-<check-name>"
+   ```
+   If the branch already exists, inform the user:
+   > "Branch `fix/pr-<PR_NUMBER>-<check-name>` already exists. Switch to it with `git checkout fix/pr-<PR_NUMBER>-<check-name>`, or delete it first."
+   Switch back to the PR branch and continue to Step 11.
+
+3. **Sanitize the check name** for branch-name safety:
+   lowercase, replace spaces and special characters with
+   hyphens, strip consecutive hyphens, remove characters
+   outside `[a-z0-9._-]`, truncate to 50 characters.
+   Example: `"Build (ubuntu/latest)"` → `build-ubuntu-latest`.
+   Also validate that `<PR_NUMBER>` is digits only.
+
+4. **Create a fix branch** from the base branch:
+   ```bash
+   git checkout <BASE_BRANCH>
+   git checkout -b fix/pr-<PR_NUMBER>-<sanitized-check-name>
+   ```
+   Branch naming: `fix/pr-<PR_NUMBER>-<sanitized-check-name>` (e.g., `fix/pr-42-yamllint`, `fix/pr-42-test-auth-timeout`)
+
+4. **Analyze and propose the fix**: Use the CI failure output and the failing file(s) to determine the minimal change needed. Keep the scope as small as possible — fix only what is failing.
+
+6. **Commit with Conventional Commits format**:
+   Write the commit message to a temporary file to avoid
+   shell injection from AI-generated description text,
+   then commit using `-F`:
+   ```bash
+   git add <changed-files>
+   git commit -s -F <temp-commit-message-file>
+   ```
+   The commit message file should contain:
+   ```
+   fix: resolve <failing-check> CI failure
+
+   <Brief description of what was wrong and how the fix addresses it.>
+
+   This failure was pre-existing on <BASE_BRANCH> and unrelated to PR #<PR_NUMBER>.
+
+   Assisted-by: OpenCode (<model>)
+   ```
+   Remove the temp file after committing.
+
+7. **Report to the user**:
+   ```
+   Fix branch created: fix/pr-<PR_NUMBER>-<check-name>
+
+   Changes:
+   - <file>: <what changed>
+
+   The branch is local. To review and push:
+     git checkout fix/pr-<PR_NUMBER>-<check-name>
+     git log -1
+     git push -u origin fix/pr-<PR_NUMBER>-<check-name>
+   ```
+
+8. **Switch back** to the PR branch:
+   ```bash
+   git checkout <PR_BRANCH>
+   ```
+
+**Guardrails**:
+- The fix MUST be scoped to the specific failing check — no unrelated changes
+- The agent MUST NOT push to the remote or file a PR automatically
+- If the fix is non-trivial (requires understanding business logic, architectural decisions, or modifying more than 3 files), inform the user instead of attempting a fix:
+  ```
+  The CI failure in <check> appears to require a non-trivial fix involving <description>.
+  I recommend investigating this separately rather than proposing an automated fix.
+  ```
+
+### 11. Offer In-line PR Comments
+
+After presenting the summary, if there are findings with severity HIGH or above, offer to post them as in-line comments on the PR:
+
+```
+I found <N> findings (X CRITICAL, Y HIGH). Would you like me to post in-line comments on the PR so the author can see them in context?
+
+I will prepare the comments and show them to you for approval before posting anything.
+```
+
+**If the user agrees**:
+
+1. **Prepare comments**: For each finding that maps to a specific file and line range in the diff, prepare an in-line comment with:
+   - The finding description
+   - The severity level
+   - A concrete suggestion for fixing the issue (if applicable)
+   - Cap at 15 comments maximum. If more than 15 findings qualify, prioritize CRITICAL over HIGH. For remaining findings beyond the cap, include them in a single summary comment.
+
+2. **Show all comments for human review**: Present each prepared comment in this format:
+   ```
+   File: <path>
+   Line: <line_number>
+   Body: <comment text>
+   ```
+
+3. **Wait for explicit confirmation**: Ask "Post these comments? (yes/no/edit)"
+   - **yes**: Post comments using the `gh` CLI. For a summary comment, write the body to a temporary file and use `--body-file` to avoid shell injection from AI-generated text:
+     ```bash
+     gh pr review <PR_NUMBER> --comment --body-file <temp-summary-file>
+     ```
+     For in-line comments, use the GitHub API with a JSON input file:
+     ```bash
+     gh api repos/{owner}/{repo}/pulls/<PR_NUMBER>/reviews \
+       --method POST \
+       --input <json-file-with-comments>
+     ```
+     The JSON file should contain the review body, event type, and inline comments array.
+     Always write comment payloads to temporary files rather than interpolating AI-generated text into shell arguments, to prevent shell injection. Remove temporary files after posting. If `gh api` returns a 403 or permission error, inform the user that their token lacks write permissions for PR comments and suggest re-authenticating with `gh auth login`.
+   - **no**: Skip posting, the summary is sufficient
+   - **edit**: Let the user modify comments before posting, then re-confirm
+
+4. **CRITICAL RULE**: NEVER post comments without explicit human confirmation. Always show the exact content that will be posted and wait for approval.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,6 +92,28 @@ Exempt from council review:
   artifacts)
 - Emergency hotfixes (must be retroactively reviewed)
 
+### PR Review
+
+Two review commands serve different workflow moments:
+
+| Command | When | Scope | Agent Model |
+|---------|------|-------|-------------|
+| `/review-council` | Pre-PR (local tree) | Multi-agent Divisor council with Gaze integration | 5+ parallel agents |
+| `/review-pr [N]` | Post-PR (GitHub PR) | Single-agent review with CI causality analysis | 1 agent, token-lean |
+
+`/review-pr` reviews a GitHub PR by number (or
+auto-detects from the current branch). It fetches CI
+check results, classifies failures as PR-caused vs
+pre-existing, runs local deterministic tools, and
+applies AI judgment for alignment, security, and
+constitution compliance. It can offer fix branches for
+pre-existing CI failures and post in-line PR comments
+(with human confirmation). Requires `gh` CLI.
+
+Use `/review-council` before pushing to validate your
+own work. Use `/review-pr` after creating a PR to
+review any PR (yours or others').
+
 ## Constitution (Highest Authority)
 
 The org constitution at `.specify/memory/constitution.md` defines four core principles that govern all hero repositories:
@@ -177,6 +199,7 @@ unbound-force/
 │   │   ├── speckit.taskstoissues.md
 │   │   ├── agent-brief.md            # /agent-brief command (AGENTS.md lifecycle)
 │   │   ├── review-council.md        # /review-council command (Divisor)
+│   │   ├── review-pr.md            # /review-pr command (GitHub PR review)
 │   │   ├── constitution-check.md    # /constitution-check command
 │   │   ├── unleash.md               # /unleash autonomous pipeline (Spec 018)
 │   │   ├── workflow-start.md        # /workflow start command (Spec 008)
@@ -825,6 +848,7 @@ without exception.
 
 ## Recent Changes
 
+- opsx/review-pr-command: Added `/review-pr` scaffold command for post-PR GitHub review. Single-agent, token-lean command adapted from org-infra's `review_pr.md` with standardization deltas: kebab-case naming, optional PR number with auto-detection, generic constitution reference, convention pack awareness with graceful degradation, severity pack integration, shell injection mitigations (`--body-file`, JSON input files, branch-name sanitization). Fetches CI check results with causality analysis (PR-caused vs pre-existing), runs local deterministic tools, performs AI review (alignment, security, constitution compliance), offers fix branches for pre-existing CI failures (with dirty-tree guard, user confirmation, collision handling), and offers in-line PR comments (15-comment cap, human confirmation gate). Requires `gh` CLI. New files: `.opencode/command/review-pr.md`, `internal/scaffold/assets/opencode/command/review-pr.md`. Modified files: `internal/scaffold/scaffold_test.go` (expectedAssetPaths 7→8 commands), `cmd/unbound-force/main_test.go` (file count 34→35), `AGENTS.md` (project structure + PR Review section). No Go logic changes. All tasks completed.
 - opsx/agent-brief-command: Added `/agent-brief` slash command for AGENTS.md lifecycle management (create, audit, improve). The command auto-detects mode: creates AGENTS.md from project analysis when none exists (hybrid template + LLM approach filling Tier 1 sections from go.mod/package.json, Makefile, CI config, README), or audits existing files against a context-sensitive section taxonomy with scoring (Excellent/Strong/Adequate/Weak/Missing). Context-sensitive Tier 1C sections (Constitution, Spec Framework) are generated or checked only when `.specify/memory/constitution.md`, `specs/`, or `openspec/` are detected. Cross-framework governance bridge check verifies the constitution is stated as governing both Speckit and OpenSpec when both frameworks exist. Bridge file handling ensures CLAUDE.md (`@AGENTS.md` import) and .cursorrules exist. New "Agent Context" doctor check group replaces the single AGENTS.md existence check with 12 deterministic structural checks: file existence, 5 Tier 1 section headers (Project Overview, Build Commands, Project Structure, Code Conventions, Technology Stack), build section code blocks, line count (warn >300), constitution reference (context-sensitive), spec framework description (context-sensitive), CLAUDE.md bridge, .cursorrules bridge. InstallHint changed from "Run: uf init" to "Run: /agent-brief in OpenCode". Scaffold asset distributed via `uf init`. New file: `.opencode/command/agent-brief.md`. Modified files: `internal/doctor/checks.go`, `internal/doctor/doctor.go`, `internal/doctor/doctor_test.go`, `internal/scaffold/scaffold_test.go`. Added 12 new doctor test functions and updated 3 existing tests. All 7 task groups and 51 tasks completed.
 - opsx/unified-config: Created `internal/config/` package with unified `Config` struct covering 7 sections (setup, scaffold, embedding, sandbox, gateway, doctor, workflow) and layered `Load()` function (user `~/.config/uf/config.yaml` > repo `.uf/config.yaml` > env vars). Added `uf config` command group with 3 subcommands: `init` (creates/updates `.uf/config.yaml` with commented template), `show` (displays merged config as YAML), `validate` (schema validation with actionable error messages). Added `github.com/goccy/go-yaml` dependency (replacing archived `gopkg.in/yaml.v3` for new code). Setup integration: config-driven `package_manager`, `skip` list, per-tool install methods, embedding model from config. Scaffold integration: removed `workflowConfigContent` constant, config-based language selection via `scaffold.language` field. Gateway integration: config-driven `port` and `provider` defaults. Agent model cleanup: removed hardcoded `model` frontmatter from 24 agent files (12 live + 12 scaffold copies). Absorbs `.uf/sandbox.yaml` into unified config with backward-compatible fallback. Go 1.24+ (CLI), `github.com/goccy/go-yaml` (YAML parsing). All tasks completed.
 - opsx/gateway-global-region-error: Replaced silent `"global"` → `"us-east5"` region fallback in `newVertexProvider()` with a clear, actionable error. When `VERTEX_LOCATION` or `CLOUD_ML_REGION` resolves to `"global"`, the gateway now returns an error at startup explaining that Vertex AI `rawPredict`/`streamRawPredict` requires a specific regional endpoint and recommending `ANTHROPIC_VERTEX_REGION` as the override. Changed `newVertexProvider()` signature from `*VertexProvider` to `(*VertexProvider, error)`, propagated through `DetectProvider()` and `NewProviderByName()`. Preserved `"us-east5"` default for the empty-region case. Added 6 new test functions (`TestNewVertexProvider_GlobalRegionError`, `TestNewVertexProvider_CloudMLRegionGlobalAlone`, `TestNewVertexProvider_GlobalOverriddenBySpecificRegion`, `TestNewVertexProvider_EmptyRegionDefault`, `TestDetectProvider_GlobalRegionError`, `TestNewProviderByName_VertexGlobalRegionError`). Updated 3 existing test call sites. Modified files: `internal/gateway/provider.go`, `internal/gateway/gateway_test.go`. No new dependencies. 16 tasks completed.

--- a/cmd/unbound-force/main_test.go
+++ b/cmd/unbound-force/main_test.go
@@ -30,9 +30,9 @@ func TestRunInit_FreshDir(t *testing.T) {
 	}
 
 	// Verify the summary includes a non-trivial file count
-	// 34 = 33 prior + 1 agent-brief.md command
-	if !strings.Contains(output, "34 files processed") {
-		t.Errorf("expected '34 files processed' in output, got:\n%s", output)
+	// 35 = 34 prior + 1 review-pr.md command
+	if !strings.Contains(output, "35 files processed") {
+		t.Errorf("expected '35 files processed' in output, got:\n%s", output)
 	}
 
 	// Verify a user-owned file was created

--- a/internal/scaffold/assets/opencode/command/review-pr.md
+++ b/internal/scaffold/assets/opencode/command/review-pr.md
@@ -1,0 +1,419 @@
+---
+description: "Review a pull request for alignment, security, and constitution compliance"
+---
+
+# Review Pull Request
+
+You are a token-efficient code reviewer. The user will provide a PR number or you will auto-detect it from the current branch. Delegate deterministic checks to local tools and CI results first, then apply AI judgment only where tools cannot reach: intent alignment, security patterns, and architectural concerns.
+
+## Arguments
+
+- **PR number** (optional): The pull request number to review (e.g., `42`). If omitted, the command auto-detects the open PR for the current branch.
+
+## Execution Steps
+
+### 0. Prerequisites
+
+Verify the `gh` CLI is available and authenticated before proceeding:
+
+```bash
+which gh
+```
+
+If `gh` is not found: **STOP** with error:
+> "`gh` CLI is not installed. Install it from https://cli.github.com/ or via your package manager."
+
+If `gh` is found, verify authentication:
+
+```bash
+gh auth status
+```
+
+If not authenticated: **STOP** with error:
+> "`gh` is installed but not authenticated. Run `gh auth login` to authenticate."
+
+### 1. Resolve PR Number
+
+**If a PR number was provided**: use it directly as `<PR_NUMBER>`.
+
+**If no PR number was provided**: auto-detect from the current branch:
+
+```bash
+gh pr view --json number --jq '.number'
+```
+
+If no open PR exists for the current branch: **STOP** with error:
+> "No open PR found for branch '`<branch>`'. Provide a PR number: `/review-pr 42`"
+
+### 2. Fetch PR Metadata (Minimal)
+
+Retrieve PR metadata first — avoid loading the full diff until needed:
+
+```bash
+gh pr view <PR_NUMBER> --json title,body,files,additions,deletions,baseRefName,headRefName,labels,milestone,commits
+```
+
+Record the PR title, description, branch name, base branch, and changed file list. **Do NOT fetch the full diff yet** — later steps determine which files need AI analysis.
+
+### 3. Fetch CI Check Results
+
+Retrieve the CI/CD check suite status for the PR:
+
+```bash
+gh pr checks <PR_NUMBER> --json name,state,description,link
+```
+
+Categorize each check as:
+- **PASS**: Check succeeded
+- **FAIL**: Check failed
+- **PENDING**: Check still running
+- **SKIPPED**: Check was skipped
+
+If checks are still PENDING, inform the user and ask whether to wait or proceed with the available results.
+
+**If all checks pass**: Record this and move to Step 4. No CI triage needed.
+
+**If any checks fail**: Proceed to Step 3a for causality determination.
+
+#### 3a. CI Failure Causality Determination
+
+For each failing check, determine whether the failure is caused by the PR's changes or is a pre-existing issue on the base branch.
+
+**Method**: Check if the same test/check also fails on the base branch:
+
+```bash
+# Get the base branch name (from Step 2 metadata, e.g., "main")
+BASE_BRANCH="<baseRefName from Step 2>"
+
+# Check the latest CI status on the base branch
+# Use --jq with $ENVIRON or --arg to avoid injection from check names containing quotes
+gh api repos/{owner}/{repo}/commits/${BASE_BRANCH}/check-runs \
+  --jq --arg name "<FAILING_CHECK_NAME>" '.check_runs[] | select(.name == $name) | {name, conclusion}'
+```
+
+**Classification**:
+
+| Base branch status | PR check status | Classification |
+|--------------------|-----------------|----------------|
+| Pass | Fail | **PR-caused** — the PR introduced the failure |
+| Fail | Fail | **Pre-existing** — failure exists independently of the PR |
+| No data | Fail | **Unknown** — treat as PR-caused (conservative) |
+
+Record the classification for each failing check. This feeds into Step 7 (AI review) and Step 9 (fix-branch).
+
+### 4. Run Local Deterministic Tools (Pre-flight)
+
+Run the project's own tools as a rapid pre-flight check. **If CI already ran and passed the same checks, skip re-running them locally** to save time.
+
+**Detection**: Check which tools are available by looking for their configuration files:
+
+```bash
+test -f Makefile && echo "MAKEFILE=yes"
+test -f .golangci.yml && echo "GO_LINT=yes"
+test -f ruff.toml -o -f pyproject.toml && echo "PYTHON_LINT=yes"
+test -f .yamllint.yml && echo "YAML_LINT=yes"
+test -f .pre-commit-config.yaml && echo "PRECOMMIT=yes"
+```
+
+**Execution** (run only what is detected, skip if CI already covers it):
+
+| Tool detected | Command to run | What it checks |
+|---------------|----------------|----------------|
+| Makefile | `make lint` (or `make check`) | Project-defined lint/format/vet |
+| `.golangci.yml` | `golangci-lint run ./...` | Go lint rules |
+| `ruff.toml` / `pyproject.toml` | `ruff check .` | Python lint rules |
+| `.yamllint.yml` | `yamllint .` | YAML lint rules |
+| `.pre-commit-config.yaml` | `pre-commit run --all-files` | Pre-commit hooks |
+| `go.mod` | `go test ./...` | Go tests |
+| `pyproject.toml` / `setup.py` | `pytest` or `python -m pytest` | Python tests |
+
+**Record results**: Capture tool exit codes and output. If tools pass, skip those categories in the AI review entirely. If tools fail, include the failure output as context.
+
+**If no tools are detected**: Note this and proceed to AI-based review for all categories.
+
+### 5. Fetch Diff (Scoped)
+
+Now fetch the diff, being token-conscious:
+
+```bash
+gh pr diff <PR_NUMBER>
+```
+
+**Large diff handling**:
+- If the diff exceeds 500 lines, process file-by-file instead of loading the entire diff
+- Skip binary files, lock files (`package-lock.json`, `go.sum`, `yarn.lock`, `bun.lock`), and auto-generated files (`*.pb.go`, `vendor/` contents)
+- For very large PRs (2000+ lines changed or 50+ files), warn the user and ask whether to review all files or focus on specific ones
+
+### 6. Locate Associated Specification
+
+Search for a specification that matches this PR across all spec directories:
+
+- Check if the PR branch name matches a spec directory:
+  - `specs/<branch-name>/spec.md` (Speckit output)
+  - `openspec/specs/<branch-name>/spec.md` (OpenSpec specs)
+  - `openspec/changes/<branch-name>/proposal.md` (OpenSpec changes)
+- Check if the PR description references a spec
+- If a Speckit spec is found, read only the **Functional Requirements** and **User Stories** sections (not the entire spec) to minimize token usage
+- If an OpenSpec proposal is found, read only the **Capabilities** and **Impact** sections
+- If no spec is found in any directory, note this and use the PR title and description as the intent source
+
+### 7. Load Convention Packs (Optional)
+
+Check if convention packs are available for enhanced review precision:
+
+```bash
+test -d .opencode/uf/packs && echo "PACKS=yes"
+```
+
+**If packs are available**:
+1. Always read `.opencode/uf/packs/default.md` (language-agnostic rules)
+2. Detect language and load the appropriate pack:
+   - `go.mod` exists → read `.opencode/uf/packs/go.md`
+   - `tsconfig.json` or `package.json` exists → read `.opencode/uf/packs/typescript.md`
+3. Read corresponding `-custom.md` files if they exist (e.g., `go-custom.md`)
+4. Read `.opencode/uf/packs/severity.md` if it exists — use its severity definitions instead of the inline fallback in Step 8
+5. Do NOT load `content.md` or `content-custom.md` — these contain writing standards for documentation agents, not code quality rules
+
+Use pack rules (CS-001, AP-001, SC-001, TC-001, DR-001, etc.) alongside the constitution for more specific, actionable findings. Reference the specific rule ID in each finding.
+
+**If packs are NOT available**: proceed without them. Use the constitution and inline severity definitions only. No error or warning needed.
+
+### 8. AI Review (Judgment-Based Only)
+
+Focus AI analysis exclusively on what deterministic tools and CI cannot check. Skip any category where local tools or CI already passed.
+
+#### 8a. Alignment Check
+
+Compare the PR intent (title + description + linked spec) against the actual code changes:
+
+- **Scope alignment**: Do the changed files match what the spec/description says should change? Flag files modified outside the stated scope.
+- **Requirement coverage**: For each requirement in the spec (if found), verify the code changes address it. Flag uncovered requirements.
+- **Completeness**: Are there partial implementations that could leave the system in an inconsistent state?
+- **Drift detection**: Does the code do anything NOT described in the intent/spec? Flag undocumented behavioral changes.
+
+#### 8b. Security Review
+
+Examine the diff for security vulnerabilities that linters cannot catch:
+
+- **Input sanitization**: Are external inputs (user input, API parameters, file paths, environment variables, command arguments) validated before use in:
+  - SQL queries (injection risk)
+  - Shell commands (command injection)
+  - File paths (path traversal)
+  - HTML/template output (XSS)
+  - YAML/JSON parsing (deserialization attacks)
+- **Unexpected workflows**: Can the code be executed in an unintended order or context?
+  - Missing authentication/authorization checks
+  - Race conditions or TOCTOU vulnerabilities
+  - State machine violations (skipping steps)
+  - Error handling that exposes sensitive information
+- **Privilege escalation**: Does the code grant permissions or elevate privileges without proper validation?
+- **Secrets and credentials**: Are there hardcoded secrets, tokens, or API keys? Are secrets logged or exposed in error messages?
+- **Dependency risks**: Are new dependencies well-maintained and from trusted sources?
+
+#### 8c. Constitution Compliance (AI-only items)
+
+Read `.specify/memory/constitution.md` if it exists. Extract all principles and their MUST/SHOULD rules. For each principle, check whether the PR's changes comply. **Only check items that local tools and CI did NOT already verify.**
+
+If no constitution file exists, note this and review against general software engineering best practices. Do NOT hardcode specific principle names or numbers — each project defines its own constitution.
+
+**Skip if already covered by local tools or CI**: naming conventions, line length, lint issues, formatting, file headers.
+
+#### 8d. CI Failure Analysis
+
+For each CI failure classified in Step 3a, provide analysis:
+
+**PR-caused failures**: Include as HIGH or CRITICAL findings:
+- Which check failed and what the error output says
+- Which PR change likely caused the failure (map failing test to changed file/function)
+- Suggested fix or direction
+
+**Pre-existing failures**: Report separately with clear labeling:
+- Confirm the failure also exists on the base branch
+- Brief root cause analysis if determinable from the error output
+- Note that this will be addressed in Step 9 (fix-branch offer)
+
+### 9. Output Format
+
+Present findings in this structured format:
+
+```markdown
+## PR Review: #<NUMBER> — <TITLE>
+
+### CI Status
+| Check | Status | Classification |
+|-------|--------|----------------|
+| <name> | PASS/FAIL | PR-caused / Pre-existing / N/A |
+
+### Local Tool Results
+<Table showing which tools ran, pass/fail status, and summary of failures if any>
+
+### Summary
+<1-2 sentence overview of what the PR does and overall assessment>
+
+### Alignment
+- <Finding with severity>
+
+### Security
+- <Finding with severity>
+
+### Constitution Compliance
+- <Finding with severity>
+
+### CI Failures (PR-caused)
+- <Finding with severity — only if PR-caused failures exist>
+
+### CI Failures (Pre-existing)
+- <Description — only if pre-existing failures exist>
+- Note: These failures exist independently of this PR. See fix-branch offer below.
+
+### Verdict
+**<APPROVE / REQUEST CHANGES / COMMENT>**
+
+<Brief justification. Pre-existing CI failures do NOT block the PR verdict.>
+```
+
+**Severity levels** (use `.opencode/uf/packs/severity.md` definitions if loaded in Step 7, otherwise use these defaults):
+- **CRITICAL**: Must be fixed before merge (security vulnerabilities, data loss risks)
+- **HIGH**: Should be fixed before merge (spec violations, missing tests for critical paths, PR-caused CI failures)
+- **MEDIUM**: Recommended to fix (code quality, minor compliance issues)
+- **LOW**: Optional improvements (style, naming suggestions)
+
+If no issues are found in a category, state "No issues found."
+
+### 10. Offer Fix-Branch for Pre-existing CI Failures
+
+If Step 3a identified any **pre-existing** CI failures, offer to create a fix branch:
+
+```
+I identified <N> pre-existing CI failure(s) that are NOT caused by this PR:
+- <check name>: <brief description of failure>
+
+These failures also occur on the base branch (<BASE_BRANCH>).
+
+Would you like me to create a fix branch with a proposed resolution?
+I will create the branch and commit locally — you can review the changes and file a PR when ready.
+```
+
+**If the user agrees**:
+
+1. **Verify clean working tree**:
+   ```bash
+   git status --porcelain
+   ```
+   If the output is not empty: **STOP** branch creation with message:
+   > "Working tree has uncommitted changes. Commit or stash them before creating a fix branch."
+   Switch back to the PR branch and continue to Step 11.
+
+2. **Check for branch name collision**:
+   ```bash
+   git branch --list "fix/pr-<PR_NUMBER>-<check-name>"
+   ```
+   If the branch already exists, inform the user:
+   > "Branch `fix/pr-<PR_NUMBER>-<check-name>` already exists. Switch to it with `git checkout fix/pr-<PR_NUMBER>-<check-name>`, or delete it first."
+   Switch back to the PR branch and continue to Step 11.
+
+3. **Sanitize the check name** for branch-name safety:
+   lowercase, replace spaces and special characters with
+   hyphens, strip consecutive hyphens, remove characters
+   outside `[a-z0-9._-]`, truncate to 50 characters.
+   Example: `"Build (ubuntu/latest)"` → `build-ubuntu-latest`.
+   Also validate that `<PR_NUMBER>` is digits only.
+
+4. **Create a fix branch** from the base branch:
+   ```bash
+   git checkout <BASE_BRANCH>
+   git checkout -b fix/pr-<PR_NUMBER>-<sanitized-check-name>
+   ```
+   Branch naming: `fix/pr-<PR_NUMBER>-<sanitized-check-name>` (e.g., `fix/pr-42-yamllint`, `fix/pr-42-test-auth-timeout`)
+
+4. **Analyze and propose the fix**: Use the CI failure output and the failing file(s) to determine the minimal change needed. Keep the scope as small as possible — fix only what is failing.
+
+6. **Commit with Conventional Commits format**:
+   Write the commit message to a temporary file to avoid
+   shell injection from AI-generated description text,
+   then commit using `-F`:
+   ```bash
+   git add <changed-files>
+   git commit -s -F <temp-commit-message-file>
+   ```
+   The commit message file should contain:
+   ```
+   fix: resolve <failing-check> CI failure
+
+   <Brief description of what was wrong and how the fix addresses it.>
+
+   This failure was pre-existing on <BASE_BRANCH> and unrelated to PR #<PR_NUMBER>.
+
+   Assisted-by: OpenCode (<model>)
+   ```
+   Remove the temp file after committing.
+
+7. **Report to the user**:
+   ```
+   Fix branch created: fix/pr-<PR_NUMBER>-<check-name>
+
+   Changes:
+   - <file>: <what changed>
+
+   The branch is local. To review and push:
+     git checkout fix/pr-<PR_NUMBER>-<check-name>
+     git log -1
+     git push -u origin fix/pr-<PR_NUMBER>-<check-name>
+   ```
+
+8. **Switch back** to the PR branch:
+   ```bash
+   git checkout <PR_BRANCH>
+   ```
+
+**Guardrails**:
+- The fix MUST be scoped to the specific failing check — no unrelated changes
+- The agent MUST NOT push to the remote or file a PR automatically
+- If the fix is non-trivial (requires understanding business logic, architectural decisions, or modifying more than 3 files), inform the user instead of attempting a fix:
+  ```
+  The CI failure in <check> appears to require a non-trivial fix involving <description>.
+  I recommend investigating this separately rather than proposing an automated fix.
+  ```
+
+### 11. Offer In-line PR Comments
+
+After presenting the summary, if there are findings with severity HIGH or above, offer to post them as in-line comments on the PR:
+
+```
+I found <N> findings (X CRITICAL, Y HIGH). Would you like me to post in-line comments on the PR so the author can see them in context?
+
+I will prepare the comments and show them to you for approval before posting anything.
+```
+
+**If the user agrees**:
+
+1. **Prepare comments**: For each finding that maps to a specific file and line range in the diff, prepare an in-line comment with:
+   - The finding description
+   - The severity level
+   - A concrete suggestion for fixing the issue (if applicable)
+   - Cap at 15 comments maximum. If more than 15 findings qualify, prioritize CRITICAL over HIGH. For remaining findings beyond the cap, include them in a single summary comment.
+
+2. **Show all comments for human review**: Present each prepared comment in this format:
+   ```
+   File: <path>
+   Line: <line_number>
+   Body: <comment text>
+   ```
+
+3. **Wait for explicit confirmation**: Ask "Post these comments? (yes/no/edit)"
+   - **yes**: Post comments using the `gh` CLI. For a summary comment, write the body to a temporary file and use `--body-file` to avoid shell injection from AI-generated text:
+     ```bash
+     gh pr review <PR_NUMBER> --comment --body-file <temp-summary-file>
+     ```
+     For in-line comments, use the GitHub API with a JSON input file:
+     ```bash
+     gh api repos/{owner}/{repo}/pulls/<PR_NUMBER>/reviews \
+       --method POST \
+       --input <json-file-with-comments>
+     ```
+     The JSON file should contain the review body, event type, and inline comments array.
+     Always write comment payloads to temporary files rather than interpolating AI-generated text into shell arguments, to prevent shell injection. Remove temporary files after posting. If `gh api` returns a 403 or permission error, inform the user that their token lacks write permissions for PR comments and suggest re-authenticating with `gh auth login`.
+   - **no**: Skip posting, the summary is sufficient
+   - **edit**: Let the user modify comments before posting, then re-confirm
+
+4. **CRITICAL RULE**: NEVER post comments without explicit human confirmation. Always show the exact content that will be posted and wait for approval.

--- a/internal/scaffold/scaffold_test.go
+++ b/internal/scaffold/scaffold_test.go
@@ -122,12 +122,13 @@ func mapAssetToSource(relPath string) string {
 // expectedAssetPaths is the canonical list of embedded assets.
 // Update this list when adding or removing assets.
 var expectedAssetPaths = []string{
-	// OpenCode commands (7) — UF-custom only; speckit.*.md externalized to specify init + /uf-init
+	// OpenCode commands (8) — UF-custom only; speckit.*.md externalized to specify init + /uf-init
 	"opencode/command/agent-brief.md",
 	"opencode/command/cobalt-crush.md",
 	"opencode/command/constitution-check.md",
 	"opencode/command/finale.md",
 	"opencode/command/review-council.md",
+	"opencode/command/review-pr.md",
 	"opencode/command/uf-init.md",
 	"opencode/command/unleash.md",
 	// OpenCode agents — Divisor personas (6) + Cobalt-Crush (1) + Mx F coach (1) + constitution-check (1)

--- a/openspec/changes/review-pr-command/.openspec.yaml
+++ b/openspec/changes/review-pr-command/.openspec.yaml
@@ -1,0 +1,3 @@
+change: review-pr-command
+schema: unbound-force
+status: proposed

--- a/openspec/changes/review-pr-command/design.md
+++ b/openspec/changes/review-pr-command/design.md
@@ -42,6 +42,10 @@ are additive, not required.
    `tsconfig.json` or `package.json` → `typescript.md`
 4. Load corresponding `-custom.md` if present
 5. Also load `severity.md` if present
+6. Exclude `content.md` and `content-custom.md` — these
+   contain writing standards (voice, brand, blog format)
+   for the Scribe/Herald/Envoy agents, not code quality
+   rules relevant to PR review
 
 ### D3. Generic constitution reference
 

--- a/openspec/changes/review-pr-command/design.md
+++ b/openspec/changes/review-pr-command/design.md
@@ -1,0 +1,140 @@
+## Design Decisions
+
+### D1. Lightweight single-agent, not council delegation
+
+**Decision**: `/review-pr` stays as a single-agent command.
+It does NOT delegate to Divisor persona agents even when
+they are present.
+
+**Rationale**: `/review-council` already provides the
+multi-agent council experience for local tree review.
+Adding Divisor delegation to `/review-pr` would duplicate
+that capability and make the command significantly more
+token-expensive. The two commands serve different workflow
+moments:
+
+- `/review-council`: pre-PR, deep multi-agent analysis
+- `/review-pr`: post-PR, lean single-agent review with
+  CI awareness
+
+Keeping `/review-pr` lightweight makes it practical for
+reviewing other people's PRs where you want a quick
+assessment, not a full council session.
+
+### D2. Convention packs as additive context
+
+**Decision**: When `.opencode/uf/packs/` exists, the
+command loads applicable packs and uses their numbered
+rules (CS-001, AP-001, SC-001, etc.) alongside the
+constitution for more specific findings. When packs are
+absent, the command relies on the constitution alone.
+
+**Rationale**: Convention packs provide precise, numbered
+rules that make findings actionable ("violates CS-004: DRY
+principle" vs "code is duplicated"). But the command must
+work in repos that don't use UF's full scaffold, so packs
+are additive, not required.
+
+**Detection logic**:
+1. Check if `.opencode/uf/packs/` directory exists
+2. Always load `default.md` (language-agnostic rules)
+3. Detect language: `go.mod` → `go.md`,
+   `tsconfig.json` or `package.json` → `typescript.md`
+4. Load corresponding `-custom.md` if present
+5. Also load `severity.md` if present
+
+### D3. Generic constitution reference
+
+**Decision**: The command reads `.specify/memory/constitution.md`
+and evaluates against whatever principles it finds, rather
+than hardcoding specific principle names or numbers.
+
+**Rationale**: org-infra's constitution has 7 principles
+(I-VII), UF's has 4 (I-IV), and other repos may have
+different sets. Hardcoding principle references makes the
+command brittle and repo-specific. The standardized version
+instructs the AI to "extract all principles and their
+MUST/SHOULD rules" generically.
+
+**Fallback**: If no constitution file exists, the command
+notes this and reviews against general software engineering
+best practices (which the AI model already knows).
+
+### D4. PR number auto-detection
+
+**Decision**: The PR number argument is optional. When
+omitted, the command detects the current branch's open PR
+via `gh pr view --json number`.
+
+**Rationale**: The most common use case is reviewing your
+own PR on the current branch. Requiring the PR number is
+unnecessary friction in that case. Explicit numbers are
+still supported for reviewing other people's PRs.
+
+**Error handling**: If no open PR exists for the current
+branch, the command errors with:
+```
+No open PR found for branch '<branch>'.
+Provide a PR number: /review-pr 42
+```
+
+### D5. Severity definitions: pack-first, inline fallback
+
+**Decision**: The command checks for
+`.opencode/uf/packs/severity.md`. If found, severity
+definitions come from the pack. If not found, inline
+definitions are used as fallback.
+
+**Rationale**: The severity pack provides per-persona
+examples and an auto-fix policy that ensure consistency
+across the UF ecosystem. But repos without UF packs still
+need severity definitions, so the inline fallback is
+preserved.
+
+### D6. Tool-owned file ownership
+
+**Decision**: The command is deployed as a tool-owned file
+under `.opencode/command/review-pr.md`.
+
+**Rationale**: All files under `opencode/command/` are
+tool-owned per the scaffold engine's `isToolOwned()`
+function. This means `uf init` re-runs will automatically
+update the command when improvements are made upstream.
+This is the desired behavior — the whole point of
+standardizing the command is that improvements flow to all
+repos.
+
+### D7. Preserved operational features
+
+The following features from org-infra's original are
+preserved without modification:
+
+| Feature | Why preserved |
+|---------|--------------|
+| CI causality analysis (2a) | Distinguishes PR-caused from pre-existing failures — unique value not found in /review-council |
+| Local tool detection (3) | Already repo-agnostic — detects Makefile, golangci-lint, ruff, yamllint, pre-commit |
+| Scoped diff fetching (4) | Token-efficient — staged loading, skip binaries/lock files |
+| Spec awareness (5) | Already checks both `specs/` and `openspec/` |
+| Fix-branch offer (8) | Solid guardrails: local only, never pushes, non-trivial fixes are deferred to human |
+| In-line PR comments (9) | Human confirmation gate: shows all comments, waits for explicit yes before posting |
+
+## Architecture
+
+No new Go packages or functions are introduced. The change
+adds a single Markdown file to the embedded scaffold assets
+and updates existing test assertions.
+
+```
+internal/scaffold/assets/opencode/command/
+  ├── review-pr.md    ← NEW (tool-owned, ~340 lines)
+  └── ... (7 existing commands unchanged)
+```
+
+The scaffold engine's existing machinery handles everything:
+- `embed.FS` embeds the file at compile time
+- `mapAssetPath()` maps `opencode/command/review-pr.md`
+  to `.opencode/command/review-pr.md`
+- `isToolOwned()` returns true for the `opencode/command/`
+  prefix
+- `insertMarkerAfterFrontmatter()` adds the version marker
+- Drift detection test validates source ↔ asset parity

--- a/openspec/changes/review-pr-command/proposal.md
+++ b/openspec/changes/review-pr-command/proposal.md
@@ -70,7 +70,7 @@ PR comment posting with human confirmation.
 
 ### Modified Capabilities
 
-- Scaffold asset count increases from 34 to 35 files
+- Scaffold asset count increases by 1 file
 - AGENTS.md updated with `/review-pr` documentation and
   relationship to `/review-council`
 

--- a/openspec/changes/review-pr-command/proposal.md
+++ b/openspec/changes/review-pr-command/proposal.md
@@ -1,0 +1,146 @@
+## Why
+
+The org-infra repository has a well-designed `/review_pr`
+command that reviews GitHub PRs with CI causality analysis,
+token-efficient diff handling, spec awareness, fix-branch
+offers for pre-existing failures, and in-line comment
+posting with human confirmation gates. Currently it is
+hand-maintained in org-infra only.
+
+This creates two problems:
+
+1. **No portability.** Other repositories that use `uf init`
+   do not get a PR review command. Each repo would need to
+   copy and adapt the command independently, leading to
+   drift across repos.
+2. **No update path.** Improvements to the command require
+   manual propagation. The `uf init` scaffold engine
+   solves this — tool-owned command files are automatically
+   updated on re-run.
+
+Meanwhile, the existing `/review-council` command reviews
+the local working tree pre-PR using the Divisor multi-agent
+council. These commands are complementary:
+
+```
+  /review-council  →  Pre-PR (local tree, multi-agent)
+  /review-pr       →  Post-PR (GitHub PR, single-agent)
+```
+
+Adding `/review-pr` to the scaffold fills the post-PR gap
+in the UF toolchain.
+
+## What Changes
+
+Add a standardized `review-pr.md` command to the `uf init`
+scaffold, adapted from org-infra's `review_pr.md` with the
+following modifications:
+
+- **Rename** from `review_pr` (underscore) to `review-pr`
+  (kebab-case) per UF naming convention
+- **PR number optional** — auto-detect from current branch
+  when no argument is given
+- **Generic constitution reference** — evaluate against
+  whatever principles the project's constitution defines,
+  not hardcoded org-infra principles I-VII
+- **Convention pack awareness** — load `.opencode/uf/packs/`
+  when available for more specific code quality findings,
+  graceful degradation when packs are absent
+- **Severity pack reference** — use `severity.md` pack
+  definitions when present, inline fallback otherwise
+
+All original operational capabilities are preserved:
+CI causality analysis, local tool detection, scoped diff
+fetching, spec awareness (both `specs/` and `openspec/`),
+fix-branch creation for pre-existing failures, and in-line
+PR comment posting with human confirmation.
+
+## Capabilities
+
+### New Capabilities
+
+- `/review-pr [N]` command deployed to all repos via
+  `uf init` as a tool-owned scaffold asset
+- Auto-detection of PR from current branch when no number
+  is provided
+- Convention pack integration for repos with
+  `.opencode/uf/packs/` (additive to constitution checks)
+- Severity pack integration for consistent severity
+  definitions across the UF ecosystem
+
+### Modified Capabilities
+
+- Scaffold asset count increases from 34 to 35 files
+- AGENTS.md updated with `/review-pr` documentation and
+  relationship to `/review-council`
+
+### Removed Capabilities
+
+None. This is purely additive.
+
+## Impact
+
+**Files created:**
+- `internal/scaffold/assets/opencode/command/review-pr.md`
+- `.opencode/command/review-pr.md` (canonical source /
+  live copy)
+
+**Files modified:**
+- `internal/scaffold/scaffold_test.go` — add to
+  `expectedAssetPaths`, update file count assertions
+- `AGENTS.md` — add command documentation
+
+**External dependencies:**
+- `gh` CLI (GitHub CLI) must be installed and authenticated
+  for the command to function. This is already a
+  recommended tool in the UF ecosystem.
+
+## Constitution Alignment
+
+Assessed against the Unbound Force org constitution
+(`.specify/memory/constitution.md` v1.1.0).
+
+### I. Autonomous Collaboration
+
+**Assessment**: N/A
+
+This change adds a developer-facing command file. It does
+not affect inter-hero artifact communication, envelope
+formats, or hero-to-hero data exchange. The command
+produces terminal output and optional GitHub PR comments —
+not hero artifacts.
+
+### II. Composability First
+
+**Assessment**: PASS
+
+The command is independently usable without any other UF
+hero or tool being present. It detects available tools
+(linters, test runners, convention packs, severity pack)
+and uses them when found, but functions fully without
+them. It does not modify or depend on `/review-council`.
+
+### III. Observable Quality
+
+**Assessment**: PASS
+
+The command produces structured output with severity
+levels, categorized findings, and a clear verdict
+(APPROVE / REQUEST CHANGES / COMMENT). CI status is
+presented in a machine-readable table with causality
+classification. When convention packs are available,
+findings reference specific numbered rules (CS-001,
+SC-002, etc.).
+
+### IV. Testability
+
+**Assessment**: PASS
+
+This change produces no new Go logic — it adds a Markdown
+command file and updates test assertions. The scaffold
+engine's existing test infrastructure (drift detection,
+asset path validation, file count assertions) provides
+automated verification. The command itself is a prompt
+file, not executable code, so traditional unit testing
+does not apply. Verification is handled through the
+scaffold test suite and manual invocation.

--- a/openspec/changes/review-pr-command/specs/review-pr-command.md
+++ b/openspec/changes/review-pr-command/specs/review-pr-command.md
@@ -24,13 +24,20 @@ compliance.
 - **FR-004** [MUST] The command MUST fetch the PR diff in a
   token-conscious manner: metadata first, diff only when
   needed. Large diffs (500+ lines) MUST be processed
-  file-by-file. Binary files, lock files, and
-  auto-generated files MUST be skipped.
+  file-by-file. Binary files, lock files (`go.sum`,
+  `package-lock.json`, `yarn.lock`, `bun.lock`), and
+  auto-generated files (`*.pb.go`, `vendor/` contents)
+  MUST be skipped. For very large PRs (2000+ lines or
+  50+ files), the command MUST warn the user and offer
+  to focus on specific files.
 
 - **FR-005** [MUST] The command MUST search for associated
-  specifications in both `specs/` and `openspec/`
-  directories. If found, only the Functional Requirements
-  and User Stories sections MUST be read.
+  specifications in `specs/`, `openspec/specs/`, and
+  `openspec/changes/` directories. For Speckit specs,
+  read only Functional Requirements and User Stories
+  sections. For OpenSpec proposals, read only the
+  Capabilities and Impact sections. If no spec is found,
+  use the PR title and description as the intent source.
 
 - **FR-006** [MUST] The AI review MUST focus on alignment
   (scope, requirement coverage, drift detection), security
@@ -58,15 +65,31 @@ compliance.
   and Verdict (APPROVE / REQUEST CHANGES / COMMENT).
 
 - **FR-011** [MUST] For pre-existing CI failures, the
-  command MUST offer to create a local fix branch. The fix
-  branch MUST NOT be pushed automatically. Non-trivial
-  fixes MUST be deferred to the human with an explanation.
+  command MUST offer to create a local fix branch. Before
+  creating the branch, the command MUST verify the working
+  tree is clean (`git status --porcelain` is empty); if
+  dirty, inform the user and skip branch creation. Fix
+  branches MUST use the naming pattern
+  `fix/pr-<N>-<check-name>` (e.g., `fix/pr-42-yamllint`).
+  If the branch already exists, the command MUST inform
+  the user and offer to switch to it or abort. The fix
+  branch MUST NOT be pushed automatically. The user MUST
+  confirm before branch creation. Non-trivial fixes (those
+  requiring business logic changes or modifying more than
+  3 files) MUST be deferred to the human with an
+  explanation.
 
 - **FR-012** [MUST] For HIGH+ findings, the command MUST
-  offer to post in-line PR comments. All comments MUST be
-  shown to the user for explicit confirmation before
-  posting. The command MUST NEVER post comments without
-  human approval.
+  offer to post in-line PR comments. Comments MUST be
+  posted using `gh pr review <N> --comment --body <text>`
+  for summary comments or `gh api` with the
+  `repos/{owner}/{repo}/pulls/<N>/reviews` endpoint for
+  line-specific comments. Comment body text MUST be
+  shell-safe quoted to prevent injection. The command MUST
+  NOT post more than 15 comments per review. All comments
+  MUST be shown to the user for explicit confirmation
+  before posting. The command MUST NEVER post comments
+  without human approval.
 
 - **FR-013** [MUST] The command MUST be deployed as a
   tool-owned scaffold asset at
@@ -78,8 +101,13 @@ compliance.
 
 - **FR-015** [MUST] The `gh` CLI MUST be the only external
   dependency for GitHub interaction. The command MUST
-  gracefully error if `gh` is not available or not
-  authenticated.
+  verify `gh` availability via PATH lookup and
+  authentication via `gh auth status` before making API
+  calls. If `gh` is not available, error with guidance to
+  install it. If not authenticated, error with guidance to
+  run `gh auth login`. If authenticated but lacking
+  permissions for comment posting, inform the user and
+  skip the comment posting step.
 
 ## Acceptance Scenarios
 
@@ -102,8 +130,15 @@ Then the command detects the open PR for the current branch
 
 Given a developer on a branch with no open PR
 When the user runs `/review-pr` (no argument)
-Then the command outputs an error message with instructions
-  to provide an explicit PR number.
+Then the command outputs: "No open PR found for branch
+  '<branch>'. Provide a PR number: /review-pr 42"
+
+### SC-003a: gh CLI not authenticated
+
+Given a developer with `gh` installed but not authenticated
+When the user runs `/review-pr 42`
+Then the command outputs an error with guidance to run
+  `gh auth login` and does not proceed with the review.
 
 ### SC-004: Convention packs enhance review
 
@@ -126,7 +161,17 @@ Given a PR where check `lint` fails on both the PR and the
   base branch
 When the command classifies CI failures
 Then the failure is classified as "Pre-existing", excluded
-  from the verdict, and a fix-branch is offered.
+  from the verdict, and a fix-branch is offered after
+  user confirmation.
+
+### SC-006a: Fix-branch with dirty working tree
+
+Given a PR with pre-existing CI failures and uncommitted
+  changes in the working tree
+When the command offers to create a fix branch
+Then the command informs the user that the working tree is
+  dirty and skips branch creation with guidance to commit
+  or stash first.
 
 ### SC-007: In-line comment confirmation gate
 

--- a/openspec/changes/review-pr-command/specs/review-pr-command.md
+++ b/openspec/changes/review-pr-command/specs/review-pr-command.md
@@ -1,0 +1,151 @@
+## Overview
+
+Add a standardized `/review-pr` command to the `uf init`
+scaffold that reviews GitHub pull requests for CI status,
+code quality, security, spec alignment, and constitution
+compliance.
+
+## Functional Requirements
+
+- **FR-001** [MUST] The command MUST accept an optional PR
+  number argument. When provided, review that specific PR.
+  When omitted, detect the current branch's open PR via
+  `gh pr view`.
+
+- **FR-002** [MUST] The command MUST fetch CI check results
+  and classify each failing check as PR-caused or
+  pre-existing by comparing against the base branch.
+
+- **FR-003** [MUST] The command MUST detect and run local
+  deterministic tools (lint, test, format) based on project
+  configuration files. If CI already ran and passed the
+  same checks, local re-execution MUST be skipped.
+
+- **FR-004** [MUST] The command MUST fetch the PR diff in a
+  token-conscious manner: metadata first, diff only when
+  needed. Large diffs (500+ lines) MUST be processed
+  file-by-file. Binary files, lock files, and
+  auto-generated files MUST be skipped.
+
+- **FR-005** [MUST] The command MUST search for associated
+  specifications in both `specs/` and `openspec/`
+  directories. If found, only the Functional Requirements
+  and User Stories sections MUST be read.
+
+- **FR-006** [MUST] The AI review MUST focus on alignment
+  (scope, requirement coverage, drift detection), security
+  (input sanitization, injection, privilege escalation,
+  secrets), and constitution compliance.
+
+- **FR-007** [MUST] Constitution compliance checking MUST
+  read `.specify/memory/constitution.md` and evaluate
+  against all principles found therein. The command MUST
+  NOT hardcode specific principle names or numbers.
+
+- **FR-008** [SHOULD] When `.opencode/uf/packs/` exists,
+  the command SHOULD load applicable convention packs
+  (default.md, language-specific pack, custom packs) and
+  reference their numbered rules in findings.
+
+- **FR-009** [SHOULD] When `.opencode/uf/packs/severity.md`
+  exists, the command SHOULD use its severity definitions.
+  When absent, inline fallback definitions MUST be used.
+
+- **FR-010** [MUST] The output MUST use a structured format
+  with sections: CI Status (table), Local Tool Results,
+  Summary, Alignment, Security, Constitution Compliance,
+  CI Failures (PR-caused), CI Failures (Pre-existing),
+  and Verdict (APPROVE / REQUEST CHANGES / COMMENT).
+
+- **FR-011** [MUST] For pre-existing CI failures, the
+  command MUST offer to create a local fix branch. The fix
+  branch MUST NOT be pushed automatically. Non-trivial
+  fixes MUST be deferred to the human with an explanation.
+
+- **FR-012** [MUST] For HIGH+ findings, the command MUST
+  offer to post in-line PR comments. All comments MUST be
+  shown to the user for explicit confirmation before
+  posting. The command MUST NEVER post comments without
+  human approval.
+
+- **FR-013** [MUST] The command MUST be deployed as a
+  tool-owned scaffold asset at
+  `internal/scaffold/assets/opencode/command/review-pr.md`.
+
+- **FR-014** [MUST] The command file MUST use kebab-case
+  naming (`review-pr.md`) consistent with all other UF
+  scaffold commands.
+
+- **FR-015** [MUST] The `gh` CLI MUST be the only external
+  dependency for GitHub interaction. The command MUST
+  gracefully error if `gh` is not available or not
+  authenticated.
+
+## Acceptance Scenarios
+
+### SC-001: Review PR by number
+
+Given a repository with `uf init` scaffolding
+When the user runs `/review-pr 42`
+Then the command fetches PR #42 metadata, CI status, and
+  diff, performs the review, and outputs structured findings
+  with a verdict.
+
+### SC-002: Auto-detect PR from branch
+
+Given a developer on branch `feat/add-auth` with an open PR
+When the user runs `/review-pr` (no argument)
+Then the command detects the open PR for the current branch
+  and reviews it.
+
+### SC-003: No open PR for branch
+
+Given a developer on a branch with no open PR
+When the user runs `/review-pr` (no argument)
+Then the command outputs an error message with instructions
+  to provide an explicit PR number.
+
+### SC-004: Convention packs enhance review
+
+Given a repository with `.opencode/uf/packs/` containing
+  `default.md` and `go.md`
+When the command performs AI review
+Then findings reference specific pack rules (e.g.,
+  "violates CS-004") alongside constitution principles.
+
+### SC-005: No convention packs graceful degradation
+
+Given a repository without `.opencode/uf/packs/`
+When the command performs AI review
+Then the review proceeds using the constitution only,
+  with no errors about missing packs.
+
+### SC-006: Pre-existing CI failure handling
+
+Given a PR where check `lint` fails on both the PR and the
+  base branch
+When the command classifies CI failures
+Then the failure is classified as "Pre-existing", excluded
+  from the verdict, and a fix-branch is offered.
+
+### SC-007: In-line comment confirmation gate
+
+Given the review produced 2 HIGH findings
+When the command offers to post in-line comments
+Then all comments are shown to the user with exact content
+  and the command waits for explicit "yes" before posting.
+
+### SC-008: Scaffold deployment
+
+Given a fresh repository
+When the user runs `uf init`
+Then `.opencode/command/review-pr.md` is created as a
+  tool-owned file with a version marker.
+
+### SC-009: Scaffold update on re-run
+
+Given a repository where `review-pr.md` was previously
+  deployed and the upstream version has changed
+When the user runs `uf init` again
+Then the file is automatically updated to the new version
+  (tool-owned behavior).

--- a/openspec/changes/review-pr-command/tasks.md
+++ b/openspec/changes/review-pr-command/tasks.md
@@ -1,56 +1,94 @@
 ## 1. Create Standardized Command File
 
-- [ ] 1.1 Create `.opencode/command/review-pr.md` as the
+- [x] 1.1 Create `.opencode/command/review-pr.md` as the
   canonical source (live copy). Adapt from org-infra's
   `review_pr.md` with all standardization deltas:
   - Kebab-case filename (`review-pr.md`)
   - Optional PR number with auto-detection preamble
+    via `gh pr view --json number` (FR-001)
   - Generic constitution reference (no hardcoded
-    principle names)
+    principle names) (FR-007)
   - Convention pack awareness with graceful degradation
-  - Severity pack reference with inline fallback
+    (FR-008)
+  - Severity pack reference with inline fallback (FR-009)
   - Proper YAML frontmatter with description
+  - AI review focus areas: alignment (scope, coverage,
+    drift), security (injection, escalation, secrets),
+    constitution compliance (FR-006)
+  - Structured output sections: CI Status table, Local
+    Tool Results, Summary, Alignment, Security,
+    Constitution Compliance, CI Failures (PR-caused),
+    CI Failures (Pre-existing), Verdict (FR-010)
+  - `gh` CLI prerequisite check via `gh auth status`
+    with actionable error messages (FR-015)
+  - Auto-generated file skip list: `go.sum`,
+    `package-lock.json`, `yarn.lock`, `bun.lock`,
+    `*.pb.go`, `vendor/` (FR-004)
+  - Spec search across `specs/`, `openspec/specs/`,
+    and `openspec/changes/` with format-aware section
+    reading (FR-005)
+  - Fix-branch guardrails: dirty-tree check, user
+    confirmation, `fix/pr-<N>-<check>` naming,
+    collision handling, non-trivial threshold (FR-011)
+  - In-line comment guardrails: explicit `gh` subcommand
+    usage, shell-safe quoting, 15-comment cap,
+    human confirmation gate (FR-012)
   - All original operational steps preserved (CI
-    causality, local tools, scoped diff, spec awareness,
-    fix-branch, in-line comments)
+    causality, local tools, scoped diff)
+  - Content packs (`content.md`, `content-custom.md`)
+    excluded from detection — they contain writing
+    standards, not code quality rules
 
 ## 2. Scaffold Asset Integration
 
-- [ ] 2.1 Copy `.opencode/command/review-pr.md` to
+- [x] 2.1 Copy `.opencode/command/review-pr.md` to
   `internal/scaffold/assets/opencode/command/review-pr.md`
   (embedded scaffold asset copy).
-- [ ] 2.2 Update `expectedAssetPaths` in
+- [x] 2.2 Update `expectedAssetPaths` in
   `internal/scaffold/scaffold_test.go` — add
   `"opencode/command/review-pr.md"` to the slice
-  (alphabetically after `review-council.md`).
+  (alphabetically after `review-council.md`). Update
+  the `// OpenCode commands (7)` comment to `(8)`.
 
 ## 3. Documentation
 
-- [ ] 3.1 Update AGENTS.md — add `/review-pr` to the
+- [x] 3.1 Update AGENTS.md — add `/review-pr` to the
   Project Structure tree under `.opencode/command/`.
-- [ ] 3.2 Update AGENTS.md — add a "PR Review" section or
+- [x] 3.2 Update AGENTS.md — add a "PR Review" section or
   table documenting when to use `/review-pr` vs
   `/review-council`, including the command's capabilities
   and `gh` CLI prerequisite.
+- [x] 3.3 Assess Website Documentation Gate — determine
+  whether `/review-pr` requires a GitHub issue in
+  `unbound-force/website`. If so, create it via
+  `gh issue create --repo unbound-force/website`.
 
 ## 4. Verification
 
-- [ ] 4.1 Run `make check` — verify build, test, vet, and
+- [x] 4.1 Run `make check` — verify build, test, vet, and
   lint all pass with the new asset file.
-- [ ] 4.2 Verify `TestAssetPaths_MatchExpected` passes
+- [x] 4.2 Verify `TestAssetPaths_MatchExpected` passes
   (confirms `expectedAssetPaths` matches actual embedded
   files).
-- [ ] 4.3 Verify `TestEmbeddedAssets_MatchSource` passes
+- [x] 4.3 Verify `TestEmbeddedAssets_MatchSource` passes
   (confirms live copy and scaffold asset are byte-identical
-  after version marker insertion).
-- [ ] 4.4 Verify `TestRun_CreatesFiles` passes (confirms
-  file count includes the new asset).
-- [ ] 4.5 Verify `TestIsToolOwned` recognizes the new
+  after version marker insertion). Depends on both task
+  1.1 (canonical source) and task 2.1 (scaffold asset).
+- [x] 4.4 Verify `TestRun_CreatesFiles` passes (confirms
+  file count includes the new asset — uses
+  `len(expectedAssetPaths)` dynamically).
+- [x] 4.5 Verify `TestIsToolOwned` recognizes the new
   command as tool-owned (no code change needed — all
   `opencode/command/` files are tool-owned by prefix
   match).
-- [ ] 4.6 Verify constitution alignment: Composability
+- [x] 4.6 Verify `TestCanonicalSources_AreEmbedded` passes
+  (confirms the new canonical source at
+  `.opencode/command/review-pr.md` is tracked in
+  `expectedAssetPaths`).
+- [x] 4.7 Verify constitution alignment: Composability
   (command works standalone without other UF tools),
   Observable Quality (structured output with severity
   levels), Testability (scaffold test suite covers
   deployment).
+<!-- spec-review: passed -->
+<!-- code-review: passed -->

--- a/openspec/changes/review-pr-command/tasks.md
+++ b/openspec/changes/review-pr-command/tasks.md
@@ -1,0 +1,56 @@
+## 1. Create Standardized Command File
+
+- [ ] 1.1 Create `.opencode/command/review-pr.md` as the
+  canonical source (live copy). Adapt from org-infra's
+  `review_pr.md` with all standardization deltas:
+  - Kebab-case filename (`review-pr.md`)
+  - Optional PR number with auto-detection preamble
+  - Generic constitution reference (no hardcoded
+    principle names)
+  - Convention pack awareness with graceful degradation
+  - Severity pack reference with inline fallback
+  - Proper YAML frontmatter with description
+  - All original operational steps preserved (CI
+    causality, local tools, scoped diff, spec awareness,
+    fix-branch, in-line comments)
+
+## 2. Scaffold Asset Integration
+
+- [ ] 2.1 Copy `.opencode/command/review-pr.md` to
+  `internal/scaffold/assets/opencode/command/review-pr.md`
+  (embedded scaffold asset copy).
+- [ ] 2.2 Update `expectedAssetPaths` in
+  `internal/scaffold/scaffold_test.go` — add
+  `"opencode/command/review-pr.md"` to the slice
+  (alphabetically after `review-council.md`).
+
+## 3. Documentation
+
+- [ ] 3.1 Update AGENTS.md — add `/review-pr` to the
+  Project Structure tree under `.opencode/command/`.
+- [ ] 3.2 Update AGENTS.md — add a "PR Review" section or
+  table documenting when to use `/review-pr` vs
+  `/review-council`, including the command's capabilities
+  and `gh` CLI prerequisite.
+
+## 4. Verification
+
+- [ ] 4.1 Run `make check` — verify build, test, vet, and
+  lint all pass with the new asset file.
+- [ ] 4.2 Verify `TestAssetPaths_MatchExpected` passes
+  (confirms `expectedAssetPaths` matches actual embedded
+  files).
+- [ ] 4.3 Verify `TestEmbeddedAssets_MatchSource` passes
+  (confirms live copy and scaffold asset are byte-identical
+  after version marker insertion).
+- [ ] 4.4 Verify `TestRun_CreatesFiles` passes (confirms
+  file count includes the new asset).
+- [ ] 4.5 Verify `TestIsToolOwned` recognizes the new
+  command as tool-owned (no code change needed — all
+  `opencode/command/` files are tool-owned by prefix
+  match).
+- [ ] 4.6 Verify constitution alignment: Composability
+  (command works standalone without other UF tools),
+  Observable Quality (structured output with severity
+  levels), Testability (scaffold test suite covers
+  deployment).


### PR DESCRIPTION
## Summary

- Add standardized `/review-pr` command to the `uf init` scaffold, adapted from org-infra's `review_pr.md`
- Single-agent, token-lean post-PR reviewer with CI causality analysis, convention pack awareness, and shell injection mitigations
- Complements `/review-council` (pre-PR, multi-agent) with a post-PR GitHub review capability

### Standardization deltas from org-infra original

| Change | Rationale |
|--------|-----------|
| `review_pr` → `review-pr` | UF kebab-case convention |
| PR number optional (auto-detect) | Detect from current branch via `gh pr view` |
| Generic constitution reference | Works with any repo's constitution |
| Convention pack awareness | Load packs when available, degrade gracefully |
| Severity pack reference | Use `severity.md` when present, inline fallback |
| Shell injection mitigations | `--body-file`, JSON input files, branch-name sanitization |
| Fix-branch guardrails | Dirty-tree guard, user confirmation, collision handling |
| In-line comment cap | 15-comment maximum, human confirmation gate |

### Files changed

- **New**: `.opencode/command/review-pr.md`, `internal/scaffold/assets/opencode/command/review-pr.md`
- **Modified**: `internal/scaffold/scaffold_test.go` (expectedAssetPaths 7→8), `cmd/unbound-force/main_test.go` (file count 34→35), `AGENTS.md` (project structure + PR Review section + Recent Changes)
- **Spec artifacts**: Updated from Divisor council spec review and code review findings
- **No Go logic changes** — Markdown command file + test assertion updates only

### Constitution alignment

- **I. Autonomous Collaboration**: N/A (no inter-hero artifacts)
- **II. Composability First**: PASS (works standalone, packs optional)
- **III. Observable Quality**: PASS (structured output with severity levels)
- **IV. Testability**: PASS (scaffold test suite covers deployment)