### PR TITLE
feat: add Podman and DevPod to setup and doctor commands

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,16 +1,12 @@
 {
   "_comment": "ANTHROPIC_API_KEY=gateway is a sentinel value indicating the uf gateway proxy handles authentication. When the gateway is not running, OpenCode uses its own configured provider.",
-  "containerEnv": {
-    "ANTHROPIC_API_KEY": "gateway",
-    "ANTHROPIC_BASE_URL": "http://host.containers.internal:53147"
-  },
-  "forwardPorts": [
-    4096
-  ],
   "image": "quay.io/unbound-force/opencode-dev:latest",
-  "postStartCommand": "nohup opencode serve --port 4096 \u003e /tmp/opencode-server.log 2\u003e\u00261 \u0026",
-  "remoteUser": "dev",
-  "runArgs": [
-    "--userns=keep-id:uid=1000,gid=1000"
-  ]
+  "runArgs": ["--userns=keep-id:uid=1000,gid=1000"],
+  "forwardPorts": [4096],
+  "containerEnv": {
+    "ANTHROPIC_BASE_URL": "http://host.containers.internal:53147",
+    "ANTHROPIC_API_KEY": "gateway"
+  },
+  "postStartCommand": "nohup opencode serve --port 4096 > /tmp/opencode-server.log 2>&1 &",
+  "remoteUser": "dev"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,11 +1,16 @@
 {
   "_comment": "ANTHROPIC_API_KEY=gateway is a sentinel value indicating the uf gateway proxy handles authentication. When the gateway is not running, OpenCode uses its own configured provider.",
-  "image": "quay.io/unbound-force/opencode-dev:latest",
-  "forwardPorts": [4096],
   "containerEnv": {
-    "ANTHROPIC_BASE_URL": "http://host.containers.internal:53147",
-    "ANTHROPIC_API_KEY": "gateway"
+    "ANTHROPIC_API_KEY": "gateway",
+    "ANTHROPIC_BASE_URL": "http://host.containers.internal:53147"
   },
-  "postStartCommand": "nohup opencode serve --port 4096 > /tmp/opencode-server.log 2>&1 & printf 'protocol=https\\nhost=github.com\\n\\n' | git credential fill 2>/dev/null | grep '^password=' | cut -d= -f2 | gh auth login --with-token 2>/dev/null || true",
-  "remoteUser": "dev"
+  "forwardPorts": [
+    4096
+  ],
+  "image": "quay.io/unbound-force/opencode-dev:latest",
+  "postStartCommand": "nohup opencode serve --port 4096 \u003e /tmp/opencode-server.log 2\u003e\u00261 \u0026",
+  "remoteUser": "dev",
+  "runArgs": [
+    "--userns=keep-id:uid=1000,gid=1000"
+  ]
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,12 +1,11 @@
 {
   "_comment": "ANTHROPIC_API_KEY=gateway is a sentinel value indicating the uf gateway proxy handles authentication. When the gateway is not running, OpenCode uses its own configured provider.",
-  "containerEnv": {
-    "ANTHROPIC_API_KEY": "gateway",
-    "ANTHROPIC_BASE_URL": "http://host.containers.internal:53147"
-  },
-  "forwardPorts": [
-    4096
-  ],
   "image": "quay.io/unbound-force/opencode-dev:latest",
+  "forwardPorts": [4096],
+  "containerEnv": {
+    "ANTHROPIC_BASE_URL": "http://host.containers.internal:53147",
+    "ANTHROPIC_API_KEY": "gateway"
+  },
+  "postStartCommand": "nohup opencode serve --port 4096 > /tmp/opencode-server.log 2>&1 & printf 'protocol=https\\nhost=github.com\\n\\n' | git credential fill 2>/dev/null | grep '^password=' | cut -d= -f2 | gh auth login --with-token 2>/dev/null || true",
   "remoteUser": "dev"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,12 @@
+{
+  "_comment": "ANTHROPIC_API_KEY=gateway is a sentinel value indicating the uf gateway proxy handles authentication. When the gateway is not running, OpenCode uses its own configured provider.",
+  "containerEnv": {
+    "ANTHROPIC_API_KEY": "gateway",
+    "ANTHROPIC_BASE_URL": "http://host.containers.internal:53147"
+  },
+  "forwardPorts": [
+    4096
+  ],
+  "image": "quay.io/unbound-force/opencode-dev:latest",
+  "remoteUser": "dev"
+}

--- a/.gaze/baseline.json
+++ b/.gaze/baseline.json
@@ -1132,8 +1132,11 @@
       "file": "internal/config/validate.go",
       "line": 10,
       "complexity": 1,
-      "line_coverage": 0,
-      "crap": 2
+      "line_coverage": 100,
+      "crap": 1,
+      "contract_coverage": 100,
+      "gaze_crap": 1,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "config",
@@ -1141,9 +1144,8 @@
       "file": "internal/config/validate.go",
       "line": 20,
       "complexity": 4,
-      "line_coverage": 0,
-      "crap": 20,
-      "fix_strategy": "add_tests"
+      "line_coverage": 100,
+      "crap": 4
     },
     {
       "package": "config",
@@ -1151,9 +1153,8 @@
       "file": "internal/config/validate.go",
       "line": 47,
       "complexity": 4,
-      "line_coverage": 0,
-      "crap": 20,
-      "fix_strategy": "add_tests"
+      "line_coverage": 100,
+      "crap": 4
     },
     {
       "package": "config",
@@ -1161,9 +1162,8 @@
       "file": "internal/config/validate.go",
       "line": 78,
       "complexity": 4,
-      "line_coverage": 0,
-      "crap": 20,
-      "fix_strategy": "add_tests"
+      "line_coverage": 100,
+      "crap": 4
     },
     {
       "package": "config",
@@ -1171,8 +1171,8 @@
       "file": "internal/config/validate.go",
       "line": 97,
       "complexity": 3,
-      "line_coverage": 0,
-      "crap": 12
+      "line_coverage": 71.42857142857143,
+      "crap": 3.2099125364431487
     },
     {
       "package": "config",
@@ -1180,8 +1180,8 @@
       "file": "internal/config/validate.go",
       "line": 115,
       "complexity": 3,
-      "line_coverage": 0,
-      "crap": 12
+      "line_coverage": 66.66666666666667,
+      "crap": 3.333333333333333
     },
     {
       "package": "dashboard",
@@ -1280,25 +1280,61 @@
       "package": "doctor",
       "function": "checkCoreTools",
       "file": "internal/doctor/checks.go",
-      "line": 135,
-      "complexity": 5,
-      "line_coverage": 100,
-      "crap": 5
+      "line": 143,
+      "complexity": 9,
+      "line_coverage": 92.3076923076923,
+      "crap": 9.0368684569868
     },
     {
       "package": "doctor",
       "function": "checkOllamaModel",
       "file": "internal/doctor/checks.go",
-      "line": 160,
+      "line": 182,
       "complexity": 3,
       "line_coverage": 81.81818181818181,
       "crap": 3.0540946656649135
     },
     {
       "package": "doctor",
+      "function": "checkPodmanRuntime",
+      "file": "internal/doctor/checks.go",
+      "line": 207,
+      "complexity": 2,
+      "line_coverage": 100,
+      "crap": 2
+    },
+    {
+      "package": "doctor",
+      "function": "checkPodmanRuntimeDarwin",
+      "file": "internal/doctor/checks.go",
+      "line": 216,
+      "complexity": 4,
+      "line_coverage": 100,
+      "crap": 4
+    },
+    {
+      "package": "doctor",
+      "function": "checkPodmanRuntimeLinux",
+      "file": "internal/doctor/checks.go",
+      "line": 248,
+      "complexity": 2,
+      "line_coverage": 100,
+      "crap": 2
+    },
+    {
+      "package": "doctor",
+      "function": "checkDockerPodmanShim",
+      "file": "internal/doctor/checks.go",
+      "line": 272,
+      "complexity": 4,
+      "line_coverage": 100,
+      "crap": 4
+    },
+    {
+      "package": "doctor",
       "function": "checkOneTool",
       "file": "internal/doctor/checks.go",
-      "line": 181,
+      "line": 302,
       "complexity": 17,
       "line_coverage": 91.17647058823529,
       "crap": 17.198529411764707,
@@ -1308,7 +1344,7 @@
       "package": "doctor",
       "function": "parseGoVersion",
       "file": "internal/doctor/checks.go",
-      "line": 283,
+      "line": 404,
       "complexity": 7,
       "line_coverage": 100,
       "crap": 7
@@ -1317,7 +1353,7 @@
       "package": "doctor",
       "function": "checkGoVersion",
       "file": "internal/doctor/checks.go",
-      "line": 298,
+      "line": 419,
       "complexity": 2,
       "line_coverage": 100,
       "crap": 2
@@ -1326,7 +1362,7 @@
       "package": "doctor",
       "function": "parseVersionParts",
       "file": "internal/doctor/checks.go",
-      "line": 311,
+      "line": 432,
       "complexity": 3,
       "line_coverage": 100,
       "crap": 3
@@ -1335,7 +1371,7 @@
       "package": "doctor",
       "function": "extractLeadingDigits",
       "file": "internal/doctor/checks.go",
-      "line": 326,
+      "line": 447,
       "complexity": 4,
       "line_coverage": 100,
       "crap": 4
@@ -1344,7 +1380,7 @@
       "package": "doctor",
       "function": "parseNodeVersion",
       "file": "internal/doctor/checks.go",
-      "line": 337,
+      "line": 458,
       "complexity": 2,
       "line_coverage": 100,
       "crap": 2
@@ -1353,16 +1389,34 @@
       "package": "doctor",
       "function": "checkNodeVersion",
       "file": "internal/doctor/checks.go",
-      "line": 346,
+      "line": 467,
       "complexity": 1,
       "line_coverage": 100,
       "crap": 1
     },
     {
       "package": "doctor",
+      "function": "parsePodmanVersion",
+      "file": "internal/doctor/checks.go",
+      "line": 477,
+      "complexity": 5,
+      "line_coverage": 100,
+      "crap": 5
+    },
+    {
+      "package": "doctor",
+      "function": "checkPodmanVersion",
+      "file": "internal/doctor/checks.go",
+      "line": 492,
+      "complexity": 2,
+      "line_coverage": 100,
+      "crap": 2
+    },
+    {
+      "package": "doctor",
       "function": "checkReplicator",
       "file": "internal/doctor/checks.go",
-      "line": 354,
+      "line": 503,
       "complexity": 13,
       "line_coverage": 94.28571428571429,
       "crap": 13.031533527696793
@@ -1371,7 +1425,7 @@
       "package": "doctor",
       "function": "checkConfiguration",
       "file": "internal/doctor/checks.go",
-      "line": 473,
+      "line": 622,
       "complexity": 3,
       "line_coverage": 100,
       "crap": 3
@@ -1380,7 +1434,7 @@
       "package": "doctor",
       "function": "checkScaffoldedFiles",
       "file": "internal/doctor/checks.go",
-      "line": 511,
+      "line": 660,
       "complexity": 5,
       "line_coverage": 100,
       "crap": 5
@@ -1389,7 +1443,7 @@
       "package": "doctor",
       "function": "checkDirWithCount",
       "file": "internal/doctor/checks.go",
-      "line": 562,
+      "line": 711,
       "complexity": 6,
       "line_coverage": 90,
       "crap": 6.036
@@ -1398,7 +1452,7 @@
       "package": "doctor",
       "function": "checkHeroAvailability",
       "file": "internal/doctor/checks.go",
-      "line": 598,
+      "line": 747,
       "complexity": 8,
       "line_coverage": 86.36363636363636,
       "crap": 8.162283996994741
@@ -1407,7 +1461,7 @@
       "package": "doctor",
       "function": "countDivisorPersonas",
       "file": "internal/doctor/checks.go",
-      "line": 661,
+      "line": 810,
       "complexity": 6,
       "line_coverage": 87.5,
       "crap": 6.0703125
@@ -1416,7 +1470,7 @@
       "package": "doctor",
       "function": "checkMCPConfig",
       "file": "internal/doctor/checks.go",
-      "line": 677,
+      "line": 826,
       "complexity": 9,
       "line_coverage": 88.88888888888889,
       "crap": 9.11111111111111
@@ -1425,7 +1479,7 @@
       "package": "doctor",
       "function": "extractMCPBinary",
       "file": "internal/doctor/checks.go",
-      "line": 760,
+      "line": 909,
       "complexity": 5,
       "line_coverage": 85.71428571428571,
       "crap": 5.072886297376093
@@ -1434,7 +1488,7 @@
       "package": "doctor",
       "function": "checkAgentSkillIntegrity",
       "file": "internal/doctor/checks.go",
-      "line": 782,
+      "line": 931,
       "complexity": 4,
       "line_coverage": 100,
       "crap": 4
@@ -1443,7 +1497,7 @@
       "package": "doctor",
       "function": "validateAgents",
       "file": "internal/doctor/checks.go",
-      "line": 807,
+      "line": 956,
       "complexity": 10,
       "line_coverage": 86.20689655172414,
       "crap": 10.262413383082537
@@ -1452,7 +1506,7 @@
       "package": "doctor",
       "function": "validateSkills",
       "file": "internal/doctor/checks.go",
-      "line": 879,
+      "line": 1028,
       "complexity": 11,
       "line_coverage": 93.54838709677419,
       "crap": 11.032493034809171
@@ -1461,17 +1515,16 @@
       "package": "doctor",
       "function": "defaultEmbedCheck",
       "file": "internal/doctor/checks.go",
-      "line": 957,
+      "line": 1106,
       "complexity": 8,
-      "line_coverage": 4.3478260869565215,
-      "crap": 64.00986274348648,
-      "fix_strategy": "add_tests"
+      "line_coverage": 100,
+      "crap": 8
     },
     {
       "package": "doctor",
       "function": "checkEmbeddingCapability",
       "file": "internal/doctor/checks.go",
-      "line": 1004,
+      "line": 1153,
       "complexity": 4,
       "line_coverage": 90,
       "crap": 4.016
@@ -1480,7 +1533,7 @@
       "package": "doctor",
       "function": "checkDewey",
       "file": "internal/doctor/checks.go",
-      "line": 1050,
+      "line": 1199,
       "complexity": 6,
       "line_coverage": 100,
       "crap": 6
@@ -1489,25 +1542,52 @@
       "package": "doctor",
       "function": "isDevPodDetected",
       "file": "internal/doctor/checks.go",
-      "line": 1146,
+      "line": 1295,
       "complexity": 4,
       "line_coverage": 85.71428571428571,
       "crap": 4.0466472303206995
     },
     {
       "package": "doctor",
+      "function": "parseDevPodVersion",
+      "file": "internal/doctor/checks.go",
+      "line": 1317,
+      "complexity": 6,
+      "line_coverage": 100,
+      "crap": 6
+    },
+    {
+      "package": "doctor",
+      "function": "checkDevPodVersionMin",
+      "file": "internal/doctor/checks.go",
+      "line": 1338,
+      "complexity": 2,
+      "line_coverage": 100,
+      "crap": 2
+    },
+    {
+      "package": "doctor",
+      "function": "hasDevPodProvider",
+      "file": "internal/doctor/checks.go",
+      "line": 1351,
+      "complexity": 5,
+      "line_coverage": 100,
+      "crap": 5
+    },
+    {
+      "package": "doctor",
       "function": "checkDevPod",
       "file": "internal/doctor/checks.go",
-      "line": 1167,
-      "complexity": 4,
-      "line_coverage": 90.9090909090909,
-      "crap": 4.012021036814425
+      "line": 1371,
+      "complexity": 9,
+      "line_coverage": 85.18518518518519,
+      "crap": 9.263374485596708
     },
     {
       "package": "doctor",
       "function": "parseFrontmatter",
       "file": "internal/doctor/checks.go",
-      "line": 1216,
+      "line": 1478,
       "complexity": 9,
       "line_coverage": 87.5,
       "crap": 9.158203125
@@ -1516,7 +1596,7 @@
       "package": "doctor",
       "function": "detectAGENTSmdSections",
       "file": "internal/doctor/checks.go",
-      "line": 1321,
+      "line": 1583,
       "complexity": 6,
       "line_coverage": 100,
       "crap": 6
@@ -1525,7 +1605,7 @@
       "package": "doctor",
       "function": "hasBuildCodeBlocks",
       "file": "internal/doctor/checks.go",
-      "line": 1344,
+      "line": 1606,
       "complexity": 7,
       "line_coverage": 100,
       "crap": 7
@@ -1534,7 +1614,7 @@
       "package": "doctor",
       "function": "hasSpecNumberedDirs",
       "file": "internal/doctor/checks.go",
-      "line": 1373,
+      "line": 1635,
       "complexity": 5,
       "line_coverage": 87.5,
       "crap": 5.048828125
@@ -1543,7 +1623,7 @@
       "package": "doctor",
       "function": "checkBridgeFile",
       "file": "internal/doctor/checks.go",
-      "line": 1391,
+      "line": 1653,
       "complexity": 3,
       "line_coverage": 100,
       "crap": 3
@@ -1552,26 +1632,34 @@
       "package": "doctor",
       "function": "checkAgentContext",
       "file": "internal/doctor/checks.go",
-      "line": 1423,
+      "line": 1685,
       "complexity": 13,
       "line_coverage": 100,
       "crap": 13
     },
     {
       "package": "doctor",
+      "function": "(*Options).goos",
+      "file": "internal/doctor/doctor.go",
+      "line": 84,
+      "complexity": 2,
+      "line_coverage": 100,
+      "crap": 2
+    },
+    {
+      "package": "doctor",
       "function": "(*Options).defaults",
       "file": "internal/doctor/doctor.go",
-      "line": 75,
+      "line": 92,
       "complexity": 11,
-      "line_coverage": 60,
-      "crap": 18.744000000000003,
-      "fix_strategy": "add_tests"
+      "line_coverage": 100,
+      "crap": 11
     },
     {
       "package": "doctor",
       "function": "defaultExecCmd",
       "file": "internal/doctor/doctor.go",
-      "line": 109,
+      "line": 126,
       "complexity": 1,
       "line_coverage": 0,
       "crap": 2
@@ -1580,7 +1668,7 @@
       "package": "doctor",
       "function": "defaultExecCmdTimeout",
       "file": "internal/doctor/doctor.go",
-      "line": 115,
+      "line": 132,
       "complexity": 1,
       "line_coverage": 0,
       "crap": 2
@@ -1589,7 +1677,7 @@
       "package": "doctor",
       "function": "Run",
       "file": "internal/doctor/doctor.go",
-      "line": 124,
+      "line": 141,
       "complexity": 4,
       "line_coverage": 84.61538461538461,
       "crap": 4.058261265361857,
@@ -1601,7 +1689,7 @@
       "package": "doctor",
       "function": "filterSkippedChecks",
       "file": "internal/doctor/doctor.go",
-      "line": 175,
+      "line": 192,
       "complexity": 8,
       "line_coverage": 100,
       "crap": 8
@@ -1610,7 +1698,7 @@
       "package": "doctor",
       "function": "computeSummary",
       "file": "internal/doctor/doctor.go",
-      "line": 208,
+      "line": 225,
       "complexity": 6,
       "line_coverage": 100,
       "crap": 6
@@ -1672,24 +1760,24 @@
       "function": "homebrewInstallCmd",
       "file": "internal/doctor/environ.go",
       "line": 259,
-      "complexity": 10,
-      "line_coverage": 91.66666666666667,
-      "crap": 10.05787037037037
+      "complexity": 12,
+      "line_coverage": 92.85714285714286,
+      "crap": 12.052478134110787
     },
     {
       "package": "doctor",
       "function": "genericInstallCmd",
       "file": "internal/doctor/environ.go",
-      "line": 288,
-      "complexity": 8,
+      "line": 292,
+      "complexity": 10,
       "line_coverage": 100,
-      "crap": 8
+      "crap": 10
     },
     {
       "package": "doctor",
       "function": "HasManager",
       "file": "internal/doctor/environ.go",
-      "line": 311,
+      "line": 319,
       "complexity": 3,
       "line_coverage": 100,
       "crap": 3,
@@ -1701,10 +1789,10 @@
       "package": "doctor",
       "function": "installURL",
       "file": "internal/doctor/environ.go",
-      "line": 321,
-      "complexity": 9,
-      "line_coverage": 90,
-      "crap": 9.081
+      "line": 329,
+      "complexity": 11,
+      "line_coverage": 91.66666666666667,
+      "crap": 11.070023148148149
     },
     {
       "package": "doctor",
@@ -1736,9 +1824,8 @@
       "file": "internal/doctor/format.go",
       "line": 104,
       "complexity": 11,
-      "line_coverage": 46.666666666666664,
-      "crap": 29.35614814814816,
-      "fix_strategy": "add_tests"
+      "line_coverage": 100,
+      "crap": 11
     },
     {
       "package": "doctor",
@@ -2716,7 +2803,7 @@
       "package": "metrics",
       "function": "(*Query).Velocity",
       "file": "internal/metrics/query.go",
-      "line": 51,
+      "line": 55,
       "complexity": 5,
       "line_coverage": 77.77777777777777,
       "crap": 5.274348422496571,
@@ -2733,7 +2820,7 @@
       "package": "metrics",
       "function": "(*Query).CycleTime",
       "file": "internal/metrics/query.go",
-      "line": 69,
+      "line": 73,
       "complexity": 5,
       "line_coverage": 83.33333333333333,
       "crap": 5.1157407407407405,
@@ -2745,7 +2832,7 @@
       "package": "metrics",
       "function": "(*Query).Bottlenecks",
       "file": "internal/metrics/query.go",
-      "line": 92,
+      "line": 96,
       "complexity": 3,
       "line_coverage": 80,
       "crap": 3.072,
@@ -2757,7 +2844,7 @@
       "package": "metrics",
       "function": "(*Query).Health",
       "file": "internal/metrics/query.go",
-      "line": 121,
+      "line": 125,
       "complexity": 3,
       "line_coverage": 71.42857142857143,
       "crap": 3.2099125364431487,
@@ -3601,9 +3688,8 @@
       "file": "internal/sandbox/sandbox.go",
       "line": 185,
       "complexity": 13,
-      "line_coverage": 54.166666666666664,
-      "crap": 29.27162905092593,
-      "fix_strategy": "add_tests"
+      "line_coverage": 100,
+      "crap": 13
     },
     {
       "package": "sandbox",
@@ -3902,7 +3988,7 @@
       "package": "scaffold",
       "function": "defaultExecCmd",
       "file": "internal/scaffold/scaffold.go",
-      "line": 53,
+      "line": 55,
       "complexity": 1,
       "line_coverage": 100,
       "crap": 1
@@ -3911,7 +3997,7 @@
       "package": "scaffold",
       "function": "Run",
       "file": "internal/scaffold/scaffold.go",
-      "line": 59,
+      "line": 61,
       "complexity": 33,
       "line_coverage": 82.22222222222223,
       "crap": 39.118716049382705,
@@ -3924,7 +4010,7 @@
       "package": "scaffold",
       "function": "warnLegacyReviewerFiles",
       "file": "internal/scaffold/scaffold.go",
-      "line": 251,
+      "line": 253,
       "complexity": 4,
       "line_coverage": 100,
       "crap": 4
@@ -3933,7 +4019,7 @@
       "package": "scaffold",
       "function": "mapAssetPath",
       "file": "internal/scaffold/scaffold.go",
-      "line": 278,
+      "line": 280,
       "complexity": 4,
       "line_coverage": 80,
       "crap": 4.128
@@ -3942,7 +4028,7 @@
       "package": "scaffold",
       "function": "isToolOwned",
       "file": "internal/scaffold/scaffold.go",
-      "line": 305,
+      "line": 307,
       "complexity": 5,
       "line_coverage": 100,
       "crap": 5
@@ -3951,7 +4037,7 @@
       "package": "scaffold",
       "function": "isDivisorAsset",
       "file": "internal/scaffold/scaffold.go",
-      "line": 331,
+      "line": 333,
       "complexity": 4,
       "line_coverage": 100,
       "crap": 4
@@ -3960,7 +4046,7 @@
       "package": "scaffold",
       "function": "isConventionPack",
       "file": "internal/scaffold/scaffold.go",
-      "line": 346,
+      "line": 348,
       "complexity": 1,
       "line_coverage": 100,
       "crap": 1
@@ -3969,7 +4055,7 @@
       "package": "scaffold",
       "function": "shouldDeployPack",
       "file": "internal/scaffold/scaffold.go",
-      "line": 355,
+      "line": 357,
       "complexity": 9,
       "line_coverage": 100,
       "crap": 9
@@ -3978,7 +4064,7 @@
       "package": "scaffold",
       "function": "detectLang",
       "file": "internal/scaffold/scaffold.go",
-      "line": 377,
+      "line": 379,
       "complexity": 3,
       "line_coverage": 100,
       "crap": 3
@@ -3987,7 +4073,7 @@
       "package": "scaffold",
       "function": "versionMarker",
       "file": "internal/scaffold/scaffold.go",
-      "line": 399,
+      "line": 401,
       "complexity": 2,
       "line_coverage": 100,
       "crap": 2
@@ -3996,7 +4082,7 @@
       "package": "scaffold",
       "function": "stripExistingMarkers",
       "file": "internal/scaffold/scaffold.go",
-      "line": 413,
+      "line": 415,
       "complexity": 4,
       "line_coverage": 100,
       "crap": 4
@@ -4005,7 +4091,7 @@
       "package": "scaffold",
       "function": "insertMarkerAfterFrontmatter",
       "file": "internal/scaffold/scaffold.go",
-      "line": 434,
+      "line": 436,
       "complexity": 6,
       "line_coverage": 86.66666666666667,
       "crap": 6.085333333333334
@@ -4016,7 +4102,7 @@
       "file": "internal/scaffold/scaffold.go",
       "line": 489,
       "complexity": 48,
-      "line_coverage": 97.02970297029702,
+      "line_coverage": 97.16981132075472,
       "crap": 48.052231036358876,
       "fix_strategy": "decompose"
     },
@@ -4024,7 +4110,7 @@
       "package": "scaffold",
       "function": "ensureGitignore",
       "file": "internal/scaffold/scaffold.go",
-      "line": 754,
+      "line": 772,
       "complexity": 10,
       "line_coverage": 82.3529411764706,
       "crap": 10.549562385507835
@@ -4033,7 +4119,7 @@
       "package": "scaffold",
       "function": "migrateCommandDir",
       "file": "internal/scaffold/scaffold.go",
-      "line": 810,
+      "line": 828,
       "complexity": 14,
       "line_coverage": 80.85106382978724,
       "crap": 15.376226847615653,
@@ -4043,7 +4129,7 @@
       "package": "scaffold",
       "function": "moveFile",
       "file": "internal/scaffold/scaffold.go",
-      "line": 921,
+      "line": 939,
       "complexity": 4,
       "line_coverage": 25,
       "crap": 10.75
@@ -4052,7 +4138,7 @@
       "package": "scaffold",
       "function": "countMDFiles",
       "file": "internal/scaffold/scaffold.go",
-      "line": 937,
+      "line": 955,
       "complexity": 5,
       "line_coverage": 87.5,
       "crap": 5.048828125
@@ -4061,7 +4147,7 @@
       "package": "scaffold",
       "function": "ensureAGENTSmdPackSection",
       "file": "internal/scaffold/scaffold.go",
-      "line": 960,
+      "line": 978,
       "complexity": 7,
       "line_coverage": 86.95652173913044,
       "crap": 7.10873674693844
@@ -4070,7 +4156,7 @@
       "package": "scaffold",
       "function": "replaceManagedBlock",
       "file": "internal/scaffold/scaffold.go",
-      "line": 1019,
+      "line": 1037,
       "complexity": 3,
       "line_coverage": 100,
       "crap": 3
@@ -4079,7 +4165,7 @@
       "package": "scaffold",
       "function": "buildCLAUDEmdBlock",
       "file": "internal/scaffold/scaffold.go",
-      "line": 1036,
+      "line": 1054,
       "complexity": 2,
       "line_coverage": 100,
       "crap": 2
@@ -4088,7 +4174,7 @@
       "package": "scaffold",
       "function": "ensureCLAUDEmd",
       "file": "internal/scaffold/scaffold.go",
-      "line": 1062,
+      "line": 1080,
       "complexity": 13,
       "line_coverage": 84.61538461538461,
       "crap": 13.615384615384615
@@ -4097,7 +4183,7 @@
       "package": "scaffold",
       "function": "buildCursorrulesBlock",
       "file": "internal/scaffold/scaffold.go",
-      "line": 1136,
+      "line": 1154,
       "complexity": 2,
       "line_coverage": 100,
       "crap": 2
@@ -4106,7 +4192,7 @@
       "package": "scaffold",
       "function": "ensureCursorrules",
       "file": "internal/scaffold/scaffold.go",
-      "line": 1166,
+      "line": 1184,
       "complexity": 13,
       "line_coverage": 84.61538461538461,
       "crap": 13.615384615384615
@@ -4115,7 +4201,7 @@
       "package": "scaffold",
       "function": "collectDeployedPacks",
       "file": "internal/scaffold/scaffold.go",
-      "line": 1240,
+      "line": 1258,
       "complexity": 3,
       "line_coverage": 100,
       "crap": 3
@@ -4124,7 +4210,7 @@
       "package": "scaffold",
       "function": "initSubTools",
       "file": "internal/scaffold/scaffold.go",
-      "line": 1259,
+      "line": 1277,
       "complexity": 25,
       "line_coverage": 95.08196721311475,
       "crap": 25.074345429793684,
@@ -4134,7 +4220,7 @@
       "package": "scaffold",
       "function": "subToolSymbol",
       "file": "internal/scaffold/scaffold.go",
-      "line": 1413,
+      "line": 1431,
       "complexity": 3,
       "line_coverage": 75,
       "crap": 3.140625
@@ -4143,7 +4229,7 @@
       "package": "scaffold",
       "function": "printSummary",
       "file": "internal/scaffold/scaffold.go",
-      "line": 1437,
+      "line": 1455,
       "complexity": 25,
       "line_coverage": 100,
       "crap": 25,
@@ -4153,7 +4239,7 @@
       "package": "scaffold",
       "function": "assetPaths",
       "file": "internal/scaffold/scaffold.go",
-      "line": 1532,
+      "line": 1550,
       "complexity": 3,
       "line_coverage": 88.88888888888889,
       "crap": 3.0123456790123457
@@ -4162,7 +4248,7 @@
       "package": "scaffold",
       "function": "assetContent",
       "file": "internal/scaffold/scaffold.go",
-      "line": 1549,
+      "line": 1567,
       "complexity": 1,
       "line_coverage": 100,
       "crap": 1
@@ -4171,7 +4257,7 @@
       "package": "scaffold",
       "function": "generateDeweySources",
       "file": "internal/scaffold/scaffold.go",
-      "line": 1563,
+      "line": 1581,
       "complexity": 11,
       "line_coverage": 88.46153846153847,
       "crap": 11.185878470641784
@@ -4180,7 +4266,7 @@
       "package": "scaffold",
       "function": "isDefaultSourcesConfig",
       "file": "internal/scaffold/scaffold.go",
-      "line": 1633,
+      "line": 1651,
       "complexity": 1,
       "line_coverage": 100,
       "crap": 1
@@ -4189,7 +4275,7 @@
       "package": "scaffold",
       "function": "extractGitHubOrg",
       "file": "internal/scaffold/scaffold.go",
-      "line": 1642,
+      "line": 1660,
       "complexity": 8,
       "line_coverage": 90,
       "crap": 8.064
@@ -4198,7 +4284,7 @@
       "package": "scaffold",
       "function": "DevcontainerContent",
       "file": "internal/scaffold/scaffold.go",
-      "line": 1681,
+      "line": 1699,
       "complexity": 1,
       "line_coverage": 0,
       "crap": 2
@@ -4207,7 +4293,7 @@
       "package": "scaffold",
       "function": "writeSourcesConfig",
       "file": "internal/scaffold/scaffold.go",
-      "line": 1690,
+      "line": 1708,
       "complexity": 4,
       "line_coverage": 100,
       "crap": 4
@@ -4384,20 +4470,55 @@
       "package": "setup",
       "function": "Run",
       "file": "internal/setup/setup.go",
-      "line": 200,
-      "complexity": 30,
-      "line_coverage": 90.09009009009009,
-      "crap": 30.875894155660408,
+      "line": 229,
+      "complexity": 2,
+      "line_coverage": 92.3076923076923,
+      "crap": 2.0018206645425582,
       "contract_coverage": 100,
-      "gaze_crap": 30,
-      "quadrant": "Q4_Dangerous",
-      "fix_strategy": "decompose"
+      "gaze_crap": 2,
+      "quadrant": "Q1_Safe"
+    },
+    {
+      "package": "setup",
+      "function": "buildSteps",
+      "file": "internal/setup/setup.go",
+      "line": 274,
+      "complexity": 5,
+      "line_coverage": 100,
+      "crap": 5
+    },
+    {
+      "package": "setup",
+      "function": "executeSteps",
+      "file": "internal/setup/setup.go",
+      "line": 334,
+      "complexity": 9,
+      "line_coverage": 95.23809523809524,
+      "crap": 9.008746355685131
+    },
+    {
+      "package": "setup",
+      "function": "printHeader",
+      "file": "internal/setup/setup.go",
+      "line": 373,
+      "complexity": 4,
+      "line_coverage": 100,
+      "crap": 4
+    },
+    {
+      "package": "setup",
+      "function": "printSummary",
+      "file": "internal/setup/setup.go",
+      "line": 400,
+      "complexity": 5,
+      "line_coverage": 100,
+      "crap": 5
     },
     {
       "package": "setup",
       "function": "installOpenCode",
       "file": "internal/setup/setup.go",
-      "line": 410,
+      "line": 432,
       "complexity": 9,
       "line_coverage": 93.33333333333333,
       "crap": 9.024000000000001
@@ -4406,7 +4527,7 @@
       "package": "setup",
       "function": "installGH",
       "file": "internal/setup/setup.go",
-      "line": 448,
+      "line": 470,
       "complexity": 6,
       "line_coverage": 90.9090909090909,
       "crap": 6.027047332832457
@@ -4415,7 +4536,7 @@
       "package": "setup",
       "function": "installOpenSpec",
       "file": "internal/setup/setup.go",
-      "line": 476,
+      "line": 498,
       "complexity": 4,
       "line_coverage": 100,
       "crap": 4
@@ -4424,17 +4545,16 @@
       "package": "setup",
       "function": "installGaze",
       "file": "internal/setup/setup.go",
-      "line": 497,
+      "line": 519,
       "complexity": 10,
-      "line_coverage": 63.1578947368421,
-      "crap": 15.0007289692375,
-      "fix_strategy": "add_tests"
+      "line_coverage": 89.47368421052632,
+      "crap": 10.116635077999709
     },
     {
       "package": "setup",
       "function": "ensureNodeJS",
       "file": "internal/setup/setup.go",
-      "line": 541,
+      "line": 563,
       "complexity": 5,
       "line_coverage": 88.88888888888889,
       "crap": 5.034293552812072
@@ -4443,7 +4563,7 @@
       "package": "setup",
       "function": "parseNodeMajor",
       "file": "internal/setup/setup.go",
-      "line": 564,
+      "line": 586,
       "complexity": 2,
       "line_coverage": 75,
       "crap": 2.0625
@@ -4452,7 +4572,7 @@
       "package": "setup",
       "function": "installNodeJS",
       "file": "internal/setup/setup.go",
-      "line": 574,
+      "line": 596,
       "complexity": 11,
       "line_coverage": 92,
       "crap": 11.061952
@@ -4461,7 +4581,7 @@
       "package": "setup",
       "function": "installUV",
       "file": "internal/setup/setup.go",
-      "line": 628,
+      "line": 650,
       "complexity": 9,
       "line_coverage": 86.66666666666667,
       "crap": 9.192
@@ -4470,7 +4590,7 @@
       "package": "setup",
       "function": "installSpecify",
       "file": "internal/setup/setup.go",
-      "line": 667,
+      "line": 689,
       "complexity": 5,
       "line_coverage": 100,
       "crap": 5
@@ -4479,7 +4599,7 @@
       "package": "setup",
       "function": "installReplicator",
       "file": "internal/setup/setup.go",
-      "line": 699,
+      "line": 721,
       "complexity": 6,
       "line_coverage": 100,
       "crap": 6
@@ -4488,7 +4608,7 @@
       "package": "setup",
       "function": "runReplicatorSetup",
       "file": "internal/setup/setup.go",
-      "line": 727,
+      "line": 749,
       "complexity": 5,
       "line_coverage": 100,
       "crap": 5
@@ -4497,7 +4617,7 @@
       "package": "setup",
       "function": "installGolangciLint",
       "file": "internal/setup/setup.go",
-      "line": 748,
+      "line": 770,
       "complexity": 6,
       "line_coverage": 54.54545454545455,
       "crap": 9.3809166040571
@@ -4506,7 +4626,7 @@
       "package": "setup",
       "function": "installGovulncheck",
       "file": "internal/setup/setup.go",
-      "line": 780,
+      "line": 802,
       "complexity": 4,
       "line_coverage": 85.71428571428571,
       "crap": 4.0466472303206995
@@ -4515,7 +4635,7 @@
       "package": "setup",
       "function": "rpmURL",
       "file": "internal/setup/setup.go",
-      "line": 797,
+      "line": 819,
       "complexity": 1,
       "line_coverage": 100,
       "crap": 1
@@ -4524,7 +4644,7 @@
       "package": "setup",
       "function": "repoName",
       "file": "internal/setup/setup.go",
-      "line": 809,
+      "line": 831,
       "complexity": 2,
       "line_coverage": 100,
       "crap": 2
@@ -4533,7 +4653,7 @@
       "package": "setup",
       "function": "rpmArch",
       "file": "internal/setup/setup.go",
-      "line": 819,
+      "line": 841,
       "complexity": 2,
       "line_coverage": 66.66666666666667,
       "crap": 2.148148148148148
@@ -4542,7 +4662,7 @@
       "package": "setup",
       "function": "installViaRpm",
       "file": "internal/setup/setup.go",
-      "line": 830,
+      "line": 852,
       "complexity": 4,
       "line_coverage": 100,
       "crap": 4
@@ -4551,7 +4671,7 @@
       "package": "setup",
       "function": "ollamaBrew",
       "file": "internal/setup/setup.go",
-      "line": 864,
+      "line": 886,
       "complexity": 2,
       "line_coverage": 100,
       "crap": 2
@@ -4560,16 +4680,61 @@
       "package": "setup",
       "function": "installOllama",
       "file": "internal/setup/setup.go",
-      "line": 875,
+      "line": 897,
       "complexity": 6,
       "line_coverage": 100,
       "crap": 6
     },
     {
       "package": "setup",
+      "function": "installPodman",
+      "file": "internal/setup/setup.go",
+      "line": 940,
+      "complexity": 9,
+      "line_coverage": 94.73684210526316,
+      "crap": 9.011809301647471
+    },
+    {
+      "package": "setup",
+      "function": "podmanMachineInit",
+      "file": "internal/setup/setup.go",
+      "line": 989,
+      "complexity": 5,
+      "line_coverage": 100,
+      "crap": 5
+    },
+    {
+      "package": "setup",
+      "function": "installDevPod",
+      "file": "internal/setup/setup.go",
+      "line": 1015,
+      "complexity": 7,
+      "line_coverage": 92.3076923076923,
+      "crap": 7.022303140646336
+    },
+    {
+      "package": "setup",
+      "function": "configureDevPodProvider",
+      "file": "internal/setup/setup.go",
+      "line": 1051,
+      "complexity": 7,
+      "line_coverage": 100,
+      "crap": 7
+    },
+    {
+      "package": "setup",
+      "function": "hasProvider",
+      "file": "internal/setup/setup.go",
+      "line": 1101,
+      "complexity": 4,
+      "line_coverage": 100,
+      "crap": 4
+    },
+    {
+      "package": "setup",
       "function": "installDewey",
       "file": "internal/setup/setup.go",
-      "line": 913,
+      "line": 1118,
       "complexity": 7,
       "line_coverage": 85.71428571428571,
       "crap": 7.142857142857143
@@ -4578,7 +4743,7 @@
       "package": "setup",
       "function": "pullEmbeddingModel",
       "file": "internal/setup/setup.go",
-      "line": 950,
+      "line": 1155,
       "complexity": 6,
       "line_coverage": 80,
       "crap": 6.287999999999999
@@ -4587,7 +4752,7 @@
       "package": "setup",
       "function": "printStepResult",
       "file": "internal/setup/setup.go",
-      "line": 978,
+      "line": 1183,
       "complexity": 6,
       "line_coverage": 100,
       "crap": 6
@@ -4596,7 +4761,7 @@
       "package": "setup",
       "function": "FormatSetupText",
       "file": "internal/setup/setup.go",
-      "line": 1003,
+      "line": 1208,
       "complexity": 2,
       "line_coverage": 100,
       "crap": 2,
@@ -4609,7 +4774,7 @@
       "package": "setup",
       "function": "atomicWriteFile",
       "file": "internal/setup/setup.go",
-      "line": 1011,
+      "line": 1216,
       "complexity": 7,
       "line_coverage": 61.111111111111114,
       "crap": 9.881858710562414
@@ -4639,7 +4804,7 @@
       "package": "sprint",
       "function": "NewSprintStore",
       "file": "internal/sprint/sprint.go",
-      "line": 21,
+      "line": 22,
       "complexity": 1,
       "line_coverage": 100,
       "crap": 1,
@@ -4656,7 +4821,7 @@
       "package": "sprint",
       "function": "(*SprintStore).Plan",
       "file": "internal/sprint/sprint.go",
-      "line": 26,
+      "line": 27,
       "complexity": 5,
       "line_coverage": 86.66666666666667,
       "crap": 5.059259259259259,
@@ -4668,7 +4833,7 @@
       "package": "sprint",
       "function": "(*SprintStore).Review",
       "file": "internal/sprint/sprint.go",
-      "line": 61,
+      "line": 62,
       "complexity": 2,
       "line_coverage": 83.33333333333333,
       "crap": 2.0185185185185186,
@@ -4680,7 +4845,7 @@
       "package": "sprint",
       "function": "(*SprintStore).Save",
       "file": "internal/sprint/sprint.go",
-      "line": 74,
+      "line": 75,
       "complexity": 3,
       "line_coverage": 71.42857142857143,
       "crap": 3.2099125364431487,
@@ -4692,7 +4857,7 @@
       "package": "sprint",
       "function": "(*SprintStore).Load",
       "file": "internal/sprint/sprint.go",
-      "line": 89,
+      "line": 90,
       "complexity": 3,
       "line_coverage": 87.5,
       "crap": 3.017578125,
@@ -4704,7 +4869,7 @@
       "package": "sprint",
       "function": "(*SprintStore).Latest",
       "file": "internal/sprint/sprint.go",
-      "line": 104,
+      "line": 105,
       "complexity": 8,
       "line_coverage": 78.57142857142857,
       "crap": 8.629737609329446,
@@ -4716,7 +4881,7 @@
       "package": "sprint",
       "function": "Standup",
       "file": "internal/sprint/sprint.go",
-      "line": 130,
+      "line": 131,
       "complexity": 6,
       "line_coverage": 75,
       "crap": 6.5625,
@@ -4816,37 +4981,27 @@
     }
   ],
   "summary": {
-    "total_functions": 477,
-    "avg_complexity": 5.033542976939203,
-    "avg_line_coverage": 78.62935594624008,
-    "avg_crap": 6.249653228718316,
-    "crapload": 35,
+    "total_functions": 496,
+    "avg_complexity": 5.002016129032258,
+    "avg_line_coverage": 81.00708452452662,
+    "avg_crap": 5.8282343479985474,
+    "crapload": 26,
     "crap_threshold": 15,
-    "gaze_crapload": 15,
+    "gaze_crapload": 14,
     "gaze_crap_threshold": 15,
-    "avg_gaze_crap": 7.466756272401433,
-    "avg_contract_coverage": 82.90322580645162,
+    "avg_gaze_crap": 7.245815527065527,
+    "avg_contract_coverage": 83.01282051282051,
     "quadrant_counts": {
-      "Q1_Safe": 138,
+      "Q1_Safe": 140,
       "Q2_ComplexButTested": 2,
       "Q3_SimpleButUnderspecified": 5,
-      "Q4_Dangerous": 10
+      "Q4_Dangerous": 9
     },
     "fix_strategy_counts": {
-      "add_tests": 16,
-      "decompose": 19
+      "add_tests": 8,
+      "decompose": 18
     },
     "worst_crap": [
-      {
-        "package": "doctor",
-        "function": "defaultEmbedCheck",
-        "file": "internal/doctor/checks.go",
-        "line": 957,
-        "complexity": 8,
-        "line_coverage": 4.3478260869565215,
-        "crap": 64.00986274348648,
-        "fix_strategy": "add_tests"
-      },
       {
         "package": "config",
         "function": "merge",
@@ -4873,7 +5028,7 @@
         "file": "internal/scaffold/scaffold.go",
         "line": 489,
         "complexity": 48,
-        "line_coverage": 97.02970297029702,
+        "line_coverage": 97.16981132075472,
         "crap": 48.052231036358876,
         "fix_strategy": "decompose"
       },
@@ -4886,6 +5041,19 @@
         "line_coverage": 0,
         "crap": 42,
         "fix_strategy": "add_tests"
+      },
+      {
+        "package": "scaffold",
+        "function": "Run",
+        "file": "internal/scaffold/scaffold.go",
+        "line": 61,
+        "complexity": 33,
+        "line_coverage": 82.22222222222223,
+        "crap": 39.118716049382705,
+        "contract_coverage": 100,
+        "gaze_crap": 33,
+        "quadrant": "Q4_Dangerous",
+        "fix_strategy": "decompose"
       }
     ],
     "worst_gaze_crap": [
@@ -4918,7 +5086,7 @@
         "package": "scaffold",
         "function": "Run",
         "file": "internal/scaffold/scaffold.go",
-        "line": 59,
+        "line": 61,
         "complexity": 33,
         "line_coverage": 82.22222222222223,
         "crap": 39.118716049382705,
@@ -4956,15 +5124,6 @@
     ],
     "recommended_actions": [
       {
-        "function": "defaultEmbedCheck",
-        "package": "doctor",
-        "file": "internal/doctor/checks.go",
-        "line": 957,
-        "fix_strategy": "add_tests",
-        "crap": 64.00986274348648,
-        "complexity": 8
-      },
-      {
         "function": "runGateway",
         "package": "main",
         "file": "cmd/unbound-force/gateway.go",
@@ -4992,55 +5151,10 @@
         "complexity": 5
       },
       {
-        "function": "formatIndicator",
-        "package": "doctor",
-        "file": "internal/doctor/format.go",
-        "line": 104,
-        "fix_strategy": "add_tests",
-        "crap": 29.35614814814816,
-        "complexity": 11
-      },
-      {
-        "function": "(*Options).defaults",
-        "package": "sandbox",
-        "file": "internal/sandbox/sandbox.go",
-        "line": 185,
-        "fix_strategy": "add_tests",
-        "crap": 29.27162905092593,
-        "complexity": 13
-      },
-      {
-        "function": "validateSetup",
-        "package": "config",
-        "file": "internal/config/validate.go",
-        "line": 20,
-        "fix_strategy": "add_tests",
-        "crap": 20,
-        "complexity": 4
-      },
-      {
-        "function": "validateGateway",
-        "package": "config",
-        "file": "internal/config/validate.go",
-        "line": 78,
-        "fix_strategy": "add_tests",
-        "crap": 20,
-        "complexity": 4
-      },
-      {
         "function": "runSandboxStatus",
         "package": "main",
         "file": "cmd/unbound-force/sandbox.go",
         "line": 537,
-        "fix_strategy": "add_tests",
-        "crap": 20,
-        "complexity": 4
-      },
-      {
-        "function": "validateSandbox",
-        "package": "config",
-        "file": "internal/config/validate.go",
-        "line": 47,
         "fix_strategy": "add_tests",
         "crap": 20,
         "complexity": 4
@@ -5053,15 +5167,6 @@
         "fix_strategy": "add_tests",
         "crap": 19.119533527696788,
         "complexity": 6
-      },
-      {
-        "function": "(*Options).defaults",
-        "package": "doctor",
-        "file": "internal/doctor/doctor.go",
-        "line": 75,
-        "fix_strategy": "add_tests",
-        "crap": 18.744000000000003,
-        "complexity": 11
       },
       {
         "function": "InitDevcontainer",
@@ -5089,19 +5194,10 @@
         "function": "migrateCommandDir",
         "package": "scaffold",
         "file": "internal/scaffold/scaffold.go",
-        "line": 810,
+        "line": 828,
         "fix_strategy": "add_tests",
         "crap": 15.376226847615653,
         "complexity": 14
-      },
-      {
-        "function": "installGaze",
-        "package": "setup",
-        "file": "internal/setup/setup.go",
-        "line": 497,
-        "fix_strategy": "add_tests",
-        "crap": 15.0007289692375,
-        "complexity": 10
       },
       {
         "function": "merge",
@@ -5116,16 +5212,16 @@
         "function": "configureOpencodeJSON",
         "package": "scaffold",
         "file": "internal/scaffold/scaffold.go",
-        "line": 485,
+        "line": 489,
         "fix_strategy": "decompose",
-        "crap": 44.05073468821247,
-        "complexity": 44
+        "crap": 48.052231036358876,
+        "complexity": 48
       },
       {
         "function": "Run",
         "package": "scaffold",
         "file": "internal/scaffold/scaffold.go",
-        "line": 59,
+        "line": 61,
         "fix_strategy": "decompose",
         "crap": 39.118716049382705,
         "gaze_crap": 33,
@@ -5141,6 +5237,84 @@
         "crap": 36.77610818933134,
         "gaze_crap": 31,
         "complexity": 31,
+        "quadrant": "Q4_Dangerous"
+      },
+      {
+        "function": "(*Orchestrator).Advance",
+        "package": "orchestration",
+        "file": "internal/orchestration/engine.go",
+        "line": 218,
+        "fix_strategy": "decompose",
+        "crap": 34.552782903802246,
+        "gaze_crap": 32,
+        "complexity": 32,
+        "quadrant": "Q4_Dangerous"
+      },
+      {
+        "function": "runMetrics",
+        "package": "main",
+        "file": "cmd/mxf/main.go",
+        "line": 318,
+        "fix_strategy": "decompose",
+        "crap": 27.153631999999998,
+        "complexity": 22
+      },
+      {
+        "function": "CollectGitHub",
+        "package": "metrics",
+        "file": "internal/metrics/collect_github.go",
+        "line": 15,
+        "fix_strategy": "decompose",
+        "crap": 26.023825782774768,
+        "gaze_crap": 26,
+        "complexity": 26,
+        "quadrant": "Q4_Dangerous"
+      },
+      {
+        "function": "initSubTools",
+        "package": "scaffold",
+        "file": "internal/scaffold/scaffold.go",
+        "line": 1277,
+        "fix_strategy": "decompose",
+        "crap": 25.074345429793684,
+        "complexity": 25
+      },
+      {
+        "function": "printSummary",
+        "package": "scaffold",
+        "file": "internal/scaffold/scaffold.go",
+        "line": 1455,
+        "fix_strategy": "decompose",
+        "crap": 25,
+        "complexity": 25
+      },
+      {
+        "function": "runRetro",
+        "package": "main",
+        "file": "cmd/mxf/main.go",
+        "line": 564,
+        "fix_strategy": "decompose",
+        "crap": 19.029232443678183,
+        "complexity": 17
+      },
+      {
+        "function": "applySandboxConfig",
+        "package": "main",
+        "file": "cmd/unbound-force/sandbox.go",
+        "line": 57,
+        "fix_strategy": "decompose",
+        "crap": 18.337962962962965,
+        "complexity": 17
+      },
+      {
+        "function": "Detect",
+        "package": "impediment",
+        "file": "internal/impediment/detect.go",
+        "line": 11,
+        "fix_strategy": "decompose",
+        "crap": 18.279883381924197,
+        "gaze_crap": 18,
+        "complexity": 18,
         "quadrant": "Q4_Dangerous"
       }
     ]

--- a/.opencode/commands/opsx-propose.md
+++ b/.opencode/commands/opsx-propose.md
@@ -38,10 +38,32 @@ When ready to implement, run /unleash (autonomous) or /opsx-apply (sequential)
    git checkout -b opsx/<name>
    ```
 
-   **Guard**: Before creating the branch, check the current branch:
-   - If already on `opsx/<name>` (exact match): skip branch creation, proceed.
-   - If on a different `opsx/*` branch: **STOP** with error: "Already on branch `opsx/<other>` -- finish or archive that change first."
-   - If on `main` or any non-opsx branch: create and checkout `opsx/<name>`.
+   **Guard**: Before creating the branch, perform these
+   checks in order:
+
+   a. **Dirty working tree check**: Run `git status --short`.
+      If there are uncommitted changes (staged, unstaged,
+      or untracked files that appear related to work):
+      - **STOP** and ask the user for confirmation before
+        switching branches. Show what uncommitted changes
+        exist and warn that switching branches with a
+        dirty working tree may cause changes to be
+        applied to the wrong branch.
+      - If the user confirms, proceed. If not, abort.
+      - Exception: if the user explicitly requested a
+        new change in the same message (e.g.,
+        `/opsx-propose fix-typos`), this still requires
+        confirmation -- never silently switch branches
+        with uncommitted work.
+
+   b. **Branch check**: Check the current branch:
+      - If already on `opsx/<name>` (exact match): skip
+        branch creation, proceed.
+      - If on a different `opsx/*` branch: **STOP** with
+        error: "Already on branch `opsx/<other>` --
+        finish or archive that change first."
+      - If on `main` or any non-opsx branch: create and
+        checkout `opsx/<name>`.
 
 ### Retrieve Context from Dewey (optional)
 

--- a/.uf/dewey/config.yaml
+++ b/.uf/dewey/config.yaml
@@ -4,3 +4,8 @@
 embedding:
   model: granite-embedding:30m
   endpoint: http://localhost:11434
+synthesis:
+  provider: vertex
+  model: claude-sonnet-4-6
+  project: my-gcp-project
+  region: us-east5

--- a/.uf/dewey/learnings/auth-1.md
+++ b/.uf/dewey/learnings/auth-1.md
@@ -1,0 +1,9 @@
+---
+tag: auth
+category: gotcha
+created_at: 2026-05-03T22:01:11Z
+identity: auth-1
+tier: draft
+---
+
+When extracting shared infrastructure from an existing package (like token refresh from gateway), the spec review will catch incomplete extraction scope. In the ollama-proxy change, the initial design proposed extracting only RefreshVertexToken and RefreshLoop, but all 5 reviewers independently flagged that this was insufficient: RefreshLoop was also used by BedrockProvider, and the proactive refresh and atomic invalidation patterns would need to be reimplemented. The resolution was to extract a full TokenManager struct to internal/auth/ that encapsulates the entire lifecycle. The key lesson: when extracting shared code, trace ALL callers across the entire codebase, not just the caller that motivated the extraction. The Bedrock dependency was invisible from the Vertex-focused perspective.

--- a/.uf/dewey/learnings/ci-1.md
+++ b/.uf/dewey/learnings/ci-1.md
@@ -1,0 +1,9 @@
+---
+tag: ci
+category: gotcha
+created_at: 2026-05-04T02:04:28Z
+identity: ci-1
+tier: draft
+---
+
+CRAP score regressions in CI are typically caused by cross-platform coverage divergence, not floating-point precision differences. IEEE 754 guarantees bit-identical arithmetic results for the CRAP formula on both ARM64 and x86_64, but the coverage percentages fed into the formula differ because platform-conditional code paths (macOS vs Linux branches, tool availability via LookPath, SELinux detection) exercise different lines on each platform. The systemic fix is twofold: (1) generate the CRAP baseline ON the CI runner via a post-merge workflow so comparisons are always same-platform, and (2) add epsilon tolerance (ε=0.5) to regression detection to absorb minor fluctuations from Go toolchain updates or non-deterministic coverage measurement. The epsilon tolerance was implemented as a local evaluate job in ci_crapload.yml since the upstream reusable workflow (complytime/org-infra) does not support a regression-epsilon input.

--- a/.uf/dewey/learnings/devpod-1.md
+++ b/.uf/dewey/learnings/devpod-1.md
@@ -1,0 +1,9 @@
+---
+tag: devpod
+category: gotcha
+created_at: 2026-05-08T18:21:29Z
+identity: devpod-1
+tier: draft
+---
+
+When adding tools to `uf setup` and `uf doctor`, the DevPod ecosystem has changed significantly: the standalone `podman` provider no longer exists. Users must alias the Docker provider via `devpod provider add docker --name podman -o DOCKER_COMMAND=podman`. This command uses DOCKER_COMMAND (not DOCKER_HOST) because the socket path varies by UID and platform. The provider detection must use exact first-column name matching on `devpod provider list` output, not substring matching, to avoid false positives from providers like "podman-custom".

--- a/.uf/dewey/learnings/doctor-1.md
+++ b/.uf/dewey/learnings/doctor-1.md
@@ -1,0 +1,9 @@
+---
+tag: doctor
+category: pattern
+created_at: 2026-05-08T18:21:33Z
+identity: doctor-1
+tier: draft
+---
+
+The doctor package's Options struct now has a `GOOS string` field for injectable platform detection, matching the setup package's existing pattern. This is intentionally lighter than the sandbox package's `Platform *PlatformConfig` struct because doctor only needs the OS string for branching, not architecture or UID mapping support. When adding platform-aware checks to doctor, always use `opts.goos()` rather than `runtime.GOOS` directly, as `runtime.GOOS` is a compile-time constant that cannot be overridden in tests. This lesson was already documented in learning/sandbox-4 but applies equally to the doctor package.

--- a/.uf/dewey/learnings/gateway-3.md
+++ b/.uf/dewey/learnings/gateway-3.md
@@ -1,0 +1,9 @@
+---
+tag: gateway
+category: pattern
+created_at: 2026-04-28T00:44:45Z
+identity: gateway-3
+tier: draft
+---
+
+When the Vertex AI gateway's background token refresh fails (e.g., gcloud ADC credentials expire), the old token must be cleared immediately rather than preserved. The original implementation logged the error but kept forwarding the stale token, producing cryptic ACCESS_TOKEN_TYPE_UNSUPPORTED (401) errors from Vertex. The fix clears both the token string and tokenExpiry timestamp atomically under tokenMu write lock when refresh fails, causing PrepareRequest to return a clear "Re-authenticate: gcloud auth application-default login" error instead. This is the same "fail explicitly rather than silently misrouting" principle that was applied to the global-region fallback in the earlier gateway-global-region-error change. The asymmetric failure behavior is intentional: background refresh clears the token (the token is likely permanently invalid), while proactive refresh in PrepareRequest preserves the token (it may still be valid until actual expiry). The proactive refresh uses sync.Mutex.TryLock() for deduplication with a 5-second timeout via goroutine+channel to prevent hung gcloud subprocesses from blocking HTTP requests.

--- a/.uf/dewey/learnings/gateway-4.md
+++ b/.uf/dewey/learnings/gateway-4.md
@@ -1,0 +1,9 @@
+---
+tag: gateway
+category: gotcha
+created_at: 2026-04-28T00:44:51Z
+identity: gateway-4
+tier: draft
+---
+
+When the uf gateway runs in detached mode (via uf gateway start --detach or auto-started by uf sandbox start), the child process re-execs with Setsid: true for session isolation. Previously cmd.Stdout and cmd.Stderr were set to nil, discarding all charmbracelet/log output from the detached process. This meant token refresh failures, provider errors, and upstream diagnostics were silently lost. The fix redirects child output to .uf/gateway.log (O_CREATE|O_WRONLY|O_TRUNC, 0600 permissions for security since the log contains auth diagnostics). The parent process closes its file handle after ExecStart since the child inherits the fd independently. The uf gateway status command now shows the log file path when it exists, guiding users to diagnostics during troubleshooting.

--- a/.uf/dewey/learnings/gateway-5.md
+++ b/.uf/dewey/learnings/gateway-5.md
@@ -1,0 +1,9 @@
+---
+tag: gateway
+category: gotcha
+created_at: 2026-04-28T00:44:56Z
+identity: gateway-5
+tier: draft
+---
+
+When adding new fields (like tokenExpiry, credExpiry) to provider structs that have existing tests constructing the struct directly, every existing test must be updated to set the new field to a valid value. Zero-value time.Time is in the past, which triggers expiry checks and causes test failures if the expiry check fires before the empty-token check. The fix was to add tokenExpiry: time.Now().Add(30 * time.Minute) to all 8 existing test struct literals. The spec review caught this proactively (Divisor Testing agent task 6.15) by requiring an explicit list of test functions to update, preventing the vague "where applicable" phrasing that could lead to missed updates.

--- a/.uf/dewey/learnings/ollamaproxy-1.md
+++ b/.uf/dewey/learnings/ollamaproxy-1.md
@@ -1,0 +1,9 @@
+---
+tag: ollamaproxy
+category: pattern
+created_at: 2026-05-03T22:01:16Z
+identity: ollamaproxy-1
+tier: draft
+---
+
+The ollama-proxy spec review surfaced a pattern for API proxy security hardening that should be applied to all future proxy commands: (1) SSRF prevention via loopback-only URL validation for upstream endpoints, (2) token redaction in error responses using a dedicated redactToken function, (3) model name validation against a safe character set before URL interpolation to prevent path traversal, (4) max request body size limits (10MB), and (5) log file permissions at 0o600. The Adversary reviewer caught all five of these from first principles — they form a reusable security checklist for any command that translates between API formats and forwards requests to cloud providers.

--- a/.uf/dewey/learnings/ollamaproxy-2.md
+++ b/.uf/dewey/learnings/ollamaproxy-2.md
@@ -1,0 +1,9 @@
+---
+tag: ollamaproxy
+category: pattern
+created_at: 2026-05-03T22:01:21Z
+identity: ollamaproxy-2
+tier: draft
+---
+
+When adding a new command that shares lifecycle infrastructure with an existing command (ollama-proxy reusing gateway patterns), extract shared utilities to dedicated packages BEFORE building the new command. The ollama-proxy change needed both internal/pidfile/ (from gateway/pid.go) and internal/auth/ (from gateway/provider.go+refresh.go). Extracting these first as independent task groups meant the new proxy package could be built cleanly without importing internal/gateway/ at all. The alternative — importing gateway directly — would have created a backwards dependency (proxy depends on gateway at the package level), which is architecturally incorrect since the proxy should be independent of the gateway.

--- a/.uf/dewey/learnings/review-council-1.md
+++ b/.uf/dewey/learnings/review-council-1.md
@@ -1,0 +1,9 @@
+---
+tag: review-council
+category: pattern
+created_at: 2026-05-07T23:20:36Z
+identity: review-council-1
+tier: draft
+---
+
+The spec review council consistently identified a missing regression test requirement (TC-006) when reviewing a bug fix proposal. Three out of five reviewers independently flagged that the tasks.md only verified existing tests pass but did not include tasks to write new regression tests that exercise the exact failure scenario (bare \r input). The lesson: when proposing a bug fix, always include explicit regression test tasks in the initial proposal. The regression test should reproduce the original failure — for example, injecting strings.NewReader("y\r") as stdin to verify the prompt correctly handles carriage-return-only line endings. A test that passes with both old and new code (like strings.NewReader("y\n")) is not a regression test. Additionally, verify existing test coverage claims by actually searching the test files rather than assuming coverage exists.

--- a/.uf/dewey/learnings/sandbox-20260510T213808-jay-flowers.md
+++ b/.uf/dewey/learnings/sandbox-20260510T213808-jay-flowers.md
@@ -1,0 +1,10 @@
+---
+tag: sandbox
+author: jay-flowers
+category: pattern
+created_at: 2026-05-10T21:38:08Z
+identity: sandbox-20260510T213808-jay-flowers
+tier: draft
+---
+
+DevPod proxies git credentials into containers via its own credential helper, but the gh CLI maintains a separate token store at ~/.config/gh/hosts.yml. To enable gh commands (PR reviews, issue management) inside DevPod sessions, the devcontainer postStartCommand can extract the GitHub token from DevPod's git credential proxy using 'printf protocol=https\nhost=github.com\n\n | git credential fill' and pipe it to 'gh auth login --with-token'. Using postStartCommand (not postCreateCommand) ensures the token is refreshed on every container start. The || true suffix provides graceful degradation when running outside DevPod or when gh is not installed. The token flows exclusively through stdin pipes (never as a command-line argument), preventing /proc/cmdline exposure.

--- a/.uf/dewey/learnings/sandbox-20260510T233923-jay-flowers.md
+++ b/.uf/dewey/learnings/sandbox-20260510T233923-jay-flowers.md
@@ -1,0 +1,10 @@
+---
+tag: sandbox
+author: jay-flowers
+category: pattern
+created_at: 2026-05-10T23:39:23Z
+identity: sandbox-20260510T233923-jay-flowers
+tier: draft
+---
+
+The devcontainer.json spec's runArgs field passes extra arguments directly to the underlying docker run or podman run command. For DevPod workspaces using the Docker provider aliased to Podman (via DOCKER_COMMAND=podman), adding "runArgs": ["--userns=keep-id:uid=1000,gid=1000"] to devcontainer.json maps the host user to UID 1000 (dev) inside the container. This eliminates the root:nobody file ownership problem without needing chown, sudo, custom providers, or containerUser overrides. The runArgs approach reuses the exact same flag proven in the Podman backend's uidMappingArgs() function. Caveat: on macOS, the Podman machine's virtiofs must support --userns=keep-id, which most modern configurations do. If it doesn't, the fallback is to remove runArgs and add a postStartCommand with sudo chown.

--- a/.uf/dewey/learnings/sandbox-4.md
+++ b/.uf/dewey/learnings/sandbox-4.md
@@ -1,0 +1,9 @@
+---
+tag: sandbox
+category: gotcha
+created_at: 2026-04-28T19:01:49Z
+identity: sandbox-4
+tier: draft
+---
+
+When adding new guards to the sandbox Start() function (like parsePodmanVersion or isRootlessPodman), ALL existing tests that call Start() will fail because their injected ExecCmd mocks don't handle the new podman commands. The fix pattern is: add cases for the new commands (podman --version, podman info) to either the shared testOpts() helper or each individual test's ExecCmd. Also, tests that exercise platform-specific logic (like macOS UID probe) should use the Platform *PlatformConfig injection field on Options rather than trying to override runtime.GOOS, which is a compile-time constant. Setting opts.Platform = &PlatformConfig{OS: "darwin", UIDMapSupported: false} allows macOS detection logic to be tested on Linux CI runners.

--- a/.uf/dewey/learnings/sandbox-5.md
+++ b/.uf/dewey/learnings/sandbox-5.md
@@ -1,0 +1,9 @@
+---
+tag: sandbox
+category: pattern
+created_at: 2026-04-28T19:01:55Z
+identity: sandbox-5
+tier: draft
+---
+
+The busybox:latest image with --entrypoint stat override is the correct approach for lightweight Podman probes that need to check file ownership or mount behavior. Using the full dev image (quay.io/unbound-force/opencode-dev:latest) for a simple stat probe is wrong because: (1) it pulls a ~1GB image when only ~5MB is needed, (2) the image's default entrypoint may execute services or bind ports, (3) the mount is :ro but the entrypoint could still read sensitive project files. The --entrypoint override prevents any image-defined entrypoint from running. This pattern was identified by the Adversary reviewer as a HIGH security finding and should be followed for any future probe containers.

--- a/.uf/dewey/learnings/sandbox-6.md
+++ b/.uf/dewey/learnings/sandbox-6.md
@@ -1,0 +1,9 @@
+---
+tag: sandbox
+category: gotcha
+created_at: 2026-05-03T19:30:07Z
+identity: sandbox-6
+tier: draft
+---
+
+When replacing a CDE backend (Che to DevPod), the isPersistentWorkspace() function in sandbox.go is a critical integration point that must be updated. It originally only checked for Podman named volumes, which meant DevPod workspaces were invisible to the persistent workspace detection path. The fix was to extend isPersistentWorkspace() to also call devpod status guarded by LookPath("devpod"). Without this, the gateway wiring for persistent Start() — a core goal of the change — would silently fail for DevPod users because Start() would fall through to the ephemeral path. The lesson: when adding a new Backend implementation, trace ALL callers of isPersistentWorkspace() and ensure the new backend's persistence model is detectable.

--- a/.uf/dewey/learnings/sandbox-7.md
+++ b/.uf/dewey/learnings/sandbox-7.md
@@ -1,0 +1,9 @@
+---
+tag: sandbox
+category: pattern
+created_at: 2026-05-03T19:30:12Z
+identity: sandbox-7
+tier: draft
+---
+
+The spec review council identified that autoDetectBackend() silently preferring DevPod when devpod is in PATH would be a behavioral break for existing users. All 5 reviewers independently flagged this. The resolution was to require BOTH devpod in PATH AND .devcontainer/devcontainer.json existence before auto-selecting DevPod. This means users must explicitly opt in via uf sandbox init before DevPod becomes the default. This pattern of requiring both binary availability AND project-level config for auto-detection should be applied to any future backend additions to prevent silent behavioral changes.

--- a/.uf/dewey/learnings/sandbox-8.md
+++ b/.uf/dewey/learnings/sandbox-8.md
@@ -1,0 +1,9 @@
+---
+tag: sandbox
+category: decision
+created_at: 2026-05-03T19:30:25Z
+identity: sandbox-8
+tier: draft
+---
+
+When integrating an external CLI tool as a Backend via subprocess (DevPod, Podman, chectl), the env var injection mechanism is a security boundary that must be specified at design time, not discovered during implementation. For DevPod, the correct flag is --workspace-env KEY=VALUE which sets env vars in the workspace container. The alternative --dotfiles-env only applies during dotfile installation and would NOT make vars available to OpenCode at runtime. The spec review caught that the design deferred this decision with "will be determined during implementation" — this was a HIGH finding because the credential injection path must be documented before code is written.

--- a/.uf/dewey/learnings/scaffold-1.md
+++ b/.uf/dewey/learnings/scaffold-1.md
@@ -1,0 +1,9 @@
+---
+tag: scaffold
+category: gotcha
+created_at: 2026-04-28T19:02:00Z
+identity: scaffold-1
+tier: draft
+---
+
+When cherry-picking commits that include scaffold asset syncs across branches, the OpenSpec template files (openspec/schemas/unbound-force/templates/*.md) frequently end up with duplicate scaffold markers because both the source and target branches independently added markers. The fix is to run a dedup pass after cherry-pick: for each .md file with 2+ markers, keep only the first. Both the live files AND their scaffold asset copies must be deduped and synced, otherwise TestEmbeddedAssets_MatchSource and TestEmbeddedAssets_SingleMarker will fail. This happened on both the gateway-token-refresh-fix and sandbox-uid-mapping branches.

--- a/.uf/dewey/learnings/setup-2.md
+++ b/.uf/dewey/learnings/setup-2.md
@@ -1,0 +1,9 @@
+---
+tag: setup
+category: gotcha
+created_at: 2026-05-08T18:21:38Z
+identity: setup-2
+tier: draft
+---
+
+When adding new steps to `uf setup`, the step count label pattern `[N/M]` is hardcoded as string literals in every `fmt.Fprintf` call. Adding 3 new steps (Podman, DevPod, DevPod provider) required updating 13 existing labels from `[N/13]` to `[N/16]` plus all existing tests that assert these labels. Additionally, existing integration tests that call `Run()` with injected `ExecCmd` need fallback cases for the new tool commands (podman, devpod, devpod provider list) to prevent cascading test failures. This is the same pattern documented in learning/sandbox-4 about new guards causing existing test failures.

--- a/.uf/dewey/learnings/setup-doctor-1.md
+++ b/.uf/dewey/learnings/setup-doctor-1.md
@@ -1,0 +1,9 @@
+---
+tag: setup-doctor
+category: pattern
+created_at: 2026-05-05T21:30:33Z
+identity: setup-doctor-1
+tier: draft
+---
+
+When removing a tool from uf setup and uf doctor, the mxf removal pattern shows the clean approach: remove the installXxx function, remove the coreTools entry, renumber all subsequent steps (both comments and progress strings), remove dedicated test functions, and clean up LookPath stub entries in unrelated tests that included the tool for environment simulation. The hero availability check (agent file detection) is a separate concern from the binary distribution check and should be left intact. A stale comment referencing the removed tool in a different test was caught during code review — always grep for the tool name across all test files, not just the dedicated test functions.

--- a/.uf/dewey/learnings/stdin-prompt-1.md
+++ b/.uf/dewey/learnings/stdin-prompt-1.md
@@ -1,0 +1,9 @@
+---
+tag: stdin-prompt
+category: gotcha
+created_at: 2026-05-07T23:20:29Z
+identity: stdin-prompt-1
+tier: draft
+---
+
+When writing interactive confirmation prompts in Go CLI tools, avoid fmt.Fscanln for reading user input from stdin. fmt.Fscanln uses whitespace-delimited token scanning semantics, not line-oriented reading. Under certain terminal configurations (particularly on macOS with iTerm2), pressing Enter can send a bare carriage return (\r, 0x0D) instead of a newline (\n, 0x0A). fmt.Fscanln does not recognize \r as a line terminator, causing it to block indefinitely while the terminal echoes ^M. The correct approach is bufio.NewScanner(stdin) with scanner.Scan() and scanner.Text(). bufio.Scanner's default ScanLines split function handles \n, \r\n, and bare \r line endings correctly. scanner.Text() returns the line with the terminator already stripped. Always combine with strings.TrimSpace for defense against trailing whitespace. This pattern preserves DI testability since bufio.Scanner accepts any io.Reader, allowing tests to inject strings.NewReader with various line endings for regression testing.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,11 +36,12 @@ make build
 make test
 # or: go test -race -count=1 ./...
 
-# Run all checks (build, test, vet, lint)
+# Run all checks (lint, test, build)
 make check
 
-# Lint
-golangci-lint run
+# Lint (vet + golangci-lint)
+make lint
+# or: go vet ./... && golangci-lint run
 ```
 
 Always run tests with `-race -count=1`. CI enforces this.
@@ -55,6 +56,7 @@ Always run tests with `-race -count=1`. CI enforces this.
 | Dependencies | `ci_dependencies.yml` | Dependency review + dependabot |
 | CRAP Load | `ci_crapload.yml` | CRAP regression analysis |
 | Release | `release.yml` | workflow_dispatch, GoReleaser + Cosign + Syft + Homebrew tap |
+| Scheduled | `ci_scheduled.yml` | Daily OSV-Scanner + Scorecards |
 
 ## Project Structure
 
@@ -62,12 +64,14 @@ Always run tests with `-race -count=1`. CI enforces this.
 unbound-force/
 ├── .specify/                         # Speckit framework (templates, scripts, memory)
 ├── .opencode/
-│   ├── agents/                       # Hero persona agents (12 active)
-│   ├── commands/                     # Slash commands (18 files)
+│   ├── agents/                       # Hero persona agents (18 active)
+│   ├── commands/                     # Slash commands (46 files)
 │   ├── skill/                        # Swarm skills packages
+│   ├── skills/                       # Additional skills packages
 │   └── uf/packs/                     # Convention packs
 ├── cmd/unbound-force/                # Cobra CLI entry point
 ├── cmd/mutimind/                     # Muti-Mind backend CLI
+├── cmd/mxf/                          # Mx F backend CLI
 ├── internal/
 │   ├── artifacts/                    # Artifact envelope I/O
 │   ├── backlog/                      # Muti-Mind backlog parsing
@@ -79,7 +83,7 @@ unbound-force/
 │   ├── impediment/                   # Impediment tracking and detection
 │   ├── metrics/                      # Metrics collection and health analysis
 │   ├── orchestration/                # Swarm orchestration engine
-│   ├── sandbox/                      # Containerized sessions (Podman/Che)
+│   ├── sandbox/                      # Containerized sessions (Podman/DevPod)
 │   ├── scaffold/                     # Core scaffold engine (embed.FS)
 │   ├── schemas/                      # JSON Schema generation/validation
 │   ├── setup/                        # Automated tool installation
@@ -88,8 +92,8 @@ unbound-force/
 ├── docs/                             # User-facing documentation
 ├── specs/                            # Architectural specs (001-035)
 ├── openspec/                         # OpenSpec tactical workflow
-├── schemas/                          # JSON Schema registry (9 types)
-├── go.mod                            # Go module (1.24+)
+├── schemas/                          # JSON Schema registry (11 types)
+├── go.mod                            # Go module (1.25+)
 ├── opencode.json                     # MCP server configuration
 ├── .goreleaser.yaml                  # Release configuration
 ├── .packit.yaml                      # Fedora packaging (Packit)
@@ -122,6 +126,19 @@ imported externally.
 - **Isolation**: `t.TempDir()` for filesystem tests
 - **Drift detection**: Tests MUST verify embedded assets match
   canonical sources
+
+## Technology Stack
+
+- **Language**: Go 1.25+ (module: `github.com/unbound-force/unbound-force`)
+- **CLI framework**: `github.com/spf13/cobra`
+- **Logging**: `github.com/charmbracelet/log`
+- **Terminal styling**: `github.com/charmbracelet/lipgloss`
+- **YAML**: `gopkg.in/yaml.v3`, `github.com/goccy/go-yaml`
+- **JSON Schema**: `github.com/invopop/jsonschema`,
+  `github.com/santhosh-tekuri/jsonschema/v6`
+- **Container runtime**: Podman (>= 4.3)
+- **Workspace manager**: DevPod (>= 0.5.0, optional)
+- **Embedding model**: `granite-embedding:30m` via Ollama
 
 ## Behavioral Rules
 
@@ -259,3 +276,5 @@ before writing or reviewing code.
 - `.opencode/uf/packs/content-custom.md`
 - `.opencode/uf/packs/go.md`
 - `.opencode/uf/packs/go-custom.md`
+- `.opencode/uf/packs/typescript.md`
+- `.opencode/uf/packs/typescript-custom.md`

--- a/cmd/unbound-force/main_test.go
+++ b/cmd/unbound-force/main_test.go
@@ -30,9 +30,9 @@ func TestRunInit_FreshDir(t *testing.T) {
 	}
 
 	// Verify the summary includes a non-trivial file count
-	// 35 = 34 prior + 1 review-pr.md command
-	if !strings.Contains(output, "35 files processed") {
-		t.Errorf("expected '35 files processed' in output, got:\n%s", output)
+	// 36 = 35 prior + 1 devcontainer/devcontainer.json
+	if !strings.Contains(output, "36 files processed") {
+		t.Errorf("expected '36 files processed' in output, got:\n%s", output)
 	}
 
 	// Verify a user-owned file was created

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -1,0 +1,234 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// --- validateSetup tests ---
+
+func TestValidateSetup_ValidPackageManagers(t *testing.T) {
+	validManagers := []string{"auto", "homebrew", "dnf", "apt", "manual", ""}
+	for _, pm := range validManagers {
+		cfg := SetupConfig{PackageManager: pm}
+		errs := validateSetup(cfg)
+		if len(errs) != 0 {
+			t.Errorf("validateSetup(%q) returned errors: %v", pm, errs)
+		}
+	}
+}
+
+func TestValidateSetup_InvalidPackageManager(t *testing.T) {
+	cfg := SetupConfig{PackageManager: "yum"}
+	errs := validateSetup(cfg)
+	if len(errs) != 1 {
+		t.Fatalf("validateSetup(yum) returned %d errors, want 1", len(errs))
+	}
+	if !strings.Contains(errs[0], "yum") {
+		t.Errorf("error = %q, want to contain %q", errs[0], "yum")
+	}
+	if !strings.Contains(errs[0], "setup.package_manager") {
+		t.Errorf("error = %q, want to contain field path", errs[0])
+	}
+}
+
+func TestValidateSetup_ValidToolMethods(t *testing.T) {
+	validMethods := []string{"auto", "homebrew", "dnf", "rpm", "apt", "curl", "skip", "nvm", "fnm", "mise", ""}
+	for _, method := range validMethods {
+		cfg := SetupConfig{
+			Tools: map[string]ToolConfig{
+				"gaze": {Method: method},
+			},
+		}
+		errs := validateSetup(cfg)
+		if len(errs) != 0 {
+			t.Errorf("validateSetup(tool method %q) returned errors: %v", method, errs)
+		}
+	}
+}
+
+func TestValidateSetup_InvalidToolMethod(t *testing.T) {
+	cfg := SetupConfig{
+		Tools: map[string]ToolConfig{
+			"gaze": {Method: "snap"},
+		},
+	}
+	errs := validateSetup(cfg)
+	if len(errs) != 1 {
+		t.Fatalf("validateSetup(tool method snap) returned %d errors, want 1", len(errs))
+	}
+	if !strings.Contains(errs[0], "gaze") {
+		t.Errorf("error = %q, want to contain tool name", errs[0])
+	}
+	if !strings.Contains(errs[0], "snap") {
+		t.Errorf("error = %q, want to contain invalid method", errs[0])
+	}
+}
+
+func TestValidateSetup_MultipleToolErrors(t *testing.T) {
+	cfg := SetupConfig{
+		PackageManager: "invalid_pm",
+		Tools: map[string]ToolConfig{
+			"gaze":    {Method: "bad1"},
+			"opencode": {Method: "bad2"},
+		},
+	}
+	errs := validateSetup(cfg)
+	// 1 for package manager + 2 for tools = 3
+	if len(errs) != 3 {
+		t.Fatalf("validateSetup returned %d errors, want 3; errors: %v", len(errs), errs)
+	}
+}
+
+// --- validateSandbox tests ---
+
+func TestValidateSandbox_ValidValues(t *testing.T) {
+	tc := []SandboxConfig{
+		{},
+		{Runtime: "auto", Backend: "auto", Mode: "isolated"},
+		{Runtime: "podman", Backend: "podman", Mode: "direct"},
+		{Runtime: "docker", Backend: "che"},
+	}
+	for _, cfg := range tc {
+		errs := validateSandbox(cfg)
+		if len(errs) != 0 {
+			t.Errorf("validateSandbox(%+v) returned errors: %v", cfg, errs)
+		}
+	}
+}
+
+func TestValidateSandbox_InvalidRuntime(t *testing.T) {
+	cfg := SandboxConfig{Runtime: "containerd"}
+	errs := validateSandbox(cfg)
+	if len(errs) != 1 {
+		t.Fatalf("validateSandbox(containerd) returned %d errors, want 1", len(errs))
+	}
+	if !strings.Contains(errs[0], "sandbox.runtime") {
+		t.Errorf("error = %q, want to contain field path", errs[0])
+	}
+	if !strings.Contains(errs[0], "containerd") {
+		t.Errorf("error = %q, want to contain invalid value", errs[0])
+	}
+}
+
+func TestValidateSandbox_InvalidBackend(t *testing.T) {
+	cfg := SandboxConfig{Backend: "kubernetes"}
+	errs := validateSandbox(cfg)
+	if len(errs) != 1 {
+		t.Fatalf("validateSandbox(kubernetes backend) returned %d errors, want 1", len(errs))
+	}
+	if !strings.Contains(errs[0], "sandbox.backend") {
+		t.Errorf("error = %q, want to contain field path", errs[0])
+	}
+}
+
+func TestValidateSandbox_InvalidMode(t *testing.T) {
+	cfg := SandboxConfig{Mode: "hybrid"}
+	errs := validateSandbox(cfg)
+	if len(errs) != 1 {
+		t.Fatalf("validateSandbox(hybrid mode) returned %d errors, want 1", len(errs))
+	}
+	if !strings.Contains(errs[0], "sandbox.mode") {
+		t.Errorf("error = %q, want to contain field path", errs[0])
+	}
+}
+
+func TestValidateSandbox_MultipleErrors(t *testing.T) {
+	cfg := SandboxConfig{
+		Runtime: "bad_runtime",
+		Backend: "bad_backend",
+		Mode:    "bad_mode",
+	}
+	errs := validateSandbox(cfg)
+	if len(errs) != 3 {
+		t.Fatalf("validateSandbox returned %d errors, want 3; errors: %v", len(errs), errs)
+	}
+}
+
+// --- validateGateway tests ---
+
+func TestValidateGateway_ValidValues(t *testing.T) {
+	tc := []GatewayConfig{
+		{},
+		{Provider: "auto", Port: 8080},
+		{Provider: "anthropic", Port: 0},
+		{Provider: "vertex", Port: 65535},
+		{Provider: "bedrock", Port: 443},
+	}
+	for _, cfg := range tc {
+		errs := validateGateway(cfg)
+		if len(errs) != 0 {
+			t.Errorf("validateGateway(%+v) returned errors: %v", cfg, errs)
+		}
+	}
+}
+
+func TestValidateGateway_InvalidProvider(t *testing.T) {
+	cfg := GatewayConfig{Provider: "openai"}
+	errs := validateGateway(cfg)
+	if len(errs) != 1 {
+		t.Fatalf("validateGateway(openai) returned %d errors, want 1", len(errs))
+	}
+	if !strings.Contains(errs[0], "gateway.provider") {
+		t.Errorf("error = %q, want to contain field path", errs[0])
+	}
+	if !strings.Contains(errs[0], "openai") {
+		t.Errorf("error = %q, want to contain invalid value", errs[0])
+	}
+}
+
+func TestValidateGateway_InvalidPort_Negative(t *testing.T) {
+	cfg := GatewayConfig{Port: -1}
+	errs := validateGateway(cfg)
+	if len(errs) != 1 {
+		t.Fatalf("validateGateway(port -1) returned %d errors, want 1", len(errs))
+	}
+	if !strings.Contains(errs[0], "gateway.port") {
+		t.Errorf("error = %q, want to contain field path", errs[0])
+	}
+}
+
+func TestValidateGateway_InvalidPort_TooHigh(t *testing.T) {
+	cfg := GatewayConfig{Port: 70000}
+	errs := validateGateway(cfg)
+	if len(errs) != 1 {
+		t.Fatalf("validateGateway(port 70000) returned %d errors, want 1", len(errs))
+	}
+	if !strings.Contains(errs[0], "70000") {
+		t.Errorf("error = %q, want to contain invalid port", errs[0])
+	}
+}
+
+func TestValidateGateway_MultipleErrors(t *testing.T) {
+	cfg := GatewayConfig{Provider: "invalid", Port: -5}
+	errs := validateGateway(cfg)
+	if len(errs) != 2 {
+		t.Fatalf("validateGateway returned %d errors, want 2; errors: %v", len(errs), errs)
+	}
+}
+
+// --- Validate (top-level) tests ---
+
+func TestValidate_ValidConfig(t *testing.T) {
+	cfg := Defaults()
+	errs := Validate(cfg)
+	if len(errs) != 0 {
+		t.Errorf("Validate(Defaults()) returned errors: %v", errs)
+	}
+}
+
+func TestValidate_AccumulatesAllErrors(t *testing.T) {
+	cfg := Config{
+		Setup:   SetupConfig{PackageManager: "invalid_pm"},
+		Sandbox: SandboxConfig{Runtime: "invalid_rt"},
+		Gateway: GatewayConfig{Provider: "invalid_pv", Port: -1},
+	}
+	errs := Validate(cfg)
+	// 1 (setup.package_manager) + 1 (sandbox.runtime) +
+	// 2 (gateway.provider + gateway.port) = 4
+	if len(errs) != 4 {
+		t.Fatalf("Validate returned %d errors, want 4; errors: %v", len(errs), errs)
+	}
+}

--- a/internal/doctor/checks.go
+++ b/internal/doctor/checks.go
@@ -129,6 +129,14 @@ var coreToolSpecs = []toolSpec{
 	{
 		name: "ollama",
 	},
+	{
+		name:         "podman",
+		required:     true,
+		versionCmd:   []string{"podman", "--version"},
+		versionParse: parsePodmanVersion,
+		minVersion:   "4.3",
+		versionCheck: checkPodmanVersion,
+	},
 }
 
 // checkCoreTools checks the core binaries per FR-001/002/003.
@@ -148,6 +156,20 @@ func checkCoreTools(opts *Options, env DetectedEnvironment) CheckGroup {
 			result = checkOllamaModel(opts, result)
 			// Replace the last result with the enriched one.
 			group.Results[len(group.Results)-1] = result
+		}
+
+		// Podman post-check: when podman passes presence +
+		// version, verify runtime health via `podman info`.
+		// Platform-aware: macOS checks machine existence first.
+		if spec.name == "podman" && result.Severity == Pass && result.Message != "not found" {
+			runtimeResult := checkPodmanRuntime(opts)
+			group.Results = append(group.Results, runtimeResult)
+
+			// Docker shim detection: check if `docker` in
+			// PATH is a symlink/shim to Podman (D8a).
+			if shimResult := checkDockerPodmanShim(opts); shimResult != nil {
+				group.Results = append(group.Results, *shimResult)
+			}
 		}
 	}
 
@@ -175,6 +197,105 @@ func checkOllamaModel(opts *Options, base CheckResult) CheckResult {
 	base.InstallHint = "ollama pull " + model
 	base.Message = base.Message + " (model not pulled)"
 	return base
+}
+
+// checkPodmanRuntime validates that Podman is functional by
+// running `podman info`. On macOS, first checks for a Podman
+// machine via `podman machine list`. Uses opts.goos() for
+// platform branching to enable cross-platform test isolation
+// per Constitution Principle IV and design D8.
+func checkPodmanRuntime(opts *Options) CheckResult {
+	if opts.goos() == "darwin" {
+		return checkPodmanRuntimeDarwin(opts)
+	}
+	return checkPodmanRuntimeLinux(opts)
+}
+
+// checkPodmanRuntimeDarwin checks Podman runtime health on macOS.
+// First verifies a Podman machine exists, then checks `podman info`.
+func checkPodmanRuntimeDarwin(opts *Options) CheckResult {
+	// Check for machine existence.
+	machineOutput, machineErr := opts.ExecCmd("podman", "machine", "list", "--format", "{{.Name}}")
+	if machineErr != nil || strings.TrimSpace(string(machineOutput)) == "" {
+		return CheckResult{
+			Name:        "podman runtime",
+			Severity:    Fail,
+			Message:     "no Podman machine found",
+			InstallHint: "podman machine init && podman machine start",
+		}
+	}
+
+	// Machine exists — check if podman info succeeds.
+	_, infoErr := opts.ExecCmd("podman", "info")
+	if infoErr != nil {
+		return CheckResult{
+			Name:        "podman runtime",
+			Severity:    Fail,
+			Message:     "Podman machine may not be running",
+			InstallHint: "podman machine start",
+		}
+	}
+
+	return CheckResult{
+		Name:     "podman runtime",
+		Severity: Pass,
+		Message:  "running",
+	}
+}
+
+// checkPodmanRuntimeLinux checks Podman runtime health on Linux.
+// Runs `podman info` directly since Linux does not use machines.
+func checkPodmanRuntimeLinux(opts *Options) CheckResult {
+	_, infoErr := opts.ExecCmd("podman", "info")
+	if infoErr != nil {
+		return CheckResult{
+			Name:        "podman runtime",
+			Severity:    Fail,
+			Message:     "Podman not responding",
+			InstallHint: "systemctl --user status podman.socket",
+		}
+	}
+
+	return CheckResult{
+		Name:     "podman runtime",
+		Severity: Pass,
+		Message:  "running",
+	}
+}
+
+// checkDockerPodmanShim checks whether `docker` in PATH is a
+// symlink or shim pointing to Podman. Returns nil if docker is
+// not in PATH (silently skipped). When docker is found, resolves
+// the binary via EvalSymlinks and checks if the resolved path
+// contains "podman". Informational only (Pass severity in both
+// cases). Design decision D8a.
+func checkDockerPodmanShim(opts *Options) *CheckResult {
+	dockerPath, err := opts.LookPath("docker")
+	if err != nil {
+		// docker not in PATH — skip silently.
+		return nil
+	}
+
+	resolved, evalErr := opts.EvalSymlinks(dockerPath)
+	if evalErr != nil {
+		// Cannot resolve symlink — skip silently.
+		return nil
+	}
+
+	if strings.Contains(strings.ToLower(resolved), "podman") {
+		return &CheckResult{
+			Name:     "docker",
+			Severity: Pass,
+			Message:  "docker is a Podman shim (" + resolved + ")",
+		}
+	}
+
+	return &CheckResult{
+		Name:     "docker",
+		Severity: Pass,
+		Message:  "Docker detected (not Podman)",
+		Detail:   "Sandbox uses Podman, not Docker. docker and podman commands may behave differently.",
+	}
 }
 
 // checkOneTool checks a single tool binary.
@@ -347,6 +468,34 @@ func checkNodeVersion(version, min string) bool {
 	vMajor, _ := parseVersionParts(version)
 	mMajor, _ := parseVersionParts(min)
 	return vMajor >= mMajor
+}
+
+// parsePodmanVersion extracts the version from `podman --version`
+// output. Expected format: "podman version X.Y.Z". Follows the
+// doctor versionParse pattern (returns string, error) rather than
+// the sandbox package's (int, int, error) pattern per design R5.
+func parsePodmanVersion(output string) (string, error) {
+	parts := strings.Fields(strings.TrimSpace(output))
+	if len(parts) < 3 {
+		return "", fmt.Errorf("could not parse podman version from: %s", output)
+	}
+	version := parts[len(parts)-1]
+	// Verify it looks like a version number.
+	if len(version) == 0 || version[0] < '0' || version[0] > '9' {
+		return "", fmt.Errorf("could not parse podman version from: %s", output)
+	}
+	return version, nil
+}
+
+// checkPodmanVersion verifies Podman version >= minimum using
+// major.minor comparison.
+func checkPodmanVersion(version, min string) bool {
+	vMajor, vMinor := parseVersionParts(version)
+	mMajor, mMinor := parseVersionParts(min)
+	if vMajor != mMajor {
+		return vMajor > mMajor
+	}
+	return vMinor >= mMinor
 }
 
 // checkReplicator checks the Replicator installation, runs
@@ -1160,10 +1309,65 @@ func isDevPodDetected(opts *Options) bool {
 		strings.Contains(string(data), "backend: \"devpod\"")
 }
 
-// checkDevPod checks DevPod-related components: binary presence
-// and devcontainer configuration. The group is only included
-// when DevPod is detected (isDevPodDetected), keeping output
-// clean for Podman-only users per design D8.
+// parseDevPodVersion extracts the version from `devpod version`
+// output. Expected format: "v0.X.Y" or "0.X.Y". Strips leading
+// "v" prefix and handles pre-release suffixes (e.g., "0.6.15-beta")
+// by truncating at the first hyphen. Follows the doctor
+// versionParse pattern per design D7a.
+func parseDevPodVersion(output string) (string, error) {
+	trimmed := strings.TrimSpace(output)
+	if trimmed == "" {
+		return "", fmt.Errorf("could not parse devpod version: empty output")
+	}
+	// Strip leading "v" prefix.
+	trimmed = strings.TrimPrefix(trimmed, "v")
+	// Truncate at first hyphen to handle pre-release suffixes.
+	if idx := strings.IndexByte(trimmed, '-'); idx >= 0 {
+		trimmed = trimmed[:idx]
+	}
+	// Verify it looks like a version number.
+	if len(trimmed) == 0 || trimmed[0] < '0' || trimmed[0] > '9' {
+		return "", fmt.Errorf("could not parse devpod version from: %s", output)
+	}
+	return trimmed, nil
+}
+
+// checkDevPodVersionMin verifies DevPod version >= minimum using
+// major.minor comparison. Uses the same parseVersionParts helper
+// as other version checks.
+func checkDevPodVersionMin(version, min string) bool {
+	vMajor, vMinor := parseVersionParts(version)
+	mMajor, mMinor := parseVersionParts(min)
+	if vMajor != mMajor {
+		return vMajor > mMajor
+	}
+	return vMinor >= mMinor
+}
+
+// hasDevPodProvider checks whether a provider named "podman" is
+// registered in DevPod by parsing `devpod provider list` output.
+// Uses exact first-column name matching per design D5 to avoid
+// false positives from providers like "podman-custom".
+func hasDevPodProvider(opts *Options, providerName string) (found bool, listFailed bool) {
+	output, err := opts.ExecCmd("devpod", "provider", "list")
+	if err != nil {
+		return false, true
+	}
+	lines := strings.Split(string(output), "\n")
+	for _, line := range lines {
+		fields := strings.Fields(line)
+		if len(fields) > 0 && fields[0] == providerName {
+			return true, false
+		}
+	}
+	return false, false
+}
+
+// checkDevPod checks DevPod-related components: binary presence,
+// version, provider registration, and devcontainer configuration.
+// The group is only included when DevPod is detected
+// (isDevPodDetected), keeping output clean for Podman-only users
+// per design D8.
 func checkDevPod(opts *Options) *CheckGroup {
 	if !isDevPodDetected(opts) {
 		return nil
@@ -1182,15 +1386,73 @@ func checkDevPod(opts *Options) *CheckGroup {
 			Message:     "not found",
 			InstallHint: "Install DevPod: https://devpod.sh/docs/getting-started/install",
 		})
+		return group
+	}
+
+	group.Results = append(group.Results, CheckResult{
+		Name:     "devpod",
+		Severity: Pass,
+		Message:  "installed",
+	})
+
+	// Check 2: devpod version >= 0.5.0.
+	versionOutput, versionErr := opts.ExecCmd("devpod", "version")
+	if versionErr == nil {
+		version, parseErr := parseDevPodVersion(string(versionOutput))
+		if parseErr == nil {
+			if checkDevPodVersionMin(version, "0.5") {
+				group.Results = append(group.Results, CheckResult{
+					Name:     "devpod version",
+					Severity: Pass,
+					Message:  version,
+				})
+			} else {
+				group.Results = append(group.Results, CheckResult{
+					Name:        "devpod version",
+					Severity:    Warn,
+					Message:     version + " (requires >= 0.5.0)",
+					InstallHint: "brew upgrade devpod",
+				})
+			}
+		} else {
+			group.Results = append(group.Results, CheckResult{
+				Name:     "devpod version",
+				Severity: Warn,
+				Message:  "version could not be parsed",
+			})
+		}
 	} else {
 		group.Results = append(group.Results, CheckResult{
-			Name:     "devpod",
-			Severity: Pass,
-			Message:  "installed",
+			Name:     "devpod version",
+			Severity: Warn,
+			Message:  "version could not be verified",
 		})
 	}
 
-	// Check 2: .devcontainer/devcontainer.json existence.
+	// Check 3: podman provider registration.
+	found, listFailed := hasDevPodProvider(opts, "podman")
+	if listFailed {
+		group.Results = append(group.Results, CheckResult{
+			Name:     "podman provider",
+			Severity: Warn,
+			Message:  "could not check providers (devpod provider list failed)",
+		})
+	} else if found {
+		group.Results = append(group.Results, CheckResult{
+			Name:     "podman provider",
+			Severity: Pass,
+			Message:  "registered",
+		})
+	} else {
+		group.Results = append(group.Results, CheckResult{
+			Name:        "podman provider",
+			Severity:    Warn,
+			Message:     "not registered",
+			InstallHint: "devpod provider add docker --name podman -o DOCKER_COMMAND=podman",
+		})
+	}
+
+	// Check 4: .devcontainer/devcontainer.json existence.
 	dcPath := filepath.Join(opts.TargetDir,
 		".devcontainer", "devcontainer.json")
 	if _, err := os.Stat(dcPath); err == nil {

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -69,6 +69,23 @@ type Options struct {
 	// EmbeddingModel is the embedding model name from config.
 	// Used instead of the compiled default when non-empty.
 	EmbeddingModel string
+
+	// GOOS overrides runtime.GOOS when non-empty. Used for
+	// platform-aware checks (e.g., Podman runtime health) and
+	// enables cross-platform test isolation per Constitution
+	// Principle IV. Matches the setup.Options GOOS pattern.
+	GOOS string
+}
+
+// goos returns the resolved OS string. When GOOS is non-empty,
+// it is used as the override; otherwise runtime.GOOS is returned.
+// This enables cross-platform test isolation per Constitution
+// Principle IV.
+func (o *Options) goos() string {
+	if o.GOOS != "" {
+		return o.GOOS
+	}
+	return runtime.GOOS
 }
 
 // defaults fills zero-value fields with production implementations.

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -938,11 +939,15 @@ func TestDoctorRun_AllPass(t *testing.T) {
 			"opencode":   "/usr/local/bin/opencode",
 			"gaze":       "/usr/local/bin/gaze",
 			"replicator": "/usr/local/bin/replicator",
+			"podman":     "/usr/local/bin/podman",
 		}),
 		ExecCmd: stubExecCmd(
 			map[string]string{
-				"go version":        "go version go1.24.3 darwin/arm64",
-				"replicator doctor": replicatorOut,
+				"go version":                             "go version go1.24.3 darwin/arm64",
+				"replicator doctor":                      replicatorOut,
+				"podman --version":                       "podman version 5.3.1",
+				"podman info":                            "host info",
+				"podman machine list --format {{.Name}}": "podman-machine-default",
 			},
 			nil,
 		),
@@ -3584,7 +3589,14 @@ func TestDevPodChecks_AllPresent(t *testing.T) {
 	opts := &Options{
 		TargetDir: dir,
 		LookPath:  stubLookPath(map[string]string{"devpod": "/usr/local/bin/devpod"}),
-		ReadFile:  os.ReadFile,
+		ExecCmd: stubExecCmd(
+			map[string]string{
+				"devpod version":       "v0.6.15",
+				"devpod provider list": "podman   docker   true\n",
+			},
+			nil,
+		),
+		ReadFile: os.ReadFile,
 	}
 
 	group := checkDevPod(opts)
@@ -3594,11 +3606,13 @@ func TestDevPodChecks_AllPresent(t *testing.T) {
 	if group.Name != "DevPod" {
 		t.Errorf("group name = %q, want DevPod", group.Name)
 	}
-	if len(group.Results) != 2 {
-		t.Fatalf("expected 2 checks, got %d", len(group.Results))
+	// 4 checks: devpod binary, devpod version, podman provider,
+	// devcontainer config.
+	if len(group.Results) != 4 {
+		t.Fatalf("expected 4 checks, got %d", len(group.Results))
 	}
 
-	// Both checks should pass.
+	// All checks should pass.
 	for _, r := range group.Results {
 		if r.Severity != Pass {
 			t.Errorf("check %q: severity = %v, want Pass", r.Name, r.Severity)
@@ -3628,7 +3642,14 @@ func TestDevPodChecks_MissingDevcontainer(t *testing.T) {
 	opts := &Options{
 		TargetDir: dir,
 		LookPath:  stubLookPath(map[string]string{"devpod": "/usr/local/bin/devpod"}),
-		ReadFile:  os.ReadFile,
+		ExecCmd: stubExecCmd(
+			map[string]string{
+				"devpod version":       "v0.6.15",
+				"devpod provider list": "podman   docker   true\n",
+			},
+			nil,
+		),
+		ReadFile: os.ReadFile,
 	}
 
 	group := checkDevPod(opts)
@@ -3710,4 +3731,785 @@ func TestCheckAgentContext_BranchProtection(t *testing.T) {
 			}
 		}
 	})
+}
+
+// --- Task Group 1: Install Hints tests ---
+
+func TestHomebrewInstallCmd_PodmanAndDevPod(t *testing.T) {
+	tests := []struct {
+		tool string
+		want string
+	}{
+		{"podman", "brew install podman"},
+		{"devpod", "brew install devpod"},
+	}
+	for _, tt := range tests {
+		got := homebrewInstallCmd(tt.tool)
+		if got != tt.want {
+			t.Errorf("homebrewInstallCmd(%q) = %q, want %q", tt.tool, got, tt.want)
+		}
+	}
+}
+
+func TestGenericInstallCmd_PodmanAndDevPod(t *testing.T) {
+	podmanHint := genericInstallCmd("podman")
+	if !strings.Contains(podmanHint, "podman.io") {
+		t.Errorf("genericInstallCmd(podman) = %q, want URL containing podman.io", podmanHint)
+	}
+	devpodHint := genericInstallCmd("devpod")
+	if !strings.Contains(devpodHint, "devpod.sh") {
+		t.Errorf("genericInstallCmd(devpod) = %q, want URL containing devpod.sh", devpodHint)
+	}
+}
+
+func TestInstallURL_PodmanAndDevPod(t *testing.T) {
+	tests := []struct {
+		tool string
+		want string
+	}{
+		{"podman", "https://podman.io"},
+		{"devpod", "https://devpod.sh"},
+	}
+	for _, tt := range tests {
+		got := installURL(tt.tool)
+		if got != tt.want {
+			t.Errorf("installURL(%q) = %q, want %q", tt.tool, got, tt.want)
+		}
+	}
+}
+
+// --- Task Group 2: Podman Core Tool Check tests ---
+
+func TestParsePodmanVersion(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{"standard", "podman version 5.3.1", "5.3.1", false},
+		{"minimum", "podman version 4.3.0", "4.3.0", false},
+		{"old", "podman version 4.2.9", "4.2.9", false},
+		{"with newline", "podman version 5.3.1\n", "5.3.1", false},
+		{"too few fields", "podman", "", true},
+		{"empty", "", "", true},
+		{"non-version", "podman version abc", "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parsePodmanVersion(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parsePodmanVersion(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("parsePodmanVersion(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCheckPodmanVersion(t *testing.T) {
+	tests := []struct {
+		version string
+		min     string
+		want    bool
+	}{
+		{"5.3.1", "4.3", true},
+		{"4.3.0", "4.3", true},
+		{"4.2.9", "4.3", false},
+		{"4.4.0", "4.3", true},
+		{"3.9.0", "4.3", false},
+		{"5.0.0", "4.3", true},
+	}
+	for _, tt := range tests {
+		got := checkPodmanVersion(tt.version, tt.min)
+		if got != tt.want {
+			t.Errorf("checkPodmanVersion(%q, %q) = %v, want %v", tt.version, tt.min, got, tt.want)
+		}
+	}
+}
+
+func TestCheckCoreTools_PodmanInSpecs(t *testing.T) {
+	t.Run("podman missing", func(t *testing.T) {
+		opts := &Options{
+			TargetDir:    t.TempDir(),
+			LookPath:     stubLookPathSimple(map[string]bool{}),
+			ExecCmd:      stubExecCmd(nil, nil),
+			EvalSymlinks: stubEvalSymlinks(nil),
+			Getenv:       stubGetenv(map[string]string{}),
+			ReadFile:     stubReadFile(nil),
+		}
+		env := DetectedEnvironment{Managers: []ManagerInfo{}}
+		group := checkCoreTools(opts, env)
+
+		results := make(map[string]CheckResult)
+		for _, r := range group.Results {
+			results[r.Name] = r
+		}
+
+		r, ok := results["podman"]
+		if !ok {
+			t.Fatal("podman check not found in Core Tools")
+		}
+		if r.Severity != Fail {
+			t.Errorf("podman missing severity = %v, want Fail (required)", r.Severity)
+		}
+		if r.InstallHint == "" {
+			t.Error("podman should have install hint when missing")
+		}
+	})
+
+	t.Run("podman present version sufficient", func(t *testing.T) {
+		opts := &Options{
+			TargetDir: t.TempDir(),
+			LookPath:  stubLookPath(map[string]string{"podman": "/usr/local/bin/podman"}),
+			ExecCmd: stubExecCmd(
+				map[string]string{
+					"podman --version": "podman version 5.3.1",
+					"podman info":      "host info",
+				},
+				nil,
+			),
+			EvalSymlinks: stubEvalSymlinks(nil),
+			Getenv:       stubGetenv(map[string]string{}),
+			ReadFile:     stubReadFile(nil),
+		}
+		env := DetectedEnvironment{Managers: []ManagerInfo{}}
+		group := checkCoreTools(opts, env)
+
+		results := make(map[string]CheckResult)
+		for _, r := range group.Results {
+			results[r.Name] = r
+		}
+
+		r, ok := results["podman"]
+		if !ok {
+			t.Fatal("podman check not found in Core Tools")
+		}
+		if r.Severity != Pass {
+			t.Errorf("podman severity = %v, want Pass", r.Severity)
+		}
+		if !strings.Contains(r.Message, "5.3.1") {
+			t.Errorf("podman message = %q, want version 5.3.1", r.Message)
+		}
+	})
+
+	t.Run("podman present version too old", func(t *testing.T) {
+		opts := &Options{
+			TargetDir: t.TempDir(),
+			LookPath:  stubLookPath(map[string]string{"podman": "/usr/local/bin/podman"}),
+			ExecCmd: stubExecCmd(
+				map[string]string{
+					"podman --version": "podman version 4.2.9",
+				},
+				nil,
+			),
+			EvalSymlinks: stubEvalSymlinks(nil),
+			Getenv:       stubGetenv(map[string]string{}),
+			ReadFile:     stubReadFile(nil),
+		}
+		env := DetectedEnvironment{Managers: []ManagerInfo{}}
+		group := checkCoreTools(opts, env)
+
+		results := make(map[string]CheckResult)
+		for _, r := range group.Results {
+			results[r.Name] = r
+		}
+
+		r, ok := results["podman"]
+		if !ok {
+			t.Fatal("podman check not found in Core Tools")
+		}
+		if r.Severity != Fail {
+			t.Errorf("podman version too old severity = %v, want Fail", r.Severity)
+		}
+		if !strings.Contains(r.Message, "requires >= 4.3") {
+			t.Errorf("podman message = %q, want 'requires >= 4.3'", r.Message)
+		}
+	})
+}
+
+func TestOptionsGOOS(t *testing.T) {
+	t.Run("default uses runtime.GOOS", func(t *testing.T) {
+		opts := &Options{}
+		got := opts.goos()
+		if got != runtime.GOOS {
+			t.Errorf("goos() = %q, want %q", got, runtime.GOOS)
+		}
+	})
+
+	t.Run("override", func(t *testing.T) {
+		opts := &Options{GOOS: "darwin"}
+		got := opts.goos()
+		if got != "darwin" {
+			t.Errorf("goos() = %q, want darwin", got)
+		}
+	})
+
+	t.Run("linux override", func(t *testing.T) {
+		opts := &Options{GOOS: "linux"}
+		got := opts.goos()
+		if got != "linux" {
+			t.Errorf("goos() = %q, want linux", got)
+		}
+	})
+}
+
+func TestCheckPodmanRuntime_DarwinMachineRunning(t *testing.T) {
+	opts := &Options{
+		GOOS: "darwin",
+		ExecCmd: stubExecCmd(
+			map[string]string{
+				"podman machine list --format {{.Name}}": "podman-machine-default",
+				"podman info": "host info",
+			},
+			nil,
+		),
+	}
+
+	result := checkPodmanRuntime(opts)
+	if result.Severity != Pass {
+		t.Errorf("severity = %v, want Pass", result.Severity)
+	}
+	if result.Message != "running" {
+		t.Errorf("message = %q, want running", result.Message)
+	}
+}
+
+func TestCheckPodmanRuntime_DarwinNoMachine(t *testing.T) {
+	opts := &Options{
+		GOOS: "darwin",
+		ExecCmd: stubExecCmd(
+			map[string]string{
+				"podman machine list --format {{.Name}}": "",
+			},
+			nil,
+		),
+	}
+
+	result := checkPodmanRuntime(opts)
+	if result.Severity != Fail {
+		t.Errorf("severity = %v, want Fail", result.Severity)
+	}
+	if !strings.Contains(result.Message, "no Podman machine") {
+		t.Errorf("message = %q, want 'no Podman machine'", result.Message)
+	}
+	if !strings.Contains(result.InstallHint, "podman machine init") {
+		t.Errorf("hint = %q, want 'podman machine init'", result.InstallHint)
+	}
+}
+
+func TestCheckPodmanRuntime_DarwinMachineExistsInfoFails(t *testing.T) {
+	opts := &Options{
+		GOOS: "darwin",
+		ExecCmd: stubExecCmd(
+			map[string]string{
+				"podman machine list --format {{.Name}}": "podman-machine-default",
+			},
+			map[string]error{
+				"podman info": fmt.Errorf("cannot connect"),
+			},
+		),
+	}
+
+	result := checkPodmanRuntime(opts)
+	if result.Severity != Fail {
+		t.Errorf("severity = %v, want Fail", result.Severity)
+	}
+	if !strings.Contains(result.Message, "may not be running") {
+		t.Errorf("message = %q, want 'may not be running'", result.Message)
+	}
+	if result.InstallHint != "podman machine start" {
+		t.Errorf("hint = %q, want 'podman machine start'", result.InstallHint)
+	}
+}
+
+func TestCheckPodmanRuntime_LinuxInfoSucceeds(t *testing.T) {
+	opts := &Options{
+		GOOS: "linux",
+		ExecCmd: stubExecCmd(
+			map[string]string{
+				"podman info": "host info",
+			},
+			nil,
+		),
+	}
+
+	result := checkPodmanRuntime(opts)
+	if result.Severity != Pass {
+		t.Errorf("severity = %v, want Pass", result.Severity)
+	}
+	if result.Message != "running" {
+		t.Errorf("message = %q, want running", result.Message)
+	}
+}
+
+func TestCheckPodmanRuntime_LinuxInfoFails(t *testing.T) {
+	opts := &Options{
+		GOOS: "linux",
+		ExecCmd: stubExecCmd(
+			nil,
+			map[string]error{
+				"podman info": fmt.Errorf("cannot connect"),
+			},
+		),
+	}
+
+	result := checkPodmanRuntime(opts)
+	if result.Severity != Fail {
+		t.Errorf("severity = %v, want Fail", result.Severity)
+	}
+	if !strings.Contains(result.Message, "not responding") {
+		t.Errorf("message = %q, want 'not responding'", result.Message)
+	}
+	if !strings.Contains(result.InstallHint, "systemctl") {
+		t.Errorf("hint = %q, want systemctl reference", result.InstallHint)
+	}
+}
+
+func TestCheckPodmanRuntime_VersionTooOldSkipsRuntime(t *testing.T) {
+	// When version is too old, the tool check returns Fail and
+	// the post-check is not triggered. Verify by checking that
+	// no "podman runtime" result appears.
+	opts := &Options{
+		TargetDir: t.TempDir(),
+		GOOS:      "darwin",
+		LookPath:  stubLookPath(map[string]string{"podman": "/usr/local/bin/podman"}),
+		ExecCmd: stubExecCmd(
+			map[string]string{
+				"podman --version": "podman version 4.2.9",
+			},
+			nil,
+		),
+		EvalSymlinks: stubEvalSymlinks(nil),
+		Getenv:       stubGetenv(map[string]string{}),
+		ReadFile:     stubReadFile(nil),
+	}
+	env := DetectedEnvironment{Managers: []ManagerInfo{}}
+	group := checkCoreTools(opts, env)
+
+	for _, r := range group.Results {
+		if r.Name == "podman runtime" {
+			t.Error("podman runtime check should be skipped when version is too old")
+		}
+	}
+}
+
+func TestCheckPodmanRuntime_DarwinMachineListFails(t *testing.T) {
+	opts := &Options{
+		GOOS: "darwin",
+		ExecCmd: stubExecCmd(
+			nil,
+			map[string]error{
+				"podman machine list --format {{.Name}}": fmt.Errorf("command failed"),
+			},
+		),
+	}
+
+	result := checkPodmanRuntime(opts)
+	if result.Severity != Fail {
+		t.Errorf("severity = %v, want Fail", result.Severity)
+	}
+	if !strings.Contains(result.InstallHint, "podman machine init") {
+		t.Errorf("hint = %q, want 'podman machine init'", result.InstallHint)
+	}
+}
+
+// --- Docker-to-Podman shim detection tests (D8a) ---
+
+func TestCheckDockerPodmanShim_DockerIsPodmanSymlink(t *testing.T) {
+	opts := &Options{
+		LookPath: stubLookPath(map[string]string{
+			"docker": "/usr/local/bin/docker",
+		}),
+		EvalSymlinks: func(path string) (string, error) {
+			if path == "/usr/local/bin/docker" {
+				return "/opt/podman/bin/podman", nil
+			}
+			return path, nil
+		},
+	}
+
+	result := checkDockerPodmanShim(opts)
+	if result == nil {
+		t.Fatal("expected non-nil result for docker symlink")
+	}
+	if result.Severity != Pass {
+		t.Errorf("severity = %v, want Pass", result.Severity)
+	}
+	if !strings.Contains(result.Message, "Podman shim") {
+		t.Errorf("message = %q, want to contain 'Podman shim'", result.Message)
+	}
+	if !strings.Contains(result.Message, "/opt/podman/bin/podman") {
+		t.Errorf("message = %q, want to contain resolved path", result.Message)
+	}
+}
+
+func TestCheckDockerPodmanShim_RealDocker(t *testing.T) {
+	opts := &Options{
+		LookPath: stubLookPath(map[string]string{
+			"docker": "/usr/bin/docker",
+		}),
+		EvalSymlinks: func(path string) (string, error) {
+			return "/usr/bin/docker", nil
+		},
+	}
+
+	result := checkDockerPodmanShim(opts)
+	if result == nil {
+		t.Fatal("expected non-nil result for real Docker")
+	}
+	if result.Severity != Pass {
+		t.Errorf("severity = %v, want Pass", result.Severity)
+	}
+	if !strings.Contains(result.Message, "Docker detected") {
+		t.Errorf("message = %q, want to contain 'Docker detected'", result.Message)
+	}
+	if !strings.Contains(result.Detail, "Sandbox uses Podman") {
+		t.Errorf("detail = %q, want to contain 'Sandbox uses Podman'", result.Detail)
+	}
+}
+
+func TestCheckDockerPodmanShim_DockerNotInPath(t *testing.T) {
+	opts := &Options{
+		LookPath: stubLookPath(map[string]string{
+			// docker not in the found map
+		}),
+	}
+
+	result := checkDockerPodmanShim(opts)
+	if result != nil {
+		t.Errorf("expected nil result when docker not in PATH, got %+v", result)
+	}
+}
+
+func TestCheckDockerPodmanShim_EvalSymlinksFails(t *testing.T) {
+	opts := &Options{
+		LookPath: stubLookPath(map[string]string{
+			"docker": "/usr/local/bin/docker",
+		}),
+		EvalSymlinks: func(path string) (string, error) {
+			return "", fmt.Errorf("permission denied")
+		},
+	}
+
+	result := checkDockerPodmanShim(opts)
+	if result != nil {
+		t.Errorf("expected nil result when EvalSymlinks fails, got %+v", result)
+	}
+}
+
+// --- Task Group 3: Enhanced DevPod Check tests ---
+
+func TestParseDevPodVersion(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{"standard", "v0.6.15", "0.6.15", false},
+		{"no prefix", "0.5.0", "0.5.0", false},
+		{"beta suffix", "v0.4.2-beta", "0.4.2", false},
+		{"with newline", "v0.6.15\n", "0.6.15", false},
+		{"empty", "", "", true},
+		{"non-version", "abc", "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseDevPodVersion(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseDevPodVersion(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("parseDevPodVersion(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCheckDevPodVersionMin(t *testing.T) {
+	tests := []struct {
+		version string
+		min     string
+		want    bool
+	}{
+		{"0.6.15", "0.5", true},
+		{"0.5.0", "0.5", true},
+		{"0.4.2", "0.5", false},
+		{"1.0.0", "0.5", true},
+		{"0.3.9", "0.5", false},
+	}
+	for _, tt := range tests {
+		got := checkDevPodVersionMin(tt.version, tt.min)
+		if got != tt.want {
+			t.Errorf("checkDevPodVersionMin(%q, %q) = %v, want %v", tt.version, tt.min, got, tt.want)
+		}
+	}
+}
+
+func TestCheckDevPod_VersionSufficient(t *testing.T) {
+	dir := t.TempDir()
+	createFile(t, dir, ".devcontainer/devcontainer.json", `{"image":"test"}`)
+
+	opts := &Options{
+		TargetDir: dir,
+		LookPath:  stubLookPath(map[string]string{"devpod": "/usr/local/bin/devpod"}),
+		ExecCmd: stubExecCmd(
+			map[string]string{
+				"devpod version":       "v0.6.15",
+				"devpod provider list": "podman   docker   true\n",
+			},
+			nil,
+		),
+		ReadFile: os.ReadFile,
+	}
+
+	group := checkDevPod(opts)
+	if group == nil {
+		t.Fatal("expected non-nil DevPod group")
+	}
+
+	results := make(map[string]CheckResult)
+	for _, r := range group.Results {
+		results[r.Name] = r
+	}
+
+	if r := results["devpod version"]; r.Severity != Pass {
+		t.Errorf("devpod version severity = %v, want Pass", r.Severity)
+	}
+}
+
+func TestCheckDevPod_VersionTooOld(t *testing.T) {
+	dir := t.TempDir()
+	createFile(t, dir, ".devcontainer/devcontainer.json", `{"image":"test"}`)
+
+	opts := &Options{
+		TargetDir: dir,
+		LookPath:  stubLookPath(map[string]string{"devpod": "/usr/local/bin/devpod"}),
+		ExecCmd: stubExecCmd(
+			map[string]string{
+				"devpod version":       "v0.4.2",
+				"devpod provider list": "podman   docker   true\n",
+			},
+			nil,
+		),
+		ReadFile: os.ReadFile,
+	}
+
+	group := checkDevPod(opts)
+	if group == nil {
+		t.Fatal("expected non-nil DevPod group")
+	}
+
+	results := make(map[string]CheckResult)
+	for _, r := range group.Results {
+		results[r.Name] = r
+	}
+
+	r, ok := results["devpod version"]
+	if !ok {
+		t.Fatal("devpod version check not found")
+	}
+	if r.Severity != Warn {
+		t.Errorf("devpod version severity = %v, want Warn", r.Severity)
+	}
+	if !strings.Contains(r.Message, "requires >= 0.5.0") {
+		t.Errorf("message = %q, want 'requires >= 0.5.0'", r.Message)
+	}
+}
+
+func TestCheckDevPod_VersionBoundary(t *testing.T) {
+	dir := t.TempDir()
+	createFile(t, dir, ".devcontainer/devcontainer.json", `{"image":"test"}`)
+
+	opts := &Options{
+		TargetDir: dir,
+		LookPath:  stubLookPath(map[string]string{"devpod": "/usr/local/bin/devpod"}),
+		ExecCmd: stubExecCmd(
+			map[string]string{
+				"devpod version":       "v0.5.0",
+				"devpod provider list": "podman   docker   true\n",
+			},
+			nil,
+		),
+		ReadFile: os.ReadFile,
+	}
+
+	group := checkDevPod(opts)
+	if group == nil {
+		t.Fatal("expected non-nil DevPod group")
+	}
+
+	results := make(map[string]CheckResult)
+	for _, r := range group.Results {
+		results[r.Name] = r
+	}
+
+	if r := results["devpod version"]; r.Severity != Pass {
+		t.Errorf("devpod version boundary severity = %v, want Pass", r.Severity)
+	}
+}
+
+func TestCheckDevPod_ProviderPresent(t *testing.T) {
+	dir := t.TempDir()
+	createFile(t, dir, ".devcontainer/devcontainer.json", `{"image":"test"}`)
+
+	providerListOutput := "NAME      TYPE     DEFAULT\npodman    docker   true\nkubernetes k8s    false\n"
+
+	opts := &Options{
+		TargetDir: dir,
+		LookPath:  stubLookPath(map[string]string{"devpod": "/usr/local/bin/devpod"}),
+		ExecCmd: stubExecCmd(
+			map[string]string{
+				"devpod version":       "v0.6.15",
+				"devpod provider list": providerListOutput,
+			},
+			nil,
+		),
+		ReadFile: os.ReadFile,
+	}
+
+	group := checkDevPod(opts)
+	if group == nil {
+		t.Fatal("expected non-nil DevPod group")
+	}
+
+	results := make(map[string]CheckResult)
+	for _, r := range group.Results {
+		results[r.Name] = r
+	}
+
+	r, ok := results["podman provider"]
+	if !ok {
+		t.Fatal("podman provider check not found")
+	}
+	if r.Severity != Pass {
+		t.Errorf("podman provider severity = %v, want Pass", r.Severity)
+	}
+}
+
+func TestCheckDevPod_ProviderSubstringNotMatched(t *testing.T) {
+	dir := t.TempDir()
+	createFile(t, dir, ".devcontainer/devcontainer.json", `{"image":"test"}`)
+
+	// "podman-custom" should NOT match "podman" (exact first-column match).
+	providerListOutput := "NAME            TYPE     DEFAULT\npodman-custom   docker   true\n"
+
+	opts := &Options{
+		TargetDir: dir,
+		LookPath:  stubLookPath(map[string]string{"devpod": "/usr/local/bin/devpod"}),
+		ExecCmd: stubExecCmd(
+			map[string]string{
+				"devpod version":       "v0.6.15",
+				"devpod provider list": providerListOutput,
+			},
+			nil,
+		),
+		ReadFile: os.ReadFile,
+	}
+
+	group := checkDevPod(opts)
+	if group == nil {
+		t.Fatal("expected non-nil DevPod group")
+	}
+
+	results := make(map[string]CheckResult)
+	for _, r := range group.Results {
+		results[r.Name] = r
+	}
+
+	r, ok := results["podman provider"]
+	if !ok {
+		t.Fatal("podman provider check not found")
+	}
+	if r.Severity != Warn {
+		t.Errorf("podman provider severity = %v, want Warn (substring should not match)", r.Severity)
+	}
+	if !strings.Contains(r.InstallHint, "devpod provider add docker") {
+		t.Errorf("hint = %q, want provider add command", r.InstallHint)
+	}
+}
+
+func TestCheckDevPod_ProviderMissing(t *testing.T) {
+	dir := t.TempDir()
+	createFile(t, dir, ".devcontainer/devcontainer.json", `{"image":"test"}`)
+
+	providerListOutput := "NAME         TYPE     DEFAULT\nkubernetes   k8s      false\n"
+
+	opts := &Options{
+		TargetDir: dir,
+		LookPath:  stubLookPath(map[string]string{"devpod": "/usr/local/bin/devpod"}),
+		ExecCmd: stubExecCmd(
+			map[string]string{
+				"devpod version":       "v0.6.15",
+				"devpod provider list": providerListOutput,
+			},
+			nil,
+		),
+		ReadFile: os.ReadFile,
+	}
+
+	group := checkDevPod(opts)
+	if group == nil {
+		t.Fatal("expected non-nil DevPod group")
+	}
+
+	results := make(map[string]CheckResult)
+	for _, r := range group.Results {
+		results[r.Name] = r
+	}
+
+	r, ok := results["podman provider"]
+	if !ok {
+		t.Fatal("podman provider check not found")
+	}
+	if r.Severity != Warn {
+		t.Errorf("podman provider severity = %v, want Warn", r.Severity)
+	}
+	if !strings.Contains(r.InstallHint, "devpod provider add docker --name podman") {
+		t.Errorf("hint = %q, want provider add command", r.InstallHint)
+	}
+}
+
+func TestCheckDevPod_ProviderListFails(t *testing.T) {
+	dir := t.TempDir()
+	createFile(t, dir, ".devcontainer/devcontainer.json", `{"image":"test"}`)
+
+	opts := &Options{
+		TargetDir: dir,
+		LookPath:  stubLookPath(map[string]string{"devpod": "/usr/local/bin/devpod"}),
+		ExecCmd: stubExecCmd(
+			map[string]string{
+				"devpod version": "v0.6.15",
+			},
+			map[string]error{
+				"devpod provider list": fmt.Errorf("command failed"),
+			},
+		),
+		ReadFile: os.ReadFile,
+	}
+
+	group := checkDevPod(opts)
+	if group == nil {
+		t.Fatal("expected non-nil DevPod group")
+	}
+
+	results := make(map[string]CheckResult)
+	for _, r := range group.Results {
+		results[r.Name] = r
+	}
+
+	r, ok := results["podman provider"]
+	if !ok {
+		t.Fatal("podman provider check not found")
+	}
+	if r.Severity != Warn {
+		t.Errorf("podman provider severity = %v, want Warn", r.Severity)
+	}
+	if !strings.Contains(r.Message, "could not check") {
+		t.Errorf("message = %q, want 'could not check'", r.Message)
+	}
 }

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -12,6 +14,7 @@ import (
 	"time"
 
 	"github.com/charmbracelet/lipgloss"
+	"github.com/muesli/termenv"
 )
 
 // --- Test helpers ---
@@ -4511,5 +4514,290 @@ func TestCheckDevPod_ProviderListFails(t *testing.T) {
 	}
 	if !strings.Contains(r.Message, "could not check") {
 		t.Errorf("message = %q, want 'could not check'", r.Message)
+	}
+}
+
+// --- formatIndicator color branch tests ---
+
+func TestFormatIndicator_WithColor(t *testing.T) {
+	// Create a renderer targeting an output that supports color.
+	renderer := lipgloss.NewRenderer(os.Stdout, termenv.WithProfile(termenv.TrueColor))
+	pass := renderer.NewStyle().Foreground(lipgloss.Color("10"))
+	warn := renderer.NewStyle().Foreground(lipgloss.Color("11"))
+	fail := renderer.NewStyle().Foreground(lipgloss.Color("9"))
+	dim := renderer.NewStyle().Foreground(lipgloss.Color("241"))
+
+	tests := []struct {
+		name   string
+		result CheckResult
+		want   string // substring expected in the rendered output
+	}{
+		{
+			name:   "pass shows checkmark",
+			result: CheckResult{Severity: Pass},
+			want:   "✅",
+		},
+		{
+			name:   "pass with install hint shows dim circle",
+			result: CheckResult{Severity: Pass, InstallHint: "some hint"},
+			want:   "⊘",
+		},
+		{
+			name:   "warn shows warning symbol",
+			result: CheckResult{Severity: Warn},
+			want:   "⚠️",
+		},
+		{
+			name:   "fail shows X",
+			result: CheckResult{Severity: Fail},
+			want:   "❌",
+		},
+		{
+			name:   "unknown severity returns question mark",
+			result: CheckResult{Severity: Severity(99)},
+			want:   "?",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := formatIndicator(tc.result, true, pass, warn, fail, dim)
+			if !strings.Contains(got, tc.want) {
+				t.Errorf("formatIndicator(color=true) = %q, want substring %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFormatIndicator_NoColor_UnknownSeverity(t *testing.T) {
+	got := formatIndicator(
+		CheckResult{Severity: Severity(99)},
+		false,
+		lipgloss.Style{}, lipgloss.Style{}, lipgloss.Style{}, lipgloss.Style{},
+	)
+	if got != "[????]" {
+		t.Errorf("formatIndicator(unknown, no color) = %q, want %q", got, "[????]")
+	}
+}
+
+// --- Options.defaults tests ---
+
+func TestOptionsDefaults_FillsZeroFields(t *testing.T) {
+	opts := &Options{}
+	opts.defaults()
+
+	if opts.TargetDir == "" {
+		t.Error("defaults() should set TargetDir to cwd")
+	}
+	if opts.Format != "text" {
+		t.Errorf("Format = %q, want %q", opts.Format, "text")
+	}
+	if opts.Stdout == nil {
+		t.Error("defaults() should set Stdout")
+	}
+	if opts.LookPath == nil {
+		t.Error("defaults() should set LookPath")
+	}
+	if opts.ExecCmd == nil {
+		t.Error("defaults() should set ExecCmd")
+	}
+	if opts.ExecCmdTimeout == nil {
+		t.Error("defaults() should set ExecCmdTimeout")
+	}
+	if opts.EvalSymlinks == nil {
+		t.Error("defaults() should set EvalSymlinks")
+	}
+	if opts.Getenv == nil {
+		t.Error("defaults() should set Getenv")
+	}
+	if opts.ReadFile == nil {
+		t.Error("defaults() should set ReadFile")
+	}
+	if opts.EmbedCheck == nil {
+		t.Error("defaults() should set EmbedCheck")
+	}
+}
+
+func TestOptionsDefaults_PreservesExistingValues(t *testing.T) {
+	customDir := t.TempDir()
+	var buf bytes.Buffer
+	customLookPath := func(string) (string, error) { return "", nil }
+
+	opts := &Options{
+		TargetDir: customDir,
+		Format:    "json",
+		Stdout:    &buf,
+		LookPath:  customLookPath,
+	}
+	opts.defaults()
+
+	if opts.TargetDir != customDir {
+		t.Errorf("TargetDir = %q, want %q (should preserve)", opts.TargetDir, customDir)
+	}
+	if opts.Format != "json" {
+		t.Errorf("Format = %q, want %q (should preserve)", opts.Format, "json")
+	}
+	if opts.Stdout != &buf {
+		t.Error("Stdout should be preserved when already set")
+	}
+	// LookPath is a func; just verify it wasn't replaced by checking non-nil.
+	if opts.LookPath == nil {
+		t.Error("LookPath should be preserved when already set")
+	}
+
+	// Verify fields that were NOT set got filled.
+	if opts.ExecCmd == nil {
+		t.Error("ExecCmd should be set by defaults()")
+	}
+	if opts.Getenv == nil {
+		t.Error("Getenv should be set by defaults()")
+	}
+}
+
+// --- defaultEmbedCheck tests ---
+
+func TestDefaultEmbedCheck_Success(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/embed" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		if r.Method != http.MethodPost {
+			t.Errorf("unexpected method: %s", r.Method)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, `{"embeddings":[[0.1,0.2,0.3]]}`)
+	}))
+	defer ts.Close()
+
+	getenv := func(key string) string {
+		if key == "OLLAMA_HOST" {
+			return ts.URL
+		}
+		return ""
+	}
+
+	check := defaultEmbedCheck(getenv)
+	if err := check("test-model"); err != nil {
+		t.Errorf("defaultEmbedCheck() returned error: %v", err)
+	}
+}
+
+func TestDefaultEmbedCheck_EmptyEmbeddings(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, `{"embeddings":[]}`)
+	}))
+	defer ts.Close()
+
+	check := defaultEmbedCheck(func(key string) string {
+		if key == "OLLAMA_HOST" {
+			return ts.URL
+		}
+		return ""
+	})
+
+	err := check("test-model")
+	if err == nil {
+		t.Fatal("expected error for empty embeddings")
+	}
+	if !strings.Contains(err.Error(), "empty embeddings") {
+		t.Errorf("error = %q, want 'empty embeddings'", err)
+	}
+}
+
+func TestDefaultEmbedCheck_ServerError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = fmt.Fprint(w, `{"error":"model not found"}`)
+	}))
+	defer ts.Close()
+
+	check := defaultEmbedCheck(func(key string) string {
+		if key == "OLLAMA_HOST" {
+			return ts.URL
+		}
+		return ""
+	})
+
+	err := check("missing-model")
+	if err == nil {
+		t.Fatal("expected error for server error response")
+	}
+	if !strings.Contains(err.Error(), "model not found") {
+		t.Errorf("error = %q, want 'model not found'", err)
+	}
+}
+
+func TestDefaultEmbedCheck_ServerErrorNoBody(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+	}))
+	defer ts.Close()
+
+	check := defaultEmbedCheck(func(key string) string {
+		if key == "OLLAMA_HOST" {
+			return ts.URL
+		}
+		return ""
+	})
+
+	err := check("test-model")
+	if err == nil {
+		t.Fatal("expected error for non-200 status")
+	}
+	if !strings.Contains(err.Error(), "502") {
+		t.Errorf("error = %q, want status code 502", err)
+	}
+}
+
+func TestDefaultEmbedCheck_ConnectionRefused(t *testing.T) {
+	check := defaultEmbedCheck(func(key string) string {
+		if key == "OLLAMA_HOST" {
+			return "http://127.0.0.1:1" // port 1 is unlikely to be open
+		}
+		return ""
+	})
+
+	err := check("test-model")
+	if err == nil {
+		t.Fatal("expected error for connection refused")
+	}
+	if !strings.Contains(err.Error(), "embed request failed") {
+		t.Errorf("error = %q, want 'embed request failed'", err)
+	}
+}
+
+func TestDefaultEmbedCheck_DefaultHost(t *testing.T) {
+	// When OLLAMA_HOST is empty, default to http://localhost:11434.
+	// We can't test the actual connection, but we can verify
+	// the function returns an error (connection refused on CI).
+	check := defaultEmbedCheck(func(string) string { return "" })
+	err := check("test-model")
+	// Should fail because localhost:11434 is not running in test.
+	if err == nil {
+		t.Log("defaultEmbedCheck succeeded (Ollama is running locally)")
+	}
+}
+
+func TestDefaultEmbedCheck_InvalidJSON(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, `not json`)
+	}))
+	defer ts.Close()
+
+	check := defaultEmbedCheck(func(key string) string {
+		if key == "OLLAMA_HOST" {
+			return ts.URL
+		}
+		return ""
+	})
+
+	err := check("test-model")
+	if err == nil {
+		t.Fatal("expected error for invalid JSON response")
+	}
+	if !strings.Contains(err.Error(), "could not parse") {
+		t.Errorf("error = %q, want 'could not parse'", err)
 	}
 }

--- a/internal/doctor/environ.go
+++ b/internal/doctor/environ.go
@@ -278,6 +278,10 @@ func homebrewInstallCmd(toolName string) string {
 			return "brew install --cask ollama-app && ollama pull granite-embedding:30m"
 		}
 		return "brew install ollama && ollama pull granite-embedding:30m"
+	case "podman":
+		return "brew install podman"
+	case "devpod":
+		return "brew install devpod"
 	default:
 		return "brew install " + toolName
 	}
@@ -301,6 +305,10 @@ func genericInstallCmd(toolName string) string {
 		return "Download from https://cli.github.com/"
 	case "ollama":
 		return "Download from https://ollama.com/download"
+	case "podman":
+		return "Download from https://podman.io/docs/installation"
+	case "devpod":
+		return "Download from https://devpod.sh/docs/getting-started/install"
 	default:
 		return "Install " + toolName
 	}
@@ -336,6 +344,10 @@ func installURL(toolName string) string {
 		return "https://github.com/unbound-force/replicator"
 	case "ollama":
 		return "https://ollama.com"
+	case "podman":
+		return "https://podman.io"
+	case "devpod":
+		return "https://devpod.sh"
 	default:
 		return ""
 	}

--- a/internal/metrics/query.go
+++ b/internal/metrics/query.go
@@ -48,6 +48,10 @@ func (q *Query) Summary(period time.Duration) (*MetricsSnapshot, error) {
 }
 
 // Velocity returns velocity per sprint for the last N sprints.
+// It returns a slice of VelocityPoint values computed from all
+// stored snapshots. When sprints > 0, the result is trimmed to
+// the most recent N entries. Returns an error if no metrics data
+// is available (Store.ReadSnapshots returns empty).
 func (q *Query) Velocity(sprints int) ([]VelocityPoint, error) {
 	snapshots, err := q.Store.ReadSnapshots(time.Time{})
 	if err != nil {

--- a/internal/sandbox/sandbox_test.go
+++ b/internal/sandbox/sandbox_test.go
@@ -4089,6 +4089,7 @@ func testDevcontainerTemplate() []byte {
     "ANTHROPIC_BASE_URL": "http://host.containers.internal:53147",
     "ANTHROPIC_API_KEY": "gateway"
   },
+  "postStartCommand": "nohup opencode serve --port 4096 > /tmp/opencode-server.log 2>&1 & printf 'protocol=https\\nhost=github.com\\n\\n' | git credential fill 2>/dev/null | grep '^password=' | cut -d= -f2 | gh auth login --with-token 2>/dev/null || true",
   "remoteUser": "dev"
 }
 `)
@@ -4144,6 +4145,15 @@ func TestRunSandboxInit_Creates(t *testing.T) {
 
 	if parsed["remoteUser"] != "dev" {
 		t.Errorf("remoteUser = %v, want dev", parsed["remoteUser"])
+	}
+
+	// Verify postStartCommand is present (D9: opencode serve + gh auth relay).
+	if psc, ok := parsed["postStartCommand"].(string); !ok || psc == "" {
+		t.Error("expected postStartCommand in devcontainer.json")
+	} else if !strings.Contains(psc, "opencode serve") {
+		t.Errorf("postStartCommand missing 'opencode serve', got: %s", psc)
+	} else if !strings.Contains(psc, "gh auth login") {
+		t.Errorf("postStartCommand missing 'gh auth login', got: %s", psc)
 	}
 
 	// Verify _comment key is present (sentinel explanation).

--- a/internal/sandbox/sandbox_test.go
+++ b/internal/sandbox/sandbox_test.go
@@ -4272,3 +4272,99 @@ func TestRunSandboxInit_CustomDemoPorts(t *testing.T) {
 	}
 }
 
+// --- Options.defaults tests ---
+
+func TestOptionsDefaults_FillsZeroFields(t *testing.T) {
+	opts := &Options{}
+	opts.defaults()
+
+	if opts.ProjectDir == "" {
+		t.Error("defaults() should set ProjectDir to cwd")
+	}
+	if opts.Mode != ModeIsolated {
+		t.Errorf("Mode = %q, want %q", opts.Mode, ModeIsolated)
+	}
+	if opts.Stdout == nil {
+		t.Error("defaults() should set Stdout")
+	}
+	if opts.Stderr == nil {
+		t.Error("defaults() should set Stderr")
+	}
+	if opts.Stdin == nil {
+		t.Error("defaults() should set Stdin")
+	}
+	if opts.LookPath == nil {
+		t.Error("defaults() should set LookPath")
+	}
+	if opts.ExecCmd == nil {
+		t.Error("defaults() should set ExecCmd")
+	}
+	if opts.ExecInteractive == nil {
+		t.Error("defaults() should set ExecInteractive")
+	}
+	if opts.Getenv == nil {
+		t.Error("defaults() should set Getenv")
+	}
+	if opts.ReadFile == nil {
+		t.Error("defaults() should set ReadFile")
+	}
+	if opts.HTTPGet == nil {
+		t.Error("defaults() should set HTTPGet")
+	}
+	if opts.HTTPDo == nil {
+		t.Error("defaults() should set HTTPDo")
+	}
+}
+
+func TestOptionsDefaults_PreservesExistingValues(t *testing.T) {
+	customDir := t.TempDir()
+	var stdout, stderr bytes.Buffer
+	stdin := strings.NewReader("")
+	customLookPath := func(string) (string, error) { return "", nil }
+	customGetenv := func(string) string { return "custom" }
+
+	opts := &Options{
+		ProjectDir: customDir,
+		Mode:       "direct",
+		Stdout:     &stdout,
+		Stderr:     &stderr,
+		Stdin:      stdin,
+		LookPath:   customLookPath,
+		Getenv:     customGetenv,
+	}
+	opts.defaults()
+
+	if opts.ProjectDir != customDir {
+		t.Errorf("ProjectDir = %q, want %q (should preserve)", opts.ProjectDir, customDir)
+	}
+	if opts.Mode != "direct" {
+		t.Errorf("Mode = %q, want %q (should preserve)", opts.Mode, "direct")
+	}
+	if opts.Stdout != &stdout {
+		t.Error("Stdout should be preserved when already set")
+	}
+	if opts.Stderr != &stderr {
+		t.Error("Stderr should be preserved when already set")
+	}
+	if opts.Getenv == nil {
+		t.Error("Getenv should be preserved when already set")
+	}
+	if got := opts.Getenv("any"); got != "custom" {
+		t.Errorf("Getenv(any) = %q, want %q (custom func should be preserved)", got, "custom")
+	}
+
+	// Verify fields that were NOT set got filled.
+	if opts.ExecCmd == nil {
+		t.Error("ExecCmd should be set by defaults()")
+	}
+	if opts.ReadFile == nil {
+		t.Error("ReadFile should be set by defaults()")
+	}
+	if opts.HTTPGet == nil {
+		t.Error("HTTPGet should be set by defaults()")
+	}
+	if opts.HTTPDo == nil {
+		t.Error("HTTPDo should be set by defaults()")
+	}
+}
+

--- a/internal/sandbox/sandbox_test.go
+++ b/internal/sandbox/sandbox_test.go
@@ -4084,12 +4084,13 @@ func testDevcontainerTemplate() []byte {
 	return []byte(`{
   "_comment": "ANTHROPIC_API_KEY=gateway is a sentinel value.",
   "image": "quay.io/unbound-force/opencode-dev:latest",
+  "runArgs": ["--userns=keep-id:uid=1000,gid=1000"],
   "forwardPorts": [4096],
   "containerEnv": {
     "ANTHROPIC_BASE_URL": "http://host.containers.internal:53147",
     "ANTHROPIC_API_KEY": "gateway"
   },
-  "postStartCommand": "nohup opencode serve --port 4096 > /tmp/opencode-server.log 2>&1 & printf 'protocol=https\\nhost=github.com\\n\\n' | git credential fill 2>/dev/null | grep '^password=' | cut -d= -f2 | gh auth login --with-token 2>/dev/null || true",
+  "postStartCommand": "nohup opencode serve --port 4096 > /tmp/opencode-server.log 2>&1 &",
   "remoteUser": "dev"
 }
 `)
@@ -4147,13 +4148,19 @@ func TestRunSandboxInit_Creates(t *testing.T) {
 		t.Errorf("remoteUser = %v, want dev", parsed["remoteUser"])
 	}
 
-	// Verify postStartCommand is present (D9: opencode serve + gh auth relay).
+	// Verify runArgs contains UID mapping (D10).
+	runArgs, ok := parsed["runArgs"].([]interface{})
+	if !ok || len(runArgs) == 0 {
+		t.Error("expected runArgs in devcontainer.json")
+	} else if ra, ok := runArgs[0].(string); !ok || !strings.Contains(ra, "--userns=keep-id") {
+		t.Errorf("runArgs[0] = %v, want --userns=keep-id:uid=1000,gid=1000", runArgs[0])
+	}
+
+	// Verify postStartCommand is present (opencode serve).
 	if psc, ok := parsed["postStartCommand"].(string); !ok || psc == "" {
 		t.Error("expected postStartCommand in devcontainer.json")
 	} else if !strings.Contains(psc, "opencode serve") {
 		t.Errorf("postStartCommand missing 'opencode serve', got: %s", psc)
-	} else if !strings.Contains(psc, "gh auth login") {
-		t.Errorf("postStartCommand missing 'gh auth login', got: %s", psc)
 	}
 
 	// Verify _comment key is present (sentinel explanation).

--- a/internal/scaffold/assets/devcontainer/devcontainer.json
+++ b/internal/scaffold/assets/devcontainer/devcontainer.json
@@ -6,5 +6,6 @@
     "ANTHROPIC_BASE_URL": "http://host.containers.internal:53147",
     "ANTHROPIC_API_KEY": "gateway"
   },
+  "postStartCommand": "nohup opencode serve --port 4096 > /tmp/opencode-server.log 2>&1 & printf 'protocol=https\\nhost=github.com\\n\\n' | git credential fill 2>/dev/null | grep '^password=' | cut -d= -f2 | gh auth login --with-token 2>/dev/null || true",
   "remoteUser": "dev"
 }

--- a/internal/scaffold/assets/devcontainer/devcontainer.json
+++ b/internal/scaffold/assets/devcontainer/devcontainer.json
@@ -1,11 +1,12 @@
 {
   "_comment": "ANTHROPIC_API_KEY=gateway is a sentinel value indicating the uf gateway proxy handles authentication. When the gateway is not running, OpenCode uses its own configured provider.",
   "image": "quay.io/unbound-force/opencode-dev:latest",
+  "runArgs": ["--userns=keep-id:uid=1000,gid=1000"],
   "forwardPorts": [4096],
   "containerEnv": {
     "ANTHROPIC_BASE_URL": "http://host.containers.internal:53147",
     "ANTHROPIC_API_KEY": "gateway"
   },
-  "postStartCommand": "nohup opencode serve --port 4096 > /tmp/opencode-server.log 2>&1 & printf 'protocol=https\\nhost=github.com\\n\\n' | git credential fill 2>/dev/null | grep '^password=' | cut -d= -f2 | gh auth login --with-token 2>/dev/null || true",
+  "postStartCommand": "nohup opencode serve --port 4096 > /tmp/opencode-server.log 2>&1 &",
   "remoteUser": "dev"
 }

--- a/internal/scaffold/scaffold.go
+++ b/internal/scaffold/scaffold.go
@@ -112,13 +112,6 @@ func Run(opts Options) (*Result, error) {
 		// Strip "assets/" prefix to get the relative path
 		relPath := strings.TrimPrefix(path, "assets/")
 
-		// Devcontainer assets are NOT deployed by uf init.
-		// They are only used by uf sandbox init via
-		// DevcontainerContent(). Per design D7.
-		if strings.HasPrefix(relPath, "devcontainer/") {
-			return nil
-		}
-
 		// DivisorOnly mode: skip non-Divisor assets
 		if opts.DivisorOnly && !isDivisorAsset(relPath) {
 			return nil
@@ -286,8 +279,8 @@ func mapAssetPath(relPath string) string {
 		return relPath
 	case strings.HasPrefix(relPath, "devcontainer/"):
 		// devcontainer/ assets map to .devcontainer/ in the
-		// target directory. NOT deployed by uf init — only
-		// used by uf sandbox init via DevcontainerContent().
+		// target directory. Deployed by both uf init and
+		// uf sandbox init (D7).
 		return "." + relPath
 	default:
 		// Unknown prefix — pass through unchanged but this

--- a/internal/scaffold/scaffold_test.go
+++ b/internal/scaffold/scaffold_test.go
@@ -51,13 +51,6 @@ func TestEmbeddedAssets_MatchSource(t *testing.T) {
 	}
 
 	for _, relPath := range paths {
-		// Skip non-deployed assets that have no canonical source
-		// at the repo root (e.g., devcontainer template is
-		// embedded-only, created by uf sandbox init).
-		if strings.HasPrefix(relPath, "devcontainer/") {
-			continue
-		}
-
 		// Map asset path to canonical source path
 		srcRel := mapAssetToSource(relPath)
 		srcPath := filepath.Join(root, srcRel)
@@ -170,6 +163,8 @@ var expectedAssetPaths = []string{
 	"openspec/schemas/unbound-force/templates/tasks.md",
 	// Swarm skills (1)
 	"opencode/skills/speckit-workflow/SKILL.md",
+	// Devcontainer template (1) — deployed by uf init (D7)
+	"devcontainer/devcontainer.json",
 }
 
 // nonDeployedAssetPaths lists embedded assets that are NOT
@@ -177,10 +172,7 @@ var expectedAssetPaths = []string{
 // functions (e.g., DevcontainerContent()) and are skipped
 // during the Run() walk. They must be listed here so
 // TestAssetPaths_MatchExpected accounts for them.
-var nonDeployedAssetPaths = []string{
-	// Devcontainer template — deployed by uf sandbox init, not uf init (D7)
-	"devcontainer/devcontainer.json",
-}
+var nonDeployedAssetPaths = []string{}
 
 func TestAssetPaths_MatchExpected(t *testing.T) {
 	paths, err := assetPaths()

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -196,6 +196,35 @@ func (o *Options) toolMethod(toolName string) string {
 	return "auto"
 }
 
+// stepDef defines a single setup step for data-driven dispatch.
+// Each step has a display name, a skip-tool key, an install function,
+// and optional gate and effect callbacks. This struct replaces the
+// repetitive if/else blocks in Run(), reducing cyclomatic complexity
+// per CS-004 (DRY) and CS-010 (single responsibility).
+type stepDef struct {
+	// name is the display name shown in progress output (e.g., "OpenCode").
+	name string
+
+	// tool is the key passed to shouldSkipTool (e.g., "opencode").
+	// Empty string means the step is never skipped by tool config.
+	tool string
+
+	// install executes the step and returns its result.
+	install func(*Options, doctor.DetectedEnvironment) stepResult
+
+	// gate returns true if the step should run. When non-nil and
+	// returning false, the step is skipped with "prerequisite not met".
+	gate func() bool
+
+	// gateDetail overrides the default "prerequisite not met" skip
+	// detail when the gate returns false.
+	gateDetail string
+
+	// effect is called after a successful install to update mutable
+	// state (e.g., setting nodeAvailable based on the result).
+	effect func(stepResult)
+}
+
 // Run executes the full setup workflow per FR-021/030/032/034/035.
 func Run(opts Options) error {
 	opts.defaults()
@@ -223,14 +252,129 @@ func Run(opts Options) error {
 	}
 	env := doctor.DetectEnvironment(doctorOpts)
 
-	var results []stepResult
+	printHeader(&opts, env)
 
-	// Print header.
+	// Mutable state tracked across steps — gate functions close
+	// over these variables to enforce inter-step dependencies.
+	var nodeAvailable, uvAvailable bool
+	replicatorAvailable := true
+
+	// Define all 16 steps as data. Order matters — later steps
+	// may gate on state set by earlier steps' effect callbacks.
+	steps := buildSteps(&opts, &nodeAvailable, &uvAvailable, &replicatorAvailable)
+
+	results := executeSteps(&opts, env, steps)
+
+	return printSummary(&opts, results)
+}
+
+// buildSteps constructs the ordered step definitions. Gate and effect
+// closures capture mutable state pointers so inter-step dependencies
+// are tracked without branching in Run().
+func buildSteps(opts *Options, nodeAvailable, uvAvailable, replicatorAvailable *bool) []stepDef {
+	return []stepDef{
+		{name: "OpenCode", tool: "opencode", install: installOpenCode},
+		{name: "Gaze", tool: "gaze", install: installGaze},
+		{name: "GitHub CLI", tool: "gh", install: installGH},
+		{
+			name: "Node.js", tool: "node", install: ensureNodeJS,
+			effect: func(r stepResult) {
+				*nodeAvailable = r.err == nil && r.action != "failed"
+			},
+		},
+		{
+			name: "OpenSpec CLI", tool: "openspec", install: installOpenSpec,
+			gate:       func() bool { return *nodeAvailable },
+			gateDetail: "no Node.js",
+		},
+		{
+			name: "uv", tool: "uv", install: installUV,
+			effect: func(r stepResult) {
+				*uvAvailable = r.err == nil && r.action != "failed"
+			},
+		},
+		{
+			name: "Specify CLI", tool: "specify", install: installSpecify,
+			gate:       func() bool { return *uvAvailable },
+			gateDetail: "no uv",
+		},
+		{
+			name: "Replicator", tool: "replicator", install: installReplicator,
+			effect: func(r stepResult) {
+				*replicatorAvailable = r.err == nil && r.action != "failed" && r.action != "skipped"
+			},
+		},
+		{
+			name: "replicator setup",
+			// No tool key — skip logic is handled entirely by the gate.
+			install: func(o *Options, _ doctor.DetectedEnvironment) stepResult {
+				return runReplicatorSetup(o)
+			},
+			gate:       func() bool { return *replicatorAvailable },
+			gateDetail: "no replicator",
+		},
+		{name: "Ollama", tool: "ollama", install: installOllama},
+		{name: "Podman", tool: "podman", install: installPodman},
+		{name: "DevPod", tool: "devpod", install: installDevPod},
+		{
+			name: "DevPod provider",
+			install: func(o *Options, _ doctor.DetectedEnvironment) stepResult {
+				return configureDevPodProvider(o)
+			},
+		},
+		{name: "Dewey", tool: "dewey", install: installDewey},
+		{name: "golangci-lint", tool: "golangci-lint", install: installGolangciLint},
+		{name: "govulncheck", tool: "govulncheck", install: installGovulncheck},
+	}
+}
+
+// executeSteps iterates through step definitions, applying skip/gate
+// logic and collecting results. This is the core dispatch loop that
+// replaces the 16 repetitive if/else blocks.
+func executeSteps(opts *Options, env doctor.DetectedEnvironment, steps []stepDef) []stepResult {
+	total := len(steps)
+	results := make([]stepResult, 0, total)
+
+	for i, step := range steps {
+		fmt.Fprintf(opts.Stdout, "  [%d/%d] %s...\n", i+1, total, step.name)
+
+		// Check tool skip list first.
+		if step.tool != "" && opts.shouldSkipTool(step.tool) {
+			r := stepResult{name: step.name, action: "skipped", detail: "excluded by config"}
+			results = append(results, r)
+			if step.effect != nil {
+				step.effect(r)
+			}
+			continue
+		}
+
+		// Check prerequisite gate.
+		if step.gate != nil && !step.gate() {
+			detail := "prerequisite not met"
+			if step.gateDetail != "" {
+				detail = step.gateDetail
+			}
+			results = append(results, stepResult{name: step.name, action: "skipped", detail: detail})
+			continue
+		}
+
+		r := step.install(opts, env)
+		results = append(results, r)
+
+		if step.effect != nil {
+			step.effect(r)
+		}
+	}
+
+	return results
+}
+
+// printHeader writes the setup banner and detected environment.
+func printHeader(opts *Options, env doctor.DetectedEnvironment) {
 	fmt.Fprintln(opts.Stdout, "Unbound Force Setup")
 	fmt.Fprintln(opts.Stdout, "===================")
 	fmt.Fprintln(opts.Stdout)
 
-	// Print detected environment.
 	fmt.Fprintln(opts.Stdout, "Detected Environment")
 	if len(env.Managers) > 0 {
 		var parts []string
@@ -249,168 +393,25 @@ func Run(opts Options) error {
 	}
 
 	fmt.Fprintln(opts.Stdout, "Installing...")
+}
 
-	// Step 1: Install OpenCode (FR-022).
-	fmt.Fprintf(opts.Stdout, "  [1/16] OpenCode...\n")
-	if opts.shouldSkipTool("opencode") {
-		results = append(results, stepResult{name: "OpenCode", action: "skipped", detail: "excluded by config"})
-	} else {
-		results = append(results, installOpenCode(&opts, env))
-	}
-
-	// Step 2: Install Gaze (FR-023).
-	fmt.Fprintf(opts.Stdout, "  [2/16] Gaze...\n")
-	if opts.shouldSkipTool("gaze") {
-		results = append(results, stepResult{name: "Gaze", action: "skipped", detail: "excluded by config"})
-	} else {
-		results = append(results, installGaze(&opts, env))
-	}
-
-	// Step 3: Install GitHub CLI.
-	fmt.Fprintf(opts.Stdout, "  [3/16] GitHub CLI...\n")
-	if opts.shouldSkipTool("gh") {
-		results = append(results, stepResult{name: "GitHub CLI", action: "skipped", detail: "excluded by config"})
-	} else {
-		results = append(results, installGH(&opts, env))
-	}
-
-	// Step 4: Ensure Node.js (FR-024).
-	fmt.Fprintf(opts.Stdout, "  [4/16] Node.js...\n")
-	nodeAvailable := false
-	if opts.shouldSkipTool("node") {
-		results = append(results, stepResult{name: "Node.js", action: "skipped", detail: "excluded by config"})
-	} else {
-		nodeResult := ensureNodeJS(&opts, env)
-		results = append(results, nodeResult)
-		nodeAvailable = nodeResult.err == nil && nodeResult.action != "failed"
-	}
-
-	// Step 5: Install OpenSpec CLI (Node.js-dependent).
-	if opts.shouldSkipTool("openspec") {
-		results = append(results, stepResult{name: "OpenSpec CLI", action: "skipped", detail: "excluded by config"})
-	} else if nodeAvailable {
-		fmt.Fprintf(opts.Stdout, "  [5/16] OpenSpec CLI...\n")
-		results = append(results, installOpenSpec(&opts, env))
-	} else {
-		results = append(results, stepResult{name: "OpenSpec CLI", action: "skipped", detail: "no Node.js"})
-	}
-
-	// Step 6: Install uv (Python package manager for Specify CLI).
-	fmt.Fprintf(opts.Stdout, "  [6/16] uv...\n")
-	uvAvailable := false
-	if opts.shouldSkipTool("uv") {
-		results = append(results, stepResult{name: "uv", action: "skipped", detail: "excluded by config"})
-	} else {
-		uvResult := installUV(&opts, env)
-		results = append(results, uvResult)
-		uvAvailable = uvResult.err == nil && uvResult.action != "failed"
-	}
-
-	// Step 7: Install Specify CLI (uv-dependent).
-	if opts.shouldSkipTool("specify") {
-		results = append(results, stepResult{name: "Specify CLI", action: "skipped", detail: "excluded by config"})
-	} else if uvAvailable {
-		fmt.Fprintf(opts.Stdout, "  [7/16] Specify CLI...\n")
-		results = append(results, installSpecify(&opts, env))
-	} else {
-		results = append(results, stepResult{name: "Specify CLI", action: "skipped", detail: "no uv"})
-	}
-
-	// Step 8: Install Replicator (Homebrew, replaces Swarm plugin).
-	fmt.Fprintf(opts.Stdout, "  [8/16] Replicator...\n")
-	replicatorSkipped := false
-	if opts.shouldSkipTool("replicator") {
-		results = append(results, stepResult{name: "Replicator", action: "skipped", detail: "excluded by config"})
-		replicatorSkipped = true
-	} else {
-		replicatorResult := installReplicator(&opts, env)
-		results = append(results, replicatorResult)
-		replicatorSkipped = replicatorResult.err != nil || replicatorResult.action == "failed" || replicatorResult.action == "skipped"
-	}
-
-	// Step 9: Run replicator setup.
-	if replicatorSkipped {
-		results = append(results, stepResult{name: "replicator setup", action: "skipped", detail: "no replicator"})
-	} else {
-		fmt.Fprintf(opts.Stdout, "  [9/16] Replicator setup...\n")
-		results = append(results, runReplicatorSetup(&opts))
-	}
-
-	// Step 10: Install Ollama (prerequisite for Dewey + Replicator embeddings).
-	fmt.Fprintf(opts.Stdout, "  [10/16] Ollama...\n")
-	if opts.shouldSkipTool("ollama") {
-		results = append(results, stepResult{name: "Ollama", action: "skipped", detail: "excluded by config"})
-	} else {
-		results = append(results, installOllama(&opts, env))
-	}
-
-	// Step 11: Install Podman (container runtime for sandbox).
-	fmt.Fprintf(opts.Stdout, "  [11/16] Podman...\n")
-	if opts.shouldSkipTool("podman") {
-		results = append(results, stepResult{name: "Podman", action: "skipped", detail: "excluded by config"})
-	} else {
-		results = append(results, installPodman(&opts, env))
-	}
-
-	// Step 12: Install DevPod (workspace manager).
-	fmt.Fprintf(opts.Stdout, "  [12/16] DevPod...\n")
-	if opts.shouldSkipTool("devpod") {
-		results = append(results, stepResult{name: "DevPod", action: "skipped", detail: "excluded by config"})
-	} else {
-		results = append(results, installDevPod(&opts, env))
-	}
-
-	// Step 13: Configure DevPod Podman provider.
-	// Gated on both devpod and podman availability.
-	fmt.Fprintf(opts.Stdout, "  [13/16] DevPod provider...\n")
-	results = append(results, configureDevPodProvider(&opts))
-
-	// Step 14: Install Dewey (after Ollama).
-	fmt.Fprintf(opts.Stdout, "  [14/16] Dewey...\n")
-	if opts.shouldSkipTool("dewey") {
-		results = append(results, stepResult{name: "Dewey", action: "skipped", detail: "excluded by config"})
-	} else {
-		results = append(results, installDewey(&opts, env))
-	}
-
-	// Step 15: Install golangci-lint (Spec 019 FR-012).
-	fmt.Fprintf(opts.Stdout, "  [15/16] golangci-lint...\n")
-	if opts.shouldSkipTool("golangci-lint") {
-		results = append(results, stepResult{name: "golangci-lint", action: "skipped", detail: "excluded by config"})
-	} else {
-		results = append(results, installGolangciLint(&opts, env))
-	}
-
-	// Step 16: Install govulncheck (Spec 019 FR-012).
-	fmt.Fprintf(opts.Stdout, "  [16/16] govulncheck...\n")
-	if opts.shouldSkipTool("govulncheck") {
-		results = append(results, stepResult{name: "govulncheck", action: "skipped", detail: "excluded by config"})
-	} else {
-		results = append(results, installGovulncheck(&opts, env))
-	}
-
-	// Print results.
+// printSummary writes step results and the completion message.
+// Returns an error if any steps failed.
+func printSummary(opts *Options, results []stepResult) error {
 	for _, r := range results {
 		printStepResult(opts.Stdout, r)
 	}
 
-	// Print completion summary (FR-034).
 	fmt.Fprintln(opts.Stdout)
-	hasFailures := false
+
+	failCount := 0
 	for _, r := range results {
 		if r.action == "failed" {
-			hasFailures = true
-			break
+			failCount++
 		}
 	}
 
-	if hasFailures {
-		failCount := 0
-		for _, r := range results {
-			if r.action == "failed" {
-				failCount++
-			}
-		}
+	if failCount > 0 {
 		fmt.Fprintln(opts.Stdout, "Setup partially complete. Fix the errors above, then re-run `uf setup`.")
 		return fmt.Errorf("%d step(s) failed", failCount)
 	}

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -251,7 +251,7 @@ func Run(opts Options) error {
 	fmt.Fprintln(opts.Stdout, "Installing...")
 
 	// Step 1: Install OpenCode (FR-022).
-	fmt.Fprintf(opts.Stdout, "  [1/13] OpenCode...\n")
+	fmt.Fprintf(opts.Stdout, "  [1/16] OpenCode...\n")
 	if opts.shouldSkipTool("opencode") {
 		results = append(results, stepResult{name: "OpenCode", action: "skipped", detail: "excluded by config"})
 	} else {
@@ -259,7 +259,7 @@ func Run(opts Options) error {
 	}
 
 	// Step 2: Install Gaze (FR-023).
-	fmt.Fprintf(opts.Stdout, "  [2/13] Gaze...\n")
+	fmt.Fprintf(opts.Stdout, "  [2/16] Gaze...\n")
 	if opts.shouldSkipTool("gaze") {
 		results = append(results, stepResult{name: "Gaze", action: "skipped", detail: "excluded by config"})
 	} else {
@@ -267,7 +267,7 @@ func Run(opts Options) error {
 	}
 
 	// Step 3: Install GitHub CLI.
-	fmt.Fprintf(opts.Stdout, "  [3/13] GitHub CLI...\n")
+	fmt.Fprintf(opts.Stdout, "  [3/16] GitHub CLI...\n")
 	if opts.shouldSkipTool("gh") {
 		results = append(results, stepResult{name: "GitHub CLI", action: "skipped", detail: "excluded by config"})
 	} else {
@@ -275,7 +275,7 @@ func Run(opts Options) error {
 	}
 
 	// Step 4: Ensure Node.js (FR-024).
-	fmt.Fprintf(opts.Stdout, "  [4/13] Node.js...\n")
+	fmt.Fprintf(opts.Stdout, "  [4/16] Node.js...\n")
 	nodeAvailable := false
 	if opts.shouldSkipTool("node") {
 		results = append(results, stepResult{name: "Node.js", action: "skipped", detail: "excluded by config"})
@@ -289,14 +289,14 @@ func Run(opts Options) error {
 	if opts.shouldSkipTool("openspec") {
 		results = append(results, stepResult{name: "OpenSpec CLI", action: "skipped", detail: "excluded by config"})
 	} else if nodeAvailable {
-		fmt.Fprintf(opts.Stdout, "  [5/13] OpenSpec CLI...\n")
+		fmt.Fprintf(opts.Stdout, "  [5/16] OpenSpec CLI...\n")
 		results = append(results, installOpenSpec(&opts, env))
 	} else {
 		results = append(results, stepResult{name: "OpenSpec CLI", action: "skipped", detail: "no Node.js"})
 	}
 
 	// Step 6: Install uv (Python package manager for Specify CLI).
-	fmt.Fprintf(opts.Stdout, "  [6/13] uv...\n")
+	fmt.Fprintf(opts.Stdout, "  [6/16] uv...\n")
 	uvAvailable := false
 	if opts.shouldSkipTool("uv") {
 		results = append(results, stepResult{name: "uv", action: "skipped", detail: "excluded by config"})
@@ -310,14 +310,14 @@ func Run(opts Options) error {
 	if opts.shouldSkipTool("specify") {
 		results = append(results, stepResult{name: "Specify CLI", action: "skipped", detail: "excluded by config"})
 	} else if uvAvailable {
-		fmt.Fprintf(opts.Stdout, "  [7/13] Specify CLI...\n")
+		fmt.Fprintf(opts.Stdout, "  [7/16] Specify CLI...\n")
 		results = append(results, installSpecify(&opts, env))
 	} else {
 		results = append(results, stepResult{name: "Specify CLI", action: "skipped", detail: "no uv"})
 	}
 
 	// Step 8: Install Replicator (Homebrew, replaces Swarm plugin).
-	fmt.Fprintf(opts.Stdout, "  [8/13] Replicator...\n")
+	fmt.Fprintf(opts.Stdout, "  [8/16] Replicator...\n")
 	replicatorSkipped := false
 	if opts.shouldSkipTool("replicator") {
 		results = append(results, stepResult{name: "Replicator", action: "skipped", detail: "excluded by config"})
@@ -332,36 +332,57 @@ func Run(opts Options) error {
 	if replicatorSkipped {
 		results = append(results, stepResult{name: "replicator setup", action: "skipped", detail: "no replicator"})
 	} else {
-		fmt.Fprintf(opts.Stdout, "  [9/13] Replicator setup...\n")
+		fmt.Fprintf(opts.Stdout, "  [9/16] Replicator setup...\n")
 		results = append(results, runReplicatorSetup(&opts))
 	}
 
 	// Step 10: Install Ollama (prerequisite for Dewey + Replicator embeddings).
-	fmt.Fprintf(opts.Stdout, "  [10/13] Ollama...\n")
+	fmt.Fprintf(opts.Stdout, "  [10/16] Ollama...\n")
 	if opts.shouldSkipTool("ollama") {
 		results = append(results, stepResult{name: "Ollama", action: "skipped", detail: "excluded by config"})
 	} else {
 		results = append(results, installOllama(&opts, env))
 	}
 
-	// Step 11: Install Dewey (after Ollama).
-	fmt.Fprintf(opts.Stdout, "  [11/13] Dewey...\n")
+	// Step 11: Install Podman (container runtime for sandbox).
+	fmt.Fprintf(opts.Stdout, "  [11/16] Podman...\n")
+	if opts.shouldSkipTool("podman") {
+		results = append(results, stepResult{name: "Podman", action: "skipped", detail: "excluded by config"})
+	} else {
+		results = append(results, installPodman(&opts, env))
+	}
+
+	// Step 12: Install DevPod (workspace manager).
+	fmt.Fprintf(opts.Stdout, "  [12/16] DevPod...\n")
+	if opts.shouldSkipTool("devpod") {
+		results = append(results, stepResult{name: "DevPod", action: "skipped", detail: "excluded by config"})
+	} else {
+		results = append(results, installDevPod(&opts, env))
+	}
+
+	// Step 13: Configure DevPod Podman provider.
+	// Gated on both devpod and podman availability.
+	fmt.Fprintf(opts.Stdout, "  [13/16] DevPod provider...\n")
+	results = append(results, configureDevPodProvider(&opts))
+
+	// Step 14: Install Dewey (after Ollama).
+	fmt.Fprintf(opts.Stdout, "  [14/16] Dewey...\n")
 	if opts.shouldSkipTool("dewey") {
 		results = append(results, stepResult{name: "Dewey", action: "skipped", detail: "excluded by config"})
 	} else {
 		results = append(results, installDewey(&opts, env))
 	}
 
-	// Step 12: Install golangci-lint (Spec 019 FR-012).
-	fmt.Fprintf(opts.Stdout, "  [12/13] golangci-lint...\n")
+	// Step 15: Install golangci-lint (Spec 019 FR-012).
+	fmt.Fprintf(opts.Stdout, "  [15/16] golangci-lint...\n")
 	if opts.shouldSkipTool("golangci-lint") {
 		results = append(results, stepResult{name: "golangci-lint", action: "skipped", detail: "excluded by config"})
 	} else {
 		results = append(results, installGolangciLint(&opts, env))
 	}
 
-	// Step 13: Install govulncheck (Spec 019 FR-012).
-	fmt.Fprintf(opts.Stdout, "  [13/13] govulncheck...\n")
+	// Step 16: Install govulncheck (Spec 019 FR-012).
+	fmt.Fprintf(opts.Stdout, "  [16/16] govulncheck...\n")
 	if opts.shouldSkipTool("govulncheck") {
 		results = append(results, stepResult{name: "govulncheck", action: "skipped", detail: "excluded by config"})
 	} else {
@@ -901,6 +922,189 @@ func installOllama(opts *Options, env doctor.DetectedEnvironment) stepResult {
 		return stepResult{name: "Ollama", action: "failed", detail: "brew install failed", err: err}
 	}
 	return stepResult{name: "Ollama", action: "installed", detail: "via Homebrew"}
+}
+
+// podmanMachineTimeout is the timeout in seconds for podman machine
+// init, which downloads a VM image (~300MB) and can be slow on
+// constrained networks. 180 seconds balances patience with preventing
+// indefinite hangs.
+const podmanMachineTimeout = "180"
+
+// installPodman installs Podman if missing. Podman is the container
+// runtime used by the sandbox for isolated agent sessions. On macOS,
+// after installation, a Podman machine is initialized and started
+// (best-effort — failures are reported but do not block the step).
+// A smoke test via `podman info` verifies the installation is
+// functional.
+func installPodman(opts *Options, env doctor.DetectedEnvironment) stepResult {
+	if opts.shouldSkipTool("podman") {
+		return stepResult{name: "Podman", action: "skipped", detail: "excluded by config"}
+	}
+
+	if _, err := opts.LookPath("podman"); err == nil {
+		return stepResult{name: "Podman", action: "already installed"}
+	}
+
+	if opts.DryRun {
+		if doctor.HasManager(env, doctor.ManagerHomebrew) {
+			return stepResult{name: "Podman", action: "dry-run", detail: "Would install: brew install podman"}
+		}
+		return stepResult{name: "Podman", action: "dry-run", detail: "Would install: download from https://podman.io/docs/installation"}
+	}
+
+	if !doctor.HasManager(env, doctor.ManagerHomebrew) {
+		return stepResult{
+			name:   "Podman",
+			action: "skipped",
+			detail: "Homebrew not available. Download from https://podman.io/docs/installation",
+		}
+	}
+
+	if _, err := opts.ExecCmd("brew", "install", "podman"); err != nil {
+		return stepResult{name: "Podman", action: "failed", detail: "brew install failed", err: err}
+	}
+
+	// macOS post-install: initialize and start a Podman machine.
+	// Podman on macOS requires a VM to run Linux containers.
+	detail := "via Homebrew"
+	if opts.GOOS == "darwin" {
+		detail = podmanMachineInit(opts, detail)
+	}
+
+	// Smoke test: verify Podman is functional.
+	if _, err := opts.ExecCmd("podman", "info"); err != nil {
+		detail += "; podman info failed"
+	} else {
+		detail += "; verified"
+	}
+
+	return stepResult{name: "Podman", action: "installed", detail: detail}
+}
+
+// podmanMachineInit checks for an existing Podman machine on macOS
+// and initializes one if none exists. Returns the updated detail
+// string with machine status appended. Machine failures are
+// best-effort — they are reported but do not fail the step (D6).
+func podmanMachineInit(opts *Options, detail string) string {
+	// Check if a machine already exists.
+	output, err := opts.ExecCmd("podman", "machine", "list", "--format", "{{.Name}}")
+	if err == nil && strings.TrimSpace(string(output)) != "" {
+		// Machine already exists — no init needed.
+		return detail
+	}
+
+	// No machine exists — initialize one with timeout to prevent
+	// indefinite hangs on slow networks (D6).
+	if _, err := opts.ExecCmd("timeout", podmanMachineTimeout, "podman", "machine", "init"); err != nil {
+		return detail + "; machine init failed"
+	}
+
+	// Start the machine.
+	if _, err := opts.ExecCmd("podman", "machine", "start"); err != nil {
+		return detail + "; machine start failed"
+	}
+
+	return detail
+}
+
+// installDevPod installs DevPod if missing. DevPod provides
+// persistent workspace management on top of Podman. Follows the
+// installGaze() pattern: Homebrew only, skip with download URL
+// if no Homebrew.
+func installDevPod(opts *Options, env doctor.DetectedEnvironment) stepResult {
+	if opts.shouldSkipTool("devpod") {
+		return stepResult{name: "DevPod", action: "skipped", detail: "excluded by config"}
+	}
+
+	if _, err := opts.LookPath("devpod"); err == nil {
+		return stepResult{name: "DevPod", action: "already installed"}
+	}
+
+	if opts.DryRun {
+		if doctor.HasManager(env, doctor.ManagerHomebrew) {
+			return stepResult{name: "DevPod", action: "dry-run", detail: "Would install: brew install devpod"}
+		}
+		return stepResult{name: "DevPod", action: "dry-run", detail: "Would install: download from https://devpod.sh/docs/getting-started/install"}
+	}
+
+	if !doctor.HasManager(env, doctor.ManagerHomebrew) {
+		return stepResult{
+			name:   "DevPod",
+			action: "skipped",
+			detail: "Homebrew not available. Download from https://devpod.sh/docs/getting-started/install",
+		}
+	}
+
+	if _, err := opts.ExecCmd("brew", "install", "devpod"); err != nil {
+		return stepResult{name: "DevPod", action: "failed", detail: "brew install failed", err: err}
+	}
+	return stepResult{name: "DevPod", action: "installed", detail: "via Homebrew"}
+}
+
+// configureDevPodProvider configures the DevPod Podman provider
+// alias. The standalone podman provider was removed from DevPod;
+// users must alias the Docker provider with DOCKER_COMMAND=podman
+// (D3). This step is gated on both devpod and podman being
+// available in PATH. Provider detection uses exact first-column
+// name matching on `devpod provider list` output (D5).
+func configureDevPodProvider(opts *Options) stepResult {
+	// Gate: both devpod and podman must be available.
+	if _, err := opts.LookPath("devpod"); err != nil {
+		return stepResult{name: "DevPod provider", action: "skipped", detail: "no devpod"}
+	}
+	if _, err := opts.LookPath("podman"); err != nil {
+		return stepResult{name: "DevPod provider", action: "skipped", detail: "no podman"}
+	}
+
+	if opts.DryRun {
+		return stepResult{
+			name:   "DevPod provider",
+			action: "dry-run",
+			detail: "Would run: devpod provider add docker --name podman -o DOCKER_COMMAND=podman",
+		}
+	}
+
+	// Check if provider is already registered.
+	output, err := opts.ExecCmd("devpod", "provider", "list")
+	if err != nil {
+		return stepResult{
+			name:   "DevPod provider",
+			action: "skipped",
+			detail: "devpod provider list failed — check devpod installation",
+		}
+	}
+
+	// Parse provider list output: exact first-column name matching
+	// to avoid false positives from providers like "podman-custom" (D5).
+	if hasProvider(string(output), "podman") {
+		return stepResult{name: "DevPod provider", action: "already installed"}
+	}
+
+	// Provider missing — add the Docker provider aliased to Podman.
+	addCmd := "devpod provider add docker --name podman -o DOCKER_COMMAND=podman"
+	if _, err := opts.ExecCmd("devpod", "provider", "add", "docker", "--name", "podman", "-o", "DOCKER_COMMAND=podman"); err != nil {
+		return stepResult{
+			name:   "DevPod provider",
+			action: "failed",
+			detail: "Run manually: " + addCmd,
+			err:    err,
+		}
+	}
+	return stepResult{name: "DevPod provider", action: "installed", detail: "podman provider configured"}
+}
+
+// hasProvider checks if a provider name appears as an exact match
+// in the first column of `devpod provider list` output. Uses exact
+// matching to avoid false positives from providers with similar
+// names (e.g., "podman-custom" should not match "podman").
+func hasProvider(output, name string) bool {
+	for _, line := range strings.Split(output, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) > 0 && fields[0] == name {
+			return true
+		}
+	}
+	return false
 }
 
 // installDewey installs Dewey and pulls the embedding model.

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -3458,3 +3458,163 @@ func TestSetupRun_SkipViaConfig(t *testing.T) {
 		}
 	}
 }
+
+// --- installGaze unit tests ---
+
+func TestInstallGaze_AlreadyInstalled(t *testing.T) {
+	opts := &Options{
+		LookPath: stubLookPath(map[string]string{
+			"gaze": "/usr/local/bin/gaze",
+		}),
+	}
+	env := doctor.DetectedEnvironment{}
+
+	result := installGaze(opts, env)
+	if result.action != "already installed" {
+		t.Errorf("action = %q, want %q", result.action, "already installed")
+	}
+	if result.name != "Gaze" {
+		t.Errorf("name = %q, want %q", result.name, "Gaze")
+	}
+}
+
+func TestInstallGaze_DryRunWithHomebrew(t *testing.T) {
+	opts := &Options{
+		DryRun:   true,
+		LookPath: stubLookPath(map[string]string{}),
+	}
+	env := doctor.DetectedEnvironment{
+		Managers: []doctor.ManagerInfo{
+			{Kind: doctor.ManagerHomebrew, Path: "/opt/homebrew/bin/brew"},
+		},
+	}
+
+	result := installGaze(opts, env)
+	if result.action != "dry-run" {
+		t.Errorf("action = %q, want %q", result.action, "dry-run")
+	}
+	if !strings.Contains(result.detail, "brew install") {
+		t.Errorf("detail = %q, want to contain 'brew install'", result.detail)
+	}
+}
+
+func TestInstallGaze_DryRunNoHomebrew(t *testing.T) {
+	opts := &Options{
+		DryRun:   true,
+		LookPath: stubLookPath(map[string]string{}),
+	}
+	env := doctor.DetectedEnvironment{}
+
+	result := installGaze(opts, env)
+	if result.action != "dry-run" {
+		t.Errorf("action = %q, want %q", result.action, "dry-run")
+	}
+	if !strings.Contains(result.detail, "GitHub releases") {
+		t.Errorf("detail = %q, want to contain 'GitHub releases'", result.detail)
+	}
+}
+
+func TestInstallGaze_NoHomebrewSkip(t *testing.T) {
+	opts := &Options{
+		LookPath: stubLookPath(map[string]string{}),
+	}
+	env := doctor.DetectedEnvironment{}
+
+	result := installGaze(opts, env)
+	if result.action != "skipped" {
+		t.Errorf("action = %q, want %q", result.action, "skipped")
+	}
+	if !strings.Contains(result.detail, "Homebrew not available") {
+		t.Errorf("detail = %q, want to contain 'Homebrew not available'", result.detail)
+	}
+}
+
+func TestInstallGaze_HomebrewInstallSuccess(t *testing.T) {
+	rec := &cmdRecorder{
+		outputs: map[string]string{
+			"brew install unbound-force/tap/gaze": "==> Installing gaze",
+		},
+	}
+	opts := &Options{
+		LookPath: stubLookPath(map[string]string{}),
+		ExecCmd:  rec.execCmd,
+	}
+	env := doctor.DetectedEnvironment{
+		Managers: []doctor.ManagerInfo{
+			{Kind: doctor.ManagerHomebrew, Path: "/opt/homebrew/bin/brew"},
+		},
+	}
+
+	result := installGaze(opts, env)
+	if result.action != "installed" {
+		t.Errorf("action = %q, want %q", result.action, "installed")
+	}
+	if !strings.Contains(result.detail, "Homebrew") {
+		t.Errorf("detail = %q, want to contain 'Homebrew'", result.detail)
+	}
+}
+
+func TestInstallGaze_HomebrewInstallFailed(t *testing.T) {
+	rec := &cmdRecorder{
+		errors: map[string]error{
+			"brew install unbound-force/tap/gaze": fmt.Errorf("brew error"),
+		},
+	}
+	opts := &Options{
+		LookPath: stubLookPath(map[string]string{}),
+		ExecCmd:  rec.execCmd,
+	}
+	env := doctor.DetectedEnvironment{
+		Managers: []doctor.ManagerInfo{
+			{Kind: doctor.ManagerHomebrew, Path: "/opt/homebrew/bin/brew"},
+		},
+	}
+
+	result := installGaze(opts, env)
+	if result.action != "failed" {
+		t.Errorf("action = %q, want %q", result.action, "failed")
+	}
+	if result.err == nil {
+		t.Error("expected non-nil error")
+	}
+}
+
+func TestInstallGaze_ExplicitHomebrewMethod(t *testing.T) {
+	rec := &cmdRecorder{
+		outputs: map[string]string{
+			"brew install unbound-force/tap/gaze": "installed",
+		},
+	}
+	opts := &Options{
+		LookPath: stubLookPath(map[string]string{}),
+		ExecCmd:  rec.execCmd,
+		ToolMethods: map[string]config.ToolConfig{
+			"gaze": {Method: "homebrew"},
+		},
+	}
+	env := doctor.DetectedEnvironment{}
+
+	result := installGaze(opts, env)
+	if result.action != "installed" {
+		t.Errorf("action = %q, want %q", result.action, "installed")
+	}
+}
+
+func TestInstallGaze_ExplicitHomebrewDryRun(t *testing.T) {
+	opts := &Options{
+		DryRun:   true,
+		LookPath: stubLookPath(map[string]string{}),
+		ToolMethods: map[string]config.ToolConfig{
+			"gaze": {Method: "homebrew"},
+		},
+	}
+	env := doctor.DetectedEnvironment{}
+
+	result := installGaze(opts, env)
+	if result.action != "dry-run" {
+		t.Errorf("action = %q, want %q", result.action, "dry-run")
+	}
+	if !strings.Contains(result.detail, "brew install") {
+		t.Errorf("detail = %q, want to contain 'brew install'", result.detail)
+	}
+}

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -171,8 +171,9 @@ func TestSetupRun_AllPresent(t *testing.T) {
 
 	rec := &cmdRecorder{
 		outputs: map[string]string{
-			"node --version": "v22.15.0",
-			"ollama list":    "NAME                    ID              SIZE\ngranite-embedding:30m   abc123          63 MB\n",
+			"node --version":    "v22.15.0",
+			"ollama list":       "NAME                    ID              SIZE\ngranite-embedding:30m   abc123          63 MB\n",
+			"devpod provider list": "podman   docker   v0.1.0\n",
 		},
 	}
 
@@ -194,6 +195,8 @@ func TestSetupRun_AllPresent(t *testing.T) {
 			"replicator":    "/usr/local/bin/replicator",
 			"dewey":         "/usr/local/bin/dewey",
 			"ollama":        "/usr/local/bin/ollama",
+			"podman":        "/usr/local/bin/podman",
+			"devpod":        "/usr/local/bin/devpod",
 			"golangci-lint": "/usr/local/bin/golangci-lint",
 			"govulncheck":   "/usr/local/bin/govulncheck",
 		}),
@@ -1305,8 +1308,9 @@ func TestSetupRun_DeweyAlreadyInstalled(t *testing.T) {
 
 	rec := &cmdRecorder{
 		outputs: map[string]string{
-			"node --version": "v22.15.0",
-			"ollama list":    "NAME                    ID              SIZE\ngranite-embedding:30m   abc123          63 MB\n",
+			"node --version":       "v22.15.0",
+			"ollama list":          "NAME                    ID              SIZE\ngranite-embedding:30m   abc123          63 MB\n",
+			"devpod provider list": "podman   docker   v0.1.0\n",
 		},
 	}
 
@@ -1324,6 +1328,8 @@ func TestSetupRun_DeweyAlreadyInstalled(t *testing.T) {
 			"replicator": "/usr/local/bin/replicator",
 			"dewey":      "/usr/local/bin/dewey",
 			"ollama":     "/usr/local/bin/ollama",
+			"podman":     "/usr/local/bin/podman",
+			"devpod":     "/usr/local/bin/devpod",
 		}),
 		ExecCmd:      rec.execCmd,
 		EvalSymlinks: stubEvalSymlinks(nil),
@@ -2579,6 +2585,838 @@ func TestEmbeddingDim_Override(t *testing.T) {
 	opts := Options{EmbeddingDimensions: 1024}
 	if d := opts.embeddingDim(); d != "1024" {
 		t.Errorf("embeddingDim = %q, want 1024", d)
+	}
+}
+
+// --- Podman installation tests ---
+
+func TestInstallPodman_AlreadyInstalled(t *testing.T) {
+	rec := &cmdRecorder{}
+
+	opts := Options{
+		Stdout: &bytes.Buffer{},
+		Stderr: &bytes.Buffer{},
+		LookPath: stubLookPath(map[string]string{
+			"podman": "/usr/local/bin/podman",
+		}),
+		ExecCmd:      rec.execCmd,
+		EvalSymlinks: stubEvalSymlinks(nil),
+		Getenv:       stubGetenv(map[string]string{}),
+	}
+	opts.defaults()
+
+	env := doctor.DetectEnvironment(&doctor.Options{
+		LookPath:     opts.LookPath,
+		EvalSymlinks: opts.EvalSymlinks,
+		Getenv:       opts.Getenv,
+	})
+
+	result := installPodman(&opts, env)
+	if result.action != "already installed" {
+		t.Errorf("expected 'already installed', got %q", result.action)
+	}
+}
+
+func TestInstallPodman_BrewInstall(t *testing.T) {
+	rec := &cmdRecorder{
+		outputs: map[string]string{
+			"podman info": "host:\n  os: linux\n",
+		},
+	}
+
+	opts := Options{
+		GOOS:   "linux",
+		Stdout: &bytes.Buffer{},
+		Stderr: &bytes.Buffer{},
+		LookPath: stubLookPath(map[string]string{
+			"brew": "/opt/homebrew/bin/brew",
+		}),
+		ExecCmd:      rec.execCmd,
+		EvalSymlinks: stubEvalSymlinks(nil),
+		Getenv:       stubGetenv(map[string]string{}),
+	}
+	opts.defaults()
+
+	env := doctor.DetectEnvironment(&doctor.Options{
+		LookPath:     opts.LookPath,
+		EvalSymlinks: opts.EvalSymlinks,
+		Getenv:       opts.Getenv,
+	})
+
+	result := installPodman(&opts, env)
+	if result.action != "installed" {
+		t.Errorf("expected 'installed', got %q", result.action)
+	}
+	if !strings.Contains(result.detail, "via Homebrew") {
+		t.Errorf("expected 'via Homebrew' in detail, got %q", result.detail)
+	}
+	if !strings.Contains(result.detail, "verified") {
+		t.Errorf("expected 'verified' in detail, got %q", result.detail)
+	}
+
+	found := false
+	for _, call := range rec.calls {
+		if call == "brew install podman" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected 'brew install podman' call, got: %v", rec.calls)
+	}
+}
+
+func TestInstallPodman_NoHomebrew(t *testing.T) {
+	rec := &cmdRecorder{}
+
+	opts := Options{
+		Stdout:       &bytes.Buffer{},
+		Stderr:       &bytes.Buffer{},
+		LookPath:     stubLookPath(map[string]string{}),
+		ExecCmd:      rec.execCmd,
+		EvalSymlinks: stubEvalSymlinks(nil),
+		Getenv:       stubGetenv(map[string]string{}),
+	}
+	opts.defaults()
+
+	env := doctor.DetectEnvironment(&doctor.Options{
+		LookPath:     opts.LookPath,
+		EvalSymlinks: opts.EvalSymlinks,
+		Getenv:       opts.Getenv,
+	})
+
+	result := installPodman(&opts, env)
+	if result.action != "skipped" {
+		t.Errorf("expected 'skipped', got %q", result.action)
+	}
+	if !strings.Contains(result.detail, "podman.io/docs/installation") {
+		t.Errorf("expected download URL in detail, got %q", result.detail)
+	}
+}
+
+func TestInstallPodman_DarwinMachineInit(t *testing.T) {
+	rec := &cmdRecorder{
+		outputs: map[string]string{
+			// No machine exists — empty output.
+			"podman machine list --format {{.Name}}": "",
+			"podman info": "host:\n  os: darwin\n",
+		},
+	}
+
+	opts := Options{
+		GOOS:   "darwin",
+		Stdout: &bytes.Buffer{},
+		Stderr: &bytes.Buffer{},
+		LookPath: stubLookPath(map[string]string{
+			"brew": "/opt/homebrew/bin/brew",
+		}),
+		ExecCmd:      rec.execCmd,
+		EvalSymlinks: stubEvalSymlinks(nil),
+		Getenv:       stubGetenv(map[string]string{}),
+	}
+	opts.defaults()
+
+	env := doctor.DetectEnvironment(&doctor.Options{
+		LookPath:     opts.LookPath,
+		EvalSymlinks: opts.EvalSymlinks,
+		Getenv:       opts.Getenv,
+	})
+
+	result := installPodman(&opts, env)
+	if result.action != "installed" {
+		t.Errorf("expected 'installed', got %q", result.action)
+	}
+	if !strings.Contains(result.detail, "verified") {
+		t.Errorf("expected 'verified' in detail, got %q", result.detail)
+	}
+
+	// Verify machine init and start were called.
+	initCalled := false
+	startCalled := false
+	for _, call := range rec.calls {
+		if strings.Contains(call, "podman machine init") {
+			initCalled = true
+		}
+		if call == "podman machine start" {
+			startCalled = true
+		}
+	}
+	if !initCalled {
+		t.Errorf("expected 'podman machine init' call, got: %v", rec.calls)
+	}
+	if !startCalled {
+		t.Errorf("expected 'podman machine start' call, got: %v", rec.calls)
+	}
+}
+
+func TestInstallPodman_DarwinMachineAlreadyExists(t *testing.T) {
+	rec := &cmdRecorder{
+		outputs: map[string]string{
+			"podman machine list --format {{.Name}}": "podman-machine-default",
+			"podman info": "host:\n  os: darwin\n",
+		},
+	}
+
+	opts := Options{
+		GOOS:   "darwin",
+		Stdout: &bytes.Buffer{},
+		Stderr: &bytes.Buffer{},
+		LookPath: stubLookPath(map[string]string{
+			"brew": "/opt/homebrew/bin/brew",
+		}),
+		ExecCmd:      rec.execCmd,
+		EvalSymlinks: stubEvalSymlinks(nil),
+		Getenv:       stubGetenv(map[string]string{}),
+	}
+	opts.defaults()
+
+	env := doctor.DetectEnvironment(&doctor.Options{
+		LookPath:     opts.LookPath,
+		EvalSymlinks: opts.EvalSymlinks,
+		Getenv:       opts.Getenv,
+	})
+
+	result := installPodman(&opts, env)
+	if result.action != "installed" {
+		t.Errorf("expected 'installed', got %q", result.action)
+	}
+
+	// Verify machine init was NOT called.
+	for _, call := range rec.calls {
+		if strings.Contains(call, "podman machine init") {
+			t.Error("should not call machine init when machine already exists")
+		}
+	}
+}
+
+func TestInstallPodman_DarwinMachineInitFails(t *testing.T) {
+	rec := &cmdRecorder{
+		outputs: map[string]string{
+			"podman machine list --format {{.Name}}": "",
+			"podman info": "host:\n  os: darwin\n",
+		},
+		errors: map[string]error{
+			"timeout 180 podman machine init": fmt.Errorf("init failed"),
+		},
+	}
+
+	opts := Options{
+		GOOS:   "darwin",
+		Stdout: &bytes.Buffer{},
+		Stderr: &bytes.Buffer{},
+		LookPath: stubLookPath(map[string]string{
+			"brew": "/opt/homebrew/bin/brew",
+		}),
+		ExecCmd:      rec.execCmd,
+		EvalSymlinks: stubEvalSymlinks(nil),
+		Getenv:       stubGetenv(map[string]string{}),
+	}
+	opts.defaults()
+
+	env := doctor.DetectEnvironment(&doctor.Options{
+		LookPath:     opts.LookPath,
+		EvalSymlinks: opts.EvalSymlinks,
+		Getenv:       opts.Getenv,
+	})
+
+	result := installPodman(&opts, env)
+	// Machine init failure does not fail the step.
+	if result.action != "installed" {
+		t.Errorf("expected 'installed', got %q", result.action)
+	}
+	if !strings.Contains(result.detail, "machine init failed") {
+		t.Errorf("expected 'machine init failed' in detail, got %q", result.detail)
+	}
+}
+
+func TestInstallPodman_DarwinMachineStartFails(t *testing.T) {
+	rec := &cmdRecorder{
+		outputs: map[string]string{
+			"podman machine list --format {{.Name}}": "",
+			"podman info": "host:\n  os: darwin\n",
+		},
+		errors: map[string]error{
+			"podman machine start": fmt.Errorf("start failed"),
+		},
+	}
+
+	opts := Options{
+		GOOS:   "darwin",
+		Stdout: &bytes.Buffer{},
+		Stderr: &bytes.Buffer{},
+		LookPath: stubLookPath(map[string]string{
+			"brew": "/opt/homebrew/bin/brew",
+		}),
+		ExecCmd:      rec.execCmd,
+		EvalSymlinks: stubEvalSymlinks(nil),
+		Getenv:       stubGetenv(map[string]string{}),
+	}
+	opts.defaults()
+
+	env := doctor.DetectEnvironment(&doctor.Options{
+		LookPath:     opts.LookPath,
+		EvalSymlinks: opts.EvalSymlinks,
+		Getenv:       opts.Getenv,
+	})
+
+	result := installPodman(&opts, env)
+	if result.action != "installed" {
+		t.Errorf("expected 'installed', got %q", result.action)
+	}
+	if !strings.Contains(result.detail, "machine start failed") {
+		t.Errorf("expected 'machine start failed' in detail, got %q", result.detail)
+	}
+}
+
+func TestInstallPodman_LinuxNoMachineInit(t *testing.T) {
+	rec := &cmdRecorder{
+		outputs: map[string]string{
+			"podman info": "host:\n  os: linux\n",
+		},
+	}
+
+	opts := Options{
+		GOOS:   "linux",
+		Stdout: &bytes.Buffer{},
+		Stderr: &bytes.Buffer{},
+		LookPath: stubLookPath(map[string]string{
+			"brew": "/opt/homebrew/bin/brew",
+		}),
+		ExecCmd:      rec.execCmd,
+		EvalSymlinks: stubEvalSymlinks(nil),
+		Getenv:       stubGetenv(map[string]string{}),
+	}
+	opts.defaults()
+
+	env := doctor.DetectEnvironment(&doctor.Options{
+		LookPath:     opts.LookPath,
+		EvalSymlinks: opts.EvalSymlinks,
+		Getenv:       opts.Getenv,
+	})
+
+	result := installPodman(&opts, env)
+	if result.action != "installed" {
+		t.Errorf("expected 'installed', got %q", result.action)
+	}
+
+	// Verify no machine init on Linux.
+	for _, call := range rec.calls {
+		if strings.Contains(call, "machine") {
+			t.Errorf("should not call machine commands on Linux: %s", call)
+		}
+	}
+}
+
+func TestInstallPodman_SmokeTestPasses(t *testing.T) {
+	rec := &cmdRecorder{
+		outputs: map[string]string{
+			"podman info": "host:\n  os: linux\n",
+		},
+	}
+
+	opts := Options{
+		GOOS:   "linux",
+		Stdout: &bytes.Buffer{},
+		Stderr: &bytes.Buffer{},
+		LookPath: stubLookPath(map[string]string{
+			"brew": "/opt/homebrew/bin/brew",
+		}),
+		ExecCmd:      rec.execCmd,
+		EvalSymlinks: stubEvalSymlinks(nil),
+		Getenv:       stubGetenv(map[string]string{}),
+	}
+	opts.defaults()
+
+	env := doctor.DetectEnvironment(&doctor.Options{
+		LookPath:     opts.LookPath,
+		EvalSymlinks: opts.EvalSymlinks,
+		Getenv:       opts.Getenv,
+	})
+
+	result := installPodman(&opts, env)
+	if !strings.Contains(result.detail, "verified") {
+		t.Errorf("expected 'verified' in detail, got %q", result.detail)
+	}
+}
+
+func TestInstallPodman_SmokeTestFails(t *testing.T) {
+	rec := &cmdRecorder{
+		errors: map[string]error{
+			"podman info": fmt.Errorf("cannot connect to Podman"),
+		},
+	}
+
+	opts := Options{
+		GOOS:   "linux",
+		Stdout: &bytes.Buffer{},
+		Stderr: &bytes.Buffer{},
+		LookPath: stubLookPath(map[string]string{
+			"brew": "/opt/homebrew/bin/brew",
+		}),
+		ExecCmd:      rec.execCmd,
+		EvalSymlinks: stubEvalSymlinks(nil),
+		Getenv:       stubGetenv(map[string]string{}),
+	}
+	opts.defaults()
+
+	env := doctor.DetectEnvironment(&doctor.Options{
+		LookPath:     opts.LookPath,
+		EvalSymlinks: opts.EvalSymlinks,
+		Getenv:       opts.Getenv,
+	})
+
+	result := installPodman(&opts, env)
+	if result.action != "installed" {
+		t.Errorf("expected 'installed', got %q", result.action)
+	}
+	if !strings.Contains(result.detail, "podman info failed") {
+		t.Errorf("expected 'podman info failed' in detail, got %q", result.detail)
+	}
+}
+
+func TestInstallPodman_DryRun(t *testing.T) {
+	rec := &cmdRecorder{}
+
+	opts := Options{
+		DryRun: true,
+		Stdout: &bytes.Buffer{},
+		Stderr: &bytes.Buffer{},
+		LookPath: stubLookPath(map[string]string{
+			"brew": "/opt/homebrew/bin/brew",
+		}),
+		ExecCmd:      rec.execCmd,
+		EvalSymlinks: stubEvalSymlinks(nil),
+		Getenv:       stubGetenv(map[string]string{}),
+	}
+	opts.defaults()
+
+	env := doctor.DetectEnvironment(&doctor.Options{
+		LookPath:     opts.LookPath,
+		EvalSymlinks: opts.EvalSymlinks,
+		Getenv:       opts.Getenv,
+	})
+
+	result := installPodman(&opts, env)
+	if result.action != "dry-run" {
+		t.Errorf("expected 'dry-run', got %q", result.action)
+	}
+	if !strings.Contains(result.detail, "brew install podman") {
+		t.Errorf("expected brew install hint, got %q", result.detail)
+	}
+}
+
+func TestInstallPodman_SkipViaConfig(t *testing.T) {
+	rec := &cmdRecorder{}
+
+	opts := Options{
+		SkipTools: []string{"podman"},
+		Stdout:    &bytes.Buffer{},
+		Stderr:    &bytes.Buffer{},
+		LookPath: stubLookPath(map[string]string{
+			"brew": "/opt/homebrew/bin/brew",
+		}),
+		ExecCmd:      rec.execCmd,
+		EvalSymlinks: stubEvalSymlinks(nil),
+		Getenv:       stubGetenv(map[string]string{}),
+	}
+	opts.defaults()
+
+	env := doctor.DetectEnvironment(&doctor.Options{
+		LookPath:     opts.LookPath,
+		EvalSymlinks: opts.EvalSymlinks,
+		Getenv:       opts.Getenv,
+	})
+
+	result := installPodman(&opts, env)
+	if result.action != "skipped" {
+		t.Errorf("expected 'skipped', got %q", result.action)
+	}
+	if !strings.Contains(result.detail, "excluded by config") {
+		t.Errorf("expected 'excluded by config' in detail, got %q", result.detail)
+	}
+}
+
+// --- DevPod installation tests ---
+
+func TestInstallDevPod_AlreadyInstalled(t *testing.T) {
+	rec := &cmdRecorder{}
+
+	opts := Options{
+		Stdout: &bytes.Buffer{},
+		Stderr: &bytes.Buffer{},
+		LookPath: stubLookPath(map[string]string{
+			"devpod": "/usr/local/bin/devpod",
+		}),
+		ExecCmd:      rec.execCmd,
+		EvalSymlinks: stubEvalSymlinks(nil),
+		Getenv:       stubGetenv(map[string]string{}),
+	}
+	opts.defaults()
+
+	env := doctor.DetectEnvironment(&doctor.Options{
+		LookPath:     opts.LookPath,
+		EvalSymlinks: opts.EvalSymlinks,
+		Getenv:       opts.Getenv,
+	})
+
+	result := installDevPod(&opts, env)
+	if result.action != "already installed" {
+		t.Errorf("expected 'already installed', got %q", result.action)
+	}
+}
+
+func TestInstallDevPod_BrewInstall(t *testing.T) {
+	rec := &cmdRecorder{}
+
+	opts := Options{
+		Stdout: &bytes.Buffer{},
+		Stderr: &bytes.Buffer{},
+		LookPath: stubLookPath(map[string]string{
+			"brew": "/opt/homebrew/bin/brew",
+		}),
+		ExecCmd:      rec.execCmd,
+		EvalSymlinks: stubEvalSymlinks(nil),
+		Getenv:       stubGetenv(map[string]string{}),
+	}
+	opts.defaults()
+
+	env := doctor.DetectEnvironment(&doctor.Options{
+		LookPath:     opts.LookPath,
+		EvalSymlinks: opts.EvalSymlinks,
+		Getenv:       opts.Getenv,
+	})
+
+	result := installDevPod(&opts, env)
+	if result.action != "installed" {
+		t.Errorf("expected 'installed', got %q", result.action)
+	}
+	if !strings.Contains(result.detail, "via Homebrew") {
+		t.Errorf("expected 'via Homebrew' in detail, got %q", result.detail)
+	}
+
+	found := false
+	for _, call := range rec.calls {
+		if call == "brew install devpod" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected 'brew install devpod' call, got: %v", rec.calls)
+	}
+}
+
+func TestInstallDevPod_NoHomebrew(t *testing.T) {
+	rec := &cmdRecorder{}
+
+	opts := Options{
+		Stdout:       &bytes.Buffer{},
+		Stderr:       &bytes.Buffer{},
+		LookPath:     stubLookPath(map[string]string{}),
+		ExecCmd:      rec.execCmd,
+		EvalSymlinks: stubEvalSymlinks(nil),
+		Getenv:       stubGetenv(map[string]string{}),
+	}
+	opts.defaults()
+
+	env := doctor.DetectEnvironment(&doctor.Options{
+		LookPath:     opts.LookPath,
+		EvalSymlinks: opts.EvalSymlinks,
+		Getenv:       opts.Getenv,
+	})
+
+	result := installDevPod(&opts, env)
+	if result.action != "skipped" {
+		t.Errorf("expected 'skipped', got %q", result.action)
+	}
+	if !strings.Contains(result.detail, "devpod.sh/docs/getting-started/install") {
+		t.Errorf("expected download URL in detail, got %q", result.detail)
+	}
+}
+
+func TestInstallDevPod_DryRun(t *testing.T) {
+	rec := &cmdRecorder{}
+
+	opts := Options{
+		DryRun: true,
+		Stdout: &bytes.Buffer{},
+		Stderr: &bytes.Buffer{},
+		LookPath: stubLookPath(map[string]string{
+			"brew": "/opt/homebrew/bin/brew",
+		}),
+		ExecCmd:      rec.execCmd,
+		EvalSymlinks: stubEvalSymlinks(nil),
+		Getenv:       stubGetenv(map[string]string{}),
+	}
+	opts.defaults()
+
+	env := doctor.DetectEnvironment(&doctor.Options{
+		LookPath:     opts.LookPath,
+		EvalSymlinks: opts.EvalSymlinks,
+		Getenv:       opts.Getenv,
+	})
+
+	result := installDevPod(&opts, env)
+	if result.action != "dry-run" {
+		t.Errorf("expected 'dry-run', got %q", result.action)
+	}
+	if !strings.Contains(result.detail, "brew install devpod") {
+		t.Errorf("expected brew install hint, got %q", result.detail)
+	}
+}
+
+func TestInstallDevPod_SkipViaConfig(t *testing.T) {
+	rec := &cmdRecorder{}
+
+	opts := Options{
+		SkipTools: []string{"devpod"},
+		Stdout:    &bytes.Buffer{},
+		Stderr:    &bytes.Buffer{},
+		LookPath: stubLookPath(map[string]string{
+			"brew": "/opt/homebrew/bin/brew",
+		}),
+		ExecCmd:      rec.execCmd,
+		EvalSymlinks: stubEvalSymlinks(nil),
+		Getenv:       stubGetenv(map[string]string{}),
+	}
+	opts.defaults()
+
+	env := doctor.DetectEnvironment(&doctor.Options{
+		LookPath:     opts.LookPath,
+		EvalSymlinks: opts.EvalSymlinks,
+		Getenv:       opts.Getenv,
+	})
+
+	result := installDevPod(&opts, env)
+	if result.action != "skipped" {
+		t.Errorf("expected 'skipped', got %q", result.action)
+	}
+}
+
+// --- DevPod provider configuration tests ---
+
+func TestConfigureDevPodProvider_AlreadyRegistered(t *testing.T) {
+	rec := &cmdRecorder{
+		outputs: map[string]string{
+			"devpod provider list": "podman   docker   v0.1.0\nkubernetes   kubernetes   v0.2.0\n",
+		},
+	}
+
+	opts := Options{
+		Stdout: &bytes.Buffer{},
+		Stderr: &bytes.Buffer{},
+		LookPath: stubLookPath(map[string]string{
+			"devpod": "/usr/local/bin/devpod",
+			"podman": "/usr/local/bin/podman",
+		}),
+		ExecCmd:      rec.execCmd,
+		EvalSymlinks: stubEvalSymlinks(nil),
+		Getenv:       stubGetenv(map[string]string{}),
+	}
+	opts.defaults()
+
+	result := configureDevPodProvider(&opts)
+	if result.action != "already installed" {
+		t.Errorf("expected 'already installed', got %q", result.action)
+	}
+}
+
+func TestConfigureDevPodProvider_MissingInstall(t *testing.T) {
+	rec := &cmdRecorder{
+		outputs: map[string]string{
+			"devpod provider list": "kubernetes   kubernetes   v0.2.0\n",
+		},
+	}
+
+	opts := Options{
+		Stdout: &bytes.Buffer{},
+		Stderr: &bytes.Buffer{},
+		LookPath: stubLookPath(map[string]string{
+			"devpod": "/usr/local/bin/devpod",
+			"podman": "/usr/local/bin/podman",
+		}),
+		ExecCmd:      rec.execCmd,
+		EvalSymlinks: stubEvalSymlinks(nil),
+		Getenv:       stubGetenv(map[string]string{}),
+	}
+	opts.defaults()
+
+	result := configureDevPodProvider(&opts)
+	if result.action != "installed" {
+		t.Errorf("expected 'installed', got %q", result.action)
+	}
+
+	// Verify the provider add command was called.
+	found := false
+	for _, call := range rec.calls {
+		if call == "devpod provider add docker --name podman -o DOCKER_COMMAND=podman" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected provider add call, got: %v", rec.calls)
+	}
+}
+
+func TestConfigureDevPodProvider_AddFails(t *testing.T) {
+	rec := &cmdRecorder{
+		outputs: map[string]string{
+			"devpod provider list": "kubernetes   kubernetes   v0.2.0\n",
+		},
+		errors: map[string]error{
+			"devpod provider add docker --name podman -o DOCKER_COMMAND=podman": fmt.Errorf("provider add failed"),
+		},
+	}
+
+	opts := Options{
+		Stdout: &bytes.Buffer{},
+		Stderr: &bytes.Buffer{},
+		LookPath: stubLookPath(map[string]string{
+			"devpod": "/usr/local/bin/devpod",
+			"podman": "/usr/local/bin/podman",
+		}),
+		ExecCmd:      rec.execCmd,
+		EvalSymlinks: stubEvalSymlinks(nil),
+		Getenv:       stubGetenv(map[string]string{}),
+	}
+	opts.defaults()
+
+	result := configureDevPodProvider(&opts)
+	if result.action != "failed" {
+		t.Errorf("expected 'failed', got %q", result.action)
+	}
+	if !strings.Contains(result.detail, "devpod provider add docker --name podman") {
+		t.Errorf("expected manual command in detail, got %q", result.detail)
+	}
+}
+
+func TestConfigureDevPodProvider_ListFails(t *testing.T) {
+	rec := &cmdRecorder{
+		errors: map[string]error{
+			"devpod provider list": fmt.Errorf("devpod error"),
+		},
+	}
+
+	opts := Options{
+		Stdout: &bytes.Buffer{},
+		Stderr: &bytes.Buffer{},
+		LookPath: stubLookPath(map[string]string{
+			"devpod": "/usr/local/bin/devpod",
+			"podman": "/usr/local/bin/podman",
+		}),
+		ExecCmd:      rec.execCmd,
+		EvalSymlinks: stubEvalSymlinks(nil),
+		Getenv:       stubGetenv(map[string]string{}),
+	}
+	opts.defaults()
+
+	result := configureDevPodProvider(&opts)
+	if result.action != "skipped" {
+		t.Errorf("expected 'skipped', got %q", result.action)
+	}
+	if !strings.Contains(result.detail, "provider list failed") {
+		t.Errorf("expected warning about list failure, got %q", result.detail)
+	}
+}
+
+func TestConfigureDevPodProvider_NoDevPod(t *testing.T) {
+	rec := &cmdRecorder{}
+
+	opts := Options{
+		Stdout: &bytes.Buffer{},
+		Stderr: &bytes.Buffer{},
+		LookPath: stubLookPath(map[string]string{
+			"podman": "/usr/local/bin/podman",
+		}),
+		ExecCmd:      rec.execCmd,
+		EvalSymlinks: stubEvalSymlinks(nil),
+		Getenv:       stubGetenv(map[string]string{}),
+	}
+	opts.defaults()
+
+	result := configureDevPodProvider(&opts)
+	if result.action != "skipped" {
+		t.Errorf("expected 'skipped', got %q", result.action)
+	}
+	if !strings.Contains(result.detail, "no devpod") {
+		t.Errorf("expected 'no devpod' in detail, got %q", result.detail)
+	}
+}
+
+func TestConfigureDevPodProvider_NoPodman(t *testing.T) {
+	rec := &cmdRecorder{}
+
+	opts := Options{
+		Stdout: &bytes.Buffer{},
+		Stderr: &bytes.Buffer{},
+		LookPath: stubLookPath(map[string]string{
+			"devpod": "/usr/local/bin/devpod",
+		}),
+		ExecCmd:      rec.execCmd,
+		EvalSymlinks: stubEvalSymlinks(nil),
+		Getenv:       stubGetenv(map[string]string{}),
+	}
+	opts.defaults()
+
+	result := configureDevPodProvider(&opts)
+	if result.action != "skipped" {
+		t.Errorf("expected 'skipped', got %q", result.action)
+	}
+	if !strings.Contains(result.detail, "no podman") {
+		t.Errorf("expected 'no podman' in detail, got %q", result.detail)
+	}
+}
+
+func TestConfigureDevPodProvider_DryRun(t *testing.T) {
+	rec := &cmdRecorder{}
+
+	opts := Options{
+		DryRun: true,
+		Stdout: &bytes.Buffer{},
+		Stderr: &bytes.Buffer{},
+		LookPath: stubLookPath(map[string]string{
+			"devpod": "/usr/local/bin/devpod",
+			"podman": "/usr/local/bin/podman",
+		}),
+		ExecCmd:      rec.execCmd,
+		EvalSymlinks: stubEvalSymlinks(nil),
+		Getenv:       stubGetenv(map[string]string{}),
+	}
+	opts.defaults()
+
+	result := configureDevPodProvider(&opts)
+	if result.action != "dry-run" {
+		t.Errorf("expected 'dry-run', got %q", result.action)
+	}
+	if !strings.Contains(result.detail, "devpod provider add docker --name podman") {
+		t.Errorf("expected provider add hint, got %q", result.detail)
+	}
+}
+
+// --- hasProvider tests ---
+
+func TestHasProvider_ExactMatch(t *testing.T) {
+	output := "podman   docker   v0.1.0\nkubernetes   kubernetes   v0.2.0\n"
+	if !hasProvider(output, "podman") {
+		t.Error("expected to find 'podman' provider")
+	}
+}
+
+func TestHasProvider_SubstringNotMatched(t *testing.T) {
+	output := "podman-custom   docker   v0.1.0\nkubernetes   kubernetes   v0.2.0\n"
+	if hasProvider(output, "podman") {
+		t.Error("'podman-custom' should not match 'podman' (exact match required)")
+	}
+}
+
+func TestHasProvider_NotFound(t *testing.T) {
+	output := "docker   docker   v0.1.0\nkubernetes   kubernetes   v0.2.0\n"
+	if hasProvider(output, "podman") {
+		t.Error("expected not to find 'podman' provider")
+	}
+}
+
+func TestHasProvider_EmptyOutput(t *testing.T) {
+	if hasProvider("", "podman") {
+		t.Error("expected not to find provider in empty output")
 	}
 }
 

--- a/internal/sprint/sprint.go
+++ b/internal/sprint/sprint.go
@@ -17,7 +17,8 @@ type SprintStore struct {
 	Dir string
 }
 
-// NewSprintStore creates a new sprint store.
+// NewSprintStore creates a new sprint store rooted at the given
+// directory. It returns a SprintStore with Dir set to dir.
 func NewSprintStore(dir string) *SprintStore {
 	return &SprintStore{Dir: dir}
 }

--- a/openspec/changes/cde-sandbox-enhancement/design.md
+++ b/openspec/changes/cde-sandbox-enhancement/design.md
@@ -150,19 +150,27 @@ new backend behind a separate spec.
 
 The devcontainer template lives at
 `internal/scaffold/assets/devcontainer/devcontainer.json`
-and is embedded via `embed.FS`. `uf sandbox init`
-writes it to `.devcontainer/devcontainer.json` in the
-project root. Includes a version marker comment for
-drift detection.
+and is embedded via `embed.FS`. The template is deployed
+to `.devcontainer/devcontainer.json` in the project root
+by both `uf init` (standard scaffold) and
+`uf sandbox init` (standalone with custom flags).
 
-NOT deployed by `uf init` — only written by
-`uf sandbox init`. Keeps `uf init` lightweight.
+Deployed by `uf init` alongside agents, commands, and
+packs. The devcontainer is a standard spec recognized
+by VS Code, GitHub Codespaces, JetBrains, and DevPod —
+having it present is harmless for non-DevPod users and
+saves an extra step for DevPod users.
 
-Because this asset is not deployed by `uf init`, it
-MUST be added to `knownNonEmbeddedFiles` in
-`scaffold_test.go` (not `expectedAssetPaths`). This
-follows the pattern established by externalized Speckit
-assets.
+`uf sandbox init` remains as a standalone command for
+users who want to regenerate the devcontainer with
+custom flags (`--image`, `--demo-ports`, `--force`)
+without running full `uf init`.
+
+Because this asset IS deployed by `uf init`, it MUST
+be added to `expectedAssetPaths` in `scaffold_test.go`
+(not `knownNonEmbeddedFiles`). The scaffold engine's
+idempotency ensures `uf init` skips the file if it
+already exists.
 
 The expected devcontainer.json output:
 ```json
@@ -174,9 +182,15 @@ The expected devcontainer.json output:
       "http://host.containers.internal:53147",
     "ANTHROPIC_API_KEY": "gateway"
   },
+  "postStartCommand": "nohup opencode serve --port 4096 > /tmp/opencode-server.log 2>&1 & printf 'protocol=https\\nhost=github.com\\n\\n' | git credential fill 2>/dev/null | grep '^password=' | cut -d= -f2 | gh auth login --with-token 2>/dev/null || true",
   "remoteUser": "dev"
 }
 ```
+
+Note: `\\n` in JSON becomes `\n` in shell. The
+`postStartCommand` value is not directly paste-able
+from the JSON source — the escaping is handled by
+the JSON parser at runtime.
 
 Note: `ANTHROPIC_API_KEY=gateway` is a sentinel value
 indicating the gateway proxy handles authentication.
@@ -196,6 +210,56 @@ cluttering output for Podman-only users.
 Checks: (1) `devpod` binary presence with install hint,
 (2) `.devcontainer/devcontainer.json` existence with
 `uf sandbox init` hint.
+
+### D9: gh CLI auth relay via postStartCommand
+
+DevPod proxies git credentials into containers via its
+own credential helper, but this does NOT relay `gh` CLI
+authentication. The `gh` CLI uses a separate token store
+(`~/.config/gh/hosts.yml`). Without explicit relay,
+`gh` commands (PR reviews, issue management, etc.) fail
+inside DevPod sessions.
+
+The `postStartCommand` includes a pipeline that extracts
+the GitHub token from DevPod's git credential proxy and
+pipes it to `gh auth login --with-token`:
+
+```sh
+printf 'protocol=https\nhost=github.com\n\n' \
+  | git credential fill 2>/dev/null \
+  | grep '^password=' | cut -d= -f2 \
+  | gh auth login --with-token 2>/dev/null || true
+```
+
+Design choices:
+- **`postStartCommand` over `postCreateCommand`**: runs
+  on every container start (not just first creation),
+  so rotated or refreshed tokens are picked up
+  automatically.
+- **`|| true` for graceful degradation**: if git
+  credentials are not available (e.g., running outside
+  DevPod, or `gh` is not installed), the command fails
+  silently and the container starts normally.
+- **JSON escaping**: `\\n` in JSON becomes `\n` in
+  shell. The command is not directly paste-able from
+  the JSON source file.
+- **Injection safety**: the pipeline uses only hardcoded
+  literals and stdin piping. No user-controlled input is
+  interpolated into shell commands. The token flows
+  through pipes (stdin), never as a command-line
+  argument, preventing `/proc/cmdline` exposure.
+- **Token persistence**: `gh auth login --with-token`
+  overwrites any existing token in
+  `~/.config/gh/hosts.yml` (0600 permissions). The
+  relayed token inherits whatever scope DevPod's
+  credential helper provides (typically a GitHub PAT
+  with repo scope). Running on every start ensures
+  rotated tokens take effect.
+- **Log isolation**: `/tmp/opencode-server.log` captures
+  only the backgrounded `opencode serve` process. The
+  credential pipeline runs in the foreground with its
+  own `2>/dev/null` redirections. Tokens cannot leak
+  into the log file.
 
 ## Risks / Trade-offs
 

--- a/openspec/changes/cde-sandbox-enhancement/design.md
+++ b/openspec/changes/cde-sandbox-enhancement/design.md
@@ -176,21 +176,17 @@ The expected devcontainer.json output:
 ```json
 {
   "image": "quay.io/unbound-force/opencode-dev:latest",
+  "runArgs": ["--userns=keep-id:uid=1000,gid=1000"],
   "forwardPorts": [4096],
   "containerEnv": {
     "ANTHROPIC_BASE_URL":
       "http://host.containers.internal:53147",
     "ANTHROPIC_API_KEY": "gateway"
   },
-  "postStartCommand": "nohup opencode serve --port 4096 > /tmp/opencode-server.log 2>&1 & printf 'protocol=https\\nhost=github.com\\n\\n' | git credential fill 2>/dev/null | grep '^password=' | cut -d= -f2 | gh auth login --with-token 2>/dev/null || true",
+  "postStartCommand": "nohup opencode serve --port 4096 > /tmp/opencode-server.log 2>&1 &",
   "remoteUser": "dev"
 }
 ```
-
-Note: `\\n` in JSON becomes `\n` in shell. The
-`postStartCommand` value is not directly paste-able
-from the JSON source — the escaping is handled by
-the JSON parser at runtime.
 
 Note: `ANTHROPIC_API_KEY=gateway` is a sentinel value
 indicating the gateway proxy handles authentication.
@@ -211,55 +207,81 @@ Checks: (1) `devpod` binary presence with install hint,
 (2) `.devcontainer/devcontainer.json` existence with
 `uf sandbox init` hint.
 
-### D9: gh CLI auth relay via postStartCommand
+### D9: gh CLI auth relay — DEFERRED
 
 DevPod proxies git credentials into containers via its
 own credential helper, but this does NOT relay `gh` CLI
-authentication. The `gh` CLI uses a separate token store
-(`~/.config/gh/hosts.yml`). Without explicit relay,
-`gh` commands (PR reviews, issue management, etc.) fail
-inside DevPod sessions.
+authentication. The original plan was to extract the
+GitHub token from DevPod's git credential proxy via
+`git credential fill` in the `postStartCommand` and
+pipe it to `gh auth login --with-token`.
 
-The `postStartCommand` includes a pipeline that extracts
-the GitHub token from DevPod's git credential proxy and
-pipes it to `gh auth login --with-token`:
+**Blocker**: DevPod v0.6.x has a nil pointer panic in
+`tunnelserver.GitCredentials` when `git credential fill`
+is called during `postStartCommand`. The crash occurs
+in DevPod's gRPC handler
+(`tunnelserver.go:221 +0xf0`), taking down the entire
+DevPod agent and failing workspace creation. The
+`|| true` fallback cannot catch a process-level panic.
 
+This feature is deferred until DevPod fixes the
+credential tunnel crash. The `gh auth` relay design
+(pipeline, injection safety, token persistence) remains
+valid and can be re-enabled when the upstream bug is
+resolved. Track via a DevPod upstream issue.
+
+The `postStartCommand` currently contains only the
+OpenCode server start:
 ```sh
-printf 'protocol=https\nhost=github.com\n\n' \
-  | git credential fill 2>/dev/null \
-  | grep '^password=' | cut -d= -f2 \
-  | gh auth login --with-token 2>/dev/null || true
+nohup opencode serve --port 4096 \
+  > /tmp/opencode-server.log 2>&1 &
 ```
 
+### D10: UID mapping via devcontainer runArgs
+
+The devcontainer template MUST include `runArgs` with
+`--userns=keep-id:uid=1000,gid=1000` to map the host
+user's UID to UID 1000 (`dev`) inside the container.
+This is the same flag proven in the Podman backend
+(`opsx/sandbox-uid-mapping`) and eliminates the
+`root:nobody` ownership problem at the source.
+
+```json
+"runArgs": ["--userns=keep-id:uid=1000,gid=1000"]
+```
+
+Without this flag, DevPod's Docker provider (aliased
+to Podman via `DOCKER_COMMAND=podman`) calls
+`podman run` without UID mapping, causing all workspace
+files to appear as `root:nobody` inside the container.
+The `dev` user (UID 1000) cannot write to these files,
+blocking editing, git operations, and builds.
+
 Design choices:
-- **`postStartCommand` over `postCreateCommand`**: runs
-  on every container start (not just first creation),
-  so rotated or refreshed tokens are picked up
-  automatically.
-- **`|| true` for graceful degradation**: if git
-  credentials are not available (e.g., running outside
-  DevPod, or `gh` is not installed), the command fails
-  silently and the container starts normally.
-- **JSON escaping**: `\\n` in JSON becomes `\n` in
-  shell. The command is not directly paste-able from
-  the JSON source file.
-- **Injection safety**: the pipeline uses only hardcoded
-  literals and stdin piping. No user-controlled input is
-  interpolated into shell commands. The token flows
-  through pipes (stdin), never as a command-line
-  argument, preventing `/proc/cmdline` exposure.
-- **Token persistence**: `gh auth login --with-token`
-  overwrites any existing token in
-  `~/.config/gh/hosts.yml` (0600 permissions). The
-  relayed token inherits whatever scope DevPod's
-  credential helper provides (typically a GitHub PAT
-  with repo scope). Running on every start ensures
-  rotated tokens take effect.
-- **Log isolation**: `/tmp/opencode-server.log` captures
-  only the backgrounded `opencode serve` process. The
-  credential pipeline runs in the foreground with its
-  own `2>/dev/null` redirections. Tokens cannot leak
-  into the log file.
+- **`runArgs` over custom provider**: the devcontainer
+  spec's `runArgs` field passes extra arguments to the
+  underlying `docker run` / `podman run` command. This
+  avoids creating a custom DevPod provider while giving
+  us the same UID mapping capability.
+- **`--userns=keep-id:uid=1000,gid=1000` over
+  `chown`**: namespace mapping is instant (no
+  performance penalty on large repos), works at the
+  kernel level, and requires no `sudo` in the container
+  image. The `chown -R` alternative scales with repo
+  size and requires either `sudo` or `containerUser:
+  root`.
+- **macOS virtiofs caveat**: on macOS, the Podman
+  machine's virtiofs must support `--userns=keep-id`.
+  Most modern Podman machine configurations support
+  this. If a user's Podman machine does not, they can
+  remove the `runArgs` line and add a
+  `postStartCommand` with `sudo chown -R dev:dev
+  /workspaces/<name>` as a fallback. This mirrors the
+  `--uidmap` escape hatch from the Podman backend.
+- **Requires Podman >= 4.3**: the extended
+  `:uid=N,gid=N` syntax was added in Podman 4.3. This
+  is already enforced by `uf doctor` and
+  `parseDevPodVersion()` / `parsePodmanVersion()`.
 
 ## Risks / Trade-offs
 

--- a/openspec/changes/cde-sandbox-enhancement/specs/sandbox-cde.md
+++ b/openspec/changes/cde-sandbox-enhancement/specs/sandbox-cde.md
@@ -203,8 +203,8 @@ ensures the file is skipped if it already exists.
 - **GIVEN** no `.devcontainer/devcontainer.json` exists
 - **WHEN** `uf init` runs
 - **THEN** `.devcontainer/devcontainer.json` MUST be
-  created with image, ports, gateway env vars,
-  postStartCommand, and remoteUser
+  created with image, runArgs (UID mapping), ports,
+  gateway env vars, postStartCommand, and remoteUser
 
 #### Scenario: uf init skips existing devcontainer
 
@@ -223,17 +223,22 @@ slice), and `--force` (overwrite) flags.
 
 The generated devcontainer MUST include:
 - `image` set to the container image
+- `runArgs` with `--userns=keep-id:uid=1000,gid=1000`
+  to map the host user to UID 1000 (`dev`) inside the
+  container, ensuring workspace files are owned by
+  `dev:dev` (D10)
 - `forwardPorts` with port 4096 plus demo ports
 - `containerEnv` with `ANTHROPIC_BASE_URL` and
   `ANTHROPIC_API_KEY=gateway`
 - `remoteUser` set to `dev`
 
 The generated devcontainer MUST also include a
-`postStartCommand` that relays DevPod git credentials
-to `gh auth login --with-token`. This enables `gh` CLI
-commands (PR reviews, issue management) inside DevPod
-sessions. The relay MUST degrade gracefully when git
-credentials are not available or `gh` is not installed.
+`postStartCommand` that starts the OpenCode server
+via `opencode serve --port 4096`.
+
+Note: gh CLI auth relay via `git credential fill` is
+deferred due to a DevPod v0.6.x crash in
+`tunnelserver.GitCredentials` (D9 — DEFERRED).
 
 Idempotent: skip if `.devcontainer/devcontainer.json`
 exists unless `--force` is set.
@@ -257,29 +262,39 @@ exists unless `--force` is set.
 - **WHEN** `uf sandbox init --force` is called
 - **THEN** the existing file MUST be overwritten
 
-#### Scenario: gh CLI authenticated on container start
+#### Scenario: gh CLI authenticated on container start — DEFERRED
 
-- **GIVEN** a DevPod workspace is running with git
-  credential proxying active
-- **WHEN** the container starts (postStartCommand runs)
-- **THEN** `gh auth status` shows authenticated to
-  github.com
+Deferred due to DevPod v0.6.x crash in
+`tunnelserver.GitCredentials` (see D9). Re-enable
+when DevPod fixes the credential tunnel panic.
 
-#### Scenario: gh auth relay degrades gracefully
+#### Scenario: gh auth relay degrades gracefully — DEFERRED
 
-- **GIVEN** no git credentials are available (e.g.,
-  running outside DevPod or `gh` is not installed)
-- **WHEN** the container starts (postStartCommand runs)
-- **THEN** the container starts normally without error
-- **AND** `gh auth status` shows not authenticated
+Deferred (same blocker as above).
 
-#### Scenario: git credentials without password field
+#### Scenario: git credentials without password field — DEFERRED
 
-- **GIVEN** `git credential fill` returns a response
-  without a `password=` line
-- **WHEN** the container starts (postStartCommand runs)
-- **THEN** the container starts normally without error
-- **AND** `gh auth status` shows not authenticated
+Deferred (same blocker as above).
+
+#### Scenario: Workspace files owned by dev user
+
+- **GIVEN** a DevPod workspace is created with the
+  devcontainer template containing `runArgs` with
+  `--userns=keep-id:uid=1000,gid=1000`
+- **WHEN** the `dev` user lists workspace files
+- **THEN** files are owned by `dev:dev` (UID 1000)
+- **AND** the `dev` user can read and write all
+  workspace files
+
+#### Scenario: UID mapping fallback on macOS
+
+- **GIVEN** the Podman machine's virtiofs does not
+  support `--userns=keep-id`
+- **WHEN** `devpod up` fails due to the `runArgs`
+- **THEN** the user can remove the `runArgs` line from
+  `.devcontainer/devcontainer.json` and add a
+  `postStartCommand` with `sudo chown -R dev:dev
+  /workspaces/<name>` as a workaround
 
 ### Requirement: Extract behavior for persistent workspaces
 

--- a/openspec/changes/cde-sandbox-enhancement/specs/sandbox-cde.md
+++ b/openspec/changes/cde-sandbox-enhancement/specs/sandbox-cde.md
@@ -191,13 +191,35 @@ Previously: `buildPersistentRunArgs()` called
   `-e ANTHROPIC_BASE_URL=http://host.containers.internal:53147`
   and MUST NOT include provider-specific keys
 
+### Requirement: Devcontainer deployed by uf init
+
+`uf init` MUST deploy `.devcontainer/devcontainer.json`
+as part of the standard scaffold, alongside agents,
+commands, and packs. The scaffold engine's idempotency
+ensures the file is skipped if it already exists.
+
+#### Scenario: uf init deploys devcontainer
+
+- **GIVEN** no `.devcontainer/devcontainer.json` exists
+- **WHEN** `uf init` runs
+- **THEN** `.devcontainer/devcontainer.json` MUST be
+  created with image, ports, gateway env vars,
+  postStartCommand, and remoteUser
+
+#### Scenario: uf init skips existing devcontainer
+
+- **GIVEN** `.devcontainer/devcontainer.json` exists
+- **WHEN** `uf init` runs
+- **THEN** the existing file MUST be preserved (skipped)
+
 ### Requirement: Devcontainer scaffolding command
 
-`uf sandbox init` MUST generate
-`.devcontainer/devcontainer.json` in the project root.
-The command MUST accept `--image` (default from config),
-`--demo-ports` (int slice), and `--force` (overwrite)
-flags.
+`uf sandbox init` MUST also generate
+`.devcontainer/devcontainer.json` as a standalone
+command for users who want to regenerate or customize
+the devcontainer independently. The command MUST accept
+`--image` (default from config), `--demo-ports` (int
+slice), and `--force` (overwrite) flags.
 
 The generated devcontainer MUST include:
 - `image` set to the container image
@@ -205,6 +227,13 @@ The generated devcontainer MUST include:
 - `containerEnv` with `ANTHROPIC_BASE_URL` and
   `ANTHROPIC_API_KEY=gateway`
 - `remoteUser` set to `dev`
+
+The generated devcontainer MUST also include a
+`postStartCommand` that relays DevPod git credentials
+to `gh auth login --with-token`. This enables `gh` CLI
+commands (PR reviews, issue management) inside DevPod
+sessions. The relay MUST degrade gracefully when git
+credentials are not available or `gh` is not installed.
 
 Idempotent: skip if `.devcontainer/devcontainer.json`
 exists unless `--force` is set.
@@ -227,6 +256,30 @@ exists unless `--force` is set.
 - **GIVEN** `.devcontainer/devcontainer.json` exists
 - **WHEN** `uf sandbox init --force` is called
 - **THEN** the existing file MUST be overwritten
+
+#### Scenario: gh CLI authenticated on container start
+
+- **GIVEN** a DevPod workspace is running with git
+  credential proxying active
+- **WHEN** the container starts (postStartCommand runs)
+- **THEN** `gh auth status` shows authenticated to
+  github.com
+
+#### Scenario: gh auth relay degrades gracefully
+
+- **GIVEN** no git credentials are available (e.g.,
+  running outside DevPod or `gh` is not installed)
+- **WHEN** the container starts (postStartCommand runs)
+- **THEN** the container starts normally without error
+- **AND** `gh auth status` shows not authenticated
+
+#### Scenario: git credentials without password field
+
+- **GIVEN** `git credential fill` returns a response
+  without a `password=` line
+- **WHEN** the container starts (postStartCommand runs)
+- **THEN** the container starts normally without error
+- **AND** `gh auth status` shows not authenticated
 
 ### Requirement: Extract behavior for persistent workspaces
 

--- a/openspec/changes/cde-sandbox-enhancement/tasks.md
+++ b/openspec/changes/cde-sandbox-enhancement/tasks.md
@@ -194,11 +194,9 @@
 - [x] 5.9 Add test: `TestRunSandboxInit_CustomDemoPorts`
   — verify extra ports in forwardPorts array
 - [x] 5.10 Add `postStartCommand` to devcontainer
-  template that relays DevPod git credentials to
-  `gh auth` via `printf` + `git credential fill` +
-  `gh auth login --with-token`, with `|| true` for
-  graceful degradation (D9). Also starts OpenCode
-  server via `opencode serve --port 4096`.
+  template that starts OpenCode server via
+  `opencode serve --port 4096`. gh auth relay (D9)
+  deferred due to DevPod v0.6.x tunnel crash.
 - [x] 5.12 Move `devcontainer/devcontainer.json` from
   `knownNonEmbeddedFiles` to `expectedAssetPaths` in
   `internal/scaffold/scaffold_test.go` so `uf init`
@@ -210,6 +208,18 @@
   `TestRunSandboxInit_Creates` does exact content
   matching on devcontainer.json — verify
   `postStartCommand` field is present in output
+- [x] 5.14 Add `"runArgs":
+  ["--userns=keep-id:uid=1000,gid=1000"]` to the
+  devcontainer template at
+  `internal/scaffold/assets/devcontainer/devcontainer.json`
+  to fix workspace file ownership (D10).
+- [x] 5.15 Update `.devcontainer/devcontainer.json` on
+  disk to match the embedded template (drift detection).
+- [x] 5.16 Update `testDevcontainerTemplate()` fixture
+  in `internal/sandbox/sandbox_test.go` to include
+  `runArgs`. Add assertion to
+  `TestRunSandboxInit_Creates` verifying `runArgs`
+  contains `--userns=keep-id:uid=1000,gid=1000`.
 
 ## 6. DevPod Doctor Checks
 

--- a/openspec/changes/cde-sandbox-enhancement/tasks.md
+++ b/openspec/changes/cde-sandbox-enhancement/tasks.md
@@ -185,15 +185,31 @@
   `.devcontainer/devcontainer.json` exists unless
   `--force`
 - [x] 5.5 Add `devcontainer/devcontainer.json` to
-  `knownNonEmbeddedFiles` in `scaffold_test.go`
-  (not deployed by `uf init`, only by
-  `uf sandbox init`)
+  `expectedAssetPaths` in `scaffold_test.go`
+  (deployed by `uf init` alongside agents/commands)
 - [x] 5.6 Add test: `TestRunSandboxInit_Creates` —
   verify devcontainer.json created with correct content
 - [x] 5.7 Add test: `TestRunSandboxInit_ExistingSkips`
 - [x] 5.8 Add test: `TestRunSandboxInit_ForceOverwrites`
 - [x] 5.9 Add test: `TestRunSandboxInit_CustomDemoPorts`
   — verify extra ports in forwardPorts array
+- [x] 5.10 Add `postStartCommand` to devcontainer
+  template that relays DevPod git credentials to
+  `gh auth` via `printf` + `git credential fill` +
+  `gh auth login --with-token`, with `|| true` for
+  graceful degradation (D9). Also starts OpenCode
+  server via `opencode serve --port 4096`.
+- [x] 5.12 Move `devcontainer/devcontainer.json` from
+  `knownNonEmbeddedFiles` to `expectedAssetPaths` in
+  `internal/scaffold/scaffold_test.go` so `uf init`
+  deploys it as part of the standard scaffold.
+- [x] 5.13 Update file count assertions in
+  `scaffold_test.go` and `cmd/unbound-force/main_test.go`
+  to reflect the new asset.
+- [x] 5.11 Update scaffold tests if
+  `TestRunSandboxInit_Creates` does exact content
+  matching on devcontainer.json — verify
+  `postStartCommand` field is present in output
 
 ## 6. DevPod Doctor Checks
 

--- a/openspec/changes/setup-sandbox-tools/.openspec.yaml
+++ b/openspec/changes/setup-sandbox-tools/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: unbound-force
+created: 2026-05-08

--- a/openspec/changes/setup-sandbox-tools/design.md
+++ b/openspec/changes/setup-sandbox-tools/design.md
@@ -1,0 +1,264 @@
+## Context
+
+`uf setup` installs 13 tools (OpenCode, Gaze, gh, Node,
+OpenSpec, uv, Specify, Replicator, replicator setup,
+Ollama, Dewey, golangci-lint, govulncheck). `uf doctor`
+validates 10 check groups plus a conditional DevPod group.
+
+Neither command handles Podman or DevPod installation.
+The existing DevPod doctor group only checks binary
+presence and devcontainer.json existence -- it does not
+verify version or provider configuration.
+
+The DevPod ecosystem changed: the standalone `podman`
+provider was removed. Users must alias the Docker
+provider: `devpod provider add docker --name podman -o DOCKER_COMMAND=podman`.
+
+## Goals / Non-Goals
+
+### Goals
+
+- Install Podman via `uf setup` with platform awareness
+  (macOS Podman machine init, Linux direct install)
+- Install DevPod via `uf setup` with Homebrew
+- Automatically configure DevPod's Podman provider alias
+- Add Podman as a required tool in `uf doctor` with
+  version check (>= 4.3) and runtime health validation
+- Validate Podman machine state on macOS (exists and
+  running) and Podman daemon responsiveness on Linux
+- Enhance DevPod doctor checks with version (>= 0.5.0)
+  and provider registration validation
+- Add install hints and URLs for both tools
+- Smoke-test Podman after setup installation
+
+### Non-Goals
+
+- Podman machine lifecycle management beyond initial
+  `machine init && machine start` during setup
+- Docker backend support for DevPod (only Podman alias)
+- Modifying the sandbox package itself (the
+  `autoDetectBackend` routing bug is a separate change)
+- Adding Podman Desktop GUI installation
+
+## Decisions
+
+### D1: Podman as required in doctor
+
+Podman is classified as `required: true` in
+`coreToolSpecs` because the sandbox is becoming
+non-optional. Doctor will report Fail severity when
+Podman is missing.
+
+### D2: DevPod as recommended in doctor
+
+DevPod is classified as `recommended: true` (Warn if
+missing) in the conditional DevPod check group. DevPod
+adds persistent workspace management on top of Podman
+but the ephemeral sandbox path works without it.
+
+### D3: DOCKER_COMMAND over DOCKER_HOST
+
+The provider alias uses `-o DOCKER_COMMAND=podman`
+rather than `-o DOCKER_HOST=unix:///run/user/$UID/podman/podman.sock`.
+DOCKER_COMMAND is simpler, portable across platforms,
+and avoids UID-dependent socket paths that vary between
+Linux and macOS Podman machine configurations.
+
+### D4: Setup step positioning
+
+New steps are inserted after Ollama (current step 10)
+and before Dewey (current step 11), grouping container
+infrastructure tools together. New ordering:
+
+| Step | Tool |
+|------|------|
+| 1-10 | Unchanged (OpenCode through Ollama) |
+| 11 | Podman |
+| 12 | DevPod |
+| 13 | DevPod provider configuration |
+| 14 | Dewey (was 11) |
+| 15 | golangci-lint (was 12) |
+| 16 | govulncheck (was 13) |
+
+Step count label updates from `[N/13]` to `[N/16]`.
+
+### D5: Provider detection via ExecCmd
+
+The provider check parses `devpod provider list` output
+using exact name matching on the first column. The
+output is split by lines, then each line is split by
+whitespace, and the first field is compared exactly to
+"podman". This avoids false positives from providers
+with "podman" as a substring (e.g., "podman-custom").
+DevPod's JSON output format is not stable for
+`provider list`, so table parsing is used.
+
+### D6: macOS Podman machine guard
+
+On macOS, Podman requires a VM (Podman machine). After
+installing Podman, setup checks if a machine exists
+(`podman machine list --format '{{.Name}}'`). If no
+machine exists, it runs `podman machine init` (with a
+180-second timeout to prevent indefinite hangs on slow
+networks) and `podman machine start`. This is a
+best-effort step -- failures are reported but do not
+block subsequent steps.
+
+### D7: Podman version parsing
+
+Podman version output is `podman version X.Y.Z`. The
+parser follows the same pattern as `parseGoVersion` and
+`parseNodeVersion` in the existing doctor code: extract
+the version string, split on dots, compare major.minor
+against the minimum (4.3).
+
+### D7a: DevPod version parsing
+
+DevPod version output is a single line: `v0.X.Y` (e.g.,
+`v0.6.15`). The parser strips the leading `v`, splits
+on dots, and compares major.minor against the minimum
+(0.5). Pre-release suffixes (e.g., `0.6.15-beta`) are
+handled by truncating at the first hyphen, matching the
+existing sandbox parser pattern in `devpod.go:252`.
+
+### D7b: GOOS injection for doctor Options
+
+The doctor `Options` struct gains a `GOOS string` field
+that overrides `runtime.GOOS` when non-empty. This
+matches the existing pattern in the setup `Options`
+struct (line 63 of `setup.go`) and keeps the two sibling
+packages consistent. The sandbox package uses a richer
+`Platform *PlatformConfig` struct, but doctor's needs
+are simpler (only OS string needed for branching) and
+the lightweight `GOOS string` approach avoids
+over-engineering.
+
+### D8: Podman runtime health check in doctor
+
+After Podman passes the version check in `coreToolSpecs`,
+a post-check validates that Podman is actually functional
+by running `podman info`. This follows the Ollama
+post-check pattern (where after presence/version, the
+embedding model is verified).
+
+The post-check is platform-aware:
+
+**macOS**: Before `podman info`, check
+`podman machine list --format '{{.Name}}'` to verify a
+machine exists. If no machine exists, report Fail with
+hint: "No Podman machine found. Run: podman machine init && podman machine start".
+If a machine exists but `podman info` fails, report Fail
+with hint: "Podman machine may not be running. Run: podman machine start".
+
+**Linux**: Run `podman info` directly. If it fails,
+report Fail with hint:
+"Podman not responding. Check: systemctl --user status podman.socket".
+
+The post-check uses `ExecCmd` injection, so tests can
+simulate all failure modes without real Podman.
+
+### D8a: Docker-to-Podman shim detection
+
+After the Podman runtime health check, doctor checks
+whether `docker` is in PATH. If found, it resolves the
+binary path via `opts.EvalSymlinks` (already injected
+on Options) and checks if the resolved path contains
+"podman". This detects the common pattern where
+`/usr/local/bin/docker -> /opt/podman/bin/podman`.
+
+The check is informational only (Pass severity in both
+cases). When docker is a Podman shim, the user gets
+confirmation that docker commands will route to Podman.
+When docker is real Docker, the user is informed that
+the sandbox uses Podman, not Docker — avoiding
+confusion about which container runtime is active.
+
+If `docker` is not in PATH, the check is silently
+skipped (no result emitted) to keep output clean.
+
+Uses `opts.LookPath` for presence detection and
+`opts.EvalSymlinks` for symlink resolution — both
+already injectable on Options.
+
+### D9: Setup smoke test after Podman install
+
+After Podman installation (and machine init on macOS),
+setup runs `podman info` as a smoke test to verify the
+installation is functional. This is a best-effort
+check: failures are reported as warnings but do not
+block subsequent steps. Users who see the warning may
+need to restart their terminal or manually start the
+Podman machine.
+
+### D10: Testability (Constitution IV)
+
+All new functions accept `*Options` with injected
+`LookPath`, `ExecCmd`, and `ReadFile`. No real binaries
+or network calls in tests. Provider detection is tested
+by injecting canned `devpod provider list` output into
+`ExecCmd`. Podman runtime checks are tested by injecting
+canned `podman info` and `podman machine list` output.
+
+## Risks / Trade-offs
+
+### R1: DevPod provider list output format
+
+The provider check parses human-readable table output
+from `devpod provider list`. If DevPod changes its
+output format, the check may produce false negatives.
+Mitigation: the check uses exact first-column matching
+which is resilient to column width and ordering changes.
+If `devpod provider list` itself fails, the check
+degrades to a skip with warning rather than a false
+negative.
+
+### R2: macOS Podman machine init is slow
+
+`podman machine init` downloads a VM image (~300MB) and
+can take 30-60 seconds. This may surprise users during
+setup. Mitigation: setup prints progress messages and
+the step is skipped if a machine already exists.
+
+### R3: Homebrew-only install path
+
+Both Podman and DevPod use Homebrew as the primary
+install method. Users without Homebrew get a skip with
+download URL. This matches the existing pattern for
+Ollama, Replicator, and other tools.
+
+### R4: podman info may fail after fresh install
+
+On macOS, `podman info` may fail immediately after
+`brew install podman` if the Podman machine hasn't
+fully started. The setup smoke test reports this as a
+warning rather than a failure. Doctor will catch the
+issue on subsequent runs.
+
+### R5: Version parser duplication (accepted)
+
+The doctor package needs `parsePodmanVersion` and
+`parseDevPodVersion` functions that duplicate logic
+from `internal/sandbox/detect.go` and `devpod.go`.
+This duplication is intentional and accepted: the
+parsers are ~10 lines each, and coupling doctor to
+sandbox would violate package independence. The doctor
+parsers follow the doctor package's existing pattern
+(`versionParse func(output string) (string, error)` +
+`versionCheck func(version string, min string) bool`)
+rather than the sandbox package's `(int, int, error)`
+pattern. Both parsers MUST handle the same edge cases
+as their sandbox counterparts (leading `v` prefix for
+DevPod, pre-release suffixes). If a third consumer
+appears, extraction to `internal/toolversion/` should
+be considered.
+
+## Coverage Strategy
+
+All new code is tested at the unit level via dependency
+injection (Constitution IV). No integration or e2e tests
+are required -- all external tool interactions are
+injected via `Options` struct fields. The existing
+`Run()` integration test pattern covers step ordering.
+Coverage target: maintain existing CI ratchet (no
+regression). New functions must have test coverage for
+happy path, error path, and platform branching.

--- a/openspec/changes/setup-sandbox-tools/proposal.md
+++ b/openspec/changes/setup-sandbox-tools/proposal.md
@@ -1,0 +1,123 @@
+## Why
+
+The sandbox is becoming a non-optional part of the Unbound
+Force workflow, yet its two infrastructure dependencies --
+Podman (container runtime) and DevPod (workspace manager) --
+are not covered by `uf setup` or `uf doctor`. Users must
+manually install Podman, install DevPod, and configure the
+DevPod Podman provider. The provider configuration changed:
+the old standalone `podman` provider no longer exists in
+DevPod; users must alias the Docker provider via
+`devpod provider add docker --name podman -o DOCKER_COMMAND=podman`.
+
+This manual process is error-prone and undiscoverable.
+There is no diagnostic feedback when the provider is
+misconfigured, leading to confusing runtime errors like
+"couldn't find default provider podman".
+
+## What Changes
+
+Add Podman and DevPod to the `uf setup` installation
+pipeline and enhance `uf doctor` diagnostics for both tools.
+
+## Capabilities
+
+### New Capabilities
+
+- `setup: podman install`: Install Podman via Homebrew with
+  platform-aware machine initialization on macOS.
+- `setup: devpod install`: Install DevPod via Homebrew with
+  fallback to download link.
+- `setup: devpod provider config`: Automatically configure
+  the DevPod Podman provider using the Docker provider alias
+  (`devpod provider add docker --name podman -o DOCKER_COMMAND=podman`).
+- `setup: podman smoke test`: After install and machine
+  init (macOS), run `podman info` to verify Podman is
+  functional. Report result but do not block subsequent
+  steps on failure.
+- `doctor: podman check`: Validate Podman presence and
+  version (>= 4.3) as a required tool in `coreToolSpecs`.
+- `doctor: podman runtime health`: Post-check after
+  version passes -- runs `podman info` to verify Podman
+  is functional. On macOS, also checks that a Podman
+  machine exists and is running. Platform-aware hints
+  on failure (macOS: `podman machine start`, Linux:
+  `systemctl --user start podman.socket`).
+- `doctor: devpod provider check`: Validate DevPod has a
+  `podman` provider registered with actionable fix hint.
+- `doctor: devpod version check`: Validate DevPod >= 0.5.0.
+
+### Modified Capabilities
+
+- `doctor: DevPod check group`: Enhanced with version check
+  and provider registration check. Existing binary and
+  devcontainer checks preserved.
+- `setup: step count`: Increases from 13 to 16 steps.
+- `doctor: coreToolSpecs`: Podman added as required tool
+  with version parsing and minimum version enforcement.
+- `doctor: install hints`: `homebrewInstallCmd`,
+  `genericInstallCmd`, and `installURL` updated with
+  entries for podman and devpod.
+
+### Removed Capabilities
+
+- None.
+
+## Impact
+
+- **`internal/setup/setup.go`**: Three new install/config
+  functions, `Run()` step counter update (13 -> 16).
+- **`internal/setup/setup_test.go`**: Tests for new install
+  functions following existing injection patterns.
+- **`internal/doctor/checks.go`**: Podman added to
+  `coreToolSpecs` as required; `checkDevPod()` enhanced
+  with version and provider checks.
+- **`internal/doctor/environ.go`**: Install hints and URLs
+  for podman and devpod.
+- **`internal/doctor/doctor_test.go`**: Tests for podman
+  core tool check and enhanced DevPod checks.
+
+## Constitution Alignment
+
+Assessed against the Unbound Force org constitution.
+
+### I. Autonomous Collaboration
+
+**Assessment**: N/A
+
+This change adds tool installation and diagnostics to the
+meta-repository CLI. It does not affect inter-hero artifact
+communication or coupling.
+
+### II. Composability First
+
+**Assessment**: PASS
+
+Podman and DevPod remain independently useful. Setup
+installs each tool separately with independent skip
+configuration (`shouldSkipTool("podman")`,
+`shouldSkipTool("devpod")`). The DevPod provider
+configuration step is gated on both tools being
+available and degrades gracefully when either is absent.
+Doctor checks use the existing conditional group pattern
+(DevPod group hidden when not detected).
+
+### III. Observable Quality
+
+**Assessment**: PASS
+
+Doctor produces machine-parseable output (JSON mode) for
+all new checks with Pass/Warn/Fail severity, install
+hints, and URLs. Setup reports step results with the
+existing `stepResult` struct. All output follows
+established formatting conventions.
+
+### IV. Testability
+
+**Assessment**: PASS
+
+All new functions use the existing `Options` struct
+dependency injection pattern. `LookPath`, `ExecCmd`,
+and `ReadFile` are injected function fields, allowing
+tests to verify behavior without real Podman or DevPod
+binaries. No external service calls required.

--- a/openspec/changes/setup-sandbox-tools/specs/setup-sandbox-tools.md
+++ b/openspec/changes/setup-sandbox-tools/specs/setup-sandbox-tools.md
@@ -1,0 +1,469 @@
+## ADDED Requirements
+
+### Requirement: Setup installs Podman
+
+`uf setup` MUST install Podman when it is not present.
+On macOS, setup MUST use `brew install podman`. On Linux,
+setup MUST use `brew install podman` when Homebrew is
+available. When Homebrew is not available, setup MUST
+skip installation and report a download URL.
+
+#### Scenario: Podman not installed, Homebrew available
+
+- **GIVEN** Podman is not in PATH
+- **AND** Homebrew is available
+- **WHEN** `uf setup` runs
+- **THEN** Podman is installed via `brew install podman`
+- **AND** the step result reports "installed" with
+  detail "via Homebrew"
+
+#### Scenario: Podman already installed
+
+- **GIVEN** Podman is in PATH
+- **WHEN** `uf setup` runs
+- **THEN** the step result reports "already installed"
+- **AND** no install command is executed
+
+#### Scenario: No Homebrew available
+
+- **GIVEN** Podman is not in PATH
+- **AND** Homebrew is not available
+- **WHEN** `uf setup` runs
+- **THEN** the step result reports "skipped"
+- **AND** detail includes a download URL
+
+### Requirement: Setup initializes Podman machine on macOS
+
+On macOS, after Podman installation, `uf setup` MUST
+check for an existing Podman machine. If no machine
+exists, setup MUST run `podman machine init` and
+`podman machine start`. The `podman machine init`
+command MUST have a timeout of 180 seconds to prevent
+indefinite hangs on slow networks. Machine init or
+start failures MUST NOT block subsequent setup steps.
+
+#### Scenario: macOS, no Podman machine exists
+
+- **GIVEN** the platform is macOS
+- **AND** Podman is installed
+- **AND** no Podman machine exists
+- **WHEN** `uf setup` runs the Podman step
+- **THEN** `podman machine init` is executed
+- **AND** `podman machine start` is executed
+
+#### Scenario: macOS, Podman machine already exists
+
+- **GIVEN** the platform is macOS
+- **AND** Podman is installed
+- **AND** a Podman machine already exists
+- **WHEN** `uf setup` runs the Podman step
+- **THEN** machine init is skipped
+
+#### Scenario: Linux, no machine needed
+
+- **GIVEN** the platform is Linux
+- **AND** Podman is installed
+- **WHEN** `uf setup` runs the Podman step
+- **THEN** no machine init is attempted
+
+#### Scenario: macOS, machine init fails
+
+- **GIVEN** the platform is macOS
+- **AND** Podman is installed
+- **AND** no Podman machine exists
+- **AND** `podman machine init` fails
+- **WHEN** `uf setup` runs the Podman step
+- **THEN** the step result reports "installed"
+- **AND** detail includes "machine init failed"
+- **AND** subsequent setup steps continue
+
+#### Scenario: macOS, machine start fails
+
+- **GIVEN** the platform is macOS
+- **AND** Podman is installed
+- **AND** `podman machine init` succeeds
+- **AND** `podman machine start` fails
+- **WHEN** `uf setup` runs the Podman step
+- **THEN** the step result reports "installed"
+- **AND** detail includes "machine start failed"
+- **AND** subsequent setup steps continue
+
+### Requirement: Setup installs DevPod
+
+`uf setup` MUST install DevPod when it is not present.
+Setup MUST use `brew install devpod` when Homebrew is
+available. When Homebrew is not available, setup MUST
+skip installation and report the DevPod download URL.
+
+#### Scenario: DevPod not installed, Homebrew available
+
+- **GIVEN** DevPod is not in PATH
+- **AND** Homebrew is available
+- **WHEN** `uf setup` runs
+- **THEN** DevPod is installed via `brew install devpod`
+- **AND** the step result reports "installed"
+
+#### Scenario: DevPod already installed
+
+- **GIVEN** DevPod is in PATH
+- **WHEN** `uf setup` runs
+- **THEN** the step result reports "already installed"
+
+#### Scenario: No Homebrew available for DevPod
+
+- **GIVEN** DevPod is not in PATH
+- **AND** Homebrew is not available
+- **WHEN** `uf setup` runs
+- **THEN** the step result reports "skipped"
+- **AND** detail includes
+  "https://devpod.sh/docs/getting-started/install"
+
+### Requirement: Setup configures DevPod Podman provider
+
+`uf setup` MUST configure a DevPod provider named
+"podman" when both DevPod and Podman are installed and
+no provider named "podman" is registered. Provider
+detection MUST use exact name matching on the first
+column of `devpod provider list` output (not substring
+matching). Setup MUST use
+`devpod provider add docker --name podman -o DOCKER_COMMAND=podman`.
+
+#### Scenario: Both tools installed, no podman provider
+
+- **GIVEN** DevPod is in PATH
+- **AND** Podman is in PATH
+- **AND** `devpod provider list` output does not contain
+  a provider named "podman"
+- **WHEN** `uf setup` runs the provider config step
+- **THEN** `devpod provider add docker --name podman -o DOCKER_COMMAND=podman` is executed
+- **AND** the step result reports "installed"
+
+#### Scenario: Provider already registered
+
+- **GIVEN** DevPod is in PATH
+- **AND** `devpod provider list` output contains a
+  provider named "podman"
+- **WHEN** `uf setup` runs the provider config step
+- **THEN** no provider add command is executed
+- **AND** the step result reports "already installed"
+
+#### Scenario: DevPod not available
+
+- **GIVEN** DevPod is not in PATH
+- **WHEN** `uf setup` runs the provider config step
+- **THEN** the step is skipped with detail "no devpod"
+
+#### Scenario: Podman not available
+
+- **GIVEN** Podman is not in PATH
+- **WHEN** `uf setup` runs the provider config step
+- **THEN** the step is skipped with detail "no podman"
+
+#### Scenario: Provider add fails
+
+- **GIVEN** DevPod and Podman are in PATH
+- **AND** no podman provider is registered
+- **AND** `devpod provider add` fails
+- **WHEN** `uf setup` runs the provider config step
+- **THEN** the step result reports "failed"
+- **AND** detail includes
+  "devpod provider add docker --name podman -o DOCKER_COMMAND=podman"
+- **AND** subsequent setup steps continue
+
+#### Scenario: Provider list command fails
+
+- **GIVEN** DevPod is in PATH
+- **AND** `devpod provider list` fails (exit code != 0)
+- **WHEN** `uf setup` runs the provider config step
+- **THEN** the step result reports "skipped"
+- **AND** detail includes a warning about provider
+  list failure
+
+### Requirement: Doctor checks Podman as required tool
+
+`uf doctor` MUST check Podman as a required tool in
+the Core Tools group. The check MUST validate presence
+via `LookPath` and version via `podman --version` with
+minimum version 4.3. Missing Podman MUST report Fail
+severity.
+
+#### Scenario: Podman installed, version sufficient
+
+- **GIVEN** Podman is in PATH
+- **AND** Podman version is >= 4.3
+- **WHEN** `uf doctor` runs
+- **THEN** the Podman check reports Pass
+- **AND** the message includes the version number
+
+#### Scenario: Podman installed, version too old
+
+- **GIVEN** Podman is in PATH
+- **AND** Podman version is < 4.3
+- **WHEN** `uf doctor` runs
+- **THEN** the Podman check reports Fail
+- **AND** the install hint is "brew install podman"
+  or "brew upgrade podman"
+
+#### Scenario: Podman not installed
+
+- **GIVEN** Podman is not in PATH
+- **WHEN** `uf doctor` runs
+- **THEN** the Podman check reports Fail
+- **AND** the install hint is "brew install podman"
+
+### Requirement: Doctor validates Podman runtime health
+
+When Podman passes the presence and version checks,
+`uf doctor` MUST perform a runtime health post-check
+by running `podman info`. The post-check MUST be
+platform-aware.
+
+On macOS, doctor MUST first check for a Podman machine
+via `podman machine list`. If no machine exists, the
+check MUST report Fail with a hint to run
+`podman machine init && podman machine start`. If a
+machine exists but `podman info` fails, the check MUST
+report Fail with a hint to run `podman machine start`.
+
+On Linux, doctor MUST run `podman info` directly. If
+it fails, the check MUST report Fail with a hint to
+check `systemctl --user status podman.socket`.
+
+#### Scenario: macOS, Podman machine running
+
+- **GIVEN** the platform is macOS
+- **AND** Podman is installed with version >= 4.3
+- **AND** a Podman machine exists and is running
+- **AND** `podman info` succeeds
+- **WHEN** `uf doctor` runs
+- **THEN** the Podman runtime check reports Pass
+- **AND** the message indicates Podman is functional
+
+#### Scenario: macOS, no Podman machine
+
+- **GIVEN** the platform is macOS
+- **AND** Podman is installed with version >= 4.3
+- **AND** `podman machine list` returns no machines
+- **WHEN** `uf doctor` runs
+- **THEN** the Podman runtime check reports Fail
+- **AND** the install hint is
+  "podman machine init && podman machine start"
+
+#### Scenario: macOS, Podman machine stopped
+
+- **GIVEN** the platform is macOS
+- **AND** Podman is installed with version >= 4.3
+- **AND** a Podman machine exists
+- **AND** `podman info` fails
+- **WHEN** `uf doctor` runs
+- **THEN** the Podman runtime check reports Fail
+- **AND** the install hint is "podman machine start"
+
+#### Scenario: Linux, Podman responsive
+
+- **GIVEN** the platform is Linux
+- **AND** Podman is installed with version >= 4.3
+- **AND** `podman info` succeeds
+- **WHEN** `uf doctor` runs
+- **THEN** the Podman runtime check reports Pass
+
+#### Scenario: Linux, Podman not responding
+
+- **GIVEN** the platform is Linux
+- **AND** Podman is installed with version >= 4.3
+- **AND** `podman info` fails
+- **WHEN** `uf doctor` runs
+- **THEN** the Podman runtime check reports Fail
+- **AND** the install hint mentions
+  "systemctl --user status podman.socket"
+
+#### Scenario: Podman version too old, skip runtime check
+
+- **GIVEN** Podman is installed with version < 4.3
+- **WHEN** `uf doctor` runs
+- **THEN** the Podman version check reports Fail
+- **AND** the runtime health post-check is skipped
+
+### Requirement: Doctor detects docker-to-podman shim
+
+When Podman passes its core tool checks, `uf doctor`
+MUST check whether `docker` is in PATH and, if so,
+resolve the binary via `EvalSymlinks` to determine if
+it is a symlink or shim pointing to Podman. The check
+MUST report an informational result.
+
+If `docker` is not in PATH, the check SHOULD be
+skipped silently (no result emitted).
+
+#### Scenario: docker is a Podman symlink
+
+- **GIVEN** `docker` is in PATH
+- **AND** the resolved path of the `docker` binary
+  contains "podman"
+- **WHEN** `uf doctor` runs
+- **THEN** the docker shim check reports Pass
+- **AND** the message indicates "docker is a
+  Podman shim"
+
+#### Scenario: docker is real Docker
+
+- **GIVEN** `docker` is in PATH
+- **AND** the resolved path of the `docker` binary
+  does not contain "podman"
+- **WHEN** `uf doctor` runs
+- **THEN** the docker shim check reports Pass
+- **AND** the message indicates "Docker detected"
+- **AND** the detail notes that the sandbox uses
+  Podman, not Docker
+
+#### Scenario: docker not in PATH
+
+- **GIVEN** `docker` is not in PATH
+- **WHEN** `uf doctor` runs
+- **THEN** no docker shim check result is emitted
+
+### Requirement: Setup verifies Podman after install
+
+After Podman installation (and machine init on macOS),
+`uf setup` SHOULD run `podman info` as a smoke test.
+Smoke test failures MUST be reported as warnings and
+MUST NOT block subsequent setup steps.
+
+#### Scenario: Smoke test passes
+
+- **GIVEN** Podman was just installed
+- **AND** Podman machine was initialized (macOS)
+- **AND** `podman info` succeeds
+- **WHEN** `uf setup` runs the Podman step
+- **THEN** the step result reports "installed"
+- **AND** detail includes "verified"
+
+#### Scenario: Smoke test fails
+
+- **GIVEN** Podman was just installed
+- **AND** `podman info` fails
+- **WHEN** `uf setup` runs the Podman step
+- **THEN** the step result reports "installed"
+- **AND** detail includes "podman info failed"
+- **AND** subsequent setup steps continue
+
+### Requirement: Doctor checks DevPod version
+
+When the DevPod check group is active, `uf doctor`
+MUST validate DevPod version >= 0.5.0. Versions below
+0.5.0 MUST report Warn severity.
+
+#### Scenario: DevPod version sufficient
+
+- **GIVEN** DevPod is installed
+- **AND** DevPod version is >= 0.5.0
+- **WHEN** `uf doctor` runs
+- **THEN** the DevPod version check reports Pass
+
+#### Scenario: DevPod version too old
+
+- **GIVEN** DevPod is installed
+- **AND** DevPod version is < 0.5.0
+- **WHEN** `uf doctor` runs
+- **THEN** the DevPod version check reports Warn
+- **AND** an update hint is provided
+
+### Requirement: Doctor Options GOOS injection
+
+The doctor `Options` struct MUST include a `GOOS string`
+field that overrides `runtime.GOOS` when non-empty.
+When `GOOS` is empty, it MUST default to `runtime.GOOS`.
+All platform-aware checks (Podman runtime health, install
+hints) MUST use this field to enable cross-platform test
+isolation per Constitution Principle IV.
+
+#### Scenario: GOOS override in tests
+
+- **GIVEN** `opts.GOOS` is set to "darwin"
+- **AND** the test runs on Linux
+- **WHEN** the Podman runtime health check runs
+- **THEN** the check follows the macOS code path
+  (machine list check before podman info)
+
+#### Scenario: GOOS default
+
+- **GIVEN** `opts.GOOS` is empty
+- **WHEN** any platform-aware check runs
+- **THEN** it uses `runtime.GOOS` as the platform
+
+### Requirement: Doctor checks DevPod Podman provider
+
+When the DevPod check group is active, `uf doctor`
+MUST verify a provider named "podman" is registered.
+Provider detection MUST use exact name matching on the
+first column of `devpod provider list` output (not
+substring matching). Missing provider MUST report Warn
+severity with the fix command as install hint.
+
+#### Scenario: Podman provider registered
+
+- **GIVEN** DevPod is installed
+- **AND** `devpod provider list` shows a provider
+  named "podman"
+- **WHEN** `uf doctor` runs
+- **THEN** the provider check reports Pass
+
+#### Scenario: Podman provider missing
+
+- **GIVEN** DevPod is installed
+- **AND** `devpod provider list` does not show a
+  provider named "podman"
+- **WHEN** `uf doctor` runs
+- **THEN** the provider check reports Warn
+- **AND** the install hint is
+  `devpod provider add docker --name podman -o DOCKER_COMMAND=podman`
+
+### Requirement: Install hints for Podman and DevPod
+
+`homebrewInstallCmd`, `genericInstallCmd`, and
+`installURL` MUST return appropriate values for
+"podman" and "devpod" tool names.
+
+#### Scenario: Homebrew install hint for Podman
+
+- **GIVEN** the tool name is "podman"
+- **WHEN** `homebrewInstallCmd` is called
+- **THEN** it returns "brew install podman"
+
+#### Scenario: Generic install hint for DevPod
+
+- **GIVEN** the tool name is "devpod"
+- **AND** Homebrew is not available
+- **WHEN** `genericInstallCmd` is called
+- **THEN** it returns a string containing
+  "https://devpod.sh"
+
+#### Scenario: Install URL for Podman
+
+- **GIVEN** the tool name is "podman"
+- **WHEN** `installURL` is called
+- **THEN** it returns "https://podman.io"
+
+#### Scenario: Install URL for DevPod
+
+- **GIVEN** the tool name is "devpod"
+- **WHEN** `installURL` is called
+- **THEN** it returns "https://devpod.sh"
+
+## MODIFIED Requirements
+
+### Requirement: Setup step count
+
+Previously: `Run()` executes 13 numbered steps.
+Now: `Run()` MUST execute 16 numbered steps. All step
+labels MUST use `[N/16]` format.
+
+### Requirement: DevPod doctor check group
+
+Previously: Checks devpod binary and devcontainer.json.
+Now: Additionally MUST check DevPod version (>= 0.5.0)
+and Podman provider registration.
+
+## REMOVED Requirements
+
+None.

--- a/openspec/changes/setup-sandbox-tools/tasks.md
+++ b/openspec/changes/setup-sandbox-tools/tasks.md
@@ -1,0 +1,233 @@
+<!--
+  [P] marks tasks eligible for parallel execution.
+  Add [P] when a task: (a) touches different files from
+  other [P] tasks in the group, (b) has no dependency
+  on prior tasks in the group, (c) can safely execute
+  without ordering constraints.
+  Do NOT add [P] when tasks modify the same file --
+  parallel workers will cause merge conflicts.
+  Tasks without [P] run sequentially first, then [P]
+  tasks run in parallel.
+-->
+
+## 1. Doctor: Install Hints and URLs
+
+- [x] 1.1 [P] Add `podman` and `devpod` entries to
+  `homebrewInstallCmd`, `genericInstallCmd`, and
+  `installURL` in `internal/doctor/environ.go`.
+  - `homebrewInstallCmd("podman")` -> `"brew install podman"`
+  - `homebrewInstallCmd("devpod")` -> `"brew install devpod"`
+  - `genericInstallCmd("podman")` -> download URL
+  - `genericInstallCmd("devpod")` -> download URL
+  - `installURL("podman")` -> `"https://podman.io"`
+  - `installURL("devpod")` -> `"https://devpod.sh"`
+
+## 2. Doctor: Podman Core Tool Check
+
+- [x] 2.1 Add Podman to `coreToolSpecs` in
+  `internal/doctor/checks.go` as a required tool with
+  version check:
+  - `name: "podman"`, `required: true`
+  - `versionCmd: []string{"podman", "--version"}`
+  - Add `parsePodmanVersion` function (parses
+    "podman version X.Y.Z" output)
+  - Add `checkPodmanVersion` function (>= 4.3)
+  - `minVersion: "4.3"`
+- [x] 2.2 Add `GOOS string` field to doctor `Options`
+  struct in `internal/doctor/doctor.go`. When non-empty,
+  it overrides `runtime.GOOS`. When empty, defaults to
+  `runtime.GOOS`. Add a helper method
+  `func (o *Options) goos() string` that returns the
+  resolved value. Update `defaults()` if needed.
+- [x] 2.3 Add Podman runtime health post-check in
+  `checkCoreTools()` in `internal/doctor/checks.go`,
+  following the Ollama post-check pattern:
+  - After Podman passes presence + version, run
+    `podman info` via `opts.ExecCmd`
+  - On macOS (`opts.goos() == "darwin"`): first check
+    `podman machine list --format '{{.Name}}'` for
+    machine existence; if no machine, Fail with hint
+    "podman machine init && podman machine start";
+    if machine exists but `podman info` fails, Fail
+    with hint "podman machine start"
+  - On Linux: run `podman info` directly; if it fails,
+    Fail with hint referencing
+    "systemctl --user status podman.socket"
+  - If `podman info` succeeds on any platform, Pass
+    with message "running"
+- [x] 2.4 [P] Add tests for `parsePodmanVersion` and
+  `checkPodmanVersion` in
+  `internal/doctor/doctor_test.go`:
+  - Parse "podman version 5.3.1"
+  - Parse "podman version 4.3.0"
+  - Reject "podman version 4.2.9"
+  - Reject unparseable output
+- [x] 2.5 [P] Add test for Podman in `coreToolSpecs`:
+  Podman missing -> Fail; Podman present, version
+  sufficient -> Pass; Podman present, version too old
+  -> Fail.
+- [x] 2.6 [P] Add tests for GOOS injection and Podman
+  runtime post-check in
+  `internal/doctor/doctor_test.go`:
+  - GOOS override works (set "darwin", verify macOS path)
+  - GOOS default (empty -> runtime.GOOS)
+  - macOS: machine exists + podman info succeeds -> Pass
+  - macOS: no machine -> Fail with machine init hint
+  - macOS: machine exists + podman info fails -> Fail
+    with machine start hint
+  - Linux: podman info succeeds -> Pass
+  - Linux: podman info fails -> Fail with socket hint
+  - Version too old -> runtime check skipped
+
+## 3. Doctor: Enhanced DevPod Checks
+
+- [x] 3.1 Add DevPod version check to `checkDevPod()`
+  in `internal/doctor/checks.go`:
+  - Run `devpod version`, parse output (format:
+    `v0.X.Y`, strip leading `v`, split on dots,
+    handle pre-release suffixes like `-beta`)
+  - Add `parseDevPodVersion` function following doctor
+    `versionParse` pattern (returns `(string, error)`)
+  - Add `checkDevPodVersionMin` function
+  - Minimum version 0.5.0; Warn if below
+- [x] 3.2 Add DevPod provider check to `checkDevPod()`
+  in `internal/doctor/checks.go`:
+  - Run `devpod provider list`, use exact first-column
+    name matching for "podman" (not substring)
+  - If `devpod provider list` fails, skip with warning
+  - Warn if missing with install hint:
+    `devpod provider add docker --name podman -o DOCKER_COMMAND=podman`
+- [x] 3.3 [P] Add tests for enhanced DevPod checks in
+  `internal/doctor/doctor_test.go`:
+  - `parseDevPodVersion`: parse "v0.6.15", "0.5.0",
+    "v0.4.2-beta", reject unparseable
+  - Version sufficient (0.6.15) -> Pass
+  - Version too old (0.4.2) -> Warn
+  - Version boundary (0.5.0) -> Pass
+  - Provider present (exact match "podman") -> Pass
+  - Provider name substring ("podman-custom") -> not
+    matched (provider missing)
+  - Provider missing -> Warn with hint
+  - Provider list command fails -> skip with warning
+
+## 4. Setup: Podman Installation
+
+- [x] 4.1 Add `installPodman()` function to
+  `internal/setup/setup.go`:
+  - LookPath check -> "already installed"
+  - Homebrew: `brew install podman`
+  - No Homebrew: skip with download URL
+  - macOS post-install: check for Podman machine via
+    `podman machine list`, run `podman machine init`
+    (with 180-second timeout) and `podman machine start`
+    if no machine exists. Machine init/start failures
+    are reported in detail but do not fail the step.
+  - Post-install smoke test: run `podman info` to
+    verify installation is functional. If it fails,
+    detail includes "podman info failed" but the step
+    reports "installed". If it passes, detail includes
+    "verified".
+  - DryRun support
+  - shouldSkipTool("podman") support
+- [x] 4.2 [P] Add tests for `installPodman()` in
+  `internal/setup/setup_test.go`:
+  - Already installed
+  - Fresh install via Homebrew
+  - No Homebrew -> skip
+  - macOS machine init (happy path)
+  - macOS machine already exists
+  - macOS machine init fails -> "installed" +
+    "machine init failed"
+  - macOS machine start fails -> "installed" +
+    "machine start failed"
+  - Linux (no machine init)
+  - Smoke test passes -> "installed" + "verified"
+  - Smoke test fails -> "installed" + "podman info
+    failed"
+  - DryRun mode
+  - Skip via config
+
+## 5. Setup: DevPod Installation
+
+- [x] 5.1 Add `installDevPod()` function to
+  `internal/setup/setup.go`:
+  - LookPath check -> "already installed"
+  - Homebrew: `brew install devpod`
+  - No Homebrew: skip with download URL
+  - DryRun support
+  - shouldSkipTool("devpod") support
+- [x] 5.2 [P] Add tests for `installDevPod()` in
+  `internal/setup/setup_test.go`:
+  - Already installed
+  - Fresh install via Homebrew
+  - No Homebrew -> skip
+  - DryRun mode
+  - Skip via config
+
+## 6. Setup: DevPod Provider Configuration
+
+- [x] 6.1 Add `configureDevPodProvider()` function to
+  `internal/setup/setup.go`:
+  - Gate on both devpod and podman being available
+  - Check `devpod provider list` for "podman" provider
+    using exact first-column name matching
+  - If `devpod provider list` fails, skip with warning
+  - If provider missing: run
+    `devpod provider add docker --name podman -o DOCKER_COMMAND=podman`
+  - If provider add fails, report "failed" with the
+    manual command as detail
+  - DryRun support
+- [x] 6.2 [P] Add tests for `configureDevPodProvider()`
+  in `internal/setup/setup_test.go`:
+  - Provider already registered -> "already installed"
+  - Provider missing -> install
+  - Provider add fails -> "failed" with manual hint
+  - Provider list fails -> "skipped" with warning
+  - DevPod not available -> skip
+  - Podman not available -> skip
+  - DryRun mode
+
+## 7. Setup: Run() Integration
+
+- [x] 7.1 Update `Run()` in `internal/setup/setup.go`:
+  - Insert Podman step after Ollama (step 11/16)
+  - Insert DevPod step (step 12/16)
+  - Insert DevPod provider step (step 13/16),
+    gated on devpod + podman availability
+  - Renumber Dewey to 14/16, golangci-lint to 15/16,
+    govulncheck to 16/16
+  - Update all 13 existing `[N/13]` labels to `[N/16]`
+  - Note: `coreToolSpecs` comment says "8 binaries"
+    but slice has 7 entries; after adding Podman it
+    will be 8, making the comment accurate
+- [x] 7.2 [P] Update existing setup tests that assert
+  step count or step labels:
+  - Search for `/13]` in `setup_test.go` -> `/16]`
+  - Search for step count assertions (e.g.,
+    `len(results) == 13`) -> update to 16
+  - Add `ExecCmd` mock fallbacks for `podman`,
+    `devpod`, `devpod provider list` in the shared
+    test helper to prevent cascading failures when
+    `Run()` invokes new steps
+
+## 8. Verification
+
+- [x] 8.1 Run `go test -race -count=1 ./internal/doctor/`
+  and `go test -race -count=1 ./internal/setup/`
+- [x] 8.2 Run `go vet ./...` and `golangci-lint run`
+- [x] 8.3 Verify constitution alignment: all new
+  functions use Options DI pattern (Principle IV),
+  each tool is independently skippable (Principle II),
+  doctor output includes machine-parseable severity
+  and hints (Principle III).
+- [x] 8.4 Verify platform-aware runtime checks: confirm
+  doctor tests cover both macOS and Linux code paths
+  for Podman runtime health (machine check vs direct
+  podman info). Verify GOOS override is injectable
+  in doctor Options for test isolation.
+- [x] 8.5 File `unbound-force/website` issue for
+  documentation updates: setup step inventory (13->16),
+  doctor check groups (Podman in Core Tools, enhanced
+  DevPod group), and new install hints.
+<!-- spec-review: passed -->
+<!-- code-review: passed -->


### PR DESCRIPTION
## Summary

- Add Podman as a required tool in `uf doctor` with version
  check (>= 4.3), runtime health validation (platform-aware:
  macOS machine check, Linux socket check), and Docker-to-Podman
  shim detection
- Enhance DevPod doctor checks with version validation (>= 0.5.0)
  and provider registration check with actionable fix hint
- Add `installPodman()`, `installDevPod()`, and
  `configureDevPodProvider()` to `uf setup` (13 → 16 steps)
  with macOS Podman machine init, smoke test, and DevPod
  provider alias (`devpod provider add docker --name podman
  -o DOCKER_COMMAND=podman`)
- Update AGENTS.md with Technology Stack section, fix stale
  counts (agents 12→18, commands 18→46, specs 001-018→001-035),
  and add missing directory entries

## User-Facing Outcomes

### `uf doctor` now shows

**Core Tools group** gains 3 new checks:
- `podman` — validates presence, version >= 4.3 (Fail if missing or too old)
- `podman runtime` — validates Podman is actually running (macOS: checks machine exists + `podman info`; Linux: checks `podman info` directly). Provides platform-specific fix hints.
- `docker` — detects if `docker` in PATH is a Podman shim (e.g., `/usr/local/bin/docker -> /opt/podman/bin/podman`). Informational only.

**DevPod group** gains 2 new checks:
- `devpod version` — validates >= 0.5.0 (Warn if too old)
- `podman provider` — validates a "podman" provider is registered in DevPod (Warn if missing, with fix command: `devpod provider add docker --name podman -o DOCKER_COMMAND=podman`)

### `uf setup` now runs 16 steps (was 13)

Three new steps after Ollama:
- **Step 11/16: Podman** — installs via Homebrew, initializes Podman machine on macOS (with 180s timeout), runs `podman info` smoke test
- **Step 12/16: DevPod** — installs via Homebrew
- **Step 13/16: DevPod provider** — automatically configures the Podman provider alias (`devpod provider add docker --name podman -o DOCKER_COMMAND=podman`), which is the step most users would never discover on their own

### Before this change
Users had to manually: install Podman, install DevPod, discover that the standalone `podman` DevPod provider no longer exists, and figure out the correct `devpod provider add docker --name podman -o DOCKER_COMMAND=podman` command. There was no diagnostic feedback when any of this was misconfigured.

### After this change
`uf setup` handles all three steps automatically. `uf doctor` validates the entire chain and provides actionable fix hints for every failure mode.

## Manual Testing

```bash
# Build from this branch
go build -o ./bin/uf ./cmd/unbound-force/

# Run doctor — should show Podman + DevPod checks
./bin/uf doctor

# Run setup in dry-run mode — shows what would be installed
./bin/uf setup --dry-run

# Verify tests pass
go test -race -count=1 ./internal/doctor/ ./internal/setup/

# Full test suite (no regressions)
go test -race -count=1 ./...
```

### Doctor expected output (on a properly configured machine)
```
Core Tools
  ✅ podman             5.x.x (/opt/podman/bin/podman)
  ✅ podman runtime     running
  ✅ docker             docker is a Podman shim (/opt/podman/bin/podman)

DevPod
  ✅ devpod             installed
  ✅ devpod version     0.6.x
  ✅ podman provider    registered
  ✅ devcontainer config .devcontainer/devcontainer.json found
```

### Doctor expected output (missing Podman)
```
Core Tools
  ❌ podman             not found
     Fix: brew install podman
```

### Doctor expected output (Podman machine not running on macOS)
```
Core Tools
  ✅ podman             5.x.x
  ❌ podman runtime     Podman machine may not be running
     Fix: podman machine start
```

### Doctor expected output (DevPod provider not configured)
```
DevPod
  ⚠️  podman provider    not registered
     Fix: devpod provider add docker --name podman -o DOCKER_COMMAND=podman
```