### PR TITLE
fix: add missing mode: subagent to five agent files

### DIFF
--- a/.opencode/agents/background-worker.md
+++ b/.opencode/agents/background-worker.md
@@ -1,6 +1,7 @@
 ---
 name: background-worker
 description: Runs background tasks without MCP tool access.
+mode: subagent
 ---
 
 # Background Worker

--- a/.opencode/agents/coordinator.md
+++ b/.opencode/agents/coordinator.md
@@ -1,6 +1,7 @@
 ---
 name: coordinator
 description: Orchestrates forge coordination and supervises worker agents.
+mode: subagent
 ---
 
 # Forge Coordinator

--- a/.opencode/agents/gaze-reporter.md
+++ b/.opencode/agents/gaze-reporter.md
@@ -5,6 +5,7 @@ description: >
   metrics, side effect classifications, and overall project health.
   Supports three modes: crap (CRAP scores only), quality (test
   quality metrics only), and full (comprehensive health assessment).
+mode: subagent
 tools:
   read: true
   bash: true

--- a/.opencode/agents/gaze-test-generator.md
+++ b/.opencode/agents/gaze-test-generator.md
@@ -5,6 +5,7 @@ description: >
   complete, compilable Go test functions, improve documentation for
   classifier visibility, and restructure assertions for mapper
   accuracy. Works on any Go project gaze can analyze.
+mode: subagent
 tools:
   read: true
   bash: true

--- a/.opencode/agents/worker.md
+++ b/.opencode/agents/worker.md
@@ -1,6 +1,7 @@
 ---
 name: worker
 description: Executes a single subtask with file reservations and progress reporting.
+mode: subagent
 ---
 
 # Forge Worker


### PR DESCRIPTION
## Summary

- Adds `mode: subagent` to five agent files that were missing it: `background-worker`, `coordinator`, `gaze-reporter`, `gaze-test-generator`, and `worker`
- Without this field, OpenCode exposed these agents as selectable modes in the UI instead of treating them as subagent-only
- The other 13 agents already had `mode: subagent` set correctly