### PR TITLE
feat(scaffold): run sub-tool inits concurrently in uf init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ Each entry follows the format: `- <change-name>: <summary>`.
 - `feedback-triage` JSON schema (v1.0.0) for capturing triage
   decisions as artifacts (Spec: openspec/changes/address-feedback/)
 
+### Changed
+- `uf init` sub-tool initializations (dewey, replicator,
+  specify, openspec, gaze) now run concurrently, reducing
+  wall-clock time from sequential sum to parallel max.
+  Dewey indexing (30-60s) no longer blocks the other four
+  tools. Individual tool failures remain non-fatal.
+  (Spec: openspec/changes/parallel-subtool-init/)
+- `uf init` now respects `setup.tools.<name>.method: skip`
+  in `.uf/config.yaml` — skipped tools are excluded from
+  initialization entirely, even when the binary is on PATH.
+  (Spec: openspec/changes/parallel-subtool-init/)
+
 ## Recent Changes
 
 - opsx/setup-sandbox-tools: Added Podman and DevPod to `uf setup` (13→16 steps) and `uf doctor`. Setup installs Podman via Homebrew with macOS Podman machine initialization (best-effort, with timeout via gtimeout/timeout fallback), installs DevPod via Homebrew, and configures the DevPod Podman provider alias (`devpod provider add docker --name podman -o DOCKER_PATH=podman`). Corrected DevPod provider option from `DOCKER_COMMAND` to `DOCKER_PATH` across setup, doctor, and spec artifacts. Doctor adds conditional DevPod check group (only when DevPod is detected): binary presence, version >= 0.5.0, podman provider registration, and `.devcontainer/devcontainer.json` existence. Podman doctor checks: version >= 4.3, runtime health via `podman info` (platform-aware), and Docker-to-Podman shim detection. Refactored setup step dispatch from 16 repetitive if/else blocks to data-driven `stepDef` slice with `executeSteps()` loop (CRAP 32 → 2). Added `hasProvider()` helper with exact first-column name matching for provider detection. Added `podmanMachineInit()` with `initMachineWithTimeout()` helper for macOS post-install (tries gtimeout, timeout, then no-timeout fallback). 6 new doctor tests, 12 new setup tests. Modified files: `internal/setup/setup.go`, `internal/setup/setup_test.go`, `internal/doctor/checks.go`, `internal/doctor/doctor.go`, `internal/doctor/doctor_test.go`, `internal/doctor/environ.go`. Website issue: unbound-force/website#121.

--- a/internal/scaffold/scaffold.go
+++ b/internal/scaffold/scaffold.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 
 	"github.com/unbound-force/unbound-force/internal/config"
 )
@@ -1291,96 +1292,175 @@ func initSubTools(opts *Options) []subToolResult {
 		opts.WriteFile = os.WriteFile
 	}
 
-	var results []subToolResult
-
 	// NOTE: .uf/config.yaml is no longer created by uf init.
 	// Users create it via `uf config init` when they need
 	// customization. See internal/config/ package.
 
-	// Dewey: init + index if binary available and workspace absent.
-	// Force re-index if workspace exists and Force is set.
-	if _, err := opts.LookPath("dewey"); err == nil {
-		deweyDir := filepath.Join(opts.TargetDir, ".uf", "dewey")
-		if _, statErr := os.Stat(deweyDir); os.IsNotExist(statErr) {
-			// First run: initialize workspace and build index.
-			_, _ = fmt.Fprintf(opts.Stdout, "  Initializing Dewey workspace...\n")
-			if _, initErr := opts.ExecCmd("dewey", "init"); initErr != nil {
-				results = append(results, subToolResult{
-					name: ".uf/dewey/", action: "failed",
-					detail: "dewey init failed"})
-				// Skip index if init failed, but still configure opencode.json.
-				results = append(results, configureOpencodeJSON(opts)...)
-				return results
-			}
-			results = append(results, subToolResult{
-				name: ".uf/dewey/", action: "initialized"})
+	// Load config to respect setup.tools.*.method: skip.
+	// Must happen here (not just in configureOpencodeJSON) so that
+	// skipped tools are never init'd or indexed.
+	// Error ignored: Load returns compiled defaults on missing or
+	// malformed config files — graceful degradation by design.
+	cfg, _ := config.Load(config.LoadOptions{
+		ProjectDir: opts.TargetDir,
+		ReadFile:   opts.ReadFile,
+	})
 
-			// Auto-detect sibling repos for Dewey sources config.
-			// Runs after dewey init creates default sources.yaml
-			// and before dewey index ingests all sources.
-			if sr := generateDeweySources(opts, false); sr != nil {
-				results = append(results, *sr)
-			}
+	// shouldSkipTool returns true when the user has configured
+	// setup.tools.<name>.method: skip in .uf/config.yaml (or
+	// the user-level config).
+	shouldSkipTool := func(name string) bool {
+		if tc, ok := cfg.Setup.Tools[name]; ok && tc.Method == "skip" {
+			return true
+		}
+		return false
+	}
 
-			_, _ = fmt.Fprintf(opts.Stdout, "  Indexing Dewey sources (this may take a moment)...\n")
-			if _, idxErr := opts.ExecCmd("dewey", "index"); idxErr != nil {
-				results = append(results, subToolResult{
-					name: "dewey index", action: "failed",
-					detail: "dewey index failed"})
-			} else {
-				results = append(results, subToolResult{
-					name: "dewey index", action: "completed"})
-			}
-		} else if opts.Force {
-			// Force: regenerate sources.yaml + re-index.
-			// Regenerate first so the updated sources config
-			// (e.g., recursive: false on disk-org) is used for
-			// the re-index. Bypasses the customization check.
-			if sr := generateDeweySources(opts, true); sr != nil {
-				results = append(results, *sr)
-			}
-			_, _ = fmt.Fprintf(opts.Stdout, "  Re-indexing Dewey sources...\n")
-			if _, idxErr := opts.ExecCmd("dewey", "index"); idxErr != nil {
-				results = append(results, subToolResult{
-					name: "dewey index", action: "failed",
-					detail: "dewey index failed"})
-			} else {
-				results = append(results, subToolResult{
-					name: "dewey index", action: "re-indexed"})
-			}
+	// Concurrent sub-tool initialization (D1, D2 from design.md).
+	//
+	// Group A (Dewey): dewey init -> generateDeweySources ->
+	//   dewey index — sequential within its goroutine.
+	// Group B (others): replicator, specify, openspec, gaze —
+	//   each in its own goroutine, all concurrent with Group A.
+	//
+	// sync.WaitGroup coordinates completion; sync.Mutex guards
+	// the shared results slice. Individual tool failures are
+	// non-fatal (FR-005) — all tools attempt init regardless.
+
+	var (
+		mu      sync.Mutex
+		wg      sync.WaitGroup
+		results []subToolResult
+	)
+
+	// appendResult safely appends to the shared results slice.
+	appendResult := func(r subToolResult) {
+		mu.Lock()
+		results = append(results, r)
+		mu.Unlock()
+	}
+
+	// appendResults safely appends multiple results.
+	appendResults := func(rs []subToolResult) {
+		mu.Lock()
+		results = append(results, rs...)
+		mu.Unlock()
+	}
+
+	// logf safely writes to opts.Stdout from any goroutine.
+	// opts.Stdout may be a bytes.Buffer in tests, which is
+	// not goroutine-safe.
+	logf := func(format string, a ...interface{}) {
+		mu.Lock()
+		_, _ = fmt.Fprintf(opts.Stdout, format, a...)
+		mu.Unlock()
+	}
+
+	// --- Group A: Dewey (sequential within goroutine) ---
+
+	if !shouldSkipTool("dewey") {
+		if _, err := opts.LookPath("dewey"); err == nil {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				deweyDir := filepath.Join(opts.TargetDir, ".uf", "dewey")
+				if _, statErr := os.Stat(deweyDir); os.IsNotExist(statErr) {
+					// First run: initialize workspace and build index.
+					logf("  Initializing Dewey workspace...\n")
+					if _, initErr := opts.ExecCmd("dewey", "init"); initErr != nil {
+						appendResult(subToolResult{
+							name: ".uf/dewey/", action: "failed",
+							detail: "dewey init failed"})
+						// Skip index if init failed; other tools
+						// continue independently (FR-005).
+						return
+					}
+					appendResult(subToolResult{
+						name: ".uf/dewey/", action: "initialized"})
+
+					// Auto-detect sibling repos for Dewey sources config.
+					// Runs after dewey init creates default sources.yaml
+					// and before dewey index ingests all sources.
+					if sr := generateDeweySources(opts, false); sr != nil {
+						appendResult(*sr)
+					}
+
+					logf("  Indexing Dewey sources (this may take a moment)...\n")
+					if _, idxErr := opts.ExecCmd("dewey", "index"); idxErr != nil {
+						appendResult(subToolResult{
+							name: "dewey index", action: "failed",
+							detail: "dewey index failed"})
+					} else {
+						appendResult(subToolResult{
+							name: "dewey index", action: "completed"})
+					}
+				} else if opts.Force {
+					// Force: regenerate sources.yaml + re-index.
+					// Regenerate first so the updated sources config
+					// (e.g., recursive: false on disk-org) is used for
+					// the re-index. Bypasses the customization check.
+					if sr := generateDeweySources(opts, true); sr != nil {
+						appendResult(*sr)
+					}
+					logf("  Re-indexing Dewey sources...\n")
+					if _, idxErr := opts.ExecCmd("dewey", "index"); idxErr != nil {
+						appendResult(subToolResult{
+							name: "dewey index", action: "failed",
+							detail: "dewey index failed"})
+					} else {
+						appendResult(subToolResult{
+							name: "dewey index", action: "re-indexed"})
+					}
+				}
+			}()
 		}
 	}
 
+	// --- Group B: Independent tools (each in own goroutine) ---
+
 	// Replicator: init if binary available and .uf/replicator/ absent.
-	// Follows the Dewey init delegation pattern above.
-	if _, err := opts.LookPath("replicator"); err == nil {
-		replicatorDir := filepath.Join(opts.TargetDir, ".uf", "replicator")
-		if _, statErr := os.Stat(replicatorDir); os.IsNotExist(statErr) {
-			_, _ = fmt.Fprintf(opts.Stdout, "  Initializing Replicator workspace...\n")
-			if _, initErr := opts.ExecCmd("replicator", "init"); initErr != nil {
-				results = append(results, subToolResult{
-					name: ".uf/replicator/", action: "failed",
-					detail: "replicator init failed"})
-			} else {
-				results = append(results, subToolResult{
-					name: ".uf/replicator/", action: "initialized"})
-			}
+	// Respects setup.tools.replicator.method: skip.
+	if !shouldSkipTool("replicator") {
+		if _, err := opts.LookPath("replicator"); err == nil {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				replicatorDir := filepath.Join(opts.TargetDir, ".uf", "replicator")
+				if _, statErr := os.Stat(replicatorDir); os.IsNotExist(statErr) {
+					logf("  Initializing Replicator workspace...\n")
+					if _, initErr := opts.ExecCmd("replicator", "init"); initErr != nil {
+						appendResult(subToolResult{
+							name: ".uf/replicator/", action: "failed",
+							detail: "replicator init failed"})
+					} else {
+						appendResult(subToolResult{
+							name: ".uf/replicator/", action: "initialized"})
+					}
+				}
+			}()
 		}
 	}
 
 	// Specify: init if binary available and .specify/ absent.
-	if _, err := opts.LookPath("specify"); err == nil {
-		specifyDir := filepath.Join(opts.TargetDir, ".specify")
-		if _, statErr := os.Stat(specifyDir); os.IsNotExist(statErr) {
-			_, _ = fmt.Fprintf(opts.Stdout, "  Initializing Speckit framework...\n")
-			if _, initErr := opts.ExecCmd("specify", "init"); initErr != nil {
-				results = append(results, subToolResult{
-					name: ".specify/", action: "failed",
-					detail: "specify init failed"})
-			} else {
-				results = append(results, subToolResult{
-					name: ".specify/", action: "initialized"})
-			}
+	// Respects setup.tools.specify.method: skip.
+	if !shouldSkipTool("specify") {
+		if _, err := opts.LookPath("specify"); err == nil {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				specifyDir := filepath.Join(opts.TargetDir, ".specify")
+				if _, statErr := os.Stat(specifyDir); os.IsNotExist(statErr) {
+					logf("  Initializing Speckit framework...\n")
+					if _, initErr := opts.ExecCmd("specify", "init"); initErr != nil {
+						appendResult(subToolResult{
+							name: ".specify/", action: "failed",
+							detail: "specify init failed"})
+					} else {
+						appendResult(subToolResult{
+							name: ".specify/", action: "initialized"})
+					}
+				}
+			}()
 		}
 	}
 
@@ -1388,40 +1468,58 @@ func initSubTools(opts *Options) []subToolResult {
 	// Gate on config.yaml (not openspec/ directory) because the
 	// embedded custom schema creates openspec/schemas/ before
 	// initSubTools() runs.
-	if _, err := opts.LookPath("openspec"); err == nil {
-		openspecConfig := filepath.Join(opts.TargetDir, "openspec", "config.yaml")
-		if _, statErr := os.Stat(openspecConfig); os.IsNotExist(statErr) {
-			_, _ = fmt.Fprintf(opts.Stdout, "  Initializing OpenSpec framework...\n")
-			if _, initErr := opts.ExecCmd("openspec", "init", "--tools", "opencode"); initErr != nil {
-				results = append(results, subToolResult{
-					name: "openspec/", action: "failed",
-					detail: "openspec init failed"})
-			} else {
-				results = append(results, subToolResult{
-					name: "openspec/", action: "initialized"})
-			}
+	// Respects setup.tools.openspec.method: skip.
+	if !shouldSkipTool("openspec") {
+		if _, err := opts.LookPath("openspec"); err == nil {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				openspecConfig := filepath.Join(opts.TargetDir, "openspec", "config.yaml")
+				if _, statErr := os.Stat(openspecConfig); os.IsNotExist(statErr) {
+					logf("  Initializing OpenSpec framework...\n")
+					if _, initErr := opts.ExecCmd("openspec", "init", "--tools", "opencode"); initErr != nil {
+						appendResult(subToolResult{
+							name: "openspec/", action: "failed",
+							detail: "openspec init failed"})
+					} else {
+						appendResult(subToolResult{
+							name: "openspec/", action: "initialized"})
+					}
+				}
+			}()
 		}
 	}
 
 	// Gaze: init if binary available and gaze agent file absent.
-	if _, err := opts.LookPath("gaze"); err == nil {
-		gazeAgent := filepath.Join(opts.TargetDir, ".opencode", "agents", "gaze-reporter.md")
-		if _, statErr := os.Stat(gazeAgent); os.IsNotExist(statErr) {
-			_, _ = fmt.Fprintf(opts.Stdout, "  Initializing Gaze integration...\n")
-			if _, initErr := opts.ExecCmd("gaze", "init"); initErr != nil {
-				results = append(results, subToolResult{
-					name: "gaze", action: "failed",
-					detail: "gaze init failed"})
-			} else {
-				results = append(results, subToolResult{
-					name: "gaze", action: "initialized"})
-			}
+	// Respects setup.tools.gaze.method: skip.
+	if !shouldSkipTool("gaze") {
+		if _, err := opts.LookPath("gaze"); err == nil {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				gazeAgent := filepath.Join(opts.TargetDir, ".opencode", "agents", "gaze-reporter.md")
+				if _, statErr := os.Stat(gazeAgent); os.IsNotExist(statErr) {
+					logf("  Initializing Gaze integration...\n")
+					if _, initErr := opts.ExecCmd("gaze", "init"); initErr != nil {
+						appendResult(subToolResult{
+							name: "gaze", action: "failed",
+							detail: "gaze init failed"})
+					} else {
+						appendResult(subToolResult{
+							name: "gaze", action: "initialized"})
+					}
+				}
+			}()
 		}
 	}
 
+	// Wait for all concurrent groups to finish before
+	// configuring opencode.json (FR-004, D4).
+	wg.Wait()
+
 	// Configure opencode.json with Dewey MCP server and Replicator MCP
 	// entries. Runs after all sub-tool initialization steps.
-	results = append(results, configureOpencodeJSON(opts)...)
+	appendResults(configureOpencodeJSON(opts))
 
 	return results
 }

--- a/internal/scaffold/scaffold.go
+++ b/internal/scaffold/scaffold.go
@@ -1333,15 +1333,8 @@ func initSubTools(opts *Options) []subToolResult {
 		results []subToolResult
 	)
 
-	// appendResult safely appends to the shared results slice.
-	appendResult := func(r subToolResult) {
-		mu.Lock()
-		results = append(results, r)
-		mu.Unlock()
-	}
-
-	// appendResults safely appends multiple results.
-	appendResults := func(rs []subToolResult) {
+	// collect safely appends results from any goroutine.
+	collect := func(rs ...subToolResult) {
 		mu.Lock()
 		results = append(results, rs...)
 		mu.Unlock()
@@ -1363,154 +1356,54 @@ func initSubTools(opts *Options) []subToolResult {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				deweyDir := filepath.Join(opts.TargetDir, ".uf", "dewey")
-				if _, statErr := os.Stat(deweyDir); os.IsNotExist(statErr) {
-					// First run: initialize workspace and build index.
-					logf("  Initializing Dewey workspace...\n")
-					if _, initErr := opts.ExecCmd("dewey", "init"); initErr != nil {
-						appendResult(subToolResult{
-							name: ".uf/dewey/", action: "failed",
-							detail: "dewey init failed"})
-						// Skip index if init failed; other tools
-						// continue independently (FR-005).
-						return
-					}
-					appendResult(subToolResult{
-						name: ".uf/dewey/", action: "initialized"})
-
-					// Auto-detect sibling repos for Dewey sources config.
-					// Runs after dewey init creates default sources.yaml
-					// and before dewey index ingests all sources.
-					if sr := generateDeweySources(opts, false); sr != nil {
-						appendResult(*sr)
-					}
-
-					logf("  Indexing Dewey sources (this may take a moment)...\n")
-					if _, idxErr := opts.ExecCmd("dewey", "index"); idxErr != nil {
-						appendResult(subToolResult{
-							name: "dewey index", action: "failed",
-							detail: "dewey index failed"})
-					} else {
-						appendResult(subToolResult{
-							name: "dewey index", action: "completed"})
-					}
-				} else if opts.Force {
-					// Force: regenerate sources.yaml + re-index.
-					// Regenerate first so the updated sources config
-					// (e.g., recursive: false on disk-org) is used for
-					// the re-index. Bypasses the customization check.
-					if sr := generateDeweySources(opts, true); sr != nil {
-						appendResult(*sr)
-					}
-					logf("  Re-indexing Dewey sources...\n")
-					if _, idxErr := opts.ExecCmd("dewey", "index"); idxErr != nil {
-						appendResult(subToolResult{
-							name: "dewey index", action: "failed",
-							detail: "dewey index failed"})
-					} else {
-						appendResult(subToolResult{
-							name: "dewey index", action: "re-indexed"})
-					}
-				}
+				collect(initDewey(opts, logf)...)
 			}()
 		}
 	}
 
 	// --- Group B: Independent tools (each in own goroutine) ---
 
-	// Replicator: init if binary available and .uf/replicator/ absent.
-	// Respects setup.tools.replicator.method: skip.
-	if !shouldSkipTool("replicator") {
-		if _, err := opts.LookPath("replicator"); err == nil {
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
-				replicatorDir := filepath.Join(opts.TargetDir, ".uf", "replicator")
-				if _, statErr := os.Stat(replicatorDir); os.IsNotExist(statErr) {
-					logf("  Initializing Replicator workspace...\n")
-					if _, initErr := opts.ExecCmd("replicator", "init"); initErr != nil {
-						appendResult(subToolResult{
-							name: ".uf/replicator/", action: "failed",
-							detail: "replicator init failed"})
-					} else {
-						appendResult(subToolResult{
-							name: ".uf/replicator/", action: "initialized"})
-					}
-				}
-			}()
-		}
+	// simpleTools defines Group B tools. Each entry maps a tool
+	// name to its sentinel path (relative to TargetDir), result
+	// name, display label, and optional extra args for ExecCmd.
+	type simpleTool struct {
+		name     string   // config + LookPath key
+		sentinel string   // path to check (skip init if exists)
+		result   string   // subToolResult.name
+		label    string   // display text for logf
+		args     []string // extra args after "init"
 	}
 
-	// Specify: init if binary available and .specify/ absent.
-	// Respects setup.tools.specify.method: skip.
-	if !shouldSkipTool("specify") {
-		if _, err := opts.LookPath("specify"); err == nil {
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
-				specifyDir := filepath.Join(opts.TargetDir, ".specify")
-				if _, statErr := os.Stat(specifyDir); os.IsNotExist(statErr) {
-					logf("  Initializing Speckit framework...\n")
-					if _, initErr := opts.ExecCmd("specify", "init"); initErr != nil {
-						appendResult(subToolResult{
-							name: ".specify/", action: "failed",
-							detail: "specify init failed"})
-					} else {
-						appendResult(subToolResult{
-							name: ".specify/", action: "initialized"})
-					}
-				}
-			}()
-		}
+	simpleTools := []simpleTool{
+		{"replicator", ".uf/replicator", ".uf/replicator/",
+			"Replicator workspace", nil},
+		{"specify", ".specify", ".specify/",
+			"Speckit framework", nil},
+		{"openspec", filepath.Join("openspec", "config.yaml"),
+			"openspec/", "OpenSpec framework",
+			[]string{"--tools", "opencode"}},
+		{"gaze", filepath.Join(".opencode", "agents", "gaze-reporter.md"),
+			"gaze", "Gaze integration", nil},
 	}
 
-	// OpenSpec: init if binary available and openspec/config.yaml absent.
-	// Gate on config.yaml (not openspec/ directory) because the
-	// embedded custom schema creates openspec/schemas/ before
-	// initSubTools() runs.
-	// Respects setup.tools.openspec.method: skip.
-	if !shouldSkipTool("openspec") {
-		if _, err := opts.LookPath("openspec"); err == nil {
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
-				openspecConfig := filepath.Join(opts.TargetDir, "openspec", "config.yaml")
-				if _, statErr := os.Stat(openspecConfig); os.IsNotExist(statErr) {
-					logf("  Initializing OpenSpec framework...\n")
-					if _, initErr := opts.ExecCmd("openspec", "init", "--tools", "opencode"); initErr != nil {
-						appendResult(subToolResult{
-							name: "openspec/", action: "failed",
-							detail: "openspec init failed"})
-					} else {
-						appendResult(subToolResult{
-							name: "openspec/", action: "initialized"})
-					}
-				}
-			}()
+	for _, tool := range simpleTools {
+		if shouldSkipTool(tool.name) {
+			continue
 		}
-	}
-
-	// Gaze: init if binary available and gaze agent file absent.
-	// Respects setup.tools.gaze.method: skip.
-	if !shouldSkipTool("gaze") {
-		if _, err := opts.LookPath("gaze"); err == nil {
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
-				gazeAgent := filepath.Join(opts.TargetDir, ".opencode", "agents", "gaze-reporter.md")
-				if _, statErr := os.Stat(gazeAgent); os.IsNotExist(statErr) {
-					logf("  Initializing Gaze integration...\n")
-					if _, initErr := opts.ExecCmd("gaze", "init"); initErr != nil {
-						appendResult(subToolResult{
-							name: "gaze", action: "failed",
-							detail: "gaze init failed"})
-					} else {
-						appendResult(subToolResult{
-							name: "gaze", action: "initialized"})
-					}
-				}
-			}()
+		if _, err := opts.LookPath(tool.name); err != nil {
+			continue
 		}
+		// Capture loop variable for goroutine closure.
+		tool := tool
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			r := initSimpleTool(opts, tool.name, tool.sentinel,
+				tool.result, tool.label, tool.args, logf)
+			if r != nil {
+				collect(*r)
+			}
+		}()
 	}
 
 	// Wait for all concurrent groups to finish before
@@ -1519,9 +1412,82 @@ func initSubTools(opts *Options) []subToolResult {
 
 	// Configure opencode.json with Dewey MCP server and Replicator MCP
 	// entries. Runs after all sub-tool initialization steps.
-	appendResults(configureOpencodeJSON(opts))
+	collect(configureOpencodeJSON(opts)...)
 
 	return results
+}
+
+// initDewey runs the Dewey initialization sequence: init ->
+// generateDeweySources -> index. The three steps MUST execute
+// in order (FR-002). Returns results for all steps attempted.
+func initDewey(opts *Options, logf func(string, ...interface{})) []subToolResult {
+	var results []subToolResult
+	deweyDir := filepath.Join(opts.TargetDir, ".uf", "dewey")
+
+	if _, statErr := os.Stat(deweyDir); os.IsNotExist(statErr) {
+		// First run: initialize workspace and build index.
+		logf("  Initializing Dewey workspace...\n")
+		if _, initErr := opts.ExecCmd("dewey", "init"); initErr != nil {
+			return []subToolResult{{
+				name: ".uf/dewey/", action: "failed",
+				detail: "dewey init failed"}}
+		}
+		results = append(results, subToolResult{
+			name: ".uf/dewey/", action: "initialized"})
+
+		// Auto-detect sibling repos for Dewey sources config.
+		if sr := generateDeweySources(opts, false); sr != nil {
+			results = append(results, *sr)
+		}
+
+		logf("  Indexing Dewey sources (this may take a moment)...\n")
+		if _, idxErr := opts.ExecCmd("dewey", "index"); idxErr != nil {
+			results = append(results, subToolResult{
+				name: "dewey index", action: "failed",
+				detail: "dewey index failed"})
+		} else {
+			results = append(results, subToolResult{
+				name: "dewey index", action: "completed"})
+		}
+		return results
+	}
+
+	if opts.Force {
+		// Force: regenerate sources.yaml + re-index.
+		if sr := generateDeweySources(opts, true); sr != nil {
+			results = append(results, *sr)
+		}
+		logf("  Re-indexing Dewey sources...\n")
+		if _, idxErr := opts.ExecCmd("dewey", "index"); idxErr != nil {
+			results = append(results, subToolResult{
+				name: "dewey index", action: "failed",
+				detail: "dewey index failed"})
+		} else {
+			results = append(results, subToolResult{
+				name: "dewey index", action: "re-indexed"})
+		}
+	}
+	return results
+}
+
+// initSimpleTool initializes a single sub-tool by checking a
+// sentinel path and running "<name> init [args...]". Returns
+// nil if the sentinel already exists (tool already initialized).
+func initSimpleTool(opts *Options, name, sentinel, resultName, label string, extraArgs []string, logf func(string, ...interface{})) *subToolResult {
+	sentinelPath := filepath.Join(opts.TargetDir, sentinel)
+	if _, statErr := os.Stat(sentinelPath); !os.IsNotExist(statErr) {
+		return nil // Already initialized.
+	}
+
+	logf("  Initializing %s...\n", label)
+	args := append([]string{"init"}, extraArgs...)
+	if _, initErr := opts.ExecCmd(name, args...); initErr != nil {
+		return &subToolResult{
+			name: resultName, action: "failed",
+			detail: name + " init failed"}
+	}
+	return &subToolResult{
+		name: resultName, action: "initialized"}
 }
 
 // subToolSymbol returns the display symbol for a sub-tool result action.

--- a/internal/scaffold/scaffold_test.go
+++ b/internal/scaffold/scaffold_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 	"testing"
 )
 
@@ -1822,6 +1823,7 @@ func stubScaffoldLookPath(found map[string]string) func(string) (string, error) 
 
 // scaffoldCmdRecorder records ExecCmd calls for scaffold tests.
 type scaffoldCmdRecorder struct {
+	mu     sync.Mutex
 	calls  []string
 	errors map[string]error
 }
@@ -1831,9 +1833,13 @@ func (r *scaffoldCmdRecorder) execCmd(name string, args ...string) ([]byte, erro
 	if len(args) > 0 {
 		key = name + " " + strings.Join(args, " ")
 	}
-	r.calls = append(r.calls, key)
 
-	if err, ok := r.errors[key]; ok {
+	r.mu.Lock()
+	r.calls = append(r.calls, key)
+	err, ok := r.errors[key]
+	r.mu.Unlock()
+
+	if ok {
 		return nil, err
 	}
 	return []byte(""), nil
@@ -3439,6 +3445,409 @@ func TestInitSubTools_DeweyExistsNoForce(t *testing.T) {
 		if call == "dewey init" || call == "dewey index" {
 			t.Errorf("unexpected dewey command when Force=false: %s", call)
 		}
+	}
+}
+
+func TestInitSubTools_DeweySkippedByConfig(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create .uf/config.yaml with dewey method: skip.
+	ufDir := filepath.Join(dir, ".uf")
+	if err := os.MkdirAll(ufDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	cfgContent := "setup:\n  tools:\n    dewey:\n      method: skip\n"
+	if err := os.WriteFile(filepath.Join(ufDir, "config.yaml"), []byte(cfgContent), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	rec := &scaffoldCmdRecorder{errors: map[string]error{}}
+
+	opts := &Options{
+		TargetDir: dir,
+		LookPath:  stubScaffoldLookPath(map[string]string{"dewey": "/usr/local/bin/dewey"}),
+		ExecCmd:   rec.execCmd,
+	}
+
+	results := initSubTools(opts)
+
+	// Dewey commands should NOT have been called.
+	for _, call := range rec.calls {
+		if call == "dewey init" || call == "dewey index" {
+			t.Errorf("dewey command should NOT be called when method is skip: %s", call)
+		}
+	}
+
+	// No dewey-related results should appear.
+	for _, r := range results {
+		if r.name == ".uf/dewey/" || r.name == "dewey index" {
+			t.Errorf("unexpected dewey result when method is skip: %s %s", r.name, r.action)
+		}
+	}
+
+	// .uf/dewey/ directory should NOT have been created.
+	if _, err := os.Stat(filepath.Join(dir, ".uf", "dewey")); !os.IsNotExist(err) {
+		t.Error(".uf/dewey/ should not exist when dewey method is skip")
+	}
+}
+
+func TestInitSubTools_DeweySkippedByConfig_ForceIgnored(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create .uf/config.yaml with dewey method: skip.
+	ufDir := filepath.Join(dir, ".uf")
+	if err := os.MkdirAll(ufDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	cfgContent := "setup:\n  tools:\n    dewey:\n      method: skip\n"
+	if err := os.WriteFile(filepath.Join(ufDir, "config.yaml"), []byte(cfgContent), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	// Create .uf/dewey/ — even with Force, skip should win.
+	if err := os.MkdirAll(filepath.Join(dir, ".uf", "dewey"), 0o755); err != nil {
+		t.Fatalf("mkdir dewey: %v", err)
+	}
+
+	rec := &scaffoldCmdRecorder{errors: map[string]error{}}
+
+	opts := &Options{
+		TargetDir: dir,
+		Force:     true,
+		LookPath:  stubScaffoldLookPath(map[string]string{"dewey": "/usr/local/bin/dewey"}),
+		ExecCmd:   rec.execCmd,
+	}
+
+	results := initSubTools(opts)
+
+	// Even with Force=true, skip config should prevent re-index.
+	for _, call := range rec.calls {
+		if call == "dewey init" || call == "dewey index" {
+			t.Errorf("dewey command should NOT be called when method is skip (even with Force): %s", call)
+		}
+	}
+	for _, r := range results {
+		if r.name == ".uf/dewey/" || r.name == "dewey index" {
+			t.Errorf("unexpected dewey result when method is skip: %s %s", r.name, r.action)
+		}
+	}
+}
+
+func TestInitSubTools_ReplicatorSkippedByConfig(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create .uf/config.yaml with replicator method: skip.
+	ufDir := filepath.Join(dir, ".uf")
+	if err := os.MkdirAll(ufDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	cfgContent := "setup:\n  tools:\n    replicator:\n      method: skip\n"
+	if err := os.WriteFile(filepath.Join(ufDir, "config.yaml"), []byte(cfgContent), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	rec := &scaffoldCmdRecorder{errors: map[string]error{}}
+
+	opts := &Options{
+		TargetDir: dir,
+		LookPath:  stubScaffoldLookPath(map[string]string{"replicator": "/usr/local/bin/replicator"}),
+		ExecCmd:   rec.execCmd,
+	}
+
+	results := initSubTools(opts)
+
+	// Replicator commands should NOT have been called.
+	for _, call := range rec.calls {
+		if call == "replicator init" {
+			t.Errorf("replicator init should NOT be called when method is skip")
+		}
+	}
+	for _, r := range results {
+		if r.name == ".uf/replicator/" {
+			t.Errorf("unexpected replicator result when method is skip: %s %s", r.name, r.action)
+		}
+	}
+}
+
+func TestInitSubTools_AllToolsSkippedByConfig(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create .uf/config.yaml with all tools set to skip.
+	ufDir := filepath.Join(dir, ".uf")
+	if err := os.MkdirAll(ufDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	cfgContent := "setup:\n  tools:\n    dewey:\n      method: skip\n    replicator:\n      method: skip\n    specify:\n      method: skip\n    openspec:\n      method: skip\n    gaze:\n      method: skip\n"
+	if err := os.WriteFile(filepath.Join(ufDir, "config.yaml"), []byte(cfgContent), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	rec := &scaffoldCmdRecorder{errors: map[string]error{}}
+
+	opts := &Options{
+		TargetDir: dir,
+		LookPath: stubScaffoldLookPath(map[string]string{
+			"dewey":      "/usr/local/bin/dewey",
+			"replicator": "/usr/local/bin/replicator",
+			"specify":    "/usr/local/bin/specify",
+			"openspec":   "/usr/local/bin/openspec",
+			"gaze":       "/usr/local/bin/gaze",
+		}),
+		ExecCmd: rec.execCmd,
+	}
+
+	results := initSubTools(opts)
+
+	// No tool commands should have been called.
+	if len(rec.calls) != 0 {
+		t.Errorf("expected no commands when all tools are skipped, got: %v", rec.calls)
+	}
+
+	// Only result should be opencode.json skipped (nothing to configure).
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result (opencode.json), got %d: %v", len(results), results)
+	}
+	if results[0].name != "opencode.json" {
+		t.Errorf("expected opencode.json result, got %s", results[0].name)
+	}
+}
+
+// Phase: Concurrent execution tests (FR-001 through FR-005).
+
+func TestInitSubTools_ConcurrentAllResults(t *testing.T) {
+	// FR-001, FR-003: All five tools available — results from all
+	// tools are collected regardless of execution order.
+	dir := t.TempDir()
+	rec := &scaffoldCmdRecorder{errors: map[string]error{}}
+
+	opts := &Options{
+		TargetDir: dir,
+		LookPath: stubScaffoldLookPath(map[string]string{
+			"dewey":      "/usr/local/bin/dewey",
+			"replicator": "/usr/local/bin/replicator",
+			"specify":    "/usr/local/bin/specify",
+			"openspec":   "/usr/local/bin/openspec",
+			"gaze":       "/usr/local/bin/gaze",
+		}),
+		ExecCmd: rec.execCmd,
+	}
+
+	results := initSubTools(opts)
+
+	// Expect results from: dewey init, dewey index, replicator,
+	// specify, openspec, gaze, opencode.json.
+	// (dewey sources may or may not appear depending on filesystem.)
+	expectedNames := map[string]bool{
+		".uf/dewey/":      false,
+		"dewey index":     false,
+		".uf/replicator/": false,
+		".specify/":       false,
+		"openspec/":       false,
+		"gaze":            false,
+		"opencode.json":   false,
+	}
+
+	for _, r := range results {
+		if _, ok := expectedNames[r.name]; ok {
+			expectedNames[r.name] = true
+		}
+	}
+
+	for name, found := range expectedNames {
+		if !found {
+			t.Errorf("missing result for %q in concurrent run", name)
+		}
+	}
+
+	// Verify all expected commands were issued.
+	rec.mu.Lock()
+	callsCopy := make([]string, len(rec.calls))
+	copy(callsCopy, rec.calls)
+	rec.mu.Unlock()
+
+	expectedCmds := []string{
+		"dewey init", "dewey index",
+		"replicator init", "specify init",
+		"openspec init --tools opencode", "gaze init",
+	}
+	for _, cmd := range expectedCmds {
+		found := false
+		for _, call := range callsCopy {
+			if call == cmd {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected command %q in concurrent run, got calls: %v", cmd, callsCopy)
+		}
+	}
+}
+
+func TestInitSubTools_ConcurrentMissingToolSkipped(t *testing.T) {
+	// FR-001: Missing tools are skipped; available tools still
+	// complete their init without delay.
+	dir := t.TempDir()
+	rec := &scaffoldCmdRecorder{errors: map[string]error{}}
+
+	// Only dewey and gaze available; others missing.
+	opts := &Options{
+		TargetDir: dir,
+		LookPath: stubScaffoldLookPath(map[string]string{
+			"dewey": "/usr/local/bin/dewey",
+			"gaze":  "/usr/local/bin/gaze",
+		}),
+		ExecCmd: rec.execCmd,
+	}
+
+	results := initSubTools(opts)
+
+	// Should see results for dewey, gaze, and opencode.json.
+	// Should NOT see replicator, specify, or openspec results.
+	resultNames := map[string]bool{}
+	for _, r := range results {
+		resultNames[r.name] = true
+	}
+
+	if !resultNames[".uf/dewey/"] {
+		t.Error("expected dewey result when dewey is available")
+	}
+	if !resultNames["gaze"] {
+		t.Error("expected gaze result when gaze is available")
+	}
+	if resultNames[".uf/replicator/"] {
+		t.Error("unexpected replicator result when replicator is not available")
+	}
+	if resultNames[".specify/"] {
+		t.Error("unexpected specify result when specify is not available")
+	}
+	if resultNames["openspec/"] {
+		t.Error("unexpected openspec result when openspec is not available")
+	}
+}
+
+func TestInitSubTools_ConcurrentOneFailureNoBlock(t *testing.T) {
+	// FR-005: One tool failure does not prevent other tools from
+	// completing. Dewey init fails; replicator and gaze succeed.
+	dir := t.TempDir()
+	rec := &scaffoldCmdRecorder{errors: map[string]error{
+		"dewey init": fmt.Errorf("simulated dewey failure"),
+	}}
+
+	opts := &Options{
+		TargetDir: dir,
+		LookPath: stubScaffoldLookPath(map[string]string{
+			"dewey":      "/usr/local/bin/dewey",
+			"replicator": "/usr/local/bin/replicator",
+			"gaze":       "/usr/local/bin/gaze",
+		}),
+		ExecCmd: rec.execCmd,
+	}
+
+	results := initSubTools(opts)
+
+	// Dewey should appear with "failed" action.
+	deweyFailed := false
+	replicatorOK := false
+	gazeOK := false
+	opencodeOK := false
+	for _, r := range results {
+		switch r.name {
+		case ".uf/dewey/":
+			if r.action == "failed" {
+				deweyFailed = true
+			}
+		case ".uf/replicator/":
+			if r.action == "initialized" {
+				replicatorOK = true
+			}
+		case "gaze":
+			if r.action == "initialized" {
+				gazeOK = true
+			}
+		case "opencode.json":
+			opencodeOK = true
+		}
+	}
+
+	if !deweyFailed {
+		t.Error("expected dewey to report failure")
+	}
+	if !replicatorOK {
+		t.Error("expected replicator to succeed despite dewey failure")
+	}
+	if !gazeOK {
+		t.Error("expected gaze to succeed despite dewey failure")
+	}
+	if !opencodeOK {
+		t.Error("expected opencode.json result after concurrent completion")
+	}
+
+	// Verify dewey index was NOT called (init failed).
+	rec.mu.Lock()
+	for _, call := range rec.calls {
+		if call == "dewey index" {
+			t.Error("dewey index should not run when dewey init fails")
+		}
+	}
+	rec.mu.Unlock()
+}
+
+func TestInitSubTools_ConcurrentOpencodeJSONAfterAll(t *testing.T) {
+	// FR-004: configureOpencodeJSON runs after all concurrent
+	// groups complete. Verified by checking opencode.json result
+	// is present and contains correct MCP entries.
+	dir := t.TempDir()
+	rec := &scaffoldCmdRecorder{errors: map[string]error{}}
+
+	opts := &Options{
+		TargetDir: dir,
+		LookPath: stubScaffoldLookPath(map[string]string{
+			"dewey":      "/usr/local/bin/dewey",
+			"replicator": "/usr/local/bin/replicator",
+		}),
+		ExecCmd: rec.execCmd,
+	}
+
+	results := initSubTools(opts)
+
+	// opencode.json must be present in results.
+	opencodeFound := false
+	for _, r := range results {
+		if r.name == "opencode.json" {
+			opencodeFound = true
+		}
+	}
+	if !opencodeFound {
+		t.Fatal("expected opencode.json result after concurrent init")
+	}
+
+	// opencode.json file should exist on disk (written by
+	// configureOpencodeJSON after wg.Wait).
+	opencodeJSON := filepath.Join(dir, "opencode.json")
+	data, err := os.ReadFile(opencodeJSON)
+	if err != nil {
+		t.Fatalf("opencode.json should exist: %v", err)
+	}
+
+	// Verify it contains expected MCP server entries for both
+	// tools that were initialized.
+	var parsed map[string]interface{}
+	if jsonErr := json.Unmarshal(data, &parsed); jsonErr != nil {
+		t.Fatalf("opencode.json is not valid JSON: %v", jsonErr)
+	}
+	mcp, ok := parsed["mcp"]
+	if !ok {
+		t.Fatal("opencode.json missing mcp key")
+	}
+	mcpMap, ok := mcp.(map[string]interface{})
+	if !ok {
+		t.Fatal("opencode.json mcp is not a map")
+	}
+	if _, hasDewey := mcpMap["dewey"]; !hasDewey {
+		t.Error("opencode.json should contain dewey MCP entry")
+	}
+	if _, hasReplicator := mcpMap["replicator"]; !hasReplicator {
+		t.Error("opencode.json should contain replicator MCP entry")
 	}
 }
 

--- a/openspec/changes/parallel-subtool-init/.openspec.yaml
+++ b/openspec/changes/parallel-subtool-init/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: unbound-force
+created: 2026-06-01

--- a/openspec/changes/parallel-subtool-init/design.md
+++ b/openspec/changes/parallel-subtool-init/design.md
@@ -1,0 +1,88 @@
+## Context
+
+`initSubTools()` in `internal/scaffold/scaffold.go` runs five
+sub-tool initializations sequentially: dewey, replicator,
+specify, openspec, and gaze. Each uses `opts.ExecCmd()` which
+calls `exec.Command(...).CombinedOutput()` -- blocking until
+the process completes.
+
+Dewey is the slowest (30-60+ seconds for initial indexing due
+to web crawling, source fetching, and embedding generation).
+The remaining four tools each take 1-5 seconds but add up when
+run serially.
+
+Per the proposal's constitution alignment, this change is
+internal to the scaffold engine and maintains composability
+(each tool remains independently callable) and testability
+(injected `ExecCmd`/`LookPath` functions enable test doubles).
+
+## Goals / Non-Goals
+
+### Goals
+- Run independent sub-tool initializations concurrently to
+  reduce total wall-clock time
+- Preserve existing error handling semantics (non-fatal
+  per-tool failures)
+- Maintain result collection (`[]subToolResult`) with same
+  content regardless of execution order
+- Thread-safe result aggregation
+
+### Non-Goals
+- Optimizing Dewey's internal indexing pipeline (separate
+  change in the dewey repo)
+- Adding progress bars or streaming output (could be a
+  follow-up)
+- Running Dewey init in the background (fire-and-forget)
+  -- all tools must complete before `initSubTools` returns
+- Changing the `Options` struct API
+
+## Decisions
+
+### D1: Use `sync.WaitGroup` + mutex, not `errgroup`
+
+`errgroup` cancels remaining goroutines on first error. Sub-tool
+failures are non-fatal -- we want all tools to attempt init
+regardless of individual failures. Use `sync.WaitGroup` for
+coordination and `sync.Mutex` for thread-safe result collection.
+
+### D2: Two concurrency groups
+
+Group the tools into two independent concurrent groups based on
+their internal dependencies:
+
+- **Group A (Dewey)**: `dewey init` -> `generateDeweySources`
+  -> `dewey index` (sequential within this group)
+- **Group B (others)**: replicator, specify, openspec, gaze
+  (all independent, run concurrently with each other and with
+  Group A)
+
+Rationale: Dewey has an internal dependency chain (init must
+precede source generation which must precede indexing). The
+other four tools have no dependencies on each other or on Dewey.
+
+### D3: Capture stdout/stderr per tool
+
+Each goroutine captures its own tool's output via the existing
+`ExecCmd` mechanism. Results are appended to the shared
+`[]subToolResult` slice under a mutex. Output interleaving is
+not a concern since `ExecCmd` uses `CombinedOutput()` (already
+captures per-process).
+
+### D4: configureOpencodeJSON runs after all tools complete
+
+`configureOpencodeJSON()` (line 1424) depends on tool
+availability checks. It MUST run after all concurrent groups
+complete. This is enforced by placing it after `wg.Wait()`.
+
+## Risks / Trade-offs
+
+- **Risk**: Concurrent file writes if two tools write to the
+  same file. **Mitigation**: Each tool writes to its own
+  directory (`.uf/dewey/`, `.specify/`, `.openspec/`,
+  `.uf/gaze/`). No overlap.
+- **Risk**: Error output harder to read if multiple tools fail
+  simultaneously. **Mitigation**: Each failure is captured in
+  its own `subToolResult` with tool name. Acceptable trade-off
+  for reduced wall-clock time.
+- **Trade-off**: Slightly more complex code in `initSubTools`.
+  Justified by the user-facing latency improvement.

--- a/openspec/changes/parallel-subtool-init/proposal.md
+++ b/openspec/changes/parallel-subtool-init/proposal.md
@@ -1,0 +1,89 @@
+## Why
+
+`uf init` runs five sub-tool initializations (dewey, replicator,
+specify, openspec, gaze) sequentially via blocking `exec.Command`
+calls. Dewey indexing alone can take 30-60+ seconds due to web
+crawling, source fetching, and embedding generation. The remaining
+four tools add additional wall-clock time despite being entirely
+independent of each other and of Dewey.
+
+Users experience `uf init` as "hanging" with no feedback while
+these sequential operations complete.
+
+## What Changes
+
+Refactor `initSubTools()` in `internal/scaffold/scaffold.go` to
+run independent sub-tool initializations concurrently using
+`sync.WaitGroup` + `sync.Mutex`. Dewey init/index is the
+slowest step and should not block the other tools. The four
+non-Dewey tools (replicator, specify, openspec, gaze) are
+independent of each other and of Dewey.
+
+Additionally, `initSubTools()` now reads the project config
+(`setup.tools.<name>.method: skip`) before launching any
+goroutines. Tools configured with `method: skip` are excluded
+entirely — no goroutine is spawned, no binary is looked up,
+and no results are produced. This uses the existing
+`config.ToolConfig.Method` field already defined in the
+config package.
+
+## Capabilities
+
+### New Capabilities
+- `concurrent-subtool-init`: Sub-tools that have no
+  interdependencies run in parallel via `sync.WaitGroup`
+- `config-tool-skip`: Tools with `setup.tools.<name>.method:
+  skip` in `.uf/config.yaml` are excluded from initialization
+
+### Modified Capabilities
+- `initSubTools`: Returns the same `[]subToolResult` but
+  completes faster by overlapping independent work
+
+### Removed Capabilities
+- None
+
+## Impact
+
+- `internal/scaffold/scaffold.go`: `initSubTools()` function
+  refactored for concurrent execution and config-based skip
+- `internal/scaffold/scaffold_test.go`: Tests updated to
+  verify concurrent behavior, result aggregation, and
+  config-based tool skipping
+- No API changes, no new dependencies (uses stdlib `sync`)
+
+## Constitution Alignment
+
+Assessed against the Unbound Force org constitution.
+
+### I. Autonomous Collaboration
+
+**Assessment**: N/A
+
+This change is internal to the scaffold engine. It does not
+affect artifact-based communication between heroes.
+
+### II. Composability First
+
+**Assessment**: PASS
+
+Each sub-tool remains independently installable and callable.
+The change only affects the orchestration of their init calls,
+not their interfaces. `LookPath` checks are preserved -- missing
+tools are still skipped gracefully.
+
+### III. Observable Quality
+
+**Assessment**: PASS
+
+Sub-tool results are still collected and returned as
+`[]subToolResult`. Logging output from each tool is captured.
+The change preserves all existing observability.
+
+### IV. Testability
+
+**Assessment**: PASS
+
+`initSubTools` already uses injected `ExecCmd` and `LookPath`
+functions on the `Options` struct, enabling test doubles. The
+concurrent execution can be tested by verifying that results
+from all tools are present regardless of execution order.

--- a/openspec/changes/parallel-subtool-init/specs/concurrent-init.md
+++ b/openspec/changes/parallel-subtool-init/specs/concurrent-init.md
@@ -1,0 +1,107 @@
+## ADDED Requirements
+
+### Requirement: FR-001 Concurrent Sub-Tool Initialization
+
+`initSubTools()` MUST run independent sub-tool initializations
+concurrently. Tools with no interdependencies MUST NOT block
+each other.
+
+#### Scenario: Independent tools run concurrently
+- **GIVEN** dewey, replicator, specify, openspec, and gaze
+  are all available on PATH
+- **WHEN** `initSubTools()` is called
+- **THEN** replicator, specify, openspec, and gaze init
+  commands start without waiting for dewey indexing to complete
+
+#### Scenario: Missing tool does not block others
+- **GIVEN** dewey is not available on PATH but replicator,
+  specify, openspec, and gaze are
+- **WHEN** `initSubTools()` is called
+- **THEN** all available tools complete their init without
+  delay from the missing tool
+
+### Requirement: FR-002 Dewey Internal Sequencing
+
+Within the Dewey initialization group, operations MUST execute
+in order: `dewey init` -> `generateDeweySources` ->
+`dewey index`. These three steps MUST NOT be parallelized
+with each other.
+
+#### Scenario: Dewey init precedes indexing
+- **GIVEN** dewey is available on PATH and `.uf/dewey/` does
+  not exist
+- **WHEN** `initSubTools()` is called
+- **THEN** `dewey init` completes before `generateDeweySources`
+  runs, and `generateDeweySources` completes before
+  `dewey index` runs
+
+### Requirement: FR-003 Result Aggregation
+
+`initSubTools()` MUST return `[]subToolResult` containing
+results from all attempted tool initializations regardless
+of execution order. The returned slice MUST include the same
+entries as the sequential implementation.
+
+#### Scenario: All results collected
+- **GIVEN** all five tools are available on PATH
+- **WHEN** `initSubTools()` completes
+- **THEN** the returned `[]subToolResult` contains entries
+  for all tools that produced results
+
+### Requirement: FR-004 Post-Completion Configuration
+
+`configureOpencodeJSON()` MUST NOT execute until all concurrent
+sub-tool initializations have completed.
+
+#### Scenario: OpenCode config runs after all tools
+- **GIVEN** all tools are available on PATH
+- **WHEN** `initSubTools()` is called
+- **THEN** `configureOpencodeJSON()` runs only after all
+  concurrent groups have finished
+
+### Requirement: FR-005 Non-Fatal Failures
+
+Individual sub-tool failures MUST NOT prevent other tools from
+completing their initialization. A failure in one tool MUST NOT
+cancel or abort other concurrent tool initializations.
+
+#### Scenario: One tool fails, others succeed
+- **GIVEN** dewey is available but `dewey init` returns an error
+- **WHEN** `initSubTools()` is called
+- **THEN** replicator, specify, openspec, and gaze still
+  complete their initialization normally
+
+### Requirement: FR-006 Config-Based Tool Skipping
+
+`initSubTools()` MUST respect `setup.tools.<name>.method: skip`
+in `.uf/config.yaml`. A tool configured with `method: skip`
+MUST NOT be initialized, even if the binary is available on
+PATH and `--force` is set.
+
+#### Scenario: Skipped tool is not initialized
+- **GIVEN** dewey is available on PATH and `.uf/config.yaml`
+  contains `setup.tools.dewey.method: skip`
+- **WHEN** `initSubTools()` is called
+- **THEN** no dewey commands are executed and no dewey-related
+  results appear in the returned slice
+
+#### Scenario: Skip overrides force
+- **GIVEN** dewey is available on PATH, `.uf/dewey/` exists,
+  `--force` is set, and `.uf/config.yaml` contains
+  `setup.tools.dewey.method: skip`
+- **WHEN** `initSubTools()` is called
+- **THEN** dewey is not re-indexed
+
+#### Scenario: All tools skipped
+- **GIVEN** all five tools are configured with `method: skip`
+- **WHEN** `initSubTools()` is called
+- **THEN** no tool commands are executed and only
+  `configureOpencodeJSON` results appear
+
+## MODIFIED Requirements
+
+None.
+
+## REMOVED Requirements
+
+None.

--- a/openspec/changes/parallel-subtool-init/tasks.md
+++ b/openspec/changes/parallel-subtool-init/tasks.md
@@ -1,0 +1,57 @@
+<!--
+  [P] marks tasks eligible for parallel execution.
+  Add [P] when a task: (a) touches different files from
+  other [P] tasks in the group, (b) has no dependency
+  on prior tasks in the group, (c) can safely execute
+  without ordering constraints.
+  Do NOT add [P] when tasks modify the same file --
+  parallel workers will cause merge conflicts.
+  Tasks without [P] run sequentially first, then [P]
+  tasks run in parallel.
+-->
+
+## 1. Config-Based Tool Skipping
+
+- [x] 1.1 Add `shouldSkipTool()` to `initSubTools()` that
+  reads `setup.tools.<name>.method: skip` from project
+  config via `config.Load()`. All five tools (dewey,
+  replicator, specify, openspec, gaze) check this before
+  `LookPath`. Implements FR-006.
+  **Files**: `internal/scaffold/scaffold.go`
+
+- [x] 1.2 Add tests for config-based skipping: single tool
+  skip, skip overrides force, replicator skip, all tools
+  skipped. Implements FR-006 scenarios.
+  **Files**: `internal/scaffold/scaffold_test.go`
+
+## 2. Refactor initSubTools for Concurrency
+
+- [x] 2.1 Refactor `initSubTools()` in
+  `internal/scaffold/scaffold.go` to use `sync.WaitGroup`
+  and `sync.Mutex` for concurrent sub-tool execution.
+  Group A (dewey init -> generateDeweySources ->
+  dewey index) runs in one goroutine. Group B tools
+  (replicator, specify, openspec, gaze) each run in
+  their own goroutine. `configureOpencodeJSON()` runs
+  after `wg.Wait()`. Implements FR-001, FR-002, FR-003,
+  FR-004, FR-005.
+  **Files**: `internal/scaffold/scaffold.go`
+
+## 3. Tests
+
+- [x] 3.1 Add test(s) verifying concurrent execution
+  behavior: all tool results are collected, missing
+  tools are skipped, one tool failure does not block
+  others, `configureOpencodeJSON` runs after all tools
+  complete. Use injected `ExecCmd`/`LookPath` test
+  doubles.
+  **Files**: `internal/scaffold/scaffold_test.go`
+
+## 4. Verification
+
+- [x] 4.1 Run `make check` (lint + test + build) and
+  confirm all pass with `-race -count=1`
+- [x] 4.2 Verify constitution alignment: composability
+  (each tool independently callable), testability
+  (injected functions enable test doubles), observable
+  quality (results still collected and returned)


### PR DESCRIPTION
## Summary

Refactor `initSubTools()` to run independent sub-tool initializations
concurrently, reducing `uf init` wall-clock time from sequential sum
to parallel max. Dewey indexing (30-60s) no longer blocks the other
four tools.

### Changes

- **Concurrent execution**: `sync.WaitGroup` + `sync.Mutex` with two
  groups — Group A (dewey init → generateDeweySources → dewey index,
  sequential within goroutine) and Group B (replicator, specify,
  openspec, gaze, each in own goroutine)
- **Config-based tool skipping**: `setup.tools.<name>.method: skip`
  in `.uf/config.yaml` excludes tools from initialization entirely
- **Thread-safe logging**: `logf()` helper serializes `opts.Stdout`
  writes across goroutines
- **8 new tests**: 4 for config-based skip behavior, 4 for concurrent
  execution (FR-001 through FR-006)
- **OpenSpec artifacts**: proposal, design, spec, and tasks

### Review Council

5/5 APPROVE — Adversary, Architect, Guard, Tester, SRE. 0 CRITICAL,
0 HIGH. All MEDIUM findings addressed before commit.

Spec: `openspec/changes/parallel-subtool-init/`