### PR TITLE
fix(release): replace Perl negative lookahead with RE2-compatible regex

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -73,7 +73,7 @@ changelog:
       order: 9999
   filters:
     exclude:
-      - '^chore(?!\(deps\)):'
+      - '^chore:'
       - '^test:'
       - Merge pull request
 


### PR DESCRIPTION
## Summary

Replace `'^chore(?!\(deps\)):'` with `'^chore:'` in `.goreleaser.yaml` changelog filters.

## Root Cause

GoReleaser v2.14.1 compiles changelog filter regexes with Go's `regexp.Compile()` which only supports RE2 syntax. The `(?!...)` negative lookahead is Perl/PCRE-only, causing the release to fail at the changelog generation step:

```
error parsing regexp: invalid or unsupported Perl syntax: `(?!`
```

## Fix

`'^chore:'` matches only bare `chore: message` commits (no scope). It does NOT match `chore(deps): bump foo` because the `(` after `chore` prevents `:` from matching immediately. So `chore(deps):` commits still reach the "Dependency Updates" changelog group (line 64).

## After Merge

Delete the v0.15.0 tag and re-trigger the release:

```bash
gh api repos/unbound-force/unbound-force/git/refs/tags/v0.15.0 -X DELETE
gh workflow run release.yml --repo unbound-force/unbound-force --ref main -f tag=v0.15.0
```