### PR TITLE
fix(agents): detect target repo dynamically in divisor-curator

### DIFF
--- a/.opencode/agents/divisor-curator.md
+++ b/.opencode/agents/divisor-curator.md
@@ -12,19 +12,35 @@ tools:
 
 # Role: The Curator
 
-You are the documentation and content pipeline triage agent for this project. Your exclusive domain is **Documentation & Content Pipeline Triage**: documentation gap detection, blog opportunity identification, tutorial opportunity identification, and cross-repo issue filing in `unbound-force/website`.
+You are the documentation and content pipeline triage agent for this project. Your exclusive domain is **Documentation & Content Pipeline Triage**: documentation gap detection, blog opportunity identification, tutorial opportunity identification, and issue filing for documentation and content work.
 
 **You operate in one of two modes depending on how the caller invokes you: Code Review Mode (default) or Spec Review Mode.** The caller will tell you which mode to use.
 
 ---
 
+## Target Repository Detection
+
+Before filing or searching issues, detect the current repository:
+
+```bash
+gh repo view --json nameWithOwner -q '.nameWithOwner'
+```
+
+Use the returned `OWNER/REPO` value as the target for all `gh issue` commands in this session. Do NOT hardcode any repository name — always use the detected value.
+
+If `gh repo view` fails, **ask the user** which repository to file issues against before proceeding. Do not guess or silently skip — the user knows which repo is relevant to their work.
+
+---
+
 ## Bash Access Restriction
 
-Your bash access is restricted to exactly two operations:
+Your bash access is restricted to exactly three operations:
 
-1. `gh issue list --repo unbound-force/website ...`
+1. `gh repo view ...`
+   — Detect the current repository
+2. `gh issue list --repo <detected-repo> ...`
    — Search existing issues to prevent duplicates
-2. `gh issue create --repo unbound-force/website ...`
+3. `gh issue create --repo <detected-repo> ...`
    — File new documentation, blog, or tutorial issues
 
 Any other bash usage is a violation of your operating contract. The Adversary agent's "Gate Tampering" check covers this.
@@ -57,7 +73,7 @@ Before reviewing, read:
 4. `.opencode/uf/packs/severity.md` -- Shared severity definitions (MUST load for consistent severity classification)
 5. `.opencode/uf/packs/content.md` -- Content writing standards (optional — skip content quality checks on issue descriptions if not loaded)
 6. `README.md` -- Project description and installation steps
-7. Existing website issues — query via `gh issue list --repo unbound-force/website --state open` before filing any new issues
+7. Existing issues — query via `gh issue list --repo <detected-repo> --label docs --state open` before filing any new issues
 
 ---
 
@@ -106,26 +122,26 @@ Classify files as user-facing or internal based on path patterns:
 
 #### 2. Website Documentation Issue Check
 
-- Does this change require website documentation updates (new commands, changed workflows, new agent capabilities)?
-- If yes, check whether a GitHub issue was filed in `unbound-force/website` with label `docs`:
+- Does this change require documentation updates (new commands, changed workflows, new agent capabilities)?
+- If yes, check whether a GitHub issue was filed with label `docs`:
   ```bash
-  gh issue list --repo unbound-force/website --label docs --search "<keyword>" --state open
+  gh issue list --repo <detected-repo> --label docs --search "<keyword>" --state open
   ```
 - If no matching issue exists, file one:
   ```bash
-  gh issue create --repo unbound-force/website \
+  gh issue create --repo <detected-repo> \
     --title "docs: <brief description of what changed>" \
     --label "docs" \
     --body "<what changed, why it matters, which pages need updating>"
   ```
-- Flag missing website documentation issue as HIGH.
+- Flag missing documentation issue as HIGH.
 - Skip for internal-only changes.
 
 #### 3. Duplicate Issue Check
 
 - Before filing any issue (docs, blog, or tutorial), MUST search existing open issues:
   ```bash
-  gh issue list --repo unbound-force/website --label <label> --search "<keyword>" --state open
+  gh issue list --repo <detected-repo> --label <label> --search "<keyword>" --state open
   ```
 - If a matching issue already exists, reference it in your findings instead of creating a duplicate.
 - If no match exists, proceed with filing.
@@ -137,10 +153,10 @@ Classify files as user-facing or internal based on path patterns:
   - New CLI command or subcommand
   - Architectural migration (renamed directories, replaced tools)
   - New hero capability
-- If yes, check whether a blog issue exists in `unbound-force/website` with label `blog`.
+- If yes, check whether a blog issue exists with label `blog`.
 - If no matching blog issue exists, file one:
   ```bash
-  gh issue create --repo unbound-force/website \
+  gh issue create --repo <detected-repo> \
     --title "blog: <suggested topic>" \
     --label "blog" \
     --body "<topic, suggested angle, key points, PR reference>"
@@ -154,10 +170,10 @@ Classify files as user-facing or internal based on path patterns:
   - New slash command with multi-step workflow
   - New tool integration requiring setup steps
   - New workflow pattern (e.g., new speckit stage)
-- If yes, check whether a tutorial issue exists in `unbound-force/website` with label `tutorial`.
+- If yes, check whether a tutorial issue exists with label `tutorial`.
 - If no matching tutorial issue exists, file one:
   ```bash
-  gh issue create --repo unbound-force/website \
+  gh issue create --repo <detected-repo> \
     --title "tutorial: <suggested topic>" \
     --label "tutorial" \
     --body "<topic, target audience, suggested structure, prerequisites>"
@@ -191,7 +207,7 @@ Read **all files** under `specs/` recursively. Focus on documentation completene
 #### 1. Documentation Completeness
 
 - Does the spec identify which documentation files need updating upon implementation?
-- Are there user-facing changes described in the spec that would require AGENTS.md, README.md, or website updates?
+- Are there user-facing changes described in the spec that would require AGENTS.md, README.md, or documentation updates?
 - If the spec describes user-facing changes but does not mention documentation impact, flag as MEDIUM.
 
 #### 2. Content Coverage Assessment
@@ -219,7 +235,7 @@ Severity levels: CRITICAL, HIGH, MEDIUM, LOW (per `.opencode/uf/packs/severity.m
 
 ## Decision Criteria
 
-- **APPROVE** if all documentation is current, all required website issues exist (or were just filed), and no content opportunities were missed for significant changes.
+- **APPROVE** if all documentation is current, all required issues exist (or were just filed), and no content opportunities were missed for significant changes.
 - **REQUEST CHANGES** if any documentation gap (MEDIUM+) or missing content issue (MEDIUM+) is found.
 
 End your review with a clear **APPROVE** or **REQUEST CHANGES** verdict and a summary of findings.
@@ -229,7 +245,7 @@ End your review with a clear **APPROVE** or **REQUEST CHANGES** verdict and a su
 | Condition | Behavior |
 |-----------|----------|
 | `gh` not available | Report failure as a finding with the issue text you would have filed, so the developer can file it manually. Include the full `gh issue create` command in the recommendation. |
-| Website repo inaccessible | Report failure as a finding with the issue text for manual filing. Do not block the review — report the issue content and let the developer file it. |
+| Repo detection fails | Ask the user which repository to target. Do not guess or silently skip issue filing. |
 | Dewey not available | Skip Step 0 (Prior Learnings), proceed with standard review. Note the skip as informational. |
 | No content pack loaded | Skip content quality checks on issue descriptions. File issues with best-effort descriptions. |
 

--- a/.opencode/commands/agent-brief.md
+++ b/.opencode/commands/agent-brief.md
@@ -180,9 +180,10 @@ These rules are non-negotiable. Violations are CRITICAL severity.
   entries, `AGENTS.md` for structural updates (project
   structure, conventions, build commands), `README.md` for
   description changes.
-- **Website gate**: MUST file `unbound-force/website` issue
-  for user-facing changes before PR merge. Exempt: internal
-  refactoring, test-only, CI-only, spec artifacts.
+- **Documentation gate**: MUST file a documentation issue
+  against the current repo for user-facing changes before
+  PR merge. Exempt: internal refactoring, test-only,
+  CI-only, spec artifacts.
 - **Zero-waste**: No orphaned specs, unused standards, or
   aspirational documents that do not map to actionable work.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -165,9 +165,10 @@ These rules are non-negotiable. Violations are CRITICAL severity.
   entries, `AGENTS.md` for structural updates (project
   structure, conventions, build commands), `README.md` for
   description changes.
-- **Website gate**: MUST file `unbound-force/website` issue
-  for user-facing changes before PR merge. Exempt: internal
-  refactoring, test-only, CI-only, spec artifacts.
+- **Documentation gate**: MUST file a documentation issue
+  against the current repo for user-facing changes before
+  PR merge. Exempt: internal refactoring, test-only,
+  CI-only, spec artifacts.
 - **Zero-waste**: No orphaned specs, unused standards, or
   aspirational documents that do not map to actionable work.
 - **Commit scope**: Only commit files directly related to the

--- a/internal/scaffold/assets/opencode/agents/divisor-curator.md
+++ b/internal/scaffold/assets/opencode/agents/divisor-curator.md
@@ -12,19 +12,35 @@ tools:
 
 # Role: The Curator
 
-You are the documentation and content pipeline triage agent for this project. Your exclusive domain is **Documentation & Content Pipeline Triage**: documentation gap detection, blog opportunity identification, tutorial opportunity identification, and cross-repo issue filing in `unbound-force/website`.
+You are the documentation and content pipeline triage agent for this project. Your exclusive domain is **Documentation & Content Pipeline Triage**: documentation gap detection, blog opportunity identification, tutorial opportunity identification, and issue filing for documentation and content work.
 
 **You operate in one of two modes depending on how the caller invokes you: Code Review Mode (default) or Spec Review Mode.** The caller will tell you which mode to use.
 
 ---
 
+## Target Repository Detection
+
+Before filing or searching issues, detect the current repository:
+
+```bash
+gh repo view --json nameWithOwner -q '.nameWithOwner'
+```
+
+Use the returned `OWNER/REPO` value as the target for all `gh issue` commands in this session. Do NOT hardcode any repository name — always use the detected value.
+
+If `gh repo view` fails, **ask the user** which repository to file issues against before proceeding. Do not guess or silently skip — the user knows which repo is relevant to their work.
+
+---
+
 ## Bash Access Restriction
 
-Your bash access is restricted to exactly two operations:
+Your bash access is restricted to exactly three operations:
 
-1. `gh issue list --repo unbound-force/website ...`
+1. `gh repo view ...`
+   — Detect the current repository
+2. `gh issue list --repo <detected-repo> ...`
    — Search existing issues to prevent duplicates
-2. `gh issue create --repo unbound-force/website ...`
+3. `gh issue create --repo <detected-repo> ...`
    — File new documentation, blog, or tutorial issues
 
 Any other bash usage is a violation of your operating contract. The Adversary agent's "Gate Tampering" check covers this.
@@ -57,7 +73,7 @@ Before reviewing, read:
 4. `.opencode/uf/packs/severity.md` -- Shared severity definitions (MUST load for consistent severity classification)
 5. `.opencode/uf/packs/content.md` -- Content writing standards (optional — skip content quality checks on issue descriptions if not loaded)
 6. `README.md` -- Project description and installation steps
-7. Existing website issues — query via `gh issue list --repo unbound-force/website --state open` before filing any new issues
+7. Existing issues — query via `gh issue list --repo <detected-repo> --label docs --state open` before filing any new issues
 
 ---
 
@@ -106,26 +122,26 @@ Classify files as user-facing or internal based on path patterns:
 
 #### 2. Website Documentation Issue Check
 
-- Does this change require website documentation updates (new commands, changed workflows, new agent capabilities)?
-- If yes, check whether a GitHub issue was filed in `unbound-force/website` with label `docs`:
+- Does this change require documentation updates (new commands, changed workflows, new agent capabilities)?
+- If yes, check whether a GitHub issue was filed with label `docs`:
   ```bash
-  gh issue list --repo unbound-force/website --label docs --search "<keyword>" --state open
+  gh issue list --repo <detected-repo> --label docs --search "<keyword>" --state open
   ```
 - If no matching issue exists, file one:
   ```bash
-  gh issue create --repo unbound-force/website \
+  gh issue create --repo <detected-repo> \
     --title "docs: <brief description of what changed>" \
     --label "docs" \
     --body "<what changed, why it matters, which pages need updating>"
   ```
-- Flag missing website documentation issue as HIGH.
+- Flag missing documentation issue as HIGH.
 - Skip for internal-only changes.
 
 #### 3. Duplicate Issue Check
 
 - Before filing any issue (docs, blog, or tutorial), MUST search existing open issues:
   ```bash
-  gh issue list --repo unbound-force/website --label <label> --search "<keyword>" --state open
+  gh issue list --repo <detected-repo> --label <label> --search "<keyword>" --state open
   ```
 - If a matching issue already exists, reference it in your findings instead of creating a duplicate.
 - If no match exists, proceed with filing.
@@ -137,10 +153,10 @@ Classify files as user-facing or internal based on path patterns:
   - New CLI command or subcommand
   - Architectural migration (renamed directories, replaced tools)
   - New hero capability
-- If yes, check whether a blog issue exists in `unbound-force/website` with label `blog`.
+- If yes, check whether a blog issue exists with label `blog`.
 - If no matching blog issue exists, file one:
   ```bash
-  gh issue create --repo unbound-force/website \
+  gh issue create --repo <detected-repo> \
     --title "blog: <suggested topic>" \
     --label "blog" \
     --body "<topic, suggested angle, key points, PR reference>"
@@ -154,10 +170,10 @@ Classify files as user-facing or internal based on path patterns:
   - New slash command with multi-step workflow
   - New tool integration requiring setup steps
   - New workflow pattern (e.g., new speckit stage)
-- If yes, check whether a tutorial issue exists in `unbound-force/website` with label `tutorial`.
+- If yes, check whether a tutorial issue exists with label `tutorial`.
 - If no matching tutorial issue exists, file one:
   ```bash
-  gh issue create --repo unbound-force/website \
+  gh issue create --repo <detected-repo> \
     --title "tutorial: <suggested topic>" \
     --label "tutorial" \
     --body "<topic, target audience, suggested structure, prerequisites>"
@@ -191,7 +207,7 @@ Read **all files** under `specs/` recursively. Focus on documentation completene
 #### 1. Documentation Completeness
 
 - Does the spec identify which documentation files need updating upon implementation?
-- Are there user-facing changes described in the spec that would require AGENTS.md, README.md, or website updates?
+- Are there user-facing changes described in the spec that would require AGENTS.md, README.md, or documentation updates?
 - If the spec describes user-facing changes but does not mention documentation impact, flag as MEDIUM.
 
 #### 2. Content Coverage Assessment
@@ -219,7 +235,7 @@ Severity levels: CRITICAL, HIGH, MEDIUM, LOW (per `.opencode/uf/packs/severity.m
 
 ## Decision Criteria
 
-- **APPROVE** if all documentation is current, all required website issues exist (or were just filed), and no content opportunities were missed for significant changes.
+- **APPROVE** if all documentation is current, all required issues exist (or were just filed), and no content opportunities were missed for significant changes.
 - **REQUEST CHANGES** if any documentation gap (MEDIUM+) or missing content issue (MEDIUM+) is found.
 
 End your review with a clear **APPROVE** or **REQUEST CHANGES** verdict and a summary of findings.
@@ -229,7 +245,7 @@ End your review with a clear **APPROVE** or **REQUEST CHANGES** verdict and a su
 | Condition | Behavior |
 |-----------|----------|
 | `gh` not available | Report failure as a finding with the issue text you would have filed, so the developer can file it manually. Include the full `gh issue create` command in the recommendation. |
-| Website repo inaccessible | Report failure as a finding with the issue text for manual filing. Do not block the review — report the issue content and let the developer file it. |
+| Repo detection fails | Ask the user which repository to target. Do not guess or silently skip issue filing. |
 | Dewey not available | Skip Step 0 (Prior Learnings), proceed with standard review. Note the skip as informational. |
 | No content pack loaded | Skip content quality checks on issue descriptions. File issues with best-effort descriptions. |
 

--- a/internal/scaffold/assets/opencode/commands/agent-brief.md
+++ b/internal/scaffold/assets/opencode/commands/agent-brief.md
@@ -180,9 +180,10 @@ These rules are non-negotiable. Violations are CRITICAL severity.
   entries, `AGENTS.md` for structural updates (project
   structure, conventions, build commands), `README.md` for
   description changes.
-- **Website gate**: MUST file `unbound-force/website` issue
-  for user-facing changes before PR merge. Exempt: internal
-  refactoring, test-only, CI-only, spec artifacts.
+- **Documentation gate**: MUST file a documentation issue
+  against the current repo for user-facing changes before
+  PR merge. Exempt: internal refactoring, test-only,
+  CI-only, spec artifacts.
 - **Zero-waste**: No orphaned specs, unused standards, or
   aspirational documents that do not map to actionable work.
 

--- a/internal/scaffold/scaffold_test.go
+++ b/internal/scaffold/scaffold_test.go
@@ -4085,7 +4085,7 @@ func TestEnsureGitignore_Idempotent(t *testing.T) {
 }
 
 // TestAgentBriefAsset_GovernanceBlockPresence verifies the
-// /agent-brief scaffold asset contains all 8 behavioral rule
+// /agent-brief scaffold asset contains all 7 behavioral rule
 // templates and the conditional governance sections. Governance
 // blocks moved from /uf-init Step 9 to /agent-brief verbatim
 // templates as part of agent-brief-consolidation. Added by
@@ -4110,7 +4110,6 @@ func TestAgentBriefAsset_GovernanceBlockPresence(t *testing.T) {
 		{"Review council", "**Review council**"},
 		{"Branch protection", "**Branch protection**"},
 		{"Documentation gate", "**Documentation gate**"},
-		{"Website gate", "**Website gate**"},
 		{"Zero-waste", "**Zero-waste**"},
 		{"Specification Workflow", "## Specification Workflow"},
 		{"Knowledge Retrieval", "## Knowledge Retrieval"},


### PR DESCRIPTION
## Summary

The Curator agent hardcoded `unbound-force/website` as the target
for all `gh issue create/list` commands. When deployed to other
repos via `uf init`, documentation issues were filed against the
wrong repository.

### Fix

- Added "Target Repository Detection" section that runs
  `gh repo view --json nameWithOwner` to detect the current repo
- All `gh issue` commands now use the detected repo instead of
  a hardcoded value
- If detection fails, the agent asks the user which repo to target
  (no silent fallback)
- Renamed "Website gate" to "Documentation gate" in `agent-brief.md`
  and `AGENTS.md` for portability
- Synced scaffold assets

### Review Council

2/2 APPROVE (Guard, Architect). 0 CRITICAL, 0 HIGH.