### PR TITLE
docs: fix inaccurate /finale description in /unleash demo step

### DIFF
--- a/.opencode/command/unleash.md
+++ b/.opencode/command/unleash.md
@@ -602,8 +602,8 @@ Present structured demo instructions to the developer.
    most recent build/test checkpoint.
 
 5. **Next Steps**: always present these options:
-   - `/finale` to commit, push, create PR, merge, and
-     return to main
+   - `/finale` to commit, push, create PR, and return
+     to main
    - `/speckit.clarify` to refine the spec and re-run
      `/unleash`
 
@@ -629,7 +629,7 @@ Format the output as:
 
 ## Next Steps
 
-- Run `/finale` to merge and release
+- Run `/finale` to create PR and watch CI
 - Run `/speckit.clarify` to refine and iterate
 ```
 

--- a/internal/scaffold/assets/opencode/command/unleash.md
+++ b/internal/scaffold/assets/opencode/command/unleash.md
@@ -602,8 +602,8 @@ Present structured demo instructions to the developer.
    most recent build/test checkpoint.
 
 5. **Next Steps**: always present these options:
-   - `/finale` to commit, push, create PR, merge, and
-     return to main
+   - `/finale` to commit, push, create PR, and return
+     to main
    - `/speckit.clarify` to refine the spec and re-run
      `/unleash`
 
@@ -629,7 +629,7 @@ Format the output as:
 
 ## Next Steps
 
-- Run `/finale` to merge and release
+- Run `/finale` to create PR and watch CI
 - Run `/speckit.clarify` to refine and iterate
 ```
 

--- a/openspec/changes/fix-finale-description/.openspec.yaml
+++ b/openspec/changes/fix-finale-description/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: unbound-force
+created: 2026-05-03

--- a/openspec/changes/fix-finale-description/design.md
+++ b/openspec/changes/fix-finale-description/design.md
@@ -1,0 +1,22 @@
+## Context
+
+`/finale` creates PRs for review — it does not merge.
+The `/unleash` Demo step incorrectly describes `/finale`
+as merging.
+
+## Goals / Non-Goals
+
+### Goals
+- Fix inaccurate `/finale` description in `/unleash`
+
+### Non-Goals
+- Modifying `/finale` behavior
+- Modifying `/unleash` behavior
+
+## Decisions
+
+### D1: Text-only fix, two locations
+
+Two lines in `unleash.md` reference merging. Both are
+corrected. The scaffold asset copy is synced to match.
+<!-- scaffolded by uf vdev -->

--- a/openspec/changes/fix-finale-description/proposal.md
+++ b/openspec/changes/fix-finale-description/proposal.md
@@ -1,0 +1,51 @@
+## Why
+
+The `/unleash` command's Step 8 (Demo) describes
+`/finale` as "commit, push, create PR, merge, and
+return to main." This contradicts `/finale`'s own
+guardrails which state: "NEVER merge the PR — /finale
+creates PRs for review, not for immediate merge."
+
+The inaccurate description sets a false expectation
+that `/finale` will merge the PR, when it actually
+stops after creating the PR and watching CI checks.
+
+## What Changes
+
+Fix two lines in `/unleash` (live + scaffold copy):
+1. Line 605: remove "merge" from the `/finale`
+   description
+2. Line 632: change "merge and release" to "create PR
+   and watch CI"
+
+## Capabilities
+
+### Modified Capabilities
+- `/unleash` Step 8 Demo output: corrected `/finale`
+  description to match its actual behavior
+
+### New Capabilities
+- None
+
+### Removed Capabilities
+- None
+
+## Impact
+
+### Files Affected
+
+| Area | Changes |
+|------|---------|
+| `.opencode/command/unleash.md` | Fix 2 lines describing `/finale` |
+| `internal/scaffold/assets/opencode/command/unleash.md` | Sync scaffold copy |
+
+### External Dependencies
+- None
+
+## Constitution Alignment
+
+### III. Observable Quality
+
+**Assessment**: PASS — fixing inaccurate documentation
+improves the accuracy of the system's self-description.
+<!-- scaffolded by uf vdev -->

--- a/openspec/changes/fix-finale-description/specs/unleash-demo.md
+++ b/openspec/changes/fix-finale-description/specs/unleash-demo.md
@@ -1,0 +1,12 @@
+## MODIFIED Requirements
+
+### Requirement: /unleash Demo Next Steps text
+
+The Demo step's Next Steps MUST NOT describe `/finale`
+as merging. The description MUST accurately reflect
+`/finale`'s behavior: commit, push, create PR, and
+return to main.
+
+Previously: "commit, push, create PR, merge, and
+return to main" and "merge and release"
+<!-- scaffolded by uf vdev -->

--- a/openspec/changes/fix-finale-description/tasks.md
+++ b/openspec/changes/fix-finale-description/tasks.md
@@ -1,0 +1,15 @@
+## 1. Fix /unleash Demo text
+
+- [x] 1.1 In `.opencode/command/unleash.md` line 605:
+  change `/finale` description from "commit, push,
+  create PR, merge, and return to main" to "commit,
+  push, create PR, and return to main"
+- [x] 1.2 In `.opencode/command/unleash.md` line 632:
+  change "Run `/finale` to merge and release" to
+  "Run `/finale` to create PR and watch CI"
+- [x] 1.3 Sync scaffold copy at
+  `internal/scaffold/assets/opencode/command/unleash.md`
+  with the same two fixes
+<!-- spec-review: passed -->
+<!-- code-review: passed -->
+<!-- scaffolded by uf vdev -->


### PR DESCRIPTION
## Summary

- Removed "merge" from `/unleash` Step 8 Demo's description of `/finale` — `/finale` creates PRs for review, it never merges
- Changed "Run `/finale` to merge and release" to "Run `/finale` to create PR and watch CI"
- Synced scaffold asset copy

Documentation-only change — no Go code, no tests, no behavior change.