### PR TITLE
fix(sandbox): set workdir for persistent Podman workspace so OpenCode starts in project directory

### DIFF
--- a/.uf/dewey/learnings/sandbox-20260513T185048-jay-flowers.md
+++ b/.uf/dewey/learnings/sandbox-20260513T185048-jay-flowers.md
@@ -1,0 +1,10 @@
+---
+tag: sandbox
+author: jay-flowers
+category: gotcha
+created_at: 2026-05-13T18:50:48Z
+identity: sandbox-20260513T185048-jay-flowers
+tier: draft
+---
+
+The persistent Podman sandbox path (buildPersistentRunArgs in podman.go) was missing --workdir and WORKSPACE env var, causing OpenCode to start in /workspace instead of /workspace/project-name. This is the same class of bug as PR #123 which fixed the ephemeral path (buildRunArgs in config.go). When podman cp copies a directory into a volume, Go's filepath.Join normalizes away trailing dots so the copy creates /workspace/project-name/ (directory itself, not contents). Both --workdir and WORKSPACE must be set to /workspace/basename so the entrypoint's cd "$WORKSPACE" lands in the correct directory. The lesson: when fixing a bug in one code path (ephemeral), always check if the same pattern exists in parallel code paths (persistent) that may have been added independently.

--- a/internal/sandbox/podman.go
+++ b/internal/sandbox/podman.go
@@ -310,6 +310,18 @@ func buildPersistentRunArgs(opts Options, platform PlatformConfig, ctrName, volN
 	// UID/GID mapping (before image argument).
 	args = append(args, uidMappingArgs(opts)...)
 
+	// Working directory: podman cp copies the project
+	// directory (not its contents) into /workspace/,
+	// creating /workspace/<basename>/. Set --workdir and
+	// WORKSPACE so the entrypoint's cd "$WORKSPACE" lands
+	// in the project directory (D1, mirrors PR #123 fix
+	// for the ephemeral path in buildRunArgs).
+	projectSubdir := fmt.Sprintf("/workspace/%s",
+		filepath.Base(opts.ProjectDir))
+	args = append(args, "--workdir", projectSubdir)
+	args = append(args, "-e",
+		fmt.Sprintf("WORKSPACE=%s", projectSubdir))
+
 	// Image name (last argument).
 	args = append(args, opts.Image)
 

--- a/internal/sandbox/sandbox_test.go
+++ b/internal/sandbox/sandbox_test.go
@@ -2958,6 +2958,50 @@ func TestBuildPersistentRunArgs_IncludesUserNS(t *testing.T) {
 	}
 }
 
+func TestBuildPersistentRunArgs_SetsWorkdir(t *testing.T) {
+	opts := testOpts()
+	opts.Image = DefaultImage
+	opts.Memory = DefaultMemory
+	opts.CPUs = DefaultCPUs
+
+	platform := PlatformConfig{OS: "linux", Arch: "amd64"}
+	args := buildPersistentRunArgs(opts, platform, "uf-sandbox-test", "uf-vol-test")
+	joined := strings.Join(args, " ")
+
+	// Verify --workdir is set to /workspace/<project-basename>.
+	expectedWorkdir := "/workspace/test-project"
+	if !strings.Contains(joined, "--workdir "+expectedWorkdir) {
+		t.Errorf("expected --workdir %s in args, got: %s", expectedWorkdir, joined)
+	}
+
+	// Verify WORKSPACE env var is set.
+	expectedEnv := "WORKSPACE=/workspace/test-project"
+	if !strings.Contains(joined, expectedEnv) {
+		t.Errorf("expected %s in args, got: %s", expectedEnv, joined)
+	}
+
+	// Verify --workdir appears before the image argument.
+	wdIdx := -1
+	imgIdx := -1
+	for i, a := range args {
+		if a == "--workdir" {
+			wdIdx = i
+		}
+		if a == DefaultImage {
+			imgIdx = i
+		}
+	}
+	if wdIdx < 0 {
+		t.Fatal("--workdir not found in args")
+	}
+	if imgIdx < 0 {
+		t.Fatal("image not found in args")
+	}
+	if wdIdx >= imgIdx {
+		t.Errorf("--workdir (idx %d) should appear before image (idx %d)", wdIdx, imgIdx)
+	}
+}
+
 // --- buildPersistentRunArgs gateway tests (Task Group 3) ---
 
 func TestBuildPersistentRunArgs_GatewayActive(t *testing.T) {

--- a/openspec/changes/fix-sandbox-persistent-workdir/.openspec.yaml
+++ b/openspec/changes/fix-sandbox-persistent-workdir/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: unbound-force
+created: 2026-05-13

--- a/openspec/changes/fix-sandbox-persistent-workdir/design.md
+++ b/openspec/changes/fix-sandbox-persistent-workdir/design.md
@@ -1,0 +1,106 @@
+## Context
+
+`PodmanBackend.Create()` copies the project into a named
+volume via `podman cp <project-dir> container:/workspace/`.
+Go's `filepath.Join(opts.ProjectDir, ".")` normalizes
+away the trailing `.`, so `podman cp` copies the directory
+itself (not its contents), placing the project at
+`/workspace/<project-name>/`.
+
+The ephemeral path (`buildRunArgs()` in config.go) sets
+`--workdir /workspace/<basename>` and
+`WORKSPACE=/workspace/<basename>` when parent mount is
+active (fix from PR #123). The persistent path
+(`buildPersistentRunArgs()` in podman.go) was never
+updated with the same fix.
+
+The container image's entrypoint reads
+`WORKSPACE="${WORKSPACE:-/workspace}"` and runs
+`cd "$WORKSPACE"` before starting `opencode serve`.
+Without the env var, it defaults to `/workspace` — one
+level above the project.
+
+## Goals / Non-Goals
+
+### Goals
+
+- Set `--workdir` and `WORKSPACE` env var in
+  `buildPersistentRunArgs()` to
+  `/workspace/<project-basename>`
+- OpenCode starts in the correct project directory
+  after `uf sandbox create --backend podman`
+- Add test coverage for the new args
+
+### Non-Goals
+
+- Fixing `filepath.Join` normalization of the trailing
+  `.` in the `podman cp` source path — the copy
+  behavior (directory into `/workspace/`) is acceptable
+  as long as workdir is set correctly
+- Adding `--mode` flag to `uf sandbox create` — the
+  persistent path always uses a read-write named volume
+- Changing DevPod backend behavior — DevPod manages its
+  own working directory via devcontainer.json
+
+## Decisions
+
+### D1: Mirror the ephemeral fix pattern
+
+Add the same `--workdir` and `WORKSPACE` pattern from
+`buildRunArgs()` (config.go:244-250) to
+`buildPersistentRunArgs()`. The persistent path always
+copies the project directory (not contents) into
+`/workspace/`, so the workdir is always
+`/workspace/<basename>` — no `useParentMount()` guard
+needed.
+
+```go
+projectSubdir := fmt.Sprintf("/workspace/%s",
+    filepath.Base(opts.ProjectDir))
+args = append(args, "--workdir", projectSubdir)
+args = append(args, "-e",
+    fmt.Sprintf("WORKSPACE=%s", projectSubdir))
+```
+
+### D2: No useParentMount guard needed
+
+Unlike the ephemeral path which conditionally mounts
+the parent directory, the persistent path always does
+`podman cp <project-dir> container:/workspace/` which
+creates `/workspace/<basename>/`. The workdir is
+unconditionally `/workspace/<basename>`.
+
+### D3: Existing containers unaffected
+
+The `--workdir` and `WORKSPACE` env var are set at
+container creation time (`podman run`). Existing
+containers created before this fix retain their
+original configuration. Users must `uf sandbox destroy`
+and `uf sandbox create` to get the fix. This is
+acceptable since the alternative (modifying running
+containers) would be fragile.
+
+### D4: PodmanBackend.Start() needs no changes
+
+When a persistent workspace is resumed via
+`podman start <container>`, the container retains its
+original `--workdir` and env vars from creation. The
+fix in `buildPersistentRunArgs()` (used only at create
+time) is sufficient.
+
+## Risks / Trade-offs
+
+- **Risk**: Users with existing persistent workspaces
+  will continue to see the wrong working directory
+  until they destroy and recreate.
+  **Mitigation**: This is a known limitation of
+  container-level configuration. The fix applies to all
+  newly created workspaces.
+
+- **Trade-off**: The `podman cp` behavior (copying the
+  directory itself vs contents) is a consequence of
+  `filepath.Join` normalizing away the trailing `.`.
+  We accept this behavior and set the workdir
+  accordingly rather than changing the copy semantics,
+  avoiding a behavioral change for existing users who
+  may have scripts that depend on the current layout.

--- a/openspec/changes/fix-sandbox-persistent-workdir/proposal.md
+++ b/openspec/changes/fix-sandbox-persistent-workdir/proposal.md
@@ -1,0 +1,86 @@
+## Why
+
+`uf sandbox create --backend podman` copies the project
+directory into a named volume at `/workspace/<project-name>/`
+via `podman cp`, but `buildPersistentRunArgs()` never sets
+`--workdir` or the `WORKSPACE` environment variable. The
+container image's entrypoint defaults to `cd /workspace`,
+so OpenCode starts one directory level above the actual
+project.
+
+This is the persistent-mode variant of the same bug fixed
+in PR #123 for the ephemeral path. PR #123 added `WORKSPACE`
+env var passing to `buildRunArgs()` (ephemeral), but the
+fix was never applied to `buildPersistentRunArgs()`
+(persistent).
+
+## What Changes
+
+Add `--workdir` and `-e WORKSPACE=` to
+`buildPersistentRunArgs()` so the container starts in
+`/workspace/<project-name>/` — the directory where
+`podman cp` placed the project source.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `buildPersistentRunArgs()`: Sets `--workdir` and
+  `WORKSPACE` env var to `/workspace/<project-basename>`
+  so the entrypoint's `cd "$WORKSPACE"` lands in the
+  project directory.
+
+### Removed Capabilities
+
+(none)
+
+## Impact
+
+- `internal/sandbox/podman.go` — `buildPersistentRunArgs()`
+  gains `--workdir` and `WORKSPACE` env var (~5 lines)
+- `internal/sandbox/sandbox_test.go` — new/updated
+  assertions for persistent args tests
+- No CLI, config, or user-facing API changes
+- No container image changes (entrypoint already reads
+  `WORKSPACE`)
+
+## Constitution Alignment
+
+Assessed against the Unbound Force org constitution.
+
+### I. Autonomous Collaboration
+
+**Assessment**: N/A
+
+This is an internal plumbing fix within the sandbox
+package. No inter-hero artifact interfaces are affected.
+
+### II. Composability First
+
+**Assessment**: PASS
+
+The fix is contained within `buildPersistentRunArgs()`
+and does not introduce new dependencies. The Podman
+backend remains independently usable.
+
+### III. Observable Quality
+
+**Assessment**: PASS
+
+The `WORKSPACE` env var is observable via
+`podman exec <container> env | grep WORKSPACE` and the
+working directory is observable via `pwd` inside the
+container. Both are machine-parseable.
+
+### IV. Testability
+
+**Assessment**: PASS
+
+The fix is testable via existing `buildPersistentRunArgs`
+unit tests — assertions verify `--workdir` and
+`WORKSPACE=` are present in the generated argument list.
+No external services required.

--- a/openspec/changes/fix-sandbox-persistent-workdir/specs/persistent-workdir.md
+++ b/openspec/changes/fix-sandbox-persistent-workdir/specs/persistent-workdir.md
@@ -1,0 +1,57 @@
+## ADDED Requirements
+
+### Requirement: Persistent workspace working directory
+
+`buildPersistentRunArgs()` MUST set `--workdir` to
+`/workspace/<project-basename>` where `<project-basename>`
+is `filepath.Base(opts.ProjectDir)`.
+
+`buildPersistentRunArgs()` MUST set the `WORKSPACE`
+environment variable to the same path via
+`-e WORKSPACE=/workspace/<project-basename>`.
+
+This ensures the container image's entrypoint
+(`cd "$WORKSPACE"`) starts OpenCode in the project
+directory, not the parent `/workspace/` directory.
+
+#### Scenario: Create persistent Podman workspace
+
+- **GIVEN** the user runs
+  `uf sandbox create --backend podman` from a project
+  directory named `my-project`
+- **WHEN** `buildPersistentRunArgs()` constructs the
+  `podman run` arguments
+- **THEN** the arguments MUST include
+  `--workdir /workspace/my-project`
+- **AND** the arguments MUST include
+  `-e WORKSPACE=/workspace/my-project`
+
+#### Scenario: OpenCode starts in project directory
+
+- **GIVEN** a persistent Podman workspace was created
+  for a project named `my-project`
+- **WHEN** the container starts and the entrypoint runs
+- **THEN** the entrypoint MUST `cd` to
+  `/workspace/my-project`
+- **AND** `opencode serve` MUST start with
+  `/workspace/my-project` as the working directory
+
+#### Scenario: Resumed workspace retains workdir
+
+- **GIVEN** a persistent Podman workspace was created
+  with `--workdir /workspace/my-project` and
+  `WORKSPACE=/workspace/my-project`
+- **WHEN** the workspace is stopped and resumed via
+  `uf sandbox start`
+- **THEN** the container MUST retain the original
+  `--workdir` and `WORKSPACE` env var
+- **AND** OpenCode MUST start in
+  `/workspace/my-project`
+
+## MODIFIED Requirements
+
+(none)
+
+## REMOVED Requirements
+
+(none)

--- a/openspec/changes/fix-sandbox-persistent-workdir/tasks.md
+++ b/openspec/changes/fix-sandbox-persistent-workdir/tasks.md
@@ -1,0 +1,54 @@
+<!--
+  [P] marks tasks eligible for parallel execution.
+  Add [P] when a task: (a) touches different files from
+  other [P] tasks in the group, (b) has no dependency
+  on prior tasks in the group, (c) can safely execute
+  without ordering constraints.
+  Do NOT add [P] when tasks modify the same file —
+  parallel workers will cause merge conflicts.
+  Tasks without [P] run sequentially first, then [P]
+  tasks run in parallel.
+-->
+
+## 1. Add workdir and WORKSPACE to persistent args
+
+- [x] 1.1 In `internal/sandbox/podman.go`, add
+  `--workdir` and `-e WORKSPACE=` to
+  `buildPersistentRunArgs()`. Insert after the UID
+  mapping args (line ~311) and before the image
+  argument. Use `filepath.Base(opts.ProjectDir)` to
+  derive the project basename. Pattern:
+  ```go
+  projectSubdir := fmt.Sprintf("/workspace/%s",
+      filepath.Base(opts.ProjectDir))
+  args = append(args, "--workdir", projectSubdir)
+  args = append(args, "-e",
+      fmt.Sprintf("WORKSPACE=%s", projectSubdir))
+  ```
+
+## 2. Add test coverage
+
+- [x] 2.1 In `internal/sandbox/sandbox_test.go`, update
+  `TestBuildPersistentRunArgs_IncludesUserNS` (or add a
+  new test `TestBuildPersistentRunArgs_SetsWorkdir`) to
+  verify:
+  - `--workdir /workspace/test-project` is present
+  - `WORKSPACE=/workspace/test-project` is present in
+    the args (as `-e WORKSPACE=...`)
+  Derive the expected basename from the `testOpts()`
+  project directory.
+
+## 3. Verification
+
+- [x] 3.1 Run `go test -race -count=1 ./internal/sandbox/...`
+  and verify all tests pass.
+- [x] 3.2 Run `make check` (lint + test + build) and
+  verify clean.
+- [x] 3.3 Verify constitution alignment: the fix uses
+  dependency injection via `Options.ProjectDir`
+  (Principle IV), produces observable env vars
+  (Principle III), and requires no inter-hero changes
+  (Principles I and II).
+
+<!-- spec-review: passed -->
+<!-- code-review: passed -->


### PR DESCRIPTION
## Summary

- Fixes persistent Podman sandbox starting OpenCode in `/workspace` instead of `/workspace/<project-name>`
- `buildPersistentRunArgs()` was missing `--workdir` and `WORKSPACE` env var (the persistent-mode variant of the bug fixed in PR #123 for the ephemeral path)
- Adds `--workdir /workspace/<basename>` and `-e WORKSPACE=/workspace/<basename>` to match the entrypoint's `cd "$WORKSPACE"` behavior
- New test: `TestBuildPersistentRunArgs_SetsWorkdir`
- OpenSpec artifacts: proposal, design (D1-D4), spec (3 scenarios), tasks

## Root Cause

`podman cp` copies the project directory (not contents) into `/workspace/<project-name>/` because `filepath.Join` normalizes away the trailing `.`. The ephemeral path sets `WORKSPACE` when parent mount is active (PR #123 fix), but `buildPersistentRunArgs()` was never updated. The entrypoint defaults to `cd /workspace` without the env var.

## Verification

```bash
uf sandbox destroy --yes
uf sandbox create --backend podman --detach
podman exec uf-sandbox-unbound-force env | grep WORKSPACE
# Expected: WORKSPACE=/workspace/unbound-force
```

Note: Existing persistent workspaces must be destroyed and recreated to pick up the fix (container env vars are set at creation time).