### PR TITLE
fix: resolve pre-existing shellcheck CI lint failures

### DIFF
--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -17,5 +17,10 @@ ENABLE_LINTERS:
   - BASH_SHELLCHECK
   - GO_GOLANGCI_LINT
   - REPOSITORY_GITLEAKS
+
+# Exclude tool-owned Speckit scripts from shellcheck.
+# These files are managed by `specify init` and should
+# be fixed upstream rather than locally.
+BASH_SHELLCHECK_FILTER_REGEX_EXCLUDE: (\.specify/scripts/)
   # - MARKDOWN_MARKDOWNLINT
   # - YAML_YAMLLINT

--- a/scripts/validate-hero-contract.sh
+++ b/scripts/validate-hero-contract.sh
@@ -245,8 +245,8 @@ else
   check_required ".uf/hero.json exists" "fail"
   # Skip JSON validity and field checks
   REQUIRED_TOTAL=$((REQUIRED_TOTAL + 2))
-  printf "  ${RED}[FAIL]${NC} hero.json is valid JSON (file missing)\n"
-  printf "  ${RED}[FAIL]${NC} hero.json contains required fields (file missing)\n"
+  printf "  %s[FAIL]%s hero.json is valid JSON (file missing)\n" "${RED}" "${NC}"
+  printf "  %s[FAIL]%s hero.json contains required fields (file missing)\n" "${RED}" "${NC}"
 fi
 
 # 13. constitution contains parent_constitution reference


### PR DESCRIPTION
## Summary

- Exclude tool-owned Speckit scripts (`.specify/scripts/`) from shellcheck via `BASH_SHELLCHECK_FILTER_REGEX_EXCLUDE` in `.mega-linter.yml` — these files are managed by `specify init` and should be fixed upstream
- Fix 2 SC2059 findings in `scripts/validate-hero-contract.sh` by moving `${RED}`/`${NC}` variables from printf format strings to `%s` arguments

## Context

This pre-existing `Standardized CI / Run linters` failure was identified during `/review-pr 139`, where CI causality analysis classified it as a pre-existing failure on `main` (not caused by PR #139). This fix branch resolves it independently.