### PR TITLE
fix: add missing permissions for reusable_vuln_scan startup

### DIFF
--- a/.github/workflows/ci_security.yml
+++ b/.github/workflows/ci_security.yml
@@ -35,6 +35,8 @@ jobs:
       contents: read
       actions: read
       security-events: write
+      packages: write   # Required by reusable_vuln_scan trivy_image job (even when skipped)
+      id-token: write   # Required by reusable_vuln_scan trivy_image job (even when skipped)
     uses: complytime/org-infra/.github/workflows/reusable_vuln_scan.yml@baf5b2e21e61581b4a3a129795286e8592e6afbb # v0.1.0
     with:
       enable_trivy_source: true


### PR DESCRIPTION
## Summary

- Fixes the `startup_failure` that has affected **every** Security Checks CI run since the workflow was introduced (13+ consecutive failures)
- Adds `packages: write` and `id-token: write` to the `call_reusable_vuln_scan` job permissions

## Root Cause

The `reusable_vuln_scan.yml` from `complytime/org-infra` bundles three jobs: OSV-Scanner, Trivy source scan, and Trivy image scan. The `trivy_image` job declares `packages: write` and `id-token: write` permissions. Even though `trivy_image` is gated by `if: ${{ inputs.enable_trivy_image && inputs.image_ref != '' }}` (which evaluates to `false` for our usage), **GitHub Actions validates the permission graph for ALL jobs at startup**, including conditionally-skipped ones.

Our caller job only granted `contents: read`, `actions: read`, and `security-events: write`. Since job-level `permissions` blocks replace workflow-level defaults (undeclared scopes default to `none`), the reusable workflow's `trivy_image` job exceeded the `none` ceiling for `packages` and `id-token`, causing the entire workflow to fail before any job could start.

## Evidence

| Repository | Has `packages: write` + `id-token: write` | Security Checks result |
|---|---|---|
| `complytime/complyctl` | Yes | Success |
| `complytime/complyscribe` | Yes | Success |
| `unbound-force/unbound-force` (before fix) | No | startup_failure |
| `complytime/org-infra` (upstream) | No | startup_failure |

## Long-term

A PoLP-compliant long-term fix should be pursued upstream in `complytime/org-infra` — either by splitting `reusable_vuln_scan.yml` into separate reusable workflows per scan type, or by making the `trivy_image` job's permissions conditional.