### PR TITLE
fix(release): set git identity for annotated tag creation on CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,6 +136,16 @@ jobs:
 
       - name: Create and push tag
         run: |
+          # Skip if tag was already created (e.g., re-run after
+          # partial failure or manual tag via GitHub API).
+          if git ls-remote --tags origin | grep -q "refs/tags/${RELEASE_TAG}$"; then
+            echo "Tag $RELEASE_TAG already exists, skipping creation."
+            exit 0
+          fi
+          # Annotated tags require a committer identity on the
+          # CI runner (git tag -a uses GIT_COMMITTER_NAME/EMAIL).
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git tag -a "$RELEASE_TAG" -m "$RELEASE_TAG"
           git push origin "$RELEASE_TAG"
           echo "Created and pushed tag: $RELEASE_TAG"


### PR DESCRIPTION
## Summary

Two release pipeline fixes that prevented v0.15.0 from building:

1. **Git identity for annotated tags**: `git tag -a` requires `user.name`/`user.email` which CI runners don't have. Set to `github-actions[bot]` before tag creation. Added skip-if-exists guard for re-run resilience.

2. **GoReleaser RE2 regex**: The changelog filter `'^chore(?!\(deps\)):'` uses a Perl negative lookahead (`(?!...)`) that Go's `regexp` package rejects. Replaced with `'^chore:'` which naturally excludes only bare `chore:` commits — `chore(deps):` is not matched because the parenthesized scope prevents `:` from following `chore` directly.

## Root Causes

**Tag identity**: `actions/checkout` does not configure `GIT_COMMITTER_NAME`/`GIT_COMMITTER_EMAIL`. Lightweight tags (`git tag`) don't need this, but annotated tags (`git tag -a`) do.

**Regex**: GoReleaser v2.14.1 compiles filter regexes with `regexp.Compile()` (RE2 only). Previous versions may have used PCRE or didn't parse these filters.

## Impact

The release workflow has been broken for every `workflow_dispatch` trigger. v0.15.0 was released manually via `gh release create` as a workaround but has no binaries.

## After Merge

```bash
# Delete the incomplete v0.15.0 release and tag
gh release delete v0.15.0 --repo unbound-force/unbound-force --yes
gh api repos/unbound-force/unbound-force/git/refs/tags/v0.15.0 -X DELETE

# Re-run the full release pipeline
gh workflow run release.yml --repo unbound-force/unbound-force --ref main -f tag=v0.15.0
```

Closes #218