### PR TITLE
fix(review): add finding consolidation, compound severity, and CI annotation ingestion

### DIFF
--- a/.opencode/agents/divisor-adversary.md
+++ b/.opencode/agents/divisor-adversary.md
@@ -64,9 +64,29 @@ Evaluate all recent changes (staged, unstaged, and untracked files). Use `git di
 
 #### 2. Dependency CVEs and Supply Chain [PACK]
 
+- **Necessity before integrity**: Is each external tool,
+  binary, or library justified? Could the project's
+  existing toolchain cover the same use case? An
+  unnecessary dependency is attack surface that should
+  not exist regardless of how well it is pinned.
 - Are there known CVEs in direct or transitive dependencies?
 - Are CI/CD pipelines using pinned dependency versions (commit SHAs, not mutable tags)?
+- Are downloaded binaries content-integrity-verified
+  (SHA256 checksum)? HTTPS + pinned version provides
+  transport security and deterministic URLs but is
+  name-addressed, not content-addressed — the publisher
+  can replace the artifact under the same tag. Assess
+  severity based on context: a missing checksum in a
+  `--privileged` CI container is MEDIUM on its own;
+  compound with other factors per `severity.md`.
 - Are secrets in CI workflows properly scoped and never echoed?
+- **CI bot corroboration**: If Scorecard, Trivy,
+  `github-advanced-security[bot]`, or other CI bots have
+  already flagged dependency/supply-chain issues on the
+  same PR, treat their findings as corroborating evidence
+  for your own assessment — not as separate concerns.
+  Cite the bot finding and use it to strengthen severity
+  classification.
 - Check the convention pack's guidance for dependency security if available.
 
 #### 3. Error Handling and Resilience
@@ -84,14 +104,40 @@ Evaluate all recent changes (staged, unstaged, and untracked files). Use `git di
 - Are there injection vectors (SQL, command, YAML, template) in user-facing inputs?
 - Does the code follow symlinks? If so, is there a guard against symlink loops or escape?
 
-#### 5. Language-Specific Security Patterns [PACK]
+#### 5. Adversarial Input Enumeration
+
+For each new input, parameter, secret, or
+configuration value introduced by the change:
+
+- **Enumerate valid and invalid values**: What is the
+  expected type, range, and format? What happens with
+  empty, null, wrong-type, wrong-case, excessively
+  long, or injection-payload values?
+- **Trace to security-sensitive operations**: Does the
+  input reach a file path, shell command, SQL query,
+  template, or privilege decision? Is it validated
+  before that point?
+- **Check bypass controls**: If the input controls a
+  security-relevant behavior (e.g., skipping a check,
+  disabling verification), is there an audit trail?
+  Can a misconfigured or malicious caller use the
+  input to silently disable a security layer?
+- **Assess severity by blast radius**: An unvalidated
+  input that controls a cosmetic label is LOW; one
+  that silently disables a security check is HIGH.
+
+This enumeration supplements the category-based checks
+above. Categories identify *classes* of vulnerability;
+input enumeration identifies *specific* vectors.
+
+#### 6. Language-Specific Security Patterns [PACK]
 
 > Skip this section if no convention pack is loaded from `.opencode/uf/packs/`.
 
 - Check the convention pack's `security_checks` section for language-specific vulnerability patterns.
 - Apply the pack's error handling conventions to the changed code.
 
-#### 6. Gate Tampering
+#### 7. Gate Tampering
 
 - Has this change removed or weakened any CI security control (`-race` flag, `govulncheck`, linter rules, pinned action SHAs, coverage thresholds)?
 - Flag as HIGH if a security-relevant gate was weakened without documented justification.

--- a/.opencode/commands/review-council.md
+++ b/.opencode/commands/review-council.md
@@ -203,7 +203,27 @@ Review the current codebase for compliance with the Behavioral Constraints in `A
 
    For each agent, instruct it to review the full branch diff (all changed files vs `main`) and return its verdict (**APPROVE** or **REQUEST CHANGES**) along with all findings.
 
-3. Collect all **REQUEST CHANGES** findings from the discovered reviewers. If all discovered reviewers return **APPROVE**, report the result and stop.
+3. Collect all **REQUEST CHANGES** findings from the
+   discovered reviewers. If all discovered reviewers
+   return **APPROVE**, report the result and stop.
+
+   **Cross-persona finding consolidation**: Before
+   proceeding to the fix loop, group findings from
+   different personas that (a) affect the same
+   component, file, or pipeline stage, (b) share a
+   common root cause, and (c) together produce a risk
+   greater than any individual finding. Merge each
+   group into a single consolidated finding:
+   - Apply compound severity escalation from
+     `severity.md` to determine the combined severity.
+   - Preserve per-persona attribution (e.g.,
+     "Adversary: missing checksum + SRE: privileged
+     blast radius → consolidated MEDIUM").
+   - Present the consolidated finding with one unified
+     recommendation addressing the root cause.
+
+   Findings with independent root causes MUST remain
+   separate even if they affect the same file.
 
 4. If there are **REQUEST CHANGES**, address the findings by making the necessary code fixes. Then re-run all discovered reviewers to verify the fixes. Repeat this loop until all discovered reviewers return **APPROVE** or the process has exceeded 3 iterations.
 
@@ -250,7 +270,16 @@ step, determine which artifacts to review:
 
    For each agent, instruct it to **operate in Spec Review Mode**: review the spec artifacts identified in the review scope above (not code), plus `.specify/memory/constitution.md` and `AGENTS.md`. Include the workflow tier (Speckit/OpenSpec) in the agent prompt so it can tailor its review accordingly. Instruct the agent to return its verdict (**APPROVE** or **REQUEST CHANGES**) along with all findings.
 
-2. Collect all **REQUEST CHANGES** findings from the discovered reviewers. If all discovered reviewers return **APPROVE**, report the result and stop.
+2. Collect all **REQUEST CHANGES** findings from the
+   discovered reviewers. If all discovered reviewers
+   return **APPROVE**, report the result and stop.
+
+   **Cross-persona finding consolidation**: Apply the
+   same consolidation rule as Code Review Mode Step 3
+   — group findings from different personas that share
+   a root cause, apply compound severity escalation
+   from `severity.md`, and present as consolidated
+   findings with per-persona attribution preserved.
 
 3. If there are **REQUEST CHANGES**, apply the **hybrid fix policy**:
 

--- a/.opencode/commands/review-pr.md
+++ b/.opencode/commands/review-pr.md
@@ -478,6 +478,18 @@ Compare the PR intent (title + description + linked spec + linked issues) agains
 - **Completeness**: Are there partial implementations that could leave the system in an inconsistent state?
 - **Drift detection**: Does the code do anything NOT described in the intent/spec? Flag undocumented behavioral changes.
 - **Issue criteria coverage**: For each acceptance criterion from linked issues (Step 6a), verify the code changes address it. Report uncovered criteria as MEDIUM findings with per-criterion status (COVERED / NOT COVERED / PARTIAL).
+- **Issue suggestion gap detection**: After checking
+  acceptance criteria, scan each linked issue body for
+  explicit code suggestions — fenced code blocks
+  (` ``` `), inline code spans, or clearly proposed
+  one-line fixes. For each suggestion found:
+  - Check whether the PR implemented the suggested
+    change.
+  - If implemented: no finding needed.
+  - If not implemented: flag as a finding. Assess
+    severity based on the risk of the gap (e.g., a
+    missing guard clause on a destructive operation is
+    HIGH; a missing style preference is LOW).
 
 #### 8b. Security Review
 
@@ -497,6 +509,27 @@ Examine the diff for security vulnerabilities that linters cannot catch:
 - **Privilege escalation**: Does the code grant permissions or elevate privileges without proper validation?
 - **Secrets and credentials**: Are there hardcoded secrets, tokens, or API keys? Are secrets logged or exposed in error messages?
 - **Dependency risks**: Are new dependencies well-maintained and from trusted sources?
+
+**Adversarial input enumeration**: For each new input,
+parameter, secret, or configuration value introduced
+by the PR, enumerate:
+- What values can a caller pass? (valid range, type,
+  format)
+- What happens for each edge case: empty string, wrong
+  type, wrong case (e.g., `"True"` vs `"true"`),
+  excessively long value, injection payload,
+  null/undefined?
+- Does validation exist? Is it sufficient? Is it
+  applied before the value reaches any security-
+  sensitive operation?
+- If the input controls a security-relevant behavior
+  (e.g., `skip_org_check`, `disable_verification`),
+  is there an audit trail when the input is used to
+  bypass a control?
+
+Flag missing or insufficient validation as findings
+with severity based on the blast radius of the
+unvalidated input.
 
 #### 8c. Constitution Compliance (AI-only items)
 
@@ -519,6 +552,82 @@ For each CI failure classified in Step 3a, provide analysis:
 - Confirm the failure also exists on the base branch
 - Brief root cause analysis if determinable from the error output
 - Note that this will be addressed in Step 10 (fix-branch offer)
+
+#### 8e. CI Bot Annotation Cross-referencing
+
+Before proceeding to consolidation, cross-reference the
+inline comments from Step 7.5b against the findings
+generated in Steps 8a–8d. Identify comments from CI
+bots (Scorecard, Trivy, `github-advanced-security[bot]`,
+Dependabot, CodeQL, etc.) that address the same files
+or concern classes as your findings.
+
+For each match:
+- **Cite the bot finding** in your own finding as
+  corroborating evidence (e.g., "Scorecard flagged the
+  same step for unpinned dependencies").
+- **Use the bot finding to strengthen** your severity
+  classification — if a bot already flagged a concern
+  and your analysis confirms it, the combined evidence
+  supports a higher confidence level.
+- Do NOT dismiss bot findings as "related but different"
+  when they address the same class of problem (e.g.,
+  dependency integrity, secrets exposure, container
+  misconfig) in the same pipeline stage or file.
+
+#### 8f. Finding Consolidation
+
+After generating all findings from Steps 8a–8e, perform
+a consolidation pass before formatting output.
+
+**Consolidation rule**: Group findings that (a) affect
+the same component, pipeline stage, or file cluster,
+(b) share a common root cause, and (c) together produce
+a risk greater than any individual finding. Merge each
+group into a single finding.
+
+For each consolidated finding:
+1. Use the highest individual severity as the floor,
+   then apply the compound severity escalation rule from
+   `severity.md` to determine if the combined severity
+   is higher.
+2. List each contributing factor as a sub-point in the
+   finding description.
+3. Cite the original category (alignment, security,
+   constitution) for each contributing factor so
+   traceability is preserved.
+4. Present one unified recommendation that addresses
+   the root cause, not separate fixes for each symptom.
+
+**When NOT to consolidate**: Findings with independent
+root causes and independent blast radii MUST remain
+separate even if they appear in the same file.
+
+#### 8g. Severity Calibration
+
+After consolidation, perform a calibration pass over
+every finding (including consolidated findings from
+Step 8f). This step counters anchoring bias — the
+tendency to compress all severities toward a "feels
+right" level based on overall PR quality impressions.
+
+For each finding:
+1. Re-read the `severity.md` definition for the
+   currently assigned severity level.
+2. Quote the specific definition clause or example
+   that matches the finding. If no clause matches,
+   check the adjacent severity levels (one above, one
+   below).
+3. If the quoted definition maps to a **different**
+   severity than the current assignment, adjust the
+   severity and note the change (e.g., "Reclassified
+   from MEDIUM to HIGH — matches HIGH definition:
+   'unpinned CI action on mutable tag'").
+4. If the definition confirms the current assignment,
+   retain it with the quoted evidence.
+
+The calibration pass MUST NOT introduce new findings
+— it only adjusts severity levels on existing findings.
 
 ### 9. Output Format
 

--- a/.opencode/uf/packs/severity.md
+++ b/.opencode/uf/packs/severity.md
@@ -78,6 +78,34 @@ impact.
 | SRE | Style improvement in error messages, optional health check enhancement, minor doc gap |
 | Architect | Formatting preference, optional structural improvement, minor comment enhancement |
 
+## Compound Severity Escalation
+
+When multiple findings share a root cause, personas MUST
+assess the **combined** severity rather than classifying
+each finding in isolation. Findings that individually
+appear LOW or MEDIUM can compound into a HIGH or
+CRITICAL finding when they create a single coherent
+attack surface or failure mode.
+
+**Rule**: If two or more findings (a) affect the same
+component or pipeline stage, (b) share a common root
+cause, and (c) together produce a risk greater than any
+individual finding, consolidate them into a single
+finding at the escalated severity. The consolidated
+finding MUST cite each contributing factor.
+
+| Pattern | Individual | Compound |
+|---------|-----------|----------|
+| Unverified binary + privileged CI container | MEDIUM + MEDIUM | HIGH (supply chain attack in privileged context) |
+| Broad permissions + missing input validation + external-facing endpoint | MEDIUM + MEDIUM + MEDIUM | HIGH (unauthenticated access with elevated privileges) |
+| Missing error handling + missing retry + critical data path | MEDIUM + LOW + context | HIGH (silent data loss on transient failure) |
+
+**When NOT to escalate**: Findings that happen to appear
+in the same PR but have independent root causes and
+independent blast radii MUST NOT be artificially
+consolidated. Consolidation applies only when the
+findings are causally linked.
+
 ## Auto-Fix Policy (Spec Review Mode)
 
 | Severity | Action | Rationale |

--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -1,15 +1,16 @@
 <!--
   SYNC IMPACT REPORT
   ==================
-  Version change: 1.0.0 → 1.1.0 (MINOR: new principle added)
+  Version change: 1.1.0 → 1.2.0 (MINOR: new principle added)
 
   Added principles:
-    - IV. Testability
+    - V. Security by Default
 
   Unchanged principles:
     - I. Autonomous Collaboration
     - II. Composability First
     - III. Observable Quality
+    - IV. Testability
 
   Unchanged sections:
     - Hero Constitution Alignment
@@ -19,7 +20,7 @@
   Templates requiring updates:
     ✅ .specify/templates/plan-template.md — no changes needed;
        Constitution Check section is generic and will align at
-       plan time using these four principles.
+       plan time using these five principles.
     ✅ .specify/templates/spec-template.md — no changes needed.
     ✅ .specify/templates/tasks-template.md — no changes needed.
     ✅ .specify/templates/checklist-template.md — no changes needed.
@@ -27,7 +28,9 @@
 
   Hero constitution alignment:
     ✅ Gaze v1.1.0 — Testability principle already matches.
-    ⚠  Website v1.0.0 — Will need to be reviewed for Testability alignment.
+    ⚠  Gaze v1.1.0 — Will need Principle V alignment review.
+    ⚠  Website v1.0.0 — Will need Testability + Principle V
+       alignment review.
 -->
 
 # Unbound Force Constitution
@@ -139,6 +142,43 @@ its own unverified complexity. Testability is a first-class governance
 concern because untestable code cannot be reliably verified by Gaze or
 any other automated mechanism. Unverified code cannot be trusted.
 
+### V. Security by Default
+
+Every component built within the Unbound Force ecosystem MUST treat
+security as a structural property, not a review-time afterthought.
+Supply chain integrity, input validation, and least privilege MUST be
+enforced by design.
+
+- **Supply chain integrity**: Dependencies MUST be verified by content
+  hash (SHA256 or equivalent) when downloaded outside a package manager's
+  built-in verification. Pinning by name and version alone (tag, semver)
+  is name-addressed and insufficient — publishers can replace artifacts
+  under the same tag. CI pipelines MUST pin actions and reusable
+  workflows by commit SHA, not mutable tags.
+- **Input validation**: All external inputs (user input, API payloads,
+  file contents, environment variables used as data, CI workflow inputs)
+  MUST be validated and sanitized before reaching any security-sensitive
+  operation (file path construction, shell execution, query building,
+  privilege decisions). Validation MUST reject unexpected types, lengths,
+  formats, and case variations.
+- **Least privilege**: Components MUST operate with the minimum
+  permissions necessary. CI containers SHOULD NOT run with `--privileged`
+  unless explicitly justified. Secrets MUST be scoped to the narrowest
+  context needed. File permissions MUST default to restrictive values
+  (0o644 for files, 0o755 for executables and directories).
+- **Dependency necessity**: Before adding an external dependency, the
+  adopter MUST justify that the project's existing toolchain cannot
+  cover the same use case. Every dependency is attack surface; the
+  default answer is "do not add."
+
+**Rationale**: AI agents make adding dependencies and generating code
+trivially fast. Without structural security guardrails, the attack
+surface of the system grows with each generation cycle. Security by
+Default ensures that supply chain integrity, input hygiene, and
+privilege boundaries are enforced before code reaches review — not
+discovered during review when anchoring bias and finding fragmentation
+can cause under-classification.
+
 ## Hero Constitution Alignment
 
 Every hero repository MUST maintain its own constitution in
@@ -148,7 +188,7 @@ org constitution — they MUST NOT contradict any org principle.
 - Hero constitutions MUST include a `parent_constitution` reference
   indicating which version of the Unbound Force org constitution
   they align with.
-- Hero constitutions MAY add principles beyond the three org
+- Hero constitutions MAY add principles beyond the five org
   principles, provided the additional principles do not contradict
   any org-level MUST rule.
 - When the org constitution is amended, all hero constitutions MUST
@@ -232,4 +272,4 @@ and project-specific guidance.
   implicit priority over another; resolution is context-dependent
   and requires written justification.
 
-**Version**: 1.1.0 | **Ratified**: 2026-02-25 | **Last Amended**: 2026-03-09
+**Version**: 1.2.0 | **Ratified**: 2026-02-25 | **Last Amended**: 2026-06-01

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,33 @@ Each entry follows the format: `- <change-name>: <summary>`.
   feedback triage (Spec: openspec/changes/address-feedback/)
 - `feedback-triage` JSON schema (v1.0.0) for capturing triage
   decisions as artifacts (Spec: openspec/changes/address-feedback/)
+- Constitution Principle V (Security by Default) covering
+  supply chain integrity, input validation, least privilege,
+  and dependency necessity (version 1.1.0 → 1.2.0)
+  (Spec: openspec/changes/review-finding-consolidation/)
+- Compound Severity Escalation section in `severity.md` —
+  instructs personas to assess combined severity when
+  multiple findings share a root cause
+  (Spec: openspec/changes/review-finding-consolidation/)
+- Severity Calibration step (8g) in `/review-pr` — forces
+  re-reading `severity.md` definitions to counter anchoring
+  bias (Fixes #233)
+- Adversarial Input Enumeration in `divisor-adversary.md`
+  (new checklist item 5) and `/review-pr` Step 8b — per-input
+  threat analysis for new parameters/secrets
+  (Fixes #233)
+- Issue Suggestion Gap Detection in `/review-pr` Step 8a —
+  checks linked issues for unimplemented code suggestions
+  (Fixes #233)
+- CI Bot Annotation Cross-referencing (Step 8e) and Finding
+  Consolidation (Step 8f) in `/review-pr` — ingests bot
+  findings as corroborating evidence and merges related
+  findings by root cause (Fixes #228)
+- Cross-persona finding consolidation in `/review-council`
+  Code Review Step 3 and Spec Review Step 2 (Fixes #228)
+- Dependency necessity check and content-integrity
+  verification guidance in `divisor-adversary.md` Audit
+  Checklist item 2 (Fixes #228)
 
 ## Recent Changes
 

--- a/internal/scaffold/assets/opencode/agents/divisor-adversary.md
+++ b/internal/scaffold/assets/opencode/agents/divisor-adversary.md
@@ -64,9 +64,29 @@ Evaluate all recent changes (staged, unstaged, and untracked files). Use `git di
 
 #### 2. Dependency CVEs and Supply Chain [PACK]
 
+- **Necessity before integrity**: Is each external tool,
+  binary, or library justified? Could the project's
+  existing toolchain cover the same use case? An
+  unnecessary dependency is attack surface that should
+  not exist regardless of how well it is pinned.
 - Are there known CVEs in direct or transitive dependencies?
 - Are CI/CD pipelines using pinned dependency versions (commit SHAs, not mutable tags)?
+- Are downloaded binaries content-integrity-verified
+  (SHA256 checksum)? HTTPS + pinned version provides
+  transport security and deterministic URLs but is
+  name-addressed, not content-addressed — the publisher
+  can replace the artifact under the same tag. Assess
+  severity based on context: a missing checksum in a
+  `--privileged` CI container is MEDIUM on its own;
+  compound with other factors per `severity.md`.
 - Are secrets in CI workflows properly scoped and never echoed?
+- **CI bot corroboration**: If Scorecard, Trivy,
+  `github-advanced-security[bot]`, or other CI bots have
+  already flagged dependency/supply-chain issues on the
+  same PR, treat their findings as corroborating evidence
+  for your own assessment — not as separate concerns.
+  Cite the bot finding and use it to strengthen severity
+  classification.
 - Check the convention pack's guidance for dependency security if available.
 
 #### 3. Error Handling and Resilience
@@ -84,14 +104,40 @@ Evaluate all recent changes (staged, unstaged, and untracked files). Use `git di
 - Are there injection vectors (SQL, command, YAML, template) in user-facing inputs?
 - Does the code follow symlinks? If so, is there a guard against symlink loops or escape?
 
-#### 5. Language-Specific Security Patterns [PACK]
+#### 5. Adversarial Input Enumeration
+
+For each new input, parameter, secret, or
+configuration value introduced by the change:
+
+- **Enumerate valid and invalid values**: What is the
+  expected type, range, and format? What happens with
+  empty, null, wrong-type, wrong-case, excessively
+  long, or injection-payload values?
+- **Trace to security-sensitive operations**: Does the
+  input reach a file path, shell command, SQL query,
+  template, or privilege decision? Is it validated
+  before that point?
+- **Check bypass controls**: If the input controls a
+  security-relevant behavior (e.g., skipping a check,
+  disabling verification), is there an audit trail?
+  Can a misconfigured or malicious caller use the
+  input to silently disable a security layer?
+- **Assess severity by blast radius**: An unvalidated
+  input that controls a cosmetic label is LOW; one
+  that silently disables a security check is HIGH.
+
+This enumeration supplements the category-based checks
+above. Categories identify *classes* of vulnerability;
+input enumeration identifies *specific* vectors.
+
+#### 6. Language-Specific Security Patterns [PACK]
 
 > Skip this section if no convention pack is loaded from `.opencode/uf/packs/`.
 
 - Check the convention pack's `security_checks` section for language-specific vulnerability patterns.
 - Apply the pack's error handling conventions to the changed code.
 
-#### 6. Gate Tampering
+#### 7. Gate Tampering
 
 - Has this change removed or weakened any CI security control (`-race` flag, `govulncheck`, linter rules, pinned action SHAs, coverage thresholds)?
 - Flag as HIGH if a security-relevant gate was weakened without documented justification.

--- a/internal/scaffold/assets/opencode/commands/review-council.md
+++ b/internal/scaffold/assets/opencode/commands/review-council.md
@@ -203,7 +203,27 @@ Review the current codebase for compliance with the Behavioral Constraints in `A
 
    For each agent, instruct it to review the full branch diff (all changed files vs `main`) and return its verdict (**APPROVE** or **REQUEST CHANGES**) along with all findings.
 
-3. Collect all **REQUEST CHANGES** findings from the discovered reviewers. If all discovered reviewers return **APPROVE**, report the result and stop.
+3. Collect all **REQUEST CHANGES** findings from the
+   discovered reviewers. If all discovered reviewers
+   return **APPROVE**, report the result and stop.
+
+   **Cross-persona finding consolidation**: Before
+   proceeding to the fix loop, group findings from
+   different personas that (a) affect the same
+   component, file, or pipeline stage, (b) share a
+   common root cause, and (c) together produce a risk
+   greater than any individual finding. Merge each
+   group into a single consolidated finding:
+   - Apply compound severity escalation from
+     `severity.md` to determine the combined severity.
+   - Preserve per-persona attribution (e.g.,
+     "Adversary: missing checksum + SRE: privileged
+     blast radius → consolidated MEDIUM").
+   - Present the consolidated finding with one unified
+     recommendation addressing the root cause.
+
+   Findings with independent root causes MUST remain
+   separate even if they affect the same file.
 
 4. If there are **REQUEST CHANGES**, address the findings by making the necessary code fixes. Then re-run all discovered reviewers to verify the fixes. Repeat this loop until all discovered reviewers return **APPROVE** or the process has exceeded 3 iterations.
 
@@ -250,7 +270,16 @@ step, determine which artifacts to review:
 
    For each agent, instruct it to **operate in Spec Review Mode**: review the spec artifacts identified in the review scope above (not code), plus `.specify/memory/constitution.md` and `AGENTS.md`. Include the workflow tier (Speckit/OpenSpec) in the agent prompt so it can tailor its review accordingly. Instruct the agent to return its verdict (**APPROVE** or **REQUEST CHANGES**) along with all findings.
 
-2. Collect all **REQUEST CHANGES** findings from the discovered reviewers. If all discovered reviewers return **APPROVE**, report the result and stop.
+2. Collect all **REQUEST CHANGES** findings from the
+   discovered reviewers. If all discovered reviewers
+   return **APPROVE**, report the result and stop.
+
+   **Cross-persona finding consolidation**: Apply the
+   same consolidation rule as Code Review Mode Step 3
+   — group findings from different personas that share
+   a root cause, apply compound severity escalation
+   from `severity.md`, and present as consolidated
+   findings with per-persona attribution preserved.
 
 3. If there are **REQUEST CHANGES**, apply the **hybrid fix policy**:
 

--- a/internal/scaffold/assets/opencode/commands/review-pr.md
+++ b/internal/scaffold/assets/opencode/commands/review-pr.md
@@ -478,6 +478,18 @@ Compare the PR intent (title + description + linked spec + linked issues) agains
 - **Completeness**: Are there partial implementations that could leave the system in an inconsistent state?
 - **Drift detection**: Does the code do anything NOT described in the intent/spec? Flag undocumented behavioral changes.
 - **Issue criteria coverage**: For each acceptance criterion from linked issues (Step 6a), verify the code changes address it. Report uncovered criteria as MEDIUM findings with per-criterion status (COVERED / NOT COVERED / PARTIAL).
+- **Issue suggestion gap detection**: After checking
+  acceptance criteria, scan each linked issue body for
+  explicit code suggestions — fenced code blocks
+  (` ``` `), inline code spans, or clearly proposed
+  one-line fixes. For each suggestion found:
+  - Check whether the PR implemented the suggested
+    change.
+  - If implemented: no finding needed.
+  - If not implemented: flag as a finding. Assess
+    severity based on the risk of the gap (e.g., a
+    missing guard clause on a destructive operation is
+    HIGH; a missing style preference is LOW).
 
 #### 8b. Security Review
 
@@ -497,6 +509,27 @@ Examine the diff for security vulnerabilities that linters cannot catch:
 - **Privilege escalation**: Does the code grant permissions or elevate privileges without proper validation?
 - **Secrets and credentials**: Are there hardcoded secrets, tokens, or API keys? Are secrets logged or exposed in error messages?
 - **Dependency risks**: Are new dependencies well-maintained and from trusted sources?
+
+**Adversarial input enumeration**: For each new input,
+parameter, secret, or configuration value introduced
+by the PR, enumerate:
+- What values can a caller pass? (valid range, type,
+  format)
+- What happens for each edge case: empty string, wrong
+  type, wrong case (e.g., `"True"` vs `"true"`),
+  excessively long value, injection payload,
+  null/undefined?
+- Does validation exist? Is it sufficient? Is it
+  applied before the value reaches any security-
+  sensitive operation?
+- If the input controls a security-relevant behavior
+  (e.g., `skip_org_check`, `disable_verification`),
+  is there an audit trail when the input is used to
+  bypass a control?
+
+Flag missing or insufficient validation as findings
+with severity based on the blast radius of the
+unvalidated input.
 
 #### 8c. Constitution Compliance (AI-only items)
 
@@ -519,6 +552,82 @@ For each CI failure classified in Step 3a, provide analysis:
 - Confirm the failure also exists on the base branch
 - Brief root cause analysis if determinable from the error output
 - Note that this will be addressed in Step 10 (fix-branch offer)
+
+#### 8e. CI Bot Annotation Cross-referencing
+
+Before proceeding to consolidation, cross-reference the
+inline comments from Step 7.5b against the findings
+generated in Steps 8a–8d. Identify comments from CI
+bots (Scorecard, Trivy, `github-advanced-security[bot]`,
+Dependabot, CodeQL, etc.) that address the same files
+or concern classes as your findings.
+
+For each match:
+- **Cite the bot finding** in your own finding as
+  corroborating evidence (e.g., "Scorecard flagged the
+  same step for unpinned dependencies").
+- **Use the bot finding to strengthen** your severity
+  classification — if a bot already flagged a concern
+  and your analysis confirms it, the combined evidence
+  supports a higher confidence level.
+- Do NOT dismiss bot findings as "related but different"
+  when they address the same class of problem (e.g.,
+  dependency integrity, secrets exposure, container
+  misconfig) in the same pipeline stage or file.
+
+#### 8f. Finding Consolidation
+
+After generating all findings from Steps 8a–8e, perform
+a consolidation pass before formatting output.
+
+**Consolidation rule**: Group findings that (a) affect
+the same component, pipeline stage, or file cluster,
+(b) share a common root cause, and (c) together produce
+a risk greater than any individual finding. Merge each
+group into a single finding.
+
+For each consolidated finding:
+1. Use the highest individual severity as the floor,
+   then apply the compound severity escalation rule from
+   `severity.md` to determine if the combined severity
+   is higher.
+2. List each contributing factor as a sub-point in the
+   finding description.
+3. Cite the original category (alignment, security,
+   constitution) for each contributing factor so
+   traceability is preserved.
+4. Present one unified recommendation that addresses
+   the root cause, not separate fixes for each symptom.
+
+**When NOT to consolidate**: Findings with independent
+root causes and independent blast radii MUST remain
+separate even if they appear in the same file.
+
+#### 8g. Severity Calibration
+
+After consolidation, perform a calibration pass over
+every finding (including consolidated findings from
+Step 8f). This step counters anchoring bias — the
+tendency to compress all severities toward a "feels
+right" level based on overall PR quality impressions.
+
+For each finding:
+1. Re-read the `severity.md` definition for the
+   currently assigned severity level.
+2. Quote the specific definition clause or example
+   that matches the finding. If no clause matches,
+   check the adjacent severity levels (one above, one
+   below).
+3. If the quoted definition maps to a **different**
+   severity than the current assignment, adjust the
+   severity and note the change (e.g., "Reclassified
+   from MEDIUM to HIGH — matches HIGH definition:
+   'unpinned CI action on mutable tag'").
+4. If the definition confirms the current assignment,
+   retain it with the quoted evidence.
+
+The calibration pass MUST NOT introduce new findings
+— it only adjusts severity levels on existing findings.
 
 ### 9. Output Format
 

--- a/internal/scaffold/assets/opencode/uf/packs/severity.md
+++ b/internal/scaffold/assets/opencode/uf/packs/severity.md
@@ -78,6 +78,34 @@ impact.
 | SRE | Style improvement in error messages, optional health check enhancement, minor doc gap |
 | Architect | Formatting preference, optional structural improvement, minor comment enhancement |
 
+## Compound Severity Escalation
+
+When multiple findings share a root cause, personas MUST
+assess the **combined** severity rather than classifying
+each finding in isolation. Findings that individually
+appear LOW or MEDIUM can compound into a HIGH or
+CRITICAL finding when they create a single coherent
+attack surface or failure mode.
+
+**Rule**: If two or more findings (a) affect the same
+component or pipeline stage, (b) share a common root
+cause, and (c) together produce a risk greater than any
+individual finding, consolidate them into a single
+finding at the escalated severity. The consolidated
+finding MUST cite each contributing factor.
+
+| Pattern | Individual | Compound |
+|---------|-----------|----------|
+| Unverified binary + privileged CI container | MEDIUM + MEDIUM | HIGH (supply chain attack in privileged context) |
+| Broad permissions + missing input validation + external-facing endpoint | MEDIUM + MEDIUM + MEDIUM | HIGH (unauthenticated access with elevated privileges) |
+| Missing error handling + missing retry + critical data path | MEDIUM + LOW + context | HIGH (silent data loss on transient failure) |
+
+**When NOT to escalate**: Findings that happen to appear
+in the same PR but have independent root causes and
+independent blast radii MUST NOT be artificially
+consolidated. Consolidation applies only when the
+findings are causally linked.
+
 ## Auto-Fix Policy (Spec Review Mode)
 
 | Severity | Action | Rationale |

--- a/openspec/changes/review-finding-consolidation/.openspec.yaml
+++ b/openspec/changes/review-finding-consolidation/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: unbound-force
+created: 2026-06-01

--- a/openspec/changes/review-finding-consolidation/design.md
+++ b/openspec/changes/review-finding-consolidation/design.md
@@ -1,0 +1,148 @@
+## Context
+
+The `/review-pr` and `/review-council` commands are the
+primary code review workflows. `/review-pr` is a
+single-pass AI review with CI integration; `/review-council`
+orchestrates multiple Divisor personas in parallel.
+
+Both workflows generate findings per-category or
+per-persona, then present them without synthesis.
+This causes three classes of error:
+
+1. Related findings split across categories/personas
+   at inconsistent severities (fragmentation)
+2. Severity levels anchored on first impressions
+   rather than rigorously calibrated against
+   definitions (anchoring bias)
+3. CI bot findings dismissed as "related but different"
+   instead of used as corroborating evidence
+
+The Adversary persona checks security categories but
+does not enumerate inputs adversarially — it asks
+"are there injection risks?" rather than "for each
+new input, what can a malicious caller pass?"
+
+The org constitution governs quality through four
+principles but has no security-specific principle,
+leaving security enforcement to per-finding judgment.
+
+## Goals / Non-Goals
+
+### Goals
+
+- Add synthesis steps that consolidate, calibrate,
+  and cross-reference findings before output
+- Add adversarial input enumeration to catch
+  input-specific threats the category checklist misses
+- Add compound severity escalation to `severity.md`
+- Add Principle V (Security by Default) to the
+  org constitution
+- Extend PR #229's existing changes with #233's
+  severity calibration and input enumeration gaps
+
+### Non-Goals
+
+- No programmatic enforcement (these are agent
+  instructions, not code)
+- No changes to the CI security pipeline (OSV-Scanner,
+  Trivy, Scorecards remain as-is)
+- No changes to the feedback learning loop (#207)
+- No Gemara integration (deferred to separate work)
+- No changes to the Divisor personas other than
+  Adversary
+
+## Decisions
+
+### D1: Severity calibration as a separate step
+
+Add Step 8g (Severity Calibration) to `/review-pr`
+as a post-generation pass rather than inlining
+calibration into each category step. This ensures
+all findings are calibrated in one pass with
+consistent reference to `severity.md` definitions.
+
+The calibration step requires: for each finding,
+quote the severity definition that matches and
+confirm or adjust the assignment. This counters
+anchoring bias by forcing a second look.
+
+### D2: Finding consolidation after CI cross-ref
+
+The ordering is: 8e (CI bot cross-ref) → 8f
+(consolidation) → 8g (calibration). This ensures
+bot evidence is available for consolidation, and
+calibration happens last on the final set of
+(potentially consolidated) findings.
+
+### D3: Adversarial input enumeration in both files
+
+Add the enumeration substep to both
+`divisor-adversary.md` (the persona definition) and
+`/review-pr` Step 8b (the command workflow). The
+persona definition is authoritative for `/review-council`
+(which delegates to the persona), while the command
+workflow is authoritative for standalone `/review-pr`
+usage. Both must be consistent.
+
+### D4: Constitution Principle V placement
+
+Add as Principle V after Testability. The principle
+covers supply chain integrity, input validation, and
+least privilege. These are foundational security
+properties that apply to all heroes, not just the
+review system.
+
+The version bump is MINOR (1.1.0 → 1.2.0) since
+this adds a new principle without altering existing
+ones. The Sync Impact Report at the top of the
+constitution file must be updated.
+
+### D5: Cross-persona consolidation scope
+
+`/review-council` consolidation applies only at the
+aggregation step (after all personas return findings),
+not during individual persona execution. Each persona
+still operates independently — consolidation is a
+post-processing step that merges findings sharing a
+root cause across personas.
+
+### D6: Anti-consolidation guard
+
+Both `severity.md` and the consolidation steps
+include an explicit anti-consolidation rule: findings
+with independent root causes and independent blast
+radii MUST remain separate even if they appear in the
+same file or PR. This prevents artificial inflation of
+severity through unrelated-finding grouping.
+
+## Risks / Trade-offs
+
+### Risk: Over-consolidation
+
+Agents may consolidate unrelated findings that happen
+to touch the same file. Mitigated by the
+anti-consolidation guard (D6) and the three-part
+test: same component, shared root cause, combined risk
+greater than individual.
+
+### Risk: Calibration step adds review latency
+
+An additional pass over all findings adds token cost
+and time. Trade-off is acceptable because the
+alternative (under-classified findings that miss real
+security issues) has a higher cost.
+
+### Risk: Constitution amendment process
+
+Adding Principle V requires hero constitution alignment
+review. Mitigated by the constitution's own amendment
+process — hero repos must open alignment issues within
+one release cycle. The principle is additive (no
+existing principles change), minimizing conflict risk.
+
+### Trade-off: Duplicate enumeration instructions
+
+The adversarial input enumeration appears in both
+`divisor-adversary.md` and `review-pr.md`. This is
+intentional (D3) but creates a maintenance surface
+for keeping them in sync.

--- a/openspec/changes/review-finding-consolidation/proposal.md
+++ b/openspec/changes/review-finding-consolidation/proposal.md
@@ -1,0 +1,132 @@
+## Why
+
+Two related issues exposed structural gaps in the review
+infrastructure that cause security findings to be
+under-classified and fragmented:
+
+1. **Finding fragmentation** (#228): During a supply
+   chain review (complytime-collector-components#229),
+   the Adversary persona split one compound finding
+   (unsigned binary download + privileged CI container)
+   into three separate findings at LOW/MEDIUM instead
+   of recognizing them as one MEDIUM-with-escalation.
+   Root causes: no dependency necessity check, no
+   compound severity rule, no finding consolidation
+   pass, CI bot annotations dismissed as unrelated,
+   no cross-persona consolidation in `/review-council`.
+
+2. **Severity anchoring bias** (#233): During a
+   different review (complytime/org-infra#285), three
+   HIGH findings were initially classified as MEDIUM
+   because the reviewer anchored on a positive first
+   impression. Root causes: no severity calibration
+   step forcing re-read of definitions, no adversarial
+   input enumeration, no linked-issue suggestion gap
+   detection.
+
+Both issues share a common theme: the security
+*detection* infrastructure is comprehensive, but the
+*synthesis* layer is missing. Agents find issues
+individually but lack reasoning steps to consolidate,
+calibrate, and cross-reference.
+
+Additionally, the org constitution has no explicit
+security principle. Security is enforced indirectly
+through gatekeeping integrity and testability, leaving
+supply chain integrity and input validation subject to
+per-finding severity judgment rather than constitutional
+authority.
+
+## What Changes
+
+### New Capabilities
+
+- **Compound Severity Escalation**: New section in
+  `severity.md` defining when individually-moderate
+  findings compose into higher-severity findings.
+- **Severity Calibration Step**: New post-Step-8 pass
+  in `/review-pr` forcing re-read of `severity.md`
+  definitions with quoted evidence for each finding.
+- **Adversarial Input Enumeration**: New substep in
+  `/review-pr` Step 8b and `divisor-adversary.md`
+  requiring per-input threat analysis for each new
+  input/parameter introduced by the PR.
+- **Constitution Principle V: Security by Default**:
+  New org-level principle elevating supply chain
+  integrity, input validation, and least privilege
+  to constitutional status.
+
+### Modified Capabilities
+
+- **`divisor-adversary.md`**: Audit Checklist item 2
+  adds dependency necessity check, content-integrity
+  verification guidance, CI bot corroboration
+  instruction, and adversarial input enumeration.
+- **`severity.md`**: Adds Compound Severity Escalation
+  section with escalation rule, example patterns, and
+  anti-consolidation guard.
+- **`/review-pr`**: Adds Steps 8e (CI bot annotation
+  cross-referencing), 8f (finding consolidation),
+  8g (severity calibration), and 8b substep
+  (adversarial input enumeration).
+- **`/review-council`**: Adds cross-persona finding
+  consolidation in Code Review Mode Step 3 and Spec
+  Review Mode Step 2.
+
+### Removed Capabilities
+
+- None.
+
+## Impact
+
+- `.opencode/agents/divisor-adversary.md` — expanded
+  Audit Checklist items 2 and new item for adversarial
+  input enumeration
+- `.opencode/uf/packs/severity.md` — new Compound
+  Severity Escalation section
+- `.opencode/commands/review-pr.md` — new Steps
+  8e, 8f, 8g, and 8b substep
+- `.opencode/commands/review-council.md` — consolidation
+  pass in Code Review Step 3 and Spec Review Step 2
+- `.specify/memory/constitution.md` — new Principle V
+
+## Constitution Alignment
+
+### I. Autonomous Collaboration
+
+**Assessment**: PASS
+
+Finding consolidation and severity calibration operate
+within each agent's own analysis pass. Cross-persona
+consolidation in `/review-council` merges findings
+from artifacts already produced by independent agents
+— no runtime coupling is introduced.
+
+### II. Composability First
+
+**Assessment**: PASS
+
+All changes are additive to existing agent files and
+convention packs. No new mandatory dependencies are
+introduced. The severity calibration step references
+`severity.md` which is already a required dependency
+for all Divisor personas.
+
+### III. Observable Quality
+
+**Assessment**: PASS
+
+Consolidated findings preserve per-persona attribution
+and cite contributing factors. Severity calibration
+requires quoting the severity definition that matches
+each finding, making classification decisions auditable.
+
+### IV. Testability
+
+**Assessment**: N/A
+
+These changes modify agent instruction files and
+convention packs (Markdown), not source code. No
+coverage strategy is needed. Verification is via
+review-based testing (run `/review-council` on a
+known PR and check finding quality).

--- a/openspec/changes/review-finding-consolidation/specs/review-synthesis.md
+++ b/openspec/changes/review-finding-consolidation/specs/review-synthesis.md
@@ -1,0 +1,175 @@
+## ADDED Requirements
+
+### Requirement: Compound Severity Escalation
+
+`severity.md` MUST define a Compound Severity
+Escalation section that instructs personas to assess
+combined severity when multiple findings share a root
+cause. The rule MUST require three conditions for
+consolidation: (a) same component or pipeline stage,
+(b) shared root cause, (c) combined risk greater than
+any individual finding. The section MUST include
+example escalation patterns and an anti-consolidation
+guard for independent findings.
+
+#### Scenario: Two related supply chain findings
+
+- **GIVEN** a PR introduces an unverified binary
+  download (MEDIUM) in a `--privileged` CI container
+  (MEDIUM)
+- **WHEN** the reviewer applies compound severity
+  escalation
+- **THEN** the two findings are consolidated into a
+  single HIGH finding citing both contributing factors
+
+#### Scenario: Two unrelated findings in same file
+
+- **GIVEN** a PR has a missing error wrap (MEDIUM) and
+  an overly broad file permission (MEDIUM) in the same
+  file but with independent root causes
+- **WHEN** the reviewer applies compound severity
+  escalation
+- **THEN** the findings remain separate at MEDIUM each
+
+### Requirement: Severity Calibration Step
+
+`/review-pr` MUST include a Severity Calibration step
+(Step 8g) after finding consolidation (Step 8f). For
+each finding, the reviewer MUST re-read the matching
+`severity.md` definition and quote it as evidence for
+the severity assignment. If the quoted definition maps
+to a different severity level, the assignment MUST be
+adjusted.
+
+#### Scenario: Anchoring bias correction
+
+- **GIVEN** a reviewer initially classifies a finding
+  as MEDIUM based on overall PR quality impression
+- **WHEN** the severity calibration step forces
+  re-reading the severity definition
+- **THEN** the finding is reclassified to HIGH because
+  the definition for HIGH explicitly matches the
+  finding's characteristics
+
+### Requirement: CI Bot Annotation Cross-referencing
+
+`/review-pr` MUST include a CI Bot Annotation
+Cross-referencing step (Step 8e) before finding
+consolidation. The step MUST cross-reference inline
+comments from CI bots (Scorecard, Trivy, GHAS,
+Dependabot, CodeQL) against the reviewer's own
+findings. Matching bot findings MUST be cited as
+corroborating evidence, not dismissed as unrelated.
+
+#### Scenario: Scorecard flags same dependency issue
+
+- **GIVEN** Scorecard has flagged an unpinned
+  dependency in a CI workflow
+- **WHEN** the Adversary persona also identifies the
+  same unpinned dependency
+- **THEN** the reviewer cites the Scorecard finding
+  as corroborating evidence and uses it to strengthen
+  the severity classification
+
+### Requirement: Finding Consolidation Pass
+
+`/review-pr` MUST include a Finding Consolidation
+step (Step 8f) after CI bot cross-referencing. The
+step MUST group findings sharing a root cause using
+the compound severity escalation rule from
+`severity.md`. Each consolidated finding MUST list
+contributing factors with original category attribution.
+
+`/review-council` MUST include a cross-persona finding
+consolidation pass in Code Review Mode (Step 3) and
+Spec Review Mode (Step 2) before the fix loop. The
+pass MUST group findings from different personas
+sharing a root cause and apply compound severity
+escalation.
+
+#### Scenario: Cross-persona consolidation
+
+- **GIVEN** the Adversary flags "missing checksum" as
+  MEDIUM and the SRE flags "privileged blast radius"
+  as MEDIUM on the same CI pipeline
+- **WHEN** `/review-council` applies cross-persona
+  consolidation
+- **THEN** the findings are merged into a single
+  consolidated finding at HIGH with attribution to
+  both personas
+
+### Requirement: Adversarial Input Enumeration
+
+`divisor-adversary.md` Audit Checklist and
+`/review-pr` Step 8b MUST include an adversarial
+input enumeration substep. For each new input,
+parameter, or secret introduced by the change, the
+reviewer MUST enumerate: (a) what values a caller can
+pass, (b) what happens for each edge case (empty,
+wrong type, wrong case, injection payload), (c)
+whether validation exists and is sufficient.
+
+#### Scenario: Case-sensitive input without validation
+
+- **GIVEN** a PR introduces a `generate_attestations`
+  string parameter that is compared case-sensitively
+- **WHEN** the reviewer enumerates adversarial inputs
+- **THEN** the reviewer identifies that passing
+  `"True"` instead of `"true"` silently skips
+  attestation generation and classifies this as HIGH
+
+### Requirement: Dependency Necessity Check
+
+`divisor-adversary.md` Audit Checklist item 2 MUST
+ask "Is each external tool, binary, or library
+justified?" before "Are dependencies pinned?" The
+check MUST determine whether the project's existing
+toolchain could cover the same use case.
+
+#### Scenario: Unnecessary binary download
+
+- **GIVEN** a PR downloads an external binary for a
+  task the project's existing tools can perform
+- **WHEN** the reviewer applies the dependency
+  necessity check
+- **THEN** the reviewer flags the dependency as
+  unnecessary attack surface and recommends removal
+
+### Requirement: Issue Suggestion Gap Detection
+
+`/review-pr` Step 8a MUST include a substep that
+scans linked issue bodies for explicit code
+suggestions (fenced code blocks, inline code). For
+each suggestion, the reviewer MUST check whether the
+PR implemented it. Unimplemented suggestions MUST be
+flagged as findings with severity based on risk.
+
+#### Scenario: Linked issue suggests guard clause
+
+- **GIVEN** a linked issue suggests adding
+  `cancel-in-progress: ${{ !github.ref_protected }}`
+- **WHEN** the PR keeps unconditional
+  `cancel-in-progress: true`
+- **THEN** the reviewer flags this as a HIGH finding
+  ("destructive operation without guard")
+
+## ADDED Requirements (Constitution)
+
+### Requirement: Principle V — Security by Default
+
+The org constitution MUST include a fifth core
+principle: Security by Default. The principle MUST
+require: (a) supply chain integrity — dependencies
+verified by content hash, (b) input validation — all
+external inputs validated before use, (c) least
+privilege — components operate with minimum necessary
+permissions.
+
+#### Scenario: New hero constitution alignment
+
+- **GIVEN** a hero repository has a constitution
+  aligned to org constitution v1.1.0
+- **WHEN** org constitution v1.2.0 adds Principle V
+- **THEN** the hero MUST open an alignment issue
+  within one release cycle to review Principle V
+  compliance

--- a/openspec/changes/review-finding-consolidation/tasks.md
+++ b/openspec/changes/review-finding-consolidation/tasks.md
@@ -1,0 +1,90 @@
+<!--
+  [P] marks tasks eligible for parallel execution.
+  Add [P] when: different files, no deps, safe to
+  parallelize. Do NOT add [P] when tasks modify the
+  same file.
+-->
+
+## 1. Severity Pack Enhancement
+
+- [x] 1.1 Add "Compound Severity Escalation" section
+  to `.opencode/uf/packs/severity.md` with escalation
+  rule (three-part test), example patterns table, and
+  anti-consolidation guard
+
+## 2. Adversary Persona Updates
+
+- [x] 2.1 Add dependency necessity check to Audit
+  Checklist item 2 in
+  `.opencode/agents/divisor-adversary.md` — "Is each
+  external tool justified?" before integrity checks
+- [x] 2.2 Add content-integrity verification guidance
+  to Audit Checklist item 2 — SHA256 vs name-addressed,
+  severity depends on execution context
+- [x] 2.3 Add CI bot corroboration instruction to
+  Audit Checklist item 2 — treat Scorecard/Trivy/GHAS
+  findings as corroborating evidence
+- [x] 2.4 Add adversarial input enumeration section to
+  Audit Checklist (new item 5 between existing items 4
+  and old item 5) — per-input threat analysis for each
+  new input/parameter/secret. Renumbered subsequent
+  items (old 5 → 6, old 6 → 7).
+
+## 3. Review-PR Command Enhancements
+
+- [x] 3.1 Add Step 8e (CI Bot Annotation
+  Cross-referencing) to
+  `.opencode/commands/review-pr.md` — cross-reference
+  Step 7.5b inline comments against Steps 8a–8d
+  findings
+- [x] 3.2 Add Step 8f (Finding Consolidation) to
+  `.opencode/commands/review-pr.md` — group findings
+  by root cause, apply compound severity escalation,
+  preserve category attribution
+- [x] 3.3 Add Step 8g (Severity Calibration) to
+  `.opencode/commands/review-pr.md` — for each finding,
+  quote matching `severity.md` definition and confirm
+  or adjust severity assignment
+- [x] 3.4 Add adversarial input enumeration substep to
+  Step 8b (Security Review) in
+  `.opencode/commands/review-pr.md`
+- [x] 3.5 Add issue suggestion gap detection substep
+  to Step 8a (Alignment Check) in
+  `.opencode/commands/review-pr.md`
+
+## 4. Review-Council Command Enhancements
+
+- [x] 4.1 [P] Add cross-persona finding consolidation
+  to Code Review Mode Step 3 in
+  `.opencode/commands/review-council.md`
+- [x] 4.2 [P] Add cross-persona finding consolidation
+  to Spec Review Mode Step 2 in
+  `.opencode/commands/review-council.md`
+
+## 5. Constitution Amendment
+
+- [x] 5.1 Add Principle V (Security by Default) to
+  `.specify/memory/constitution.md` — supply chain
+  integrity, input validation, least privilege,
+  dependency necessity
+- [x] 5.2 Update constitution version from 1.1.0 to
+  1.2.0 and amend date
+- [x] 5.3 Update Sync Impact Report comment block at
+  top of constitution file
+- [x] 5.4 Update Hero Constitution Alignment section
+  — note that hero repos need Principle V alignment
+  review
+
+## 6. Verification
+
+- [x] 6.1 Verify `severity.md` compound escalation
+  section includes both escalation examples and
+  anti-consolidation guard
+- [x] 6.2 Verify `/review-pr` Steps 8e → 8f → 8g
+  are in correct order (CI cross-ref → consolidation
+  → calibration)
+- [x] 6.3 Verify adversarial input enumeration is
+  consistent between `divisor-adversary.md` and
+  `review-pr.md` Step 8b
+- [x] 6.4 Verify constitution Principle V does not
+  contradict existing principles I–IV


### PR DESCRIPTION
## Summary

- Adds dependency necessity check, content-integrity verification guidance, and CI bot corroboration to the Adversary persona checklist
- Adds adversarial input enumeration as new Audit Checklist item 5 in `divisor-adversary.md` and as a substep in `/review-pr` Step 8b
- Adds compound severity escalation rule to `severity.md` so individually-moderate findings sharing a root cause are correctly classified at the combined severity
- Adds Steps 8e (CI Bot Annotation Cross-referencing), 8f (Finding Consolidation), and 8g (Severity Calibration) to `/review-pr`
- Adds issue suggestion gap detection substep to `/review-pr` Step 8a
- Adds cross-persona finding consolidation to `/review-council` at the collection step in both Code Review and Spec Review modes
- Adds Constitution Principle V (Security by Default) covering supply chain integrity, input validation, least privilege, and dependency necessity
- Includes full OpenSpec spec artifacts under `openspec/changes/review-finding-consolidation/`

Motivated by post-mortem of two reviews:
1. [complytime-collector-components#229](https://github.com/complytime/complytime-collector-components/pull/229) — Adversary persona split a single supply chain finding into three separate LOW/MEDIUM findings (finding fragmentation, #228)
2. [complytime/org-infra#285](https://github.com/complytime/org-infra/pull/285) — Three HIGH findings were initially classified as MEDIUM due to anchoring bias (severity under-rating, #233)

## Files Changed

| File | Change |
|------|--------|
| `.opencode/agents/divisor-adversary.md` | Add necessity-before-integrity check, content-integrity verification, CI bot corroboration (item 2); add adversarial input enumeration (new item 5); renumber items 5→6, 6→7 |
| `.opencode/uf/packs/severity.md` | Add Compound Severity Escalation section with rule, examples table, and anti-consolidation guard |
| `.opencode/commands/review-pr.md` | Add Steps 8e (CI bot cross-ref), 8f (consolidation), 8g (severity calibration); add adversarial input enumeration substep in 8b; add issue suggestion gap detection in 8a |
| `.opencode/commands/review-council.md` | Add cross-persona finding consolidation at Step 3 (Code Review) and Step 2 (Spec Review) |
| `.specify/memory/constitution.md` | Add Principle V (Security by Default); version 1.1.0 → 1.2.0; update Sync Impact Report and hero alignment notes |
| `CHANGELOG.md` | Add Unreleased entries for all new features |
| `openspec/changes/review-finding-consolidation/` | Full OpenSpec artifacts: proposal, design, delta spec, tasks |

## Test plan

- [ ] Check out this branch (`gh pr checkout 229`), then run `/review-council` to verify the new severity.md section is loaded and the consolidation pass runs
- [ ] Run `/review-pr` on a PR with known CI bot annotations to verify Step 8e cross-referencing
- [ ] Verify consolidation logic in `/review-pr` Step 8f and `/review-council` Step 3 produces a single finding for related issues
- [ ] Verify severity calibration (Step 8g) quotes `severity.md` definitions for each finding
- [ ] Verify adversarial input enumeration runs for PRs introducing new parameters
- [ ] Review constitution Principle V for consistency with Principles I–IV

Website issue: unbound-force/website#142

Fixes #228
Fixes #233
Refer discussion: https://github.com/orgs/unbound-force/discussions/236