### PR TITLE
fix: remove self-referential /speckit.implement from guardrail

### DIFF
--- a/.opencode/commands/speckit.implement.md
+++ b/.opencode/commands/speckit.implement.md
@@ -155,7 +155,7 @@ Note: This command assumes a complete task breakdown exists in tasks.md. If task
 
 - **NEVER modify source code** — this command updates
   spec artifacts ONLY. Implementation changes belong in
-  `/speckit.implement`, `/unleash`, or `/cobalt-crush`.
+  `/unleash` or `/cobalt-crush`.
 - **NEVER modify test files, Go source, Markdown agents,
   convention packs, or config files** outside the
   `specs/NNN-*/` feature directory.

--- a/openspec/changes/fix-speckit-implement-guardrail/.openspec.yaml
+++ b/openspec/changes/fix-speckit-implement-guardrail/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: unbound-force
+created: 2026-06-04

--- a/openspec/changes/fix-speckit-implement-guardrail/design.md
+++ b/openspec/changes/fix-speckit-implement-guardrail/design.md
@@ -1,0 +1,62 @@
+## Context
+
+`.opencode/commands/speckit.implement.md` is the slash
+command that advances a Speckit spec through its
+implementation phase. It manages checkbox state in
+`tasks.md`, tracks progress, and delegates actual
+coding to `/unleash` or `/cobalt-crush`. It never
+modifies source code directly.
+
+Lines 156-158 contain a guardrail that was copied from
+a spec-authoring command without being updated. The
+guardrail correctly forbids source code changes but
+then lists `/speckit.implement` (this command) as a
+valid destination for implementation work, creating a
+self-referential contradiction.
+
+The fix is a one-line text edit: remove the
+`/speckit.implement,` token from line 158, leaving
+`/unleash` and `/cobalt-crush` as the only valid
+implementation destinations.
+
+## Goals / Non-Goals
+
+### Goals
+- Remove the self-reference from the guardrail on
+  line 158 of `.opencode/commands/speckit.implement.md`
+- Preserve the intent of the guardrail (this command
+  does not modify source code)
+- Leave the corrected guardrail pointing to `/unleash`
+  and `/cobalt-crush` as the proper implementation
+  commands
+
+### Non-Goals
+- Do not change the guardrail's intent or any other
+  part of the file
+- Do not audit or fix other commands for similar issues
+- Do not add tests (the file is prompt content, not
+  executable code)
+
+## Decisions
+
+**Single-file, single-line edit**: The fix is confined
+to one line in one file. No other files reference this
+guardrail text. The scaffold copy of this command (if
+one exists in `internal/scaffold/assets/`) must also
+be checked and updated if present.
+
+**No spec delta**: The change does not alter any
+functional requirement, API, or data model. A full
+delta spec is not warranted. The proposal and this
+design document are sufficient specification.
+
+## Risks / Trade-offs
+
+**Risk**: Scaffold copy out of sync. If
+`internal/scaffold/assets/opencode/commands/speckit.implement.md`
+exists, it must receive the same fix or newly scaffolded
+repos will receive the broken guardrail. The task list
+includes an explicit check for this.
+
+**Trade-off**: None. The fix is unambiguous and has no
+behavioral side effects.

--- a/openspec/changes/fix-speckit-implement-guardrail/proposal.md
+++ b/openspec/changes/fix-speckit-implement-guardrail/proposal.md
@@ -1,0 +1,81 @@
+## Why
+
+`.opencode/commands/speckit.implement.md` contains a
+guardrail copied from spec-authoring commands that was
+never corrected for its new context. Lines 156-158 read:
+
+```
+- **NEVER modify source code** — this command updates
+  spec artifacts ONLY. Implementation changes belong in
+  `/speckit.implement`, `/unleash`, or `/cobalt-crush`.
+```
+
+`/speckit.implement` is the command that contains this
+guardrail — listing itself as the implementation
+destination contradicts the guardrail's own prohibition.
+An agent reading this guardrail receives contradictory
+instructions: "never implement here" and "implement
+here". This is a copy-paste error from spec-authoring
+commands (e.g., `/speckit.plan`) where the guardrail
+is appropriate and `/speckit.implement` is legitimately
+the correct delegation target.
+
+Fixes unbound-force/unbound-force#238.
+
+## What Changes
+
+Remove `/speckit.implement` from the guardrail's list
+of implementation destinations in
+`.opencode/commands/speckit.implement.md` line 158.
+
+## Capabilities
+
+### Modified Capabilities
+- `/speckit.implement` guardrail: no longer lists
+  itself as a valid implementation destination
+
+### New Capabilities
+- None
+
+### Removed Capabilities
+- None
+
+## Impact
+
+### Files Affected
+
+| Area | Changes |
+|------|---------|
+| `.opencode/commands/speckit.implement.md` | Remove self-reference on line 158 |
+
+### External Dependencies
+- None
+
+## Constitution Alignment
+
+Assessed against the Unbound Force org constitution.
+
+### I. Autonomous Collaboration
+
+**Assessment**: N/A — this change fixes documentation
+in a slash command file. It does not affect
+artifact-based communication between heroes.
+
+### II. Composability First
+
+**Assessment**: N/A — this change does not introduce
+or remove any dependencies between components.
+
+### III. Observable Quality
+
+**Assessment**: PASS — correcting a self-contradictory
+guardrail improves the accuracy of the system's
+self-description. Agents receive unambiguous
+instructions, which is a form of observable quality
+in the prompt layer.
+
+### IV. Testability
+
+**Assessment**: N/A — slash command markdown files are
+not directly unit-tested. The correctness of the
+change is verified by reading the file after the edit.

--- a/openspec/changes/fix-speckit-implement-guardrail/tasks.md
+++ b/openspec/changes/fix-speckit-implement-guardrail/tasks.md
@@ -1,0 +1,17 @@
+## 1. Apply the fix
+
+- [x] 1.1 In `.opencode/commands/speckit.implement.md`
+  line 158: remove `/speckit.implement,` so the line
+  reads `  /unleash` or `/cobalt-crush`.`
+- [x] 1.2 Confirm no scaffold copy exists at
+  `internal/scaffold/assets/opencode/commands/speckit.implement.md`
+  (confirmed absent — no action needed)
+
+## 2. Verify
+
+- [x] 2.1 Read the updated guardrail block (lines
+  156-158) and confirm the self-reference is gone and
+  the remaining text is grammatically correct
+<!-- spec-review: passed -->
+<!-- code-review: passed -->
+<!-- scaffolded by uf vdev -->


### PR DESCRIPTION
## Summary

`.opencode/commands/speckit.implement.md` lines 156-158 contained a guardrail copied from spec-authoring commands that listed `/speckit.implement` — itself — as a valid destination for implementation changes, while simultaneously forbidding implementation changes. This is a self-referential contradiction.

The fix removes `/speckit.implement` from the list, leaving `/unleash` and `/cobalt-crush` as the correct delegation targets.

## Changes

- `.opencode/commands/speckit.implement.md`: remove `/speckit.implement,` from guardrail line 158
- `openspec/changes/fix-speckit-implement-guardrail/`: OpenSpec artifacts for this change

Closes #238

---

Today I'm submitting fixes for the unbound-force ecosystem in the spirit of trying it out and helping out, please don't expect my continued availability, thanks!