### PR TITLE
feat: add [P] parallel marker support to OpenSpec task template

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -530,6 +530,22 @@ Requires Node.js >= 20.19.0 and the OpenSpec CLI:
 
 When a task from `tasks.md` is completed during implementation, its checkbox **must** be updated from `- [ ]` to `- [x]` immediately. Do not defer this -- mark tasks complete as they are finished, not in a batch after all work is done.
 
+### Parallel Task Markers
+
+Both Speckit and OpenSpec task formats support `[P]`
+markers for parallel-eligible tasks. `/unleash` and
+Replicator detect `[P]` markers regardless of task ID
+format (Speckit `T001` or OpenSpec `1.1`).
+
+Format: `- [ ] N.M [P] Task description`
+
+A task is parallel-eligible when it: (a) touches
+different files from other `[P]` tasks in the same
+group, (b) has no dependency on prior tasks, (c) can
+execute without ordering constraints. Tasks without
+`[P]` run sequentially first, then `[P]` tasks run in
+parallel (up to 4 concurrent workers via git worktrees).
+
 ### Documentation Validation Gate
 
 Before marking any task complete, validate whether the change requires documentation updates:
@@ -888,6 +904,7 @@ without exception.
 
 ## Recent Changes
 
+- 035-openspec-parallel-markers: Added `[P]` parallel marker support to OpenSpec task template and schema instructions. Updated `openspec/schemas/unbound-force/templates/tasks.md` with `[P]` marker examples (sequential + parallel tasks in same group) and an HTML comment explaining the convention. Updated `openspec/schemas/unbound-force/schema.yaml` tasks instruction to guide the LLM on when to add `[P]` (different files, no dependencies) and when not to (same file). Added "Parallel Task Markers" subsection to AGENTS.md documenting the alignment between Speckit and OpenSpec task formats. No Go code changes. Closes #153.
 - opsx/sandbox-uid-mapping: Fixed rootless Podman UID mismatch that broke `uf sandbox` direct mode and git operations on both macOS and Linux. Added `--userns=keep-id:uid=1000,gid=1000` to all `podman run` invocations via shared `uidMappingArgs()` helper (both `buildRunArgs()` and `buildPersistentRunArgs()`). Added macOS Podman machine UID probe using `busybox:latest` with `--entrypoint stat` override — fails with actionable error when virtiofs doesn't map UIDs correctly. Added `--uidmap` CLI flag as escape hatch for macOS users whose Podman machine can't be reconfigured (explicit `--uidmap`/`--gidmap` mapping). Added `Platform *PlatformConfig` injection field for cross-platform testability. Added `parsePodmanVersion()` enforcing Podman >= 4.3 at runtime. Added `isRootlessPodman()` guard rejecting `--uidmap` under rootful Podman (privilege escalation prevention). Added post-copy `chown -R dev:dev /workspace` in `PodmanBackend.Create()`. New `UIDMap` field in `Options`, `SandboxConfig`, and CLI flags. Added 21 new test functions, fixed 8 existing tests. Modified files: `internal/sandbox/config.go`, `internal/sandbox/podman.go`, `internal/sandbox/detect.go`, `internal/sandbox/sandbox.go`, `internal/sandbox/sandbox_test.go`, `internal/config/config.go`, `internal/config/config_test.go`, `cmd/unbound-force/sandbox.go`, `cmd/unbound-force/sandbox_test.go`. No new dependencies. 9 task groups and 50 tasks completed.
 - opsx/gateway-token-refresh-fix: Fixed silent token expiry failures in the gateway's Vertex AI and Bedrock providers. Added token/credential expiry tracking (`tokenExpiry time.Time` on `VertexProvider`, `credExpiry time.Time` on `BedrockProvider`) with 55-minute/50-minute safety margins. When a background refresh fails, the stored token/credentials are now cleared atomically under the write lock, causing `PrepareRequest` to return a clear "Re-authenticate" error instead of silently forwarding stale credentials that Vertex rejects with `ACCESS_TOKEN_TYPE_UNSUPPORTED`. Added proactive refresh in `PrepareRequest` — when a token is within 5 minutes of expiry, a synchronous refresh is attempted with `sync.Mutex.TryLock()` deduplication to prevent thundering herd. Detached gateway child process now redirects stdout/stderr to `.uf/gateway.log` (0600 permissions) instead of discarding logs. `uf gateway status` displays the log file path. Named constants extracted (`vertexTokenLifetime`, `proactiveRefreshWindow`, `bedrockCredLifetime`). Added 14 new test functions including regression test (`TestVertexPrepareRequest_StaleTokenRegression` per TC-006), concurrent deduplication test with `sync.WaitGroup` barrier and `atomic.Int32` counter, and foreground negative case. Updated 8 existing test call sites. Synced 18 pre-existing scaffold asset drifts. Modified files: `internal/gateway/provider.go`, `internal/gateway/gateway.go`, `internal/gateway/gateway_test.go`. No new dependencies. 7 task groups and 42 tasks completed.
 - opsx/review-pr-reliability: Fixed 6 reliability issues in `/review-pr` command that caused 12 wasted tool calls and an incomplete review during PR #139. Added argument-first parsing gate (prevents auto-detection when PR number provided), execution mode check in Step 0 (stops early when local tools can't run in plan/read-only mode), mandatory CI coverage matrix in Step 4 (makes CI→local tool dedup decision visible and auditable), save-and-navigate diff handling in Step 5 (replaces nonexistent `gh pr diff -- <path>` file-filter syntax with concrete temp-file technique), GitHub API guidance for PR branch file access (replaces failing `git show`/`git fetch` with `gh api`), and PR-introduced spec detection in Step 6 (finds specs in the PR's changed file list when not on base branch). Fixed pre-existing step numbering issue in Step 10. Modified files: `.opencode/command/review-pr.md`, `internal/scaffold/assets/opencode/command/review-pr.md`, `AGENTS.md`. No Go code changes. 8 task groups and 28 tasks completed.

--- a/internal/scaffold/assets/openspec/schemas/unbound-force/schema.yaml
+++ b/internal/scaffold/assets/openspec/schemas/unbound-force/schema.yaml
@@ -55,6 +55,15 @@ artifacts:
       checkboxes. Group related tasks. Include a task
       for verifying constitution alignment if the
       proposal identified relevant principles.
+      Add [P] marker after the task number on tasks
+      that are eligible for parallel execution.
+      A task is parallel-eligible when it: (a) touches
+      different files from other [P] tasks in the same
+      group, (b) has no dependency on prior tasks in
+      the group, (c) can safely execute without ordering
+      constraints. Do NOT add [P] when tasks modify the
+      same file — parallel workers will cause merge
+      conflicts. Format: - [ ] N.M [P] description.
     requires: [specs, design]
 
 apply:

--- a/internal/scaffold/assets/openspec/schemas/unbound-force/templates/tasks.md
+++ b/internal/scaffold/assets/openspec/schemas/unbound-force/templates/tasks.md
@@ -1,7 +1,20 @@
+<!--
+  [P] marks tasks eligible for parallel execution.
+  Add [P] when a task: (a) touches different files from
+  other [P] tasks in the group, (b) has no dependency
+  on prior tasks in the group, (c) can safely execute
+  without ordering constraints.
+  Do NOT add [P] when tasks modify the same file —
+  parallel workers will cause merge conflicts.
+  Tasks without [P] run sequentially first, then [P]
+  tasks run in parallel.
+-->
+
 ## 1. <!-- Task Group -->
 
-- [ ] 1.1 <!-- task description -->
-- [ ] 1.2 <!-- task description -->
+- [ ] 1.1 <!-- sequential task (runs first) -->
+- [ ] 1.2 [P] <!-- parallel task (different file) -->
+- [ ] 1.3 [P] <!-- parallel task (different file) -->
 
 ## 2. <!-- Task Group -->
 

--- a/openspec/schemas/unbound-force/schema.yaml
+++ b/openspec/schemas/unbound-force/schema.yaml
@@ -55,6 +55,15 @@ artifacts:
       checkboxes. Group related tasks. Include a task
       for verifying constitution alignment if the
       proposal identified relevant principles.
+      Add [P] marker after the task number on tasks
+      that are eligible for parallel execution.
+      A task is parallel-eligible when it: (a) touches
+      different files from other [P] tasks in the same
+      group, (b) has no dependency on prior tasks in
+      the group, (c) can safely execute without ordering
+      constraints. Do NOT add [P] when tasks modify the
+      same file — parallel workers will cause merge
+      conflicts. Format: - [ ] N.M [P] description.
     requires: [specs, design]
 
 apply:

--- a/openspec/schemas/unbound-force/templates/tasks.md
+++ b/openspec/schemas/unbound-force/templates/tasks.md
@@ -1,7 +1,20 @@
+<!--
+  [P] marks tasks eligible for parallel execution.
+  Add [P] when a task: (a) touches different files from
+  other [P] tasks in the group, (b) has no dependency
+  on prior tasks in the group, (c) can safely execute
+  without ordering constraints.
+  Do NOT add [P] when tasks modify the same file —
+  parallel workers will cause merge conflicts.
+  Tasks without [P] run sequentially first, then [P]
+  tasks run in parallel.
+-->
+
 ## 1. <!-- Task Group -->
 
-- [ ] 1.1 <!-- task description -->
-- [ ] 1.2 <!-- task description -->
+- [ ] 1.1 <!-- sequential task (runs first) -->
+- [ ] 1.2 [P] <!-- parallel task (different file) -->
+- [ ] 1.3 [P] <!-- parallel task (different file) -->
 
 ## 2. <!-- Task Group -->
 

--- a/specs/035-openspec-parallel-markers/checklists/requirements.md
+++ b/specs/035-openspec-parallel-markers/checklists/requirements.md
@@ -1,0 +1,37 @@
+# Specification Quality Checklist: OpenSpec Parallel Markers
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-03
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass. Spec is ready for `/speckit.plan` or `/speckit.clarify`.
+- The spec deliberately avoids mentioning specific file paths in requirements (those are implementation details). The Key Entities section references the files for context but the FRs are stated in terms of behavior.
+- No [NEEDS CLARIFICATION] markers — the issue was sufficiently detailed to make all decisions.
+<!-- scaffolded by uf vdev -->

--- a/specs/035-openspec-parallel-markers/plan.md
+++ b/specs/035-openspec-parallel-markers/plan.md
@@ -1,0 +1,48 @@
+---
+title: OpenSpec Parallel Markers — Implementation Plan
+status: draft
+created: 2026-05-03
+spec: "035"
+---
+
+# Implementation Plan: OpenSpec Parallel Markers
+
+## Scope
+
+Two files modified, one file updated:
+
+1. **Task template** — Add `[P]` marker examples and
+   a comment explaining when to use `[P]`
+2. **Schema instructions** — Update the `tasks`
+   artifact's `instruction` field to guide the LLM
+   on when and how to add `[P]` markers
+3. **AGENTS.md** — Document the `[P]` alignment between
+   Speckit and OpenSpec task formats
+
+## Approach
+
+This is a template-and-documentation change. No Go code
+is modified. No tests are affected (the template is a
+Markdown file, the schema is YAML — neither is compiled
+or tested by the Go test suite).
+
+The `[P]` marker is already parsed by `/unleash` and
+Replicator via string matching. No parser changes are
+needed — the marker format is the same regardless of
+whether the task ID is Speckit-style (`T001`) or
+OpenSpec-style (`1.1`).
+
+## Files
+
+| File | Change |
+|------|--------|
+| `openspec/schemas/unbound-force/templates/tasks.md` | Add `[P]` examples + comment |
+| `openspec/schemas/unbound-force/schema.yaml` | Expand `tasks` instruction |
+| `AGENTS.md` | Document `[P]` alignment |
+
+## Risks
+
+None. This change is backward compatible — existing
+`tasks.md` files without `[P]` markers continue to
+work unchanged.
+<!-- scaffolded by uf vdev -->

--- a/specs/035-openspec-parallel-markers/spec.md
+++ b/specs/035-openspec-parallel-markers/spec.md
@@ -1,0 +1,177 @@
+---
+title: OpenSpec Parallel Markers
+status: draft
+created: 2026-05-03
+spec: "035"
+---
+
+# Feature Specification: OpenSpec Parallel Markers
+
+**Feature Branch**: `035-openspec-parallel-markers`
+**Created**: 2026-05-03
+**Status**: Draft
+**Input**: GitHub issue #153 — Add [P] parallel marker
+support to OpenSpec task template
+
+## User Scenarios & Testing
+
+### User Story 1 — Parallel Task Execution for OpenSpec Changes (Priority: P1)
+
+As a developer using `/unleash` on an OpenSpec branch,
+I want independent tasks within a task group to be
+marked with `[P]` so that Replicator can execute them
+in parallel via git worktrees, reducing implementation
+time for multi-file changes.
+
+**Why this priority**: This is the core value
+proposition. Without `[P]` markers, every OpenSpec
+task runs sequentially even when tasks touch different
+files and have no dependencies. For changes with 5+
+independent tasks, this can double or triple execution
+time.
+
+**Independent Test**: Run `/unleash` on an `opsx/*`
+branch whose `tasks.md` contains `[P]`-marked tasks.
+Verify that Replicator spawns parallel workers for
+`[P]` tasks and sequential workers for non-`[P]` tasks.
+
+**Acceptance Scenarios**:
+
+1. **Given** an OpenSpec `tasks.md` with `[P]`-marked
+   tasks, **When** `/unleash` runs the implementation
+   step, **Then** `[P]` tasks within the same group
+   are executed in parallel (up to 4 concurrent workers)
+2. **Given** an OpenSpec `tasks.md` with a mix of `[P]`
+   and non-`[P]` tasks, **When** `/unleash` runs,
+   **Then** non-`[P]` tasks execute first sequentially,
+   followed by `[P]` tasks in parallel
+3. **Given** an OpenSpec `tasks.md` with no `[P]`
+   markers, **When** `/unleash` runs, **Then** all
+   tasks execute sequentially (backward compatible)
+
+---
+
+### User Story 2 — LLM-Generated Parallel Markers (Priority: P1)
+
+As a developer using `/opsx:propose`, I want the LLM
+to automatically add `[P]` markers to tasks that touch
+different files and have no inter-task dependencies, so
+that I don't have to manually mark tasks for parallel
+execution.
+
+**Why this priority**: Manual `[P]` marking defeats the
+purpose of automation. The schema instructions must
+guide the LLM to identify independent tasks and mark
+them correctly.
+
+**Independent Test**: Run `/opsx:propose` for a change
+that produces multiple independent tasks. Verify that
+the generated `tasks.md` contains `[P]` markers on
+tasks that touch different files.
+
+**Acceptance Scenarios**:
+
+1. **Given** a proposal with multiple independent file
+   changes, **When** `/opsx:propose` generates tasks,
+   **Then** tasks touching different files with no
+   shared dependencies are marked `[P]`
+2. **Given** a proposal with sequential dependencies,
+   **When** `/opsx:propose` generates tasks, **Then**
+   dependent tasks are NOT marked `[P]`
+3. **Given** a single-file change, **When**
+   `/opsx:propose` generates tasks, **Then** no tasks
+   are marked `[P]` (parallel execution of tasks
+   touching the same file risks merge conflicts)
+
+---
+
+### Edge Cases
+
+- What happens when two `[P]` tasks modify the same
+  file? Replicator's worktree merge will detect
+  conflict markers and exit with instructions. The
+  schema instructions should prevent this by only
+  marking tasks as `[P]` when they touch different
+  files.
+- What happens when a `[P]` task depends on a non-`[P]`
+  task in the same group? The non-`[P]` task runs first
+  (sequential), then `[P]` tasks run in parallel. This
+  is the existing `/unleash` behavior for Speckit tasks.
+- What about existing OpenSpec `tasks.md` files without
+  `[P]` markers? They continue to work — all tasks run
+  sequentially. This is fully backward compatible.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: The OpenSpec task template MUST demonstrate
+  the `[P]` marker format:
+  `- [ ] N.M [P] Task description`
+- **FR-002**: The OpenSpec schema instructions MUST
+  instruct the LLM to add `[P]` markers on tasks that
+  meet ALL of: (a) touch different files from other
+  `[P]` tasks in the same group, (b) have no dependency
+  on prior tasks in the group, (c) can safely execute
+  without ordering constraints
+- **FR-003**: The OpenSpec schema instructions MUST
+  instruct the LLM to NOT mark tasks as `[P]` when
+  they modify the same file as another task in the group
+- **FR-004**: The template MUST include an example
+  showing both `[P]` (parallel) and non-`[P]`
+  (sequential) tasks in the same group to demonstrate
+  the mixed pattern
+- **FR-005**: The change MUST be backward compatible —
+  existing `tasks.md` files without `[P]` markers MUST
+  continue to work unchanged
+
+### Key Entities
+
+- **Task template**: The Markdown template at
+  `openspec/schemas/unbound-force/templates/tasks.md`
+  that scaffolds the structure for generated tasks
+- **Schema instructions**: The `instruction` field in
+  `openspec/schemas/unbound-force/schema.yaml` that
+  guides the LLM during task generation
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001**: `/opsx:propose` generates `tasks.md` files
+  with `[P]` markers on independent tasks when the
+  change involves multiple independent file modifications
+- **SC-002**: `/unleash` on an `opsx/*` branch correctly
+  splits `[P]` and non-`[P]` tasks into parallel and
+  sequential groups (this already works — no Replicator
+  changes needed)
+- **SC-003**: Existing OpenSpec `tasks.md` files without
+  `[P]` markers continue to execute successfully in
+  `/unleash` (backward compatibility)
+- **SC-004**: The task template clearly demonstrates
+  the `[P]` marker format and usage rules
+
+## Dependencies
+
+- **Spec 018 — Unleash Command**: Defines the `[P]`
+  marker detection and parallel execution logic
+  (already implemented)
+- **Spec 008 — Swarm Orchestration**: Defines the
+  worktree-based parallel execution infrastructure
+  (already implemented)
+- **Replicator**: Already detects `[P]` markers
+  regardless of task ID format — no Replicator changes
+  needed
+
+## Assumptions
+
+- The `[P]` marker format (`- [ ] N.M [P] description`)
+  is already parsed by `/unleash` and Replicator. No
+  parser changes are needed — the marker is detected via
+  string matching on `[P]`.
+- The OpenSpec numbered task format (`1.1`, `1.2`) is
+  compatible with the `[P]` marker — the marker appears
+  after the task number, same as in Speckit format.
+- LLM-generated task files will follow the template
+  and schema instructions for `[P]` placement.
+<!-- scaffolded by uf vdev -->

--- a/specs/035-openspec-parallel-markers/tasks.md
+++ b/specs/035-openspec-parallel-markers/tasks.md
@@ -1,0 +1,34 @@
+## 1. Update Task Template
+
+- [x] 1.1 Update `openspec/schemas/unbound-force/templates/tasks.md`:
+  add `[P]` marker examples showing both parallel and
+  sequential tasks in the same group, with a comment
+  explaining the `[P]` convention (tasks touching
+  different files with no dependencies)
+
+## 2. Update Schema Instructions
+
+- [x] 2.1 Update `openspec/schemas/unbound-force/schema.yaml`:
+  expand the `tasks` artifact `instruction` field to
+  include guidance on when to add `[P]` markers
+  (different files, no inter-task dependencies) and
+  when NOT to add them (same file, sequential
+  dependency)
+
+## 3. Documentation
+
+- [x] 3.1 [P] Update AGENTS.md: document the `[P]`
+  marker alignment between Speckit and OpenSpec task
+  formats in the "Specification Framework" section
+- [x] 3.2 [P] Update AGENTS.md "Recent Changes" with
+  this change summary
+
+## 4. Verification
+
+- [x] 4.1 Run `go build ./...` — verify clean build
+  (no Go changes but confirms no regressions)
+- [x] 4.2 Verify the template renders correctly as
+  Markdown
+<!-- spec-review: passed -->
+<!-- code-review: passed -->
+<!-- scaffolded by uf vdev -->


### PR DESCRIPTION
## Summary

Closes #153.

- Added `[P]` parallel marker support to the OpenSpec task template (`openspec/schemas/unbound-force/templates/tasks.md`), with examples showing sequential + parallel tasks in the same group and an HTML comment explaining the convention
- Updated schema instructions (`openspec/schemas/unbound-force/schema.yaml`) to guide the LLM on when to add `[P]` (different files, no dependencies) and when not to (same file, sequential dependency)
- Added "Parallel Task Markers" subsection to AGENTS.md documenting the alignment between Speckit and OpenSpec task formats

No Go code changes. No Replicator changes needed — it already detects `[P]` markers regardless of task ID format.