### PR TITLE
chore: skip empty custom convention pack imports in CLAUDE.md

### DIFF
--- a/.gaze/baseline.json
+++ b/.gaze/baseline.json
@@ -1309,8 +1309,8 @@
       "file": "internal/doctor/checks.go",
       "line": 216,
       "complexity": 4,
-      "line_coverage": 71.42857142857143,
-      "crap": 4.373177842565598
+      "line_coverage": 0,
+      "crap": 20
     },
     {
       "package": "doctor",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,12 +6,9 @@
 ## Convention Packs
 
 @.opencode/uf/packs/default.md
-@.opencode/uf/packs/default-custom.md
 @.opencode/uf/packs/severity.md
 @.opencode/uf/packs/content.md
-@.opencode/uf/packs/content-custom.md
 @.opencode/uf/packs/go.md
-@.opencode/uf/packs/go-custom.md
 
 ## Review Agents (read on-demand)
 

--- a/internal/scaffold/scaffold.go
+++ b/internal/scaffold/scaffold.go
@@ -1300,6 +1300,14 @@ func collectDeployedPacks(lang, root string) []string {
 	if lang != "" && lang != "default" {
 		candidates = append(candidates, lang+".md", lang+"-custom.md")
 	}
+	return filterEmptyCustomPacks(candidates, root)
+}
+
+// filterEmptyCustomPacks removes *-custom.md entries whose on-disk
+// files are empty stubs (no rule content after the sentinel comment).
+// When root is empty, all candidates are returned unchanged (no
+// filesystem access).
+func filterEmptyCustomPacks(candidates []string, root string) []string {
 	if root == "" {
 		return candidates
 	}

--- a/internal/scaffold/scaffold.go
+++ b/internal/scaffold/scaffold.go
@@ -1001,7 +1001,7 @@ func ensureAGENTSmdPackSection(opts *Options, lang string) subToolResult {
 		}
 	}
 
-	packs := collectDeployedPacks(lang)
+	packs := collectDeployedPacks(lang, opts.TargetDir)
 	var section strings.Builder
 	section.WriteString("\n" + agentsmdPackMarker + "\n\n")
 	section.WriteString("This repository uses convention packs scaffolded by\n")
@@ -1052,8 +1052,11 @@ func replaceManagedBlock(content, marker, newBlock string) (string, bool) {
 const claudemdMarker = "# Unbound Force — managed by uf init"
 
 // buildCLAUDEmdBlock generates the managed block for CLAUDE.md.
-func buildCLAUDEmdBlock(lang string) string {
-	packs := collectDeployedPacks(lang)
+// root is the project root directory; when non-empty, empty custom
+// packs are excluded from the generated @-import lines (see
+// collectDeployedPacks).
+func buildCLAUDEmdBlock(lang, root string) string {
+	packs := collectDeployedPacks(lang, root)
 	var block strings.Builder
 	block.WriteString(claudemdMarker + "\n\n")
 	block.WriteString("@AGENTS.md\n")
@@ -1090,7 +1093,7 @@ func ensureCLAUDEmd(opts *Options, lang string) subToolResult {
 		}
 	}
 
-	newBlock := buildCLAUDEmdBlock(lang)
+	newBlock := buildCLAUDEmdBlock(lang, opts.TargetDir)
 
 	// Marker present -- check whether managed block needs updating.
 	if readErr == nil && strings.Contains(string(existing), claudemdMarker) {
@@ -1152,8 +1155,10 @@ func ensureCLAUDEmd(opts *Options, lang string) subToolResult {
 const cursorrulesMarker = claudemdMarker
 
 // buildCursorrulesBlock generates the managed block for .cursorrules.
-func buildCursorrulesBlock(lang string) string {
-	packs := collectDeployedPacks(lang)
+// root is the project root directory; when non-empty, empty custom
+// packs are excluded (see collectDeployedPacks).
+func buildCursorrulesBlock(lang, root string) string {
+	packs := collectDeployedPacks(lang, root)
 	var block strings.Builder
 	block.WriteString(cursorrulesMarker + "\n\n")
 	block.WriteString("This project follows coding conventions defined in\n")
@@ -1194,7 +1199,7 @@ func ensureCursorrules(opts *Options, lang string) subToolResult {
 		}
 	}
 
-	newBlock := buildCursorrulesBlock(lang)
+	newBlock := buildCursorrulesBlock(lang, opts.TargetDir)
 
 	// Marker present -- check whether managed block needs updating.
 	if readErr == nil && strings.Contains(string(existing), cursorrulesMarker) {
@@ -1251,13 +1256,41 @@ func ensureCursorrules(opts *Options, lang string) subToolResult {
 	}
 }
 
+// hasRuleContent reports whether the convention pack file at path
+// contains actual rule content — defined as at least one non-whitespace
+// character after the last occurrence of the placeholder sentinel
+// comment. If the file cannot be read (missing, permission error,
+// etc.), hasRuleContent returns true so that the caller fails open and
+// does not silently drop an import the user may have populated.
+func hasRuleContent(path string) bool {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return true // fail-open: unknown → include
+	}
+	const sentinel = "<!-- Add project-specific rules below this line -->"
+	content := string(data)
+	idx := strings.LastIndex(content, sentinel)
+	if idx < 0 {
+		return true // no sentinel → assume non-empty scaffold
+	}
+	after := content[idx+len(sentinel):]
+	return strings.TrimSpace(after) != ""
+}
+
 // collectDeployedPacks returns the list of convention pack filenames
 // that would be deployed for the given resolved language. The list
 // always includes default.md, default-custom.md, severity.md,
 // content.md, and content-custom.md. Language-specific packs are
 // added when lang is not "default".
-func collectDeployedPacks(lang string) []string {
-	packs := []string{
+//
+// When root is non-empty, each *-custom.md entry is checked with
+// hasRuleContent against the file on disk at
+// <root>/.opencode/uf/packs/<name>. Empty stubs are omitted from the
+// returned list. Non-custom packs are always included regardless of
+// root. When root is empty the function behaves as before (all packs
+// returned, no filesystem access).
+func collectDeployedPacks(lang, root string) []string {
+	candidates := []string{
 		"default.md",
 		"default-custom.md",
 		"severity.md",
@@ -1265,7 +1298,20 @@ func collectDeployedPacks(lang string) []string {
 		"content-custom.md",
 	}
 	if lang != "" && lang != "default" {
-		packs = append(packs, lang+".md", lang+"-custom.md")
+		candidates = append(candidates, lang+".md", lang+"-custom.md")
+	}
+	if root == "" {
+		return candidates
+	}
+	packs := make([]string, 0, len(candidates))
+	for _, name := range candidates {
+		if strings.HasSuffix(name, "-custom.md") {
+			path := filepath.Join(root, ".opencode", "uf", "packs", name)
+			if !hasRuleContent(path) {
+				continue // skip empty stub
+			}
+		}
+		packs = append(packs, name)
 	}
 	return packs
 }

--- a/internal/scaffold/scaffold_test.go
+++ b/internal/scaffold/scaffold_test.go
@@ -4380,7 +4380,7 @@ func TestReplaceManagedBlock_PreservesPrefix(t *testing.T) {
 func TestEnsureCLAUDEmd_AlreadyConfigured(t *testing.T) {
 	dir := t.TempDir()
 
-	existing := buildCLAUDEmdBlock("go")
+	existing := buildCLAUDEmdBlock("go", "")
 	claudePath := filepath.Join(dir, "CLAUDE.md")
 	if err := os.WriteFile(claudePath, []byte(existing), 0o644); err != nil {
 		t.Fatalf("write CLAUDE.md: %v", err)
@@ -4585,7 +4585,7 @@ func TestEnsureCursorrules_ExistingWithoutMarker(t *testing.T) {
 func TestEnsureCursorrules_AlreadyConfigured(t *testing.T) {
 	dir := t.TempDir()
 
-	existing := buildCursorrulesBlock("go")
+	existing := buildCursorrulesBlock("go", "")
 	rulesPath := filepath.Join(dir, ".cursorrules")
 	if err := os.WriteFile(rulesPath, []byte(existing), 0o644); err != nil {
 		t.Fatalf("write .cursorrules: %v", err)
@@ -4714,7 +4714,7 @@ func TestEnsureCursorrules_Idempotent(t *testing.T) {
 }
 
 func TestCollectDeployedPacks_Go(t *testing.T) {
-	packs := collectDeployedPacks("go")
+	packs := collectDeployedPacks("go", "")
 
 	expected := map[string]bool{
 		"default.md":        true,
@@ -4737,7 +4737,7 @@ func TestCollectDeployedPacks_Go(t *testing.T) {
 }
 
 func TestCollectDeployedPacks_TypeScript(t *testing.T) {
-	packs := collectDeployedPacks("typescript")
+	packs := collectDeployedPacks("typescript", "")
 
 	found := false
 	for _, p := range packs {
@@ -4751,7 +4751,7 @@ func TestCollectDeployedPacks_TypeScript(t *testing.T) {
 }
 
 func TestCollectDeployedPacks_Default(t *testing.T) {
-	packs := collectDeployedPacks("default")
+	packs := collectDeployedPacks("default", "")
 
 	for _, p := range packs {
 		if p == "default.md" || p == "default-custom.md" ||
@@ -4763,6 +4763,274 @@ func TestCollectDeployedPacks_Default(t *testing.T) {
 	}
 	if len(packs) != 5 {
 		t.Errorf("expected 5 packs for default lang, got %d", len(packs))
+	}
+}
+
+// --- hasRuleContent tests ---
+
+func TestHasRuleContent_EmptyStub(t *testing.T) {
+	dir := t.TempDir()
+	stub := `---
+pack_id: default-custom
+language: Any
+version: 1.0.0
+---
+
+# Custom Rules: Default
+
+Project-specific conventions.
+
+## Custom Rules
+
+<!-- Add project-specific rules below this line -->`
+	path := filepath.Join(dir, "default-custom.md")
+	if err := os.WriteFile(path, []byte(stub), 0o644); err != nil {
+		t.Fatalf("write stub: %v", err)
+	}
+
+	if hasRuleContent(path) {
+		t.Error("expected false for empty stub, got true")
+	}
+}
+
+func TestHasRuleContent_WhitespaceOnlyAfterSentinel(t *testing.T) {
+	dir := t.TempDir()
+	stub := "<!-- Add project-specific rules below this line -->\n\n   \n\t\n"
+	path := filepath.Join(dir, "go-custom.md")
+	if err := os.WriteFile(path, []byte(stub), 0o644); err != nil {
+		t.Fatalf("write stub: %v", err)
+	}
+
+	if hasRuleContent(path) {
+		t.Error("expected false for whitespace-only after sentinel, got true")
+	}
+}
+
+func TestHasRuleContent_PopulatedFile(t *testing.T) {
+	dir := t.TempDir()
+	populated := `---
+pack_id: go-custom
+language: Go
+version: 1.0.0
+---
+
+## Custom Rules
+
+<!-- Add project-specific rules below this line -->
+
+## CR-001 [MUST] Use structured logging
+
+All log calls MUST use charmbracelet/log.
+`
+	path := filepath.Join(dir, "go-custom.md")
+	if err := os.WriteFile(path, []byte(populated), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	if !hasRuleContent(path) {
+		t.Error("expected true for populated file, got false")
+	}
+}
+
+func TestHasRuleContent_NoSentinel(t *testing.T) {
+	dir := t.TempDir()
+	// File with content but no sentinel — treat as non-empty (fail-open).
+	path := filepath.Join(dir, "content-custom.md")
+	if err := os.WriteFile(path, []byte("some content"), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	if !hasRuleContent(path) {
+		t.Error("expected true (no sentinel → fail-open), got false")
+	}
+}
+
+func TestHasRuleContent_MissingFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "nonexistent.md")
+
+	if !hasRuleContent(path) {
+		t.Error("expected true for missing file (fail-open), got false")
+	}
+}
+
+// --- collectDeployedPacks with root tests ---
+
+func TestCollectDeployedPacks_WithRoot_AllEmpty(t *testing.T) {
+	dir := t.TempDir()
+	packsDir := filepath.Join(dir, ".opencode", "uf", "packs")
+	if err := os.MkdirAll(packsDir, 0o755); err != nil {
+		t.Fatalf("mkdir packs: %v", err)
+	}
+
+	sentinel := "<!-- Add project-specific rules below this line -->"
+	stubs := []string{"default-custom.md", "content-custom.md", "go-custom.md"}
+	for _, name := range stubs {
+		if err := os.WriteFile(filepath.Join(packsDir, name), []byte(sentinel), 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+
+	packs := collectDeployedPacks("go", dir)
+
+	for _, p := range packs {
+		if strings.HasSuffix(p, "-custom.md") {
+			t.Errorf("empty custom pack %q should be excluded, but was included", p)
+		}
+	}
+	// Non-custom packs must still be present.
+	required := []string{"default.md", "severity.md", "content.md", "go.md"}
+	packSet := make(map[string]bool, len(packs))
+	for _, p := range packs {
+		packSet[p] = true
+	}
+	for _, r := range required {
+		if !packSet[r] {
+			t.Errorf("required pack %q missing from result", r)
+		}
+	}
+}
+
+func TestCollectDeployedPacks_WithRoot_OnePopulated(t *testing.T) {
+	dir := t.TempDir()
+	packsDir := filepath.Join(dir, ".opencode", "uf", "packs")
+	if err := os.MkdirAll(packsDir, 0o755); err != nil {
+		t.Fatalf("mkdir packs: %v", err)
+	}
+
+	sentinel := "<!-- Add project-specific rules below this line -->"
+	// default-custom and content-custom are empty stubs.
+	for _, name := range []string{"default-custom.md", "content-custom.md"} {
+		if err := os.WriteFile(filepath.Join(packsDir, name), []byte(sentinel), 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+	// go-custom is populated.
+	populated := sentinel + "\n\n## CR-001 [MUST] Example rule\n"
+	if err := os.WriteFile(filepath.Join(packsDir, "go-custom.md"), []byte(populated), 0o644); err != nil {
+		t.Fatalf("write go-custom.md: %v", err)
+	}
+
+	packs := collectDeployedPacks("go", dir)
+
+	packSet := make(map[string]bool, len(packs))
+	for _, p := range packs {
+		packSet[p] = true
+	}
+	if !packSet["go-custom.md"] {
+		t.Error("go-custom.md should be included (populated)")
+	}
+	if packSet["default-custom.md"] {
+		t.Error("default-custom.md should be excluded (empty)")
+	}
+	if packSet["content-custom.md"] {
+		t.Error("content-custom.md should be excluded (empty)")
+	}
+}
+
+func TestCollectDeployedPacks_WithRoot_EmptyRootFallback(t *testing.T) {
+	// When root is "", all packs including empty custom packs are returned
+	// (backward-compatible behaviour; no filesystem access).
+	packs := collectDeployedPacks("go", "")
+
+	packSet := make(map[string]bool, len(packs))
+	for _, p := range packs {
+		packSet[p] = true
+	}
+	for _, name := range []string{"default-custom.md", "content-custom.md", "go-custom.md"} {
+		if !packSet[name] {
+			t.Errorf("expected %q in packs when root is empty, got: %v", name, packs)
+		}
+	}
+}
+
+// --- ensureCLAUDEmd with empty custom packs tests ---
+
+func TestEnsureCLAUDEmd_EmptyCustomPacksOmitted(t *testing.T) {
+	dir := t.TempDir()
+	packsDir := filepath.Join(dir, ".opencode", "uf", "packs")
+	if err := os.MkdirAll(packsDir, 0o755); err != nil {
+		t.Fatalf("mkdir packs: %v", err)
+	}
+
+	sentinel := "<!-- Add project-specific rules below this line -->"
+	for _, name := range []string{"default-custom.md", "content-custom.md", "go-custom.md"} {
+		if err := os.WriteFile(filepath.Join(packsDir, name), []byte(sentinel), 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+
+	opts := &Options{
+		TargetDir: dir,
+		ReadFile:  os.ReadFile,
+		WriteFile: os.WriteFile,
+	}
+
+	result := ensureCLAUDEmd(opts, "go")
+	if result.action == "failed" {
+		t.Fatalf("ensureCLAUDEmd failed: %s", result.detail)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, "CLAUDE.md"))
+	if err != nil {
+		t.Fatalf("read CLAUDE.md: %v", err)
+	}
+	content := string(data)
+
+	for _, name := range []string{"default-custom.md", "content-custom.md", "go-custom.md"} {
+		if strings.Contains(content, name) {
+			t.Errorf("empty custom pack %q should not appear in CLAUDE.md, but found it", name)
+		}
+	}
+	// Non-custom packs must be present.
+	for _, name := range []string{"default.md", "severity.md", "content.md", "go.md"} {
+		if !strings.Contains(content, name) {
+			t.Errorf("required pack %q missing from CLAUDE.md", name)
+		}
+	}
+}
+
+func TestEnsureCLAUDEmd_PopulatedCustomPackIncluded(t *testing.T) {
+	dir := t.TempDir()
+	packsDir := filepath.Join(dir, ".opencode", "uf", "packs")
+	if err := os.MkdirAll(packsDir, 0o755); err != nil {
+		t.Fatalf("mkdir packs: %v", err)
+	}
+
+	sentinel := "<!-- Add project-specific rules below this line -->"
+	// default-custom empty, go-custom populated.
+	if err := os.WriteFile(filepath.Join(packsDir, "default-custom.md"), []byte(sentinel), 0o644); err != nil {
+		t.Fatalf("write default-custom.md: %v", err)
+	}
+	populated := sentinel + "\n\n## CR-001 [MUST] rule\n"
+	if err := os.WriteFile(filepath.Join(packsDir, "go-custom.md"), []byte(populated), 0o644); err != nil {
+		t.Fatalf("write go-custom.md: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(packsDir, "content-custom.md"), []byte(sentinel), 0o644); err != nil {
+		t.Fatalf("write content-custom.md: %v", err)
+	}
+
+	opts := &Options{
+		TargetDir: dir,
+		ReadFile:  os.ReadFile,
+		WriteFile: os.WriteFile,
+	}
+
+	result := ensureCLAUDEmd(opts, "go")
+	if result.action == "failed" {
+		t.Fatalf("ensureCLAUDEmd failed: %s", result.detail)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, "CLAUDE.md"))
+	if err != nil {
+		t.Fatalf("read CLAUDE.md: %v", err)
+	}
+	content := string(data)
+
+	if !strings.Contains(content, "go-custom.md") {
+		t.Error("go-custom.md should appear in CLAUDE.md (populated)")
+	}
+	if strings.Contains(content, "default-custom.md") {
+		t.Error("default-custom.md should not appear in CLAUDE.md (empty)")
 	}
 }
 

--- a/internal/scaffold/scaffold_test.go
+++ b/internal/scaffold/scaffold_test.go
@@ -4943,6 +4943,72 @@ func TestCollectDeployedPacks_WithRoot_EmptyRootFallback(t *testing.T) {
 	}
 }
 
+// --- filterEmptyCustomPacks tests ---
+
+func TestFilterEmptyCustomPacks_EmptyRoot(t *testing.T) {
+	candidates := []string{"default.md", "default-custom.md", "go.md"}
+	got := filterEmptyCustomPacks(candidates, "")
+
+	if len(got) != len(candidates) {
+		t.Errorf("expected %d packs with empty root, got %d", len(candidates), len(got))
+	}
+	for i, name := range candidates {
+		if got[i] != name {
+			t.Errorf("pack[%d] = %q, want %q", i, got[i], name)
+		}
+	}
+}
+
+func TestFilterEmptyCustomPacks_ExcludesEmptyStubs(t *testing.T) {
+	dir := t.TempDir()
+	packsDir := filepath.Join(dir, ".opencode", "uf", "packs")
+	if err := os.MkdirAll(packsDir, 0o755); err != nil {
+		t.Fatalf("mkdir packs: %v", err)
+	}
+
+	sentinel := "<!-- Add project-specific rules below this line -->"
+	if err := os.WriteFile(filepath.Join(packsDir, "default-custom.md"), []byte(sentinel), 0o644); err != nil {
+		t.Fatalf("write stub: %v", err)
+	}
+
+	candidates := []string{"default.md", "default-custom.md", "severity.md"}
+	got := filterEmptyCustomPacks(candidates, dir)
+
+	gotSet := make(map[string]bool, len(got))
+	for _, p := range got {
+		gotSet[p] = true
+	}
+	if gotSet["default-custom.md"] {
+		t.Error("empty default-custom.md should be excluded")
+	}
+	if !gotSet["default.md"] {
+		t.Error("non-custom default.md should be included")
+	}
+	if !gotSet["severity.md"] {
+		t.Error("non-custom severity.md should be included")
+	}
+}
+
+func TestFilterEmptyCustomPacks_KeepsPopulated(t *testing.T) {
+	dir := t.TempDir()
+	packsDir := filepath.Join(dir, ".opencode", "uf", "packs")
+	if err := os.MkdirAll(packsDir, 0o755); err != nil {
+		t.Fatalf("mkdir packs: %v", err)
+	}
+
+	populated := "<!-- Add project-specific rules below this line -->\n\n## CR-001 Real rule\n"
+	if err := os.WriteFile(filepath.Join(packsDir, "go-custom.md"), []byte(populated), 0o644); err != nil {
+		t.Fatalf("write populated: %v", err)
+	}
+
+	candidates := []string{"go.md", "go-custom.md"}
+	got := filterEmptyCustomPacks(candidates, dir)
+
+	if len(got) != 2 {
+		t.Errorf("expected 2 packs (populated custom kept), got %d: %v", len(got), got)
+	}
+}
+
 // --- ensureCLAUDEmd with empty custom packs tests ---
 
 func TestEnsureCLAUDEmd_EmptyCustomPacksOmitted(t *testing.T) {

--- a/openspec/changes/skip-empty-custom-packs/.openspec.yaml
+++ b/openspec/changes/skip-empty-custom-packs/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: unbound-force
+created: 2026-06-04

--- a/openspec/changes/skip-empty-custom-packs/design.md
+++ b/openspec/changes/skip-empty-custom-packs/design.md
@@ -1,0 +1,130 @@
+## Context
+
+`uf init` generates a managed block in `CLAUDE.md` via
+`buildCLAUDEmdBlock` (`scaffold.go:1055`), which calls
+`collectDeployedPacks` (`scaffold.go:1259`) to assemble the
+list of `@`-import lines. `collectDeployedPacks` returns all
+custom packs unconditionally — it has no knowledge of whether
+the files on disk contain real content.
+
+Three custom pack stubs (`default-custom.md`, `go-custom.md`,
+`content-custom.md`) are thus always imported, even though
+they contain only boilerplate scaffolding and the placeholder
+comment `<!-- Add project-specific rules below this line -->`.
+No rules are present in any of these files across the five
+repos in the org.
+
+The proposal establishes that this is a pure scaffold-engine
+concern, with no changes to embedded asset templates or CLI
+interface. Constitution alignment was assessed as PASS on all
+four principles.
+
+## Goals / Non-Goals
+
+### Goals
+- Custom pack `@` imports are omitted from `CLAUDE.md` when
+  the corresponding file on disk contains no rules below the
+  placeholder sentinel.
+- `uf init --reinit` re-evaluates emptiness on each run, so
+  a pack that gains content is automatically re-added.
+- The existing `collectDeployedPacks` test surface is
+  preserved (function signature is backward-compatible).
+- The new helper `hasRuleContent` is unit-testable in
+  isolation with `t.TempDir()` fixture files.
+- The existing `CLAUDE.md` in this repo has its three empty
+  custom pack `@` imports removed as part of this change.
+
+### Non-Goals
+- Modifying the embedded scaffold asset templates — stubs
+  continue to be written to disk on first `uf init`.
+- Emitting a user-visible warning or log line when a pack is
+  skipped (may be added later; not required for correctness).
+- Changing the typescript-custom.md behaviour — it follows
+  the same code path and benefits automatically.
+- Any change to non-Go repos or cross-repo scaffolding.
+
+## Decisions
+
+### D1 — Sentinel-based emptiness detection
+
+**Decision**: A pack is "empty" if it contains no
+non-whitespace content after the last occurrence of the HTML
+comment `<!-- Add project-specific rules below this line -->`.
+
+**Rationale**: The sentinel is stable (defined in the embedded
+asset template), unambiguous (it appears exactly once in every
+stub), and robust against whitespace-only trailing content.
+Alternative: check overall file size — rejected because it
+would misfire if a user inadvertently saves trailing
+whitespace, and it doesn't pinpoint the rule section.
+
+### D2 — `hasRuleContent(path string) bool` helper
+
+**Decision**: Introduce a new unexported helper that takes a
+file path, reads the file, finds the sentinel, and returns
+`true` iff there is non-whitespace content after it. Returns
+`true` on any I/O error (fail-open: if we can't read the file,
+include it — don't silently drop a pack the user may have
+populated).
+
+**Rationale**: Fail-open is safer. If `CLAUDE.md` is being
+generated in a context where the custom pack is inaccessible
+(e.g., a filesystem permission edge case), including the
+import is harmless; omitting it could silently drop rules.
+
+### D3 — `collectDeployedPacks` gains optional root parameter
+
+**Decision**: Add a second parameter `root string` to
+`collectDeployedPacks`. When `root == ""`, the function
+behaves identically to before (all packs included). When
+`root != ""`, each custom pack filename is checked via
+`hasRuleContent(filepath.Join(root, ".opencode/uf/packs/",
+name))`. Non-custom packs are never filtered.
+
+**Rationale**: Keeping the root optional preserves all
+existing call sites in tests that pass no directory. It also
+makes the function usable in the existing `shouldDeployPack`
+divisor path without requiring a filesystem.
+
+### D4 — `buildCLAUDEmdBlock` passes `opts.TargetDir`
+
+**Decision**: `buildCLAUDEmdBlock` gains a `root string`
+parameter and passes it straight through to
+`collectDeployedPacks`. `ensureCLAUDEmd` passes
+`opts.TargetDir` (already available at the call site,
+`scaffold.go:1093`).
+
+**Rationale**: Minimal change surface. No other callers of
+`buildCLAUDEmdBlock` exist; they are both internal and in
+tests. Updating the signature is safe.
+
+### D5 — Remove three `@` imports from CLAUDE.md in this repo
+
+**Decision**: As part of this PR, manually remove the three
+empty custom pack `@` import lines from `CLAUDE.md`. The next
+`uf init --reinit` would do this automatically, but doing it
+now keeps the repo immediately consistent.
+
+**Rationale**: This is the most visible and immediate fix for
+the issue reporter. It also serves as a concrete regression
+target in tests.
+
+## Risks / Trade-offs
+
+**Risk**: A user populates a custom pack, runs `uf init
+--reinit`, and expects the import to be added back — this now
+works correctly (D2 fail-open + D3 conditional check), but it
+requires the file to exist at `opts.TargetDir` at the time
+of `uf init`. If the file is populated but the tool is run
+from a different working directory, the file won't be found
+and the pack will be omitted. Accepted: this is an edge case;
+the normal flow is to run `uf init` from the repo root.
+
+**Trade-off**: `hasRuleContent` reads each custom pack file
+on every `uf init` run. For three small (~20-line) files this
+is negligible. Even in a pathological multi-pack scenario the
+cost is trivially small.
+
+**No backward-incompatible interface change**: The
+`collectDeployedPacks` signature change is internal. No
+exported API is altered.

--- a/openspec/changes/skip-empty-custom-packs/proposal.md
+++ b/openspec/changes/skip-empty-custom-packs/proposal.md
@@ -1,0 +1,114 @@
+## Why
+
+Three convention pack stubs (`default-custom.md`,
+`go-custom.md`, `content-custom.md`) are unconditionally
+imported via `@` directives in `CLAUDE.md` by every `uf init`
+run. Each file contains only a YAML frontmatter block, a
+section heading, usage instructions, and a placeholder HTML
+comment — no actual rules. Across all five repos in the
+Unbound Force org, none of these files contain real content.
+
+Loading empty files into every agent session wastes context
+tokens with no operational benefit. The cost is proportional
+to session frequency: high-throughput swarm workflows amplify
+the waste. The issue is systemic — `buildCLAUDEmdBlock` in
+the scaffold engine adds these imports unconditionally, so
+`uf init --reinit` will re-add them even if a user manually
+removes them.
+
+## What Changes
+
+The scaffold engine's `CLAUDE.md` block builder is changed to
+detect whether a `*-custom.md` pack contains actual rule
+content before emitting its `@` import line. A custom pack is
+considered "empty" if it has no non-whitespace content below
+the `<!-- Add project-specific rules below this line -->`
+sentinel comment. Empty custom packs are silently omitted from
+the generated `CLAUDE.md` block.
+
+The scaffold continues to write the stub files on first `uf
+init` (they remain available for users to fill in). The change
+is purely in which files get imported into `CLAUDE.md`, not in
+which files get written to disk.
+
+The embedded scaffold asset templates (`internal/scaffold/
+assets/opencode/uf/packs/*-custom.md`) are not modified —
+they remain the canonical starter stubs.
+
+## Capabilities
+
+### New Capabilities
+- `empty-pack-skip`: When generating the `CLAUDE.md` managed
+  block, custom packs that contain no rules below the
+  placeholder sentinel are omitted from `@` import lines.
+
+### Modified Capabilities
+- `collectDeployedPacks`: Extended with an optional filesystem
+  check parameter; when a project root is provided, custom
+  pack entries are filtered through `hasRuleContent()`.
+- `buildCLAUDEmdBlock`: Passes the project root to
+  `collectDeployedPacks` so the live files on disk are
+  evaluated.
+- `ensureCLAUDEmd`: Already calls `buildCLAUDEmdBlock` with
+  the target directory — no additional change needed here.
+
+### Removed Capabilities
+- None.
+
+## Impact
+
+- `internal/scaffold/scaffold.go`: Two functions modified
+  (`collectDeployedPacks`, `buildCLAUDEmdBlock`), one new
+  helper added (`hasRuleContent`).
+- `internal/scaffold/scaffold_test.go`: New test cases for the
+  empty-pack-skip behaviour.
+- `CLAUDE.md` in this repo: Three `@` import lines removed on
+  the next `uf init --reinit` (or by direct edit as part of
+  this change).
+- No CLI interface changes. No schema changes. No changes to
+  the embedded asset templates.
+
+## Constitution Alignment
+
+Assessed against the Unbound Force org constitution.
+
+### I. Autonomous Collaboration
+
+**Assessment**: PASS
+
+The change does not alter any artifact format or inter-hero
+communication protocol. `CLAUDE.md` is a convention pack
+loader, not an artifact boundary. Heroes continue to
+communicate through the same well-defined artifacts. The only
+effect is that agents receive a smaller (but equally correct)
+context window.
+
+### II. Composability First
+
+**Assessment**: PASS
+
+The scaffold engine remains fully standalone. The new
+`hasRuleContent` helper reads only local filesystem paths
+already resolved within `Run()`'s working directory. No new
+external dependencies are introduced. Repos that have
+populated custom packs continue to receive their `@` imports
+unchanged.
+
+### III. Observable Quality
+
+**Assessment**: PASS
+
+The change produces no machine-parseable output of its own,
+but it improves the quality of every agent session by
+eliminating noise from the context. The `uf init` run log
+could optionally emit a notice when a pack is skipped, but
+this is not required for correctness.
+
+### IV. Testability
+
+**Assessment**: PASS
+
+The new `hasRuleContent` helper is a pure function of a file
+path; it can be tested in isolation using `t.TempDir()` with
+crafted stub files. The existing scaffold test suite already
+uses this pattern. No external services are required.

--- a/openspec/changes/skip-empty-custom-packs/specs/scaffold-claude-md.md
+++ b/openspec/changes/skip-empty-custom-packs/specs/scaffold-claude-md.md
@@ -1,0 +1,111 @@
+## ADDED Requirements
+
+### Requirement: FR-01 Empty Custom Pack Detection
+
+The scaffold engine MUST provide a helper function that
+determines whether a convention pack file on disk contains
+actual rule content. A file is considered to have rule content
+if and only if there is at least one non-whitespace character
+after the last occurrence of the placeholder sentinel string
+`<!-- Add project-specific rules below this line -->`. If the
+file does not exist or cannot be read, the helper MUST return
+`true` (fail-open).
+
+#### Scenario: Empty stub file returns false
+
+- **GIVEN** a custom pack file that contains only the
+  boilerplate scaffold (YAML frontmatter, section heading,
+  description, `## Custom Rules` heading, and the placeholder
+  HTML comment) with no content after the placeholder
+- **WHEN** `hasRuleContent` is called with the file path
+- **THEN** it returns `false`
+
+#### Scenario: Populated file returns true
+
+- **GIVEN** a custom pack file that contains one or more
+  non-whitespace characters after the placeholder comment
+- **WHEN** `hasRuleContent` is called with the file path
+- **THEN** it returns `true`
+
+#### Scenario: Missing file returns true (fail-open)
+
+- **GIVEN** a file path that does not exist on disk
+- **WHEN** `hasRuleContent` is called with that path
+- **THEN** it returns `true`
+
+### Requirement: FR-02 Conditional Custom Pack Import
+
+When generating the managed `CLAUDE.md` block, the scaffold
+engine MUST omit the `@.opencode/uf/packs/<name>` import line
+for any `*-custom.md` pack whose corresponding file on disk
+satisfies the empty detection rule (FR-01). Non-custom packs
+(e.g., `default.md`, `go.md`) MUST always be included
+regardless of content.
+
+#### Scenario: All custom packs empty — imports omitted
+
+- **GIVEN** a project root where all deployed `*-custom.md`
+  files contain no rule content (per FR-01)
+- **WHEN** `uf init` runs and generates the managed `CLAUDE.md`
+  block
+- **THEN** the generated block contains no `@` import lines
+  for any `*-custom.md` pack
+
+#### Scenario: One custom pack populated — only it is imported
+
+- **GIVEN** a project root where `go-custom.md` contains rule
+  content and `default-custom.md` and `content-custom.md` are
+  empty stubs
+- **WHEN** `uf init` runs and generates the managed `CLAUDE.md`
+  block
+- **THEN** the generated block contains an import for
+  `go-custom.md` and no imports for `default-custom.md` or
+  `content-custom.md`
+
+#### Scenario: Root not provided — all packs included (no-op)
+
+- **GIVEN** `collectDeployedPacks` is called without a project
+  root (empty string)
+- **WHEN** the function executes
+- **THEN** all packs including custom packs are returned
+  (backward-compatible behaviour)
+
+### Requirement: FR-03 Idempotent Re-evaluation
+
+When `uf init --reinit` is run after a user has added content
+to a previously empty custom pack, the managed `CLAUDE.md`
+block MUST be updated to include the now-populated custom pack
+import. This MUST be automatic with no additional user action
+required beyond running `uf init --reinit`.
+
+#### Scenario: Custom pack gains content after initial init
+
+- **GIVEN** a repo where `uf init` was previously run and
+  `default-custom.md` was empty (import omitted from CLAUDE.md)
+- **WHEN** the user adds rules to `default-custom.md` and
+  runs `uf init --reinit`
+- **THEN** the managed `CLAUDE.md` block is updated to include
+  `@.opencode/uf/packs/default-custom.md`
+
+## MODIFIED Requirements
+
+### Requirement: CLAUDE.md Managed Block Generation
+
+Previously: `buildCLAUDEmdBlock(lang string) string` included
+all custom packs unconditionally.
+
+The function signature SHALL be updated to
+`buildCLAUDEmdBlock(lang, root string) string` where `root`
+is the project root directory. The function MUST pass `root`
+to `collectDeployedPacks` so that empty custom packs are
+excluded when a root is provided.
+
+Similarly, `collectDeployedPacks(lang string) []string` SHALL
+be updated to `collectDeployedPacks(lang, root string)
+[]string`. When `root == ""`, the function MUST return the
+same list as before (all packs). When `root != ""`, the
+function MUST filter out custom packs that fail FR-01.
+
+## REMOVED Requirements
+
+None.

--- a/openspec/changes/skip-empty-custom-packs/tasks.md
+++ b/openspec/changes/skip-empty-custom-packs/tasks.md
@@ -1,0 +1,72 @@
+<!--
+  [P] marks tasks eligible for parallel execution.
+  Add [P] when a task: (a) touches different files from
+  other [P] tasks in the group, (b) has no dependency
+  on prior tasks in the group, (c) can safely execute
+  without ordering constraints.
+  Do NOT add [P] when tasks modify the same file —
+  parallel workers will cause merge conflicts.
+  Tasks without [P] run sequentially first, then [P]
+  tasks run in parallel.
+-->
+
+## 1. Scaffold Engine — Logic
+
+- [x] 1.1 Add `hasRuleContent(path string) bool` helper to
+  `internal/scaffold/scaffold.go`. The function reads the file
+  at `path`, finds the last occurrence of the sentinel string
+  `<!-- Add project-specific rules below this line -->`, and
+  returns `true` iff there is any non-whitespace content after
+  it. Returns `true` on any I/O error (fail-open). Place the
+  helper near `collectDeployedPacks`.
+- [x] 1.2 Update `collectDeployedPacks(lang string) []string`
+  signature to `collectDeployedPacks(lang, root string)
+  []string`. When `root == ""`, behaviour is unchanged (all
+  packs returned). When `root != ""`, filter each `*-custom.md`
+  entry through `hasRuleContent(filepath.Join(root,
+  ".opencode/uf/packs/", name))`.
+- [x] 1.3 Update `buildCLAUDEmdBlock(lang string) string`
+  signature to `buildCLAUDEmdBlock(lang, root string) string`.
+  Pass `root` to `collectDeployedPacks`.
+- [x] 1.4 Update the one call site of `buildCLAUDEmdBlock` in
+  `ensureCLAUDEmd` (`scaffold.go:1093`) to pass
+  `opts.TargetDir` as the `root` argument.
+
+## 2. Scaffold Engine — Tests
+
+- [x] 2.1 Add unit tests for `hasRuleContent` in
+  `internal/scaffold/scaffold_test.go` (or a new
+  `scaffold_claude_test.go` if the file is too large). Use
+  `t.TempDir()`. Cover: empty stub (returns false), stub with
+  content after sentinel (returns true), no sentinel present
+  (returns true), file does not exist (returns true).
+- [x] 2.2 Add unit tests for `collectDeployedPacks` with a
+  non-empty root. Cover: all custom packs empty → custom packs
+  absent from result; one custom pack populated → only that
+  one included; non-custom packs always present.
+- [x] 2.3 Add an integration-style test for
+  `ensureCLAUDEmd` (using the existing dependency-injection
+  pattern with `opts.ReadFile`/`opts.WriteFile`) that asserts
+  empty custom packs are omitted from the generated block.
+  Verify the existing test for non-empty root `""` behaviour
+  still passes (backward compat).
+
+## 3. CLAUDE.md — Remove Empty Imports
+
+- [x] 3.1 Edit `CLAUDE.md` in the repo root: remove the three
+  `@` import lines for empty custom packs:
+  - `@.opencode/uf/packs/default-custom.md`
+  - `@.opencode/uf/packs/content-custom.md`
+  - `@.opencode/uf/packs/go-custom.md`
+
+## 4. Verification
+
+- [x] 4.1 Run `go build ./...` — must succeed with no errors.
+- [x] 4.2 Run `go test -race -count=1 ./internal/scaffold/...`
+  — all tests must pass.
+- [x] 4.3 Run `go vet ./...` — no issues.
+- [x] 4.4 Confirm `CLAUDE.md` no longer contains any
+  `*-custom.md` import lines after the change.
+- [x] 4.5 Verify constitution alignment: confirm no
+  exported API was changed and no external dependencies were
+  added.


### PR DESCRIPTION
## Summary

Empty `*-custom.md` stubs (`default-custom`, `go-custom`,
`content-custom`) were unconditionally imported via `@` directives
into `CLAUDE.md` on every `uf init` run, wasting context tokens with
no operational value.

- Add `hasRuleContent` helper that detects whether a custom pack file
  contains actual rule content below the placeholder sentinel comment.
  Fails open on I/O errors (missing file → include, not exclude).
- Update `collectDeployedPacks`, `buildCLAUDEmdBlock`,
  `buildCursorrulesBlock`, and `ensureAGENTSmdPackSection` to accept
  a project root; empty custom packs are silently omitted from
  generated import lists when a root is provided.
- Remove three empty custom pack `@` imports from `CLAUDE.md`
  immediately. Any pack that gains content will be re-added
  automatically on the next `uf init --reinit` run.
- 10 new test cases covering all edge cases (empty stub, whitespace-only
  after sentinel, populated, no sentinel, missing file, all-empty root,
  one-populated root, backward-compat empty root, two `ensureCLAUDEmd`
  integration tests).

Closes #239

Today I'm submitting fixes for the unbound-force ecosystem in the spirit of trying it out and helping out, please don't expect my continued availability, thanks!