### PR TITLE
feat(scaffold): add Python convention pack and doctor checks

### DIFF
--- a/.gaze/baseline.json
+++ b/.gaze/baseline.json
@@ -1309,8 +1309,8 @@
       "file": "internal/doctor/checks.go",
       "line": 216,
       "complexity": 4,
-      "line_coverage": 71.42857142857143,
-      "crap": 4.373177842565598
+      "line_coverage": 0,
+      "crap": 20
     },
     {
       "package": "doctor",

--- a/.opencode/uf/packs/python-custom.md
+++ b/.opencode/uf/packs/python-custom.md
@@ -1,0 +1,19 @@
+---
+pack_id: python-custom
+language: Python
+version: 1.0.0
+---
+
+# Custom Rules: Python
+
+Project-specific Python conventions that extend the canonical
+Python convention pack. Rules in this file are loaded alongside
+`python.md` by Cobalt-Crush (during implementation) and
+all Divisor persona agents (during review).
+
+Use the `CR-NNN` prefix for all custom rules. Use `[MUST]`,
+`[SHOULD]`, or `[MAY]` severity indicators per RFC 2119.
+
+## Custom Rules
+
+<!-- Add project-specific rules below this line -->

--- a/.opencode/uf/packs/python.md
+++ b/.opencode/uf/packs/python.md
@@ -1,0 +1,267 @@
+---
+pack_id: python
+language: Python
+version: 1.0.0
+---
+
+# Convention Pack: Python
+
+This convention pack defines Python-specific review
+criteria for The Divisor PR reviewer framework. Persona
+agents load this pack dynamically at review time to
+evaluate Python codebases against language-specific
+coding style, architectural patterns, security checks,
+testing conventions, type annotations, and documentation
+requirements.
+
+Rules use RFC 2119 severity indicators: [MUST] for
+mandatory requirements, [SHOULD] for strong recommendations,
+and [MAY] for optional best practices.
+
+---
+
+## Coding Style
+
+- **CS-001** [MUST] Code MUST be auto-formatted with a
+  consistent formatter (`black`, `ruff format`, or
+  equivalent). No manual formatting overrides. Line
+  length MUST match the project's configured limit.
+  Formatting changes MUST NOT be mixed with logic
+  changes in the same commit.
+
+- **CS-002** [MUST] Imports MUST be auto-sorted with a
+  consistent tool (`isort`, `ruff` with isort rules, or
+  equivalent). Organize in groups separated by blank
+  lines: standard library, third-party packages,
+  local/project modules.
+
+- **CS-003** [MUST] Code MUST pass a linter (`flake8`,
+  `ruff check`, or equivalent) with the project's
+  configured ruleset. No lint errors committed without
+  explicit suppression comments that include the specific
+  code and justification (e.g., `# noqa: E501 - URL`).
+
+- **CS-004** [MUST] Use `snake_case` for functions,
+  methods, variables, and module names. Use `PascalCase`
+  for class names. Use `UPPER_SNAKE_CASE` for module-level
+  constants.
+
+- **CS-005** [MUST] All functions that can fail MUST raise
+  specific exception types or return typed results. Never
+  silently swallow exceptions. Every `except` clause MUST
+  either handle, re-raise, or log the exception with
+  context.
+
+- **CS-006** [MUST] Bare `except:` and `except Exception:`
+  MUST NOT be used unless re-raising or logging with full
+  context. Catch the most specific exception type possible.
+
+- **CS-007** [MUST] Use f-strings for string formatting.
+  Do not use `%` formatting or `.format()` in new code.
+
+- **CS-008** [MUST] No mutable default arguments. Use
+  `None` as default and initialize inside the function
+  body (e.g., `def foo(items=None): items = items or []`).
+
+- **CS-009** [MUST] Use `with` statements for all resource
+  management (files, database connections, locks, network
+  sessions). Never rely on garbage collection for cleanup.
+
+- **CS-010** [SHOULD] Keep functions focused on a single
+  responsibility. Functions exceeding ~50 lines of logic
+  SHOULD be evaluated for decomposition.
+
+- **CS-011** [SHOULD] Use `pathlib.Path` for filesystem
+  path construction instead of `os.path.join` in new code.
+
+- **CS-012** [SHOULD] Use list/dict/set comprehensions
+  where they improve readability. Avoid nested
+  comprehensions deeper than two levels.
+
+- **CS-013** [SHOULD] Prefer `dataclasses`, Pydantic
+  models, or typed NamedTuples over plain dicts for
+  structured data with known schemas.
+
+---
+
+## Architectural Patterns
+
+- **AP-001** [MUST] Each module MUST have a single,
+  well-defined responsibility. A module that handles both
+  business logic and I/O coordination is a violation.
+
+- **AP-002** [SHOULD] Dependencies SHOULD be injected
+  rather than hard-instantiated. Functions and constructors
+  SHOULD accept interfaces or abstractions rather than
+  concrete implementations where testability benefits.
+
+- **AP-003** [MUST] Circular imports MUST NOT exist. If
+  module A imports module B, module B MUST NOT import
+  module A (directly or transitively). Use local imports,
+  `TYPE_CHECKING` guards, or extract shared types to break
+  cycles.
+
+- **AP-004** [SHOULD] Configuration SHOULD be loaded from
+  environment variables, config files, or framework
+  settings (e.g., `django.conf.settings`), not hardcoded.
+
+- **AP-005** [SHOULD] Long modules (>500 lines) SHOULD be
+  evaluated for splitting into submodules with a package
+  `__init__.py` that re-exports the public API.
+
+- **AP-006** [MUST] Application code MUST NOT import from
+  test modules. Test utilities shared across test files
+  SHOULD live in `conftest.py` or a dedicated test helpers
+  package.
+
+---
+
+## Security Checks
+
+- **SC-001** [MUST] Never hardcode secrets, API keys,
+  tokens, or credentials in source code. Secrets MUST be
+  loaded from environment variables, secret managers, or
+  encrypted configuration. Files matching common secret
+  patterns (`.env`, `credentials.json`, `*.pem`, `*.key`)
+  MUST NOT be committed.
+
+- **SC-002** [MUST] All user input MUST be validated and
+  sanitized before use. Use parameterized queries for
+  database access -- never string concatenation or
+  f-string interpolation in SQL.
+
+- **SC-003** [MUST] Use `defusedxml` or equivalent for
+  XML parsing of untrusted input. Never use
+  `xml.etree.ElementTree` or `lxml` with untrusted data
+  without disabling entity expansion. Test-only XML
+  parsing of trusted fixtures MAY use standard library
+  parsers.
+
+- **SC-004** [MUST] Code MUST pass security static
+  analysis (`bandit`, `ruff` S rules, or equivalent).
+  Address all HIGH and CRITICAL findings before merge.
+
+- **SC-005** [SHOULD] Dependencies SHOULD be audited
+  regularly with `pip-audit`, Dependabot, or equivalent
+  tooling. PRs introducing new dependencies SHOULD note
+  maintenance status and known vulnerabilities.
+  Dependencies with critical CVEs MUST NOT be merged.
+
+- **SC-006** [MUST] File operations with user-supplied
+  paths MUST validate against directory traversal. Use
+  `os.path.realpath()` or `pathlib.Path.resolve()` and
+  verify the result is within the expected root.
+
+- **SC-007** [MUST] Never pass user-supplied or external
+  input to `shell=True` subprocess calls. [SHOULD] Prefer
+  `subprocess.run()` with list arguments and `shell=False`
+  for new code. Internal utility wrappers that use
+  `shell=True` with hardcoded or developer-controlled
+  commands are acceptable when documented.
+
+- **SC-008** [SHOULD] Set safe file permissions when
+  creating files: `0o644` for regular files, `0o755` for
+  executable scripts and directories. Avoid world-writable
+  permissions.
+
+---
+
+## Testing Conventions
+
+- **TC-001** [MUST] Use `pytest` as the test runner. Do
+  not use `unittest.TestCase` for new tests. Existing
+  `TestCase` subclasses are acceptable until migrated.
+
+- **TC-002** [MUST] New functionality MUST be accompanied
+  by tests covering the primary success path and at least
+  one failure/edge case path.
+
+- **TC-003** [MUST] Bug fixes MUST include a regression
+  test that reproduces the original failure and verifies
+  the fix.
+
+- **TC-004** [MUST] External dependencies (APIs, databases,
+  filesystem, network) MUST be mocked in unit tests using
+  `unittest.mock.patch`, `pytest-mock`, or `pytest`
+  fixtures. Tests MUST NOT require external services or
+  network connectivity.
+
+- **TC-005** [MUST] Tests MUST be isolated -- each test
+  MUST be independently runnable without depending on
+  execution order or shared mutable state.
+
+- **TC-006** [SHOULD] Use `pytest.mark.parametrize` for
+  table-driven tests when exercising multiple input/output
+  combinations for the same function.
+
+- **TC-007** [SHOULD] Test names SHOULD clearly describe
+  the scenario: `test_<function>_<condition>_<expected>`
+  (e.g., `test_parse_empty_input_returns_none`).
+
+- **TC-008** [SHOULD] Use `factory-boy`, `pytest` fixtures,
+  or equivalent for test data construction. Avoid large
+  inline dicts or manual object construction repeated
+  across tests.
+
+- **TC-009** [SHOULD] Coverage SHOULD be measured with
+  `pytest-cov` or equivalent. A `--cov-fail-under`
+  threshold SHOULD be enforced in CI to prevent coverage
+  regression.
+
+- **TC-010** [SHOULD] Place test files in a `tests/`
+  directory mirroring the source structure, or co-locate
+  with source files using the `test_<module>.py` naming
+  convention. Test file naming MUST follow the project's
+  established convention consistently.
+
+- **TC-011** [SHOULD] Use `conftest.py` for shared
+  fixtures. Do not duplicate fixture definitions across
+  test files.
+
+---
+
+## Type Annotations
+
+- **TA-001** [SHOULD] All new public functions and methods
+  SHOULD have type annotations on parameters and return
+  values.
+
+- **TA-002** [SHOULD] Run a type checker (`mypy`, `pyright`,
+  `ty`, or equivalent) and address type errors
+  incrementally -- do not disable the type checker globally.
+
+- **TA-003** [SHOULD] Use built-in generics (`list[str]`,
+  `dict[str, int]`, `X | None`) for Python 3.10+. For
+  Python 3.9 and below, use `typing` module constructs
+  (`Optional`, `Union`, `List`, `Dict`).
+
+- **TA-004** [SHOULD] Prefer `Protocol` classes over ABC
+  for structural typing where duck typing is the intent.
+
+---
+
+## Documentation Requirements
+
+- **DR-001** [MUST] All public functions, classes, and
+  methods MUST have docstrings. Use a consistent docstring
+  format (Google-style, NumPy-style, or reStructuredText)
+  across the project.
+
+- **DR-002** [MUST] Commit messages MUST use Conventional
+  Commits format: `type: description` (e.g., `feat:`,
+  `fix:`, `docs:`, `chore:`, `refactor:`).
+
+- **DR-003** [SHOULD] User-visible changes SHOULD be
+  recorded in a changelog or release notes following the
+  project's established format.
+
+- **DR-004** [SHOULD] Configuration options, environment
+  variables, and feature flags SHOULD be documented in
+  the project README or a dedicated configuration
+  reference.
+
+---
+
+## Custom Rules
+
+<!-- This section is intentionally empty in the canonical pack. Project-specific custom rules belong in python-custom.md -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -285,5 +285,7 @@ before writing or reviewing code.
 - `.opencode/uf/packs/content-custom.md`
 - `.opencode/uf/packs/go.md`
 - `.opencode/uf/packs/go-custom.md`
+- `.opencode/uf/packs/python.md`
+- `.opencode/uf/packs/python-custom.md`
 - `.opencode/uf/packs/typescript.md`
 - `.opencode/uf/packs/typescript-custom.md`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ Each entry follows the format: `- <change-name>: <summary>`.
 ## Unreleased
 
 ### Added
+- `python-convention-pack`: Added Python convention pack
+  (`python.md`, `python-custom.md`) with 46 rules across 7
+  sections (Coding Style, Architectural Patterns, Security
+  Checks, Testing Conventions, Type Annotations, Documentation
+  Requirements, Custom Rules). Expanded `detectLang()` with 5
+  additional Python markers (`setup.py`, `setup.cfg`,
+  `requirements.txt`, `tox.ini`, `Pipfile`). Added conditional
+  "Python Tools" doctor check group with 9 tool categories
+  and tool-agnostic alternative detection (ruff satisfies
+  formatter, linter, import sorter, security scanner).
+  (Spec: openspec/changes/python-convention-pack/)
 - `/address-feedback` slash command for structured PR review
   feedback triage (Spec: openspec/changes/address-feedback/)
 - `feedback-triage` JSON schema (v1.0.0) for capturing triage

--- a/cmd/unbound-force/main_test.go
+++ b/cmd/unbound-force/main_test.go
@@ -30,11 +30,12 @@ func TestRunInit_FreshDir(t *testing.T) {
 	}
 
 	// Verify the summary includes a non-trivial file count
-	// 36 = 35 prior + 1 address-feedback.md command
+	// 38 = 36 prior + 2 Python convention pack files
+	// (python.md + python-custom.md).
 	// (devcontainer excluded — OS-specific, generated
 	// per-user by uf sandbox init).
-	if !strings.Contains(output, "36 files processed") {
-		t.Errorf("expected '36 files processed' in output, got:\n%s", output)
+	if !strings.Contains(output, "38 files processed") {
+		t.Errorf("expected '38 files processed' in output, got:\n%s", output)
 	}
 
 	// Verify a user-owned file was created

--- a/internal/doctor/checks.go
+++ b/internal/doctor/checks.go
@@ -1830,3 +1830,144 @@ func checkAgentContext(opts *Options) CheckGroup {
 
 	return group
 }
+
+// pythonMarkerFiles lists the files that indicate a Python project.
+// Duplicated from scaffold.detectLang() to avoid a cross-package
+// import (per design D6 in the python-convention-pack spec).
+var pythonMarkerFiles = []string{
+	"pyproject.toml",
+	"setup.py",
+	"setup.cfg",
+	"requirements.txt",
+	"tox.ini",
+	"Pipfile",
+}
+
+// isPythonProject returns true if any Python project marker file
+// exists in the target directory.
+func isPythonProject(targetDir string) bool {
+	for _, f := range pythonMarkerFiles {
+		if _, err := os.Stat(filepath.Join(targetDir, f)); err == nil {
+			return true
+		}
+	}
+	return false
+}
+
+// pythonToolCheck defines a Python tool category check. Categories
+// with multiple alternatives (e.g., formatter: black or ruff) pass
+// if any alternative is found.
+type pythonToolCheck struct {
+	name        string   // Display name for the check result
+	binaries    []string // Binaries to look for (pass if any found)
+	required    bool     // Fail severity if none found
+	recommended bool     // Warn severity if none found
+	installHint string   // Hint when none found
+}
+
+// pythonToolChecks defines the 9 Python tool category checks per
+// design D5. Tool-agnostic categories list alternatives per D3.
+var pythonToolChecks = []pythonToolCheck{
+	{
+		name:        "python3",
+		binaries:    []string{"python3"},
+		required:    true,
+		installHint: "Install Python 3: https://www.python.org/downloads/",
+	},
+	{
+		name:        "pip/uv",
+		binaries:    []string{"pip", "uv"},
+		recommended: true,
+		installHint: "Install pip or uv: https://docs.astral.sh/uv/",
+	},
+	{
+		name:        "pytest",
+		binaries:    []string{"pytest"},
+		required:    true,
+		installHint: "pip install pytest",
+	},
+	{
+		name:        "formatter",
+		binaries:    []string{"black", "ruff"},
+		recommended: true,
+		installHint: "pip install black  (or: pip install ruff)",
+	},
+	{
+		name:        "linter",
+		binaries:    []string{"flake8", "ruff"},
+		recommended: true,
+		installHint: "pip install flake8  (or: pip install ruff)",
+	},
+	{
+		name:        "import sorter",
+		binaries:    []string{"isort", "ruff"},
+		recommended: true,
+		installHint: "pip install isort  (or: pip install ruff)",
+	},
+	{
+		name:        "security scanner",
+		binaries:    []string{"bandit", "ruff"},
+		recommended: true,
+		installHint: "pip install bandit  (or: pip install ruff)",
+	},
+	{
+		name:        "mypy",
+		binaries:    []string{"mypy"},
+		installHint: "pip install mypy",
+	},
+	{
+		name:        "tox",
+		binaries:    []string{"tox"},
+		installHint: "pip install tox",
+	},
+}
+
+// checkPythonTools checks Python toolchain prerequisites.
+// Returns a CheckGroup named "Python Tools" with results for
+// each tool category. Tool-agnostic categories pass if any
+// alternative binary is found.
+func checkPythonTools(opts *Options) CheckGroup {
+	group := CheckGroup{
+		Name:    "Python Tools",
+		Results: []CheckResult{},
+	}
+
+	for _, tc := range pythonToolChecks {
+		result := checkAnyTool(tc, opts)
+		group.Results = append(group.Results, result)
+	}
+
+	return group
+}
+
+// checkAnyTool checks whether any of the binaries in a
+// pythonToolCheck are available. Returns Pass if any binary
+// is found, with the found binary name in the message. Returns
+// Fail/Warn/Pass (informational) based on severity when none found.
+func checkAnyTool(tc pythonToolCheck, opts *Options) CheckResult {
+	for _, bin := range tc.binaries {
+		path, err := opts.LookPath(bin)
+		if err == nil {
+			return CheckResult{
+				Name:     tc.name,
+				Severity: Pass,
+				Message:  bin + " installed",
+				Detail:   path,
+			}
+		}
+	}
+
+	sev := Pass
+	if tc.required {
+		sev = Fail
+	} else if tc.recommended {
+		sev = Warn
+	}
+
+	return CheckResult{
+		Name:        tc.name,
+		Severity:    sev,
+		Message:     "not found",
+		InstallHint: tc.installHint,
+	}
+}

--- a/internal/doctor/checks.go
+++ b/internal/doctor/checks.go
@@ -1941,10 +1941,29 @@ func checkPythonTools(opts *Options) CheckGroup {
 }
 
 // checkAnyTool checks whether any of the binaries in a
-// pythonToolCheck are available. Returns Pass if any binary
-// is found, with the found binary name in the message. Returns
-// Fail/Warn/Pass (informational) based on severity when none found.
+// pythonToolCheck are available. Returns Pass if the first
+// found binary matches, with its name in the message. Returns
+// Fail/Warn/Pass (informational) based on severity when none
+// found. Respects ToolSeverities config overrides, consistent
+// with checkOneTool.
 func checkAnyTool(tc pythonToolCheck, opts *Options) CheckResult {
+	// Apply ToolSeverities config override before checking.
+	if opts.ToolSeverities != nil {
+		if override, ok := opts.ToolSeverities[tc.name]; ok {
+			switch override {
+			case "required":
+				tc.required = true
+				tc.recommended = false
+			case "recommended":
+				tc.required = false
+				tc.recommended = true
+			case "optional":
+				tc.required = false
+				tc.recommended = false
+			}
+		}
+	}
+
 	for _, bin := range tc.binaries {
 		path, err := opts.LookPath(bin)
 		if err == nil {

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -162,15 +162,8 @@ func Run(opts Options) (*Report, error) {
 	}
 
 	// Context-sensitive groups: only included when relevant
-	// tools are detected (per design D8).
-	if devpodGroup := checkDevPod(&opts); devpodGroup != nil {
-		allGroups = append(allGroups, *devpodGroup)
-	}
-
-	// Python tools: included when a Python project marker is detected.
-	if isPythonProject(opts.TargetDir) {
-		allGroups = append(allGroups, checkPythonTools(&opts))
-	}
+	// tools or project markers are detected.
+	allGroups = appendConditionalGroups(allGroups, &opts)
 
 	// Apply SkipChecks filter: remove check groups or
 	// individual results whose name matches a skip entry.
@@ -190,6 +183,23 @@ func Run(opts Options) (*Report, error) {
 	}
 
 	return report, nil
+}
+
+// appendConditionalGroups adds context-sensitive check groups
+// that are only relevant when specific tools or project markers
+// are detected. Extracted from Run() to keep its complexity low.
+func appendConditionalGroups(groups []CheckGroup, opts *Options) []CheckGroup {
+	// DevPod tools: included when DevPod is detected (per design D8).
+	if devpodGroup := checkDevPod(opts); devpodGroup != nil {
+		groups = append(groups, *devpodGroup)
+	}
+
+	// Python tools: included when a Python project marker is detected.
+	if isPythonProject(opts.TargetDir) {
+		groups = append(groups, checkPythonTools(opts))
+	}
+
+	return groups
 }
 
 // filterSkippedChecks removes check groups or individual results

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -167,6 +167,11 @@ func Run(opts Options) (*Report, error) {
 		allGroups = append(allGroups, *devpodGroup)
 	}
 
+	// Python tools: included when a Python project marker is detected.
+	if isPythonProject(opts.TargetDir) {
+		allGroups = append(allGroups, checkPythonTools(&opts))
+	}
+
 	// Apply SkipChecks filter: remove check groups or
 	// individual results whose name matches a skip entry.
 	groups := filterSkippedChecks(allGroups, opts.SkipChecks)

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -4210,16 +4210,147 @@ func TestCheckPythonTools_RuffSatisfiesMultiple(t *testing.T) {
 }
 
 func TestCheckPythonTools_NotIncludedForGoProject(t *testing.T) {
+	// Verify the Python Tools group is excluded from Run()
+	// when no Python marker files exist in the target directory.
 	dir := t.TempDir()
-	// Create a Go project marker, no Python markers.
-	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module test"), 0o644); err != nil {
-		t.Fatalf("create go.mod: %v", err)
+
+	// Create minimal scaffolded files (Go project, no Python).
+	createFile(t, dir, ".opencode/agents/test.md", "---\ndescription: test\n---\n# Agent")
+	createFile(t, dir, ".opencode/commands/test.md", "# Command")
+	createFile(t, dir, ".opencode/uf/packs/go.md", "# Go")
+	createFile(t, dir, "AGENTS.md", "# Agents")
+	createFile(t, dir, "opencode.json", `{"mcpServers":{}}`)
+
+	opts := Options{
+		TargetDir: dir,
+		Format:    "text",
+		Stdout:    &bytes.Buffer{},
+		LookPath:  stubLookPath(map[string]string{}),
+		ExecCmd:   stubExecCmd(nil, nil),
+		EvalSymlinks: stubEvalSymlinks(nil),
+		Getenv:    stubGetenv(map[string]string{}),
+		ReadFile:  os.ReadFile,
 	}
 
-	if isPythonProject(dir) {
-		t.Error("isPythonProject() should be false for Go project")
+	report, _ := Run(opts)
+	if report == nil {
+		t.Fatal("Run returned nil report")
 	}
-	// Verify the guard in Run() would exclude the group.
-	// We test the detection function directly since Run() has
-	// too many dependencies to isolate cleanly.
+
+	for _, g := range report.Groups {
+		if g.Name == "Python Tools" {
+			t.Error("Python Tools group should not be included for non-Python project")
+		}
+	}
+}
+
+func TestCheckPythonTools_IncludedForPythonProject(t *testing.T) {
+	// Verify the Python Tools group IS included in Run()
+	// when a Python marker file exists.
+	dir := t.TempDir()
+
+	// Create minimal scaffolded files with a Python marker.
+	createFile(t, dir, ".opencode/agents/test.md", "---\ndescription: test\n---\n# Agent")
+	createFile(t, dir, ".opencode/commands/test.md", "# Command")
+	createFile(t, dir, ".opencode/uf/packs/go.md", "# Go")
+	createFile(t, dir, "AGENTS.md", "# Agents")
+	createFile(t, dir, "opencode.json", `{"mcpServers":{}}`)
+	createFile(t, dir, "pyproject.toml", "[project]\nname = \"test\"\n")
+
+	opts := Options{
+		TargetDir: dir,
+		Format:    "text",
+		Stdout:    &bytes.Buffer{},
+		LookPath: stubLookPath(map[string]string{
+			"python3": "/usr/bin/python3",
+			"pytest":  "/usr/bin/pytest",
+		}),
+		ExecCmd:      stubExecCmd(nil, nil),
+		EvalSymlinks: stubEvalSymlinks(nil),
+		Getenv:       stubGetenv(map[string]string{}),
+		ReadFile:     os.ReadFile,
+	}
+
+	report, _ := Run(opts)
+	if report == nil {
+		t.Fatal("Run returned nil report")
+	}
+
+	found := false
+	for _, g := range report.Groups {
+		if g.Name == "Python Tools" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("Python Tools group should be included for Python project")
+	}
+}
+
+func TestCheckAnyTool_ToolSeveritiesOverride(t *testing.T) {
+	// Verify ToolSeverities config overrides work for
+	// Python tool categories, consistent with checkOneTool.
+	opts := &Options{
+		LookPath: stubLookPathSimple(map[string]bool{}),
+		ToolSeverities: map[string]string{
+			"mypy": "required", // default: optional (Pass) -> required (Fail)
+		},
+	}
+	opts.defaults()
+
+	tc := pythonToolCheck{
+		name:        "mypy",
+		binaries:    []string{"mypy"},
+		installHint: "pip install mypy",
+		// no required/recommended set -> default optional (Pass)
+	}
+
+	result := checkAnyTool(tc, opts)
+	if result.Severity != Fail {
+		t.Errorf("severity = %v, want Fail (ToolSeverities override to required)", result.Severity)
+	}
+
+	// Also test downgrade: required -> optional.
+	opts.ToolSeverities = map[string]string{
+		"python3": "optional",
+	}
+	tc = pythonToolCheck{
+		name:        "python3",
+		binaries:    []string{"python3"},
+		required:    true, // normally Fail
+		installHint: "Install Python 3",
+	}
+
+	result = checkAnyTool(tc, opts)
+	if result.Severity != Pass {
+		t.Errorf("severity = %v, want Pass (ToolSeverities override to optional)", result.Severity)
+	}
+}
+
+func TestCheckAnyTool_FirstBinaryWins(t *testing.T) {
+	// When multiple binaries are available, checkAnyTool
+	// returns the first-listed binary in the message.
+	opts := &Options{
+		LookPath: stubLookPathSimple(map[string]bool{
+			"black": true,
+			"ruff":  true,
+		}),
+	}
+	opts.defaults()
+
+	tc := pythonToolCheck{
+		name:        "formatter",
+		binaries:    []string{"black", "ruff"},
+		recommended: true,
+		installHint: "pip install black  (or: pip install ruff)",
+	}
+
+	result := checkAnyTool(tc, opts)
+	if result.Severity != Pass {
+		t.Errorf("severity = %v, want Pass", result.Severity)
+	}
+	if result.Message != "black installed" {
+		t.Errorf("message = %q, want %q (first binary wins)", result.Message, "black installed")
+	}
 }

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -4068,3 +4068,158 @@ func TestCheckEmbeddingCapability_GenericError(t *testing.T) {
 		t.Errorf("install hint = %q, want combined hint with 'ollama pull'", result.InstallHint)
 	}
 }
+
+// --- Python Tools tests ---
+
+func TestIsPythonProject(t *testing.T) {
+	markers := []string{
+		"pyproject.toml",
+		"setup.py",
+		"setup.cfg",
+		"requirements.txt",
+		"tox.ini",
+		"Pipfile",
+	}
+
+	for _, marker := range markers {
+		t.Run(marker, func(t *testing.T) {
+			dir := t.TempDir()
+			if err := os.WriteFile(filepath.Join(dir, marker), []byte{}, 0o644); err != nil {
+				t.Fatalf("create marker %s: %v", marker, err)
+			}
+			if !isPythonProject(dir) {
+				t.Errorf("isPythonProject() = false for %s, want true", marker)
+			}
+		})
+	}
+
+	t.Run("no markers", func(t *testing.T) {
+		dir := t.TempDir()
+		if isPythonProject(dir) {
+			t.Error("isPythonProject() = true for empty dir, want false")
+		}
+	})
+
+	t.Run("go project not python", func(t *testing.T) {
+		dir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module test"), 0o644); err != nil {
+			t.Fatalf("create go.mod: %v", err)
+		}
+		if isPythonProject(dir) {
+			t.Error("isPythonProject() = true for Go project, want false")
+		}
+	})
+}
+
+func TestCheckPythonTools_AllPresent(t *testing.T) {
+	opts := &Options{
+		LookPath: stubLookPathSimple(map[string]bool{
+			"python3": true,
+			"pip":     true,
+			"pytest":  true,
+			"black":   true,
+			"flake8":  true,
+			"isort":   true,
+			"bandit":  true,
+			"mypy":    true,
+			"tox":     true,
+		}),
+	}
+	opts.defaults()
+
+	group := checkPythonTools(opts)
+
+	if group.Name != "Python Tools" {
+		t.Errorf("group name = %q, want %q", group.Name, "Python Tools")
+	}
+
+	for _, r := range group.Results {
+		if r.Severity != Pass {
+			t.Errorf("check %q: severity = %v, want Pass", r.Name, r.Severity)
+		}
+	}
+}
+
+func TestCheckPythonTools_NonePresent(t *testing.T) {
+	opts := &Options{
+		LookPath: stubLookPathSimple(map[string]bool{}),
+	}
+	opts.defaults()
+
+	group := checkPythonTools(opts)
+
+	expectedSeverity := map[string]Severity{
+		"python3":          Fail, // required
+		"pip/uv":           Warn, // recommended
+		"pytest":           Fail, // required
+		"formatter":        Warn, // recommended
+		"linter":           Warn, // recommended
+		"import sorter":    Warn, // recommended
+		"security scanner": Warn, // recommended
+		"mypy":             Pass, // optional
+		"tox":              Pass, // optional
+	}
+
+	for _, r := range group.Results {
+		want, ok := expectedSeverity[r.Name]
+		if !ok {
+			t.Errorf("unexpected check %q in results", r.Name)
+			continue
+		}
+		if r.Severity != want {
+			t.Errorf("check %q: severity = %v, want %v", r.Name, r.Severity, want)
+		}
+		if r.Message != "not found" {
+			t.Errorf("check %q: message = %q, want %q", r.Name, r.Message, "not found")
+		}
+	}
+}
+
+func TestCheckPythonTools_RuffSatisfiesMultiple(t *testing.T) {
+	// When only ruff is installed, it should satisfy formatter,
+	// linter, import sorter, and security scanner categories.
+	opts := &Options{
+		LookPath: stubLookPathSimple(map[string]bool{
+			"python3": true,
+			"pytest":  true,
+			"ruff":    true,
+		}),
+	}
+	opts.defaults()
+
+	group := checkPythonTools(opts)
+
+	// These categories should pass via ruff.
+	ruffCategories := map[string]bool{
+		"formatter":        true,
+		"linter":           true,
+		"import sorter":    true,
+		"security scanner": true,
+	}
+
+	for _, r := range group.Results {
+		if ruffCategories[r.Name] {
+			if r.Severity != Pass {
+				t.Errorf("check %q: severity = %v, want Pass (ruff should satisfy)", r.Name, r.Severity)
+			}
+			if !strings.Contains(r.Message, "ruff") {
+				t.Errorf("check %q: message = %q, want to contain 'ruff'", r.Name, r.Message)
+			}
+		}
+	}
+}
+
+func TestCheckPythonTools_NotIncludedForGoProject(t *testing.T) {
+	dir := t.TempDir()
+	// Create a Go project marker, no Python markers.
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module test"), 0o644); err != nil {
+		t.Fatalf("create go.mod: %v", err)
+	}
+
+	if isPythonProject(dir) {
+		t.Error("isPythonProject() should be false for Go project")
+	}
+	// Verify the guard in Run() would exclude the group.
+	// We test the detection function directly since Run() has
+	// too many dependencies to isolate cleanly.
+}

--- a/internal/scaffold/assets/opencode/uf/packs/python-custom.md
+++ b/internal/scaffold/assets/opencode/uf/packs/python-custom.md
@@ -1,0 +1,19 @@
+---
+pack_id: python-custom
+language: Python
+version: 1.0.0
+---
+
+# Custom Rules: Python
+
+Project-specific Python conventions that extend the canonical
+Python convention pack. Rules in this file are loaded alongside
+`python.md` by Cobalt-Crush (during implementation) and
+all Divisor persona agents (during review).
+
+Use the `CR-NNN` prefix for all custom rules. Use `[MUST]`,
+`[SHOULD]`, or `[MAY]` severity indicators per RFC 2119.
+
+## Custom Rules
+
+<!-- Add project-specific rules below this line -->

--- a/internal/scaffold/assets/opencode/uf/packs/python.md
+++ b/internal/scaffold/assets/opencode/uf/packs/python.md
@@ -1,0 +1,267 @@
+---
+pack_id: python
+language: Python
+version: 1.0.0
+---
+
+# Convention Pack: Python
+
+This convention pack defines Python-specific review
+criteria for The Divisor PR reviewer framework. Persona
+agents load this pack dynamically at review time to
+evaluate Python codebases against language-specific
+coding style, architectural patterns, security checks,
+testing conventions, type annotations, and documentation
+requirements.
+
+Rules use RFC 2119 severity indicators: [MUST] for
+mandatory requirements, [SHOULD] for strong recommendations,
+and [MAY] for optional best practices.
+
+---
+
+## Coding Style
+
+- **CS-001** [MUST] Code MUST be auto-formatted with a
+  consistent formatter (`black`, `ruff format`, or
+  equivalent). No manual formatting overrides. Line
+  length MUST match the project's configured limit.
+  Formatting changes MUST NOT be mixed with logic
+  changes in the same commit.
+
+- **CS-002** [MUST] Imports MUST be auto-sorted with a
+  consistent tool (`isort`, `ruff` with isort rules, or
+  equivalent). Organize in groups separated by blank
+  lines: standard library, third-party packages,
+  local/project modules.
+
+- **CS-003** [MUST] Code MUST pass a linter (`flake8`,
+  `ruff check`, or equivalent) with the project's
+  configured ruleset. No lint errors committed without
+  explicit suppression comments that include the specific
+  code and justification (e.g., `# noqa: E501 - URL`).
+
+- **CS-004** [MUST] Use `snake_case` for functions,
+  methods, variables, and module names. Use `PascalCase`
+  for class names. Use `UPPER_SNAKE_CASE` for module-level
+  constants.
+
+- **CS-005** [MUST] All functions that can fail MUST raise
+  specific exception types or return typed results. Never
+  silently swallow exceptions. Every `except` clause MUST
+  either handle, re-raise, or log the exception with
+  context.
+
+- **CS-006** [MUST] Bare `except:` and `except Exception:`
+  MUST NOT be used unless re-raising or logging with full
+  context. Catch the most specific exception type possible.
+
+- **CS-007** [MUST] Use f-strings for string formatting.
+  Do not use `%` formatting or `.format()` in new code.
+
+- **CS-008** [MUST] No mutable default arguments. Use
+  `None` as default and initialize inside the function
+  body (e.g., `def foo(items=None): items = items or []`).
+
+- **CS-009** [MUST] Use `with` statements for all resource
+  management (files, database connections, locks, network
+  sessions). Never rely on garbage collection for cleanup.
+
+- **CS-010** [SHOULD] Keep functions focused on a single
+  responsibility. Functions exceeding ~50 lines of logic
+  SHOULD be evaluated for decomposition.
+
+- **CS-011** [SHOULD] Use `pathlib.Path` for filesystem
+  path construction instead of `os.path.join` in new code.
+
+- **CS-012** [SHOULD] Use list/dict/set comprehensions
+  where they improve readability. Avoid nested
+  comprehensions deeper than two levels.
+
+- **CS-013** [SHOULD] Prefer `dataclasses`, Pydantic
+  models, or typed NamedTuples over plain dicts for
+  structured data with known schemas.
+
+---
+
+## Architectural Patterns
+
+- **AP-001** [MUST] Each module MUST have a single,
+  well-defined responsibility. A module that handles both
+  business logic and I/O coordination is a violation.
+
+- **AP-002** [SHOULD] Dependencies SHOULD be injected
+  rather than hard-instantiated. Functions and constructors
+  SHOULD accept interfaces or abstractions rather than
+  concrete implementations where testability benefits.
+
+- **AP-003** [MUST] Circular imports MUST NOT exist. If
+  module A imports module B, module B MUST NOT import
+  module A (directly or transitively). Use local imports,
+  `TYPE_CHECKING` guards, or extract shared types to break
+  cycles.
+
+- **AP-004** [SHOULD] Configuration SHOULD be loaded from
+  environment variables, config files, or framework
+  settings (e.g., `django.conf.settings`), not hardcoded.
+
+- **AP-005** [SHOULD] Long modules (>500 lines) SHOULD be
+  evaluated for splitting into submodules with a package
+  `__init__.py` that re-exports the public API.
+
+- **AP-006** [MUST] Application code MUST NOT import from
+  test modules. Test utilities shared across test files
+  SHOULD live in `conftest.py` or a dedicated test helpers
+  package.
+
+---
+
+## Security Checks
+
+- **SC-001** [MUST] Never hardcode secrets, API keys,
+  tokens, or credentials in source code. Secrets MUST be
+  loaded from environment variables, secret managers, or
+  encrypted configuration. Files matching common secret
+  patterns (`.env`, `credentials.json`, `*.pem`, `*.key`)
+  MUST NOT be committed.
+
+- **SC-002** [MUST] All user input MUST be validated and
+  sanitized before use. Use parameterized queries for
+  database access -- never string concatenation or
+  f-string interpolation in SQL.
+
+- **SC-003** [MUST] Use `defusedxml` or equivalent for
+  XML parsing of untrusted input. Never use
+  `xml.etree.ElementTree` or `lxml` with untrusted data
+  without disabling entity expansion. Test-only XML
+  parsing of trusted fixtures MAY use standard library
+  parsers.
+
+- **SC-004** [MUST] Code MUST pass security static
+  analysis (`bandit`, `ruff` S rules, or equivalent).
+  Address all HIGH and CRITICAL findings before merge.
+
+- **SC-005** [SHOULD] Dependencies SHOULD be audited
+  regularly with `pip-audit`, Dependabot, or equivalent
+  tooling. PRs introducing new dependencies SHOULD note
+  maintenance status and known vulnerabilities.
+  Dependencies with critical CVEs MUST NOT be merged.
+
+- **SC-006** [MUST] File operations with user-supplied
+  paths MUST validate against directory traversal. Use
+  `os.path.realpath()` or `pathlib.Path.resolve()` and
+  verify the result is within the expected root.
+
+- **SC-007** [MUST] Never pass user-supplied or external
+  input to `shell=True` subprocess calls. [SHOULD] Prefer
+  `subprocess.run()` with list arguments and `shell=False`
+  for new code. Internal utility wrappers that use
+  `shell=True` with hardcoded or developer-controlled
+  commands are acceptable when documented.
+
+- **SC-008** [SHOULD] Set safe file permissions when
+  creating files: `0o644` for regular files, `0o755` for
+  executable scripts and directories. Avoid world-writable
+  permissions.
+
+---
+
+## Testing Conventions
+
+- **TC-001** [MUST] Use `pytest` as the test runner. Do
+  not use `unittest.TestCase` for new tests. Existing
+  `TestCase` subclasses are acceptable until migrated.
+
+- **TC-002** [MUST] New functionality MUST be accompanied
+  by tests covering the primary success path and at least
+  one failure/edge case path.
+
+- **TC-003** [MUST] Bug fixes MUST include a regression
+  test that reproduces the original failure and verifies
+  the fix.
+
+- **TC-004** [MUST] External dependencies (APIs, databases,
+  filesystem, network) MUST be mocked in unit tests using
+  `unittest.mock.patch`, `pytest-mock`, or `pytest`
+  fixtures. Tests MUST NOT require external services or
+  network connectivity.
+
+- **TC-005** [MUST] Tests MUST be isolated -- each test
+  MUST be independently runnable without depending on
+  execution order or shared mutable state.
+
+- **TC-006** [SHOULD] Use `pytest.mark.parametrize` for
+  table-driven tests when exercising multiple input/output
+  combinations for the same function.
+
+- **TC-007** [SHOULD] Test names SHOULD clearly describe
+  the scenario: `test_<function>_<condition>_<expected>`
+  (e.g., `test_parse_empty_input_returns_none`).
+
+- **TC-008** [SHOULD] Use `factory-boy`, `pytest` fixtures,
+  or equivalent for test data construction. Avoid large
+  inline dicts or manual object construction repeated
+  across tests.
+
+- **TC-009** [SHOULD] Coverage SHOULD be measured with
+  `pytest-cov` or equivalent. A `--cov-fail-under`
+  threshold SHOULD be enforced in CI to prevent coverage
+  regression.
+
+- **TC-010** [SHOULD] Place test files in a `tests/`
+  directory mirroring the source structure, or co-locate
+  with source files using the `test_<module>.py` naming
+  convention. Test file naming MUST follow the project's
+  established convention consistently.
+
+- **TC-011** [SHOULD] Use `conftest.py` for shared
+  fixtures. Do not duplicate fixture definitions across
+  test files.
+
+---
+
+## Type Annotations
+
+- **TA-001** [SHOULD] All new public functions and methods
+  SHOULD have type annotations on parameters and return
+  values.
+
+- **TA-002** [SHOULD] Run a type checker (`mypy`, `pyright`,
+  `ty`, or equivalent) and address type errors
+  incrementally -- do not disable the type checker globally.
+
+- **TA-003** [SHOULD] Use built-in generics (`list[str]`,
+  `dict[str, int]`, `X | None`) for Python 3.10+. For
+  Python 3.9 and below, use `typing` module constructs
+  (`Optional`, `Union`, `List`, `Dict`).
+
+- **TA-004** [SHOULD] Prefer `Protocol` classes over ABC
+  for structural typing where duck typing is the intent.
+
+---
+
+## Documentation Requirements
+
+- **DR-001** [MUST] All public functions, classes, and
+  methods MUST have docstrings. Use a consistent docstring
+  format (Google-style, NumPy-style, or reStructuredText)
+  across the project.
+
+- **DR-002** [MUST] Commit messages MUST use Conventional
+  Commits format: `type: description` (e.g., `feat:`,
+  `fix:`, `docs:`, `chore:`, `refactor:`).
+
+- **DR-003** [SHOULD] User-visible changes SHOULD be
+  recorded in a changelog or release notes following the
+  project's established format.
+
+- **DR-004** [SHOULD] Configuration options, environment
+  variables, and feature flags SHOULD be documented in
+  the project README or a dedicated configuration
+  reference.
+
+---
+
+## Custom Rules
+
+<!-- This section is intentionally empty in the canonical pack. Project-specific custom rules belong in python-custom.md -->

--- a/internal/scaffold/scaffold.go
+++ b/internal/scaffold/scaffold.go
@@ -384,6 +384,11 @@ func detectLang(targetDir string) string {
 		{"tsconfig.json", "typescript"},
 		{"package.json", "typescript"},
 		{"pyproject.toml", "python"},
+		{"setup.py", "python"},
+		{"setup.cfg", "python"},
+		{"requirements.txt", "python"},
+		{"tox.ini", "python"},
+		{"Pipfile", "python"},
 		{"Cargo.toml", "rust"},
 	}
 	for _, m := range markers {

--- a/internal/scaffold/scaffold_test.go
+++ b/internal/scaffold/scaffold_test.go
@@ -153,13 +153,15 @@ var expectedAssetPaths = []string{
 	"opencode/agents/divisor-scribe.md",
 	"opencode/agents/divisor-herald.md",
 	"opencode/agents/divisor-envoy.md",
-	// Convention packs — shared by all heroes (9)
+	// Convention packs — shared by all heroes (11)
 	"opencode/uf/packs/content-custom.md",
 	"opencode/uf/packs/content.md",
 	"opencode/uf/packs/default-custom.md",
 	"opencode/uf/packs/default.md",
 	"opencode/uf/packs/go-custom.md",
 	"opencode/uf/packs/go.md",
+	"opencode/uf/packs/python-custom.md",
+	"opencode/uf/packs/python.md",
 	"opencode/uf/packs/severity.md",
 	"opencode/uf/packs/typescript-custom.md",
 	"opencode/uf/packs/typescript.md",
@@ -577,10 +579,13 @@ func TestIsToolOwned(t *testing.T) {
 		{"opencode/uf/packs/go.md", true},
 		{"opencode/uf/packs/default.md", true},
 		{"opencode/uf/packs/typescript.md", true},
+		// Tool-owned: convention packs (canonical) — Python
+		{"opencode/uf/packs/python.md", true},
 		// User-owned: convention packs (custom)
 		{"opencode/uf/packs/go-custom.md", false},
 		{"opencode/uf/packs/default-custom.md", false},
 		{"opencode/uf/packs/typescript-custom.md", false},
+		{"opencode/uf/packs/python-custom.md", false},
 		// User-owned: agents (including Divisor personas and Cobalt-Crush)
 		{"opencode/agents/divisor-guard.md", false},
 		{"opencode/agents/divisor-architect.md", false},
@@ -1149,6 +1154,8 @@ func TestIsDivisorAsset(t *testing.T) {
 		{"opencode/uf/packs/default.md", true},
 		{"opencode/uf/packs/go-custom.md", true},
 		{"opencode/uf/packs/severity.md", true},
+		{"opencode/uf/packs/python.md", true},
+		{"opencode/uf/packs/python-custom.md", true},
 		// Non-Divisor assets
 		{"opencode/agents/constitution-check.md", false},
 		{"opencode/commands/speckit.specify.md", false},
@@ -1175,10 +1182,18 @@ func TestDetectLang(t *testing.T) {
 		{"go project", []string{"go.mod"}, "go"},
 		{"typescript tsconfig", []string{"tsconfig.json"}, "typescript"},
 		{"typescript package.json", []string{"package.json"}, "typescript"},
-		{"python project", []string{"pyproject.toml"}, "python"},
+		{"python pyproject.toml", []string{"pyproject.toml"}, "python"},
+		{"python setup.py", []string{"setup.py"}, "python"},
+		{"python setup.cfg", []string{"setup.cfg"}, "python"},
+		{"python requirements.txt", []string{"requirements.txt"}, "python"},
+		{"python tox.ini", []string{"tox.ini"}, "python"},
+		{"python Pipfile", []string{"Pipfile"}, "python"},
+		{"python pyproject takes priority", []string{"pyproject.toml", "setup.py", "requirements.txt"}, "python"},
 		{"rust project", []string{"Cargo.toml"}, "rust"},
 		{"no markers", []string{}, ""},
 		{"go takes priority over ts", []string{"go.mod", "package.json"}, "go"},
+		{"go takes priority over python", []string{"go.mod", "requirements.txt"}, "go"},
+		{"ts takes priority over python", []string{"tsconfig.json", "pyproject.toml"}, "typescript"},
 	}
 
 	for _, tt := range tests {
@@ -1218,13 +1233,21 @@ func TestShouldDeployPack(t *testing.T) {
 		{"opencode/uf/packs/go-custom.md", "go", true},
 		{"opencode/uf/packs/typescript.md", "typescript", true},
 		{"opencode/uf/packs/typescript-custom.md", "typescript", true},
+		// Python packs deploy for python lang
+		{"opencode/uf/packs/python.md", "python", true},
+		{"opencode/uf/packs/python-custom.md", "python", true},
 		// Non-matching language packs do NOT deploy
 		{"opencode/uf/packs/typescript.md", "go", false},
 		{"opencode/uf/packs/typescript-custom.md", "go", false},
 		{"opencode/uf/packs/go.md", "typescript", false},
 		{"opencode/uf/packs/go-custom.md", "typescript", false},
+		{"opencode/uf/packs/python.md", "go", false},
+		{"opencode/uf/packs/python-custom.md", "go", false},
+		{"opencode/uf/packs/go.md", "python", false},
+		{"opencode/uf/packs/go-custom.md", "python", false},
 		// Default lang gets only default packs
 		{"opencode/uf/packs/go.md", "default", false},
+		{"opencode/uf/packs/python.md", "default", false},
 		{"opencode/uf/packs/default.md", "default", true},
 	}
 

--- a/openspec/changes/python-convention-pack/design.md
+++ b/openspec/changes/python-convention-pack/design.md
@@ -47,8 +47,8 @@ See `proposal.md` for motivation and constitution alignment.
   pyproject.toml generation, virtualenv setup)
 - Rust convention pack (placeholder detection exists but
   pack creation is a separate change)
-- SDEngine-specific custom rules (those go in
-  `python-custom.md` in the SDEngine repo, not here)
+- Project-specific custom rules (those go in
+  `python-custom.md` in each adopting repo, not here)
 
 ## Decisions
 
@@ -86,9 +86,10 @@ rule identifiers.
 
 The Python ecosystem is undergoing a tooling consolidation.
 Ruff is rapidly replacing black + flake8 + isort as a
-unified formatter and linter. Projects like aegis-ai use
-ruff exclusively; projects like SDEngine use the traditional
-trio. A convention pack that mandates specific tools (e.g.,
+unified formatter and linter. Some projects use ruff
+exclusively; others use the traditional black + flake8 +
+isort trio. A convention pack that mandates specific
+tools (e.g.,
 "MUST use black") would create false negatives for projects
 using equivalent modern alternatives.
 
@@ -201,7 +202,7 @@ Python packs but `uf doctor` will not check Python tools
 The original draft of SC-008 said "Use `subprocess.run()`
 with `shell=False`. Never pass user input to `shell=True`
 subprocess calls." This is too absolute -- real-world
-codebases (e.g., SDEngine) have command execution utilities
+codebases have command execution utilities
 that use `shell=True` internally with controlled, non-user-
 supplied command strings. Requiring `shell=False` everywhere
 would force rewrites of foundational utilities with no
@@ -219,9 +220,8 @@ The revised rule narrows the prohibition:
 **Rationale**: The security risk is shell injection from
 untrusted input, not the `shell=True` flag itself. A blanket
 prohibition would create friction for onboarding without
-improving security posture. SDEngine's `Cmd.run(shell=True)`
-is used with fixed command strings -- the risk is low.
-Projects that need stricter enforcement can override via
+improving security posture. Projects that need stricter
+enforcement can override via
 `python-custom.md`.
 
 ### D8: python-custom.md is an empty template

--- a/openspec/changes/python-convention-pack/design.md
+++ b/openspec/changes/python-convention-pack/design.md
@@ -1,0 +1,274 @@
+## Context
+
+The Unbound Force scaffold engine deploys language-specific
+convention packs via `uf init`. The `shouldDeployPack()`
+function filters packs by the resolved language, and
+`collectDeployedPacks()` builds the list of pack filenames
+for cross-tool bridge files (AGENTS.md, CLAUDE.md,
+.cursorrules). Language detection in `detectLang()` checks
+for well-known marker files (`go.mod`, `tsconfig.json`,
+`package.json`, `pyproject.toml`, `Cargo.toml`).
+
+Convention packs exist for Go (`go.md`) and TypeScript
+(`typescript.md`). Python detection via `pyproject.toml`
+already returns `"python"`, but no `python.md` pack exists
+in the embedded assets. The result: `uf init` on a Python
+project skips language-specific pack deployment and
+cross-tool bridge files list only default packs.
+
+The doctor system (`internal/doctor/`) checks tool
+prerequisites via `coreToolSpecs` and dedicated check
+functions. Tool checks are Go-centric (go, opencode, gaze,
+node, gh, replicator, ollama, podman). No Python-specific
+tool checks exist.
+
+See `proposal.md` for motivation and constitution alignment.
+
+## Goals / Non-Goals
+
+### Goals
+- `uf init --lang python` (or auto-detection) deploys
+  `python.md` and `python-custom.md` convention packs
+- `uf init --divisor --lang python` deploys the Python
+  pack in Divisor-only mode
+- Cross-tool bridge files (AGENTS.md, CLAUDE.md,
+  .cursorrules) list Python packs when language is Python
+- `detectLang()` recognizes additional Python markers
+  (`setup.py`, `setup.cfg`, `requirements.txt`, `tox.ini`,
+  `Pipfile`) beyond the existing `pyproject.toml`
+- `uf doctor` checks Python toolchain prerequisites when
+  the project language is Python
+- All existing Go and TypeScript behavior is unchanged
+
+### Non-Goals
+- Python-specific Gaze integration (Snake Eyes -- separate
+  project in zero-dot-force labs)
+- Python project scaffolding beyond convention packs (e.g.,
+  pyproject.toml generation, virtualenv setup)
+- Rust convention pack (placeholder detection exists but
+  pack creation is a separate change)
+- SDEngine-specific custom rules (those go in
+  `python-custom.md` in the SDEngine repo, not here)
+
+## Decisions
+
+### D1: Pack format matches Go and TypeScript exactly
+
+The Python pack uses the same structure as `go.md` and
+`typescript.md`: YAML frontmatter (`pack_id`, `language`,
+`version`), followed by sections for Coding Style,
+Architectural Patterns, Security Checks, Testing
+Conventions, Documentation Requirements, and Custom Rules.
+
+Additionally, a **Type Annotations** section is added
+between Testing Conventions and Documentation Requirements.
+This is Python-specific -- Go has type safety built in,
+and TypeScript's type system is covered in Coding Style.
+
+**Rationale**: Consistency with existing packs. Divisor
+persona agents parse packs by section heading. A new
+section heading is safe because agents match on content,
+not on a hardcoded section list.
+
+### D2: Rule numbering follows established convention
+
+Rules use the same prefix scheme as Go and TypeScript:
+CS-NNN (Coding Style), AP-NNN (Architectural Patterns),
+SC-NNN (Security Checks), TC-NNN (Testing Conventions),
+TA-NNN (Type Annotations -- new prefix), DR-NNN
+(Documentation Requirements).
+
+**Rationale**: Consistent numbering enables cross-pack
+references (e.g., "per CS-001") and machine parsing of
+rule identifiers.
+
+### D3: Tool rules are outcome-focused, not tool-specific
+
+The Python ecosystem is undergoing a tooling consolidation.
+Ruff is rapidly replacing black + flake8 + isort as a
+unified formatter and linter. Projects like aegis-ai use
+ruff exclusively; projects like SDEngine use the traditional
+trio. A convention pack that mandates specific tools (e.g.,
+"MUST use black") would create false negatives for projects
+using equivalent modern alternatives.
+
+Rules that reference tooling are written as outcome
+requirements with tool examples:
+
+- CS-001: "MUST be auto-formatted consistently" (black,
+  ruff format, or equivalent)
+- CS-002: "imports MUST be auto-sorted" (isort, ruff with
+  isort rules, or equivalent)
+- CS-003: "MUST pass a linter" (flake8, ruff check, or
+  equivalent)
+- SC-005: "MUST run security static analysis" (bandit,
+  ruff S rules, or equivalent)
+
+**Rationale**: Convention packs should be durable. Coupling
+rules to specific tools creates maintenance burden as the
+ecosystem evolves. Outcome-focused rules evaluate code
+quality, not tool preferences. Projects that need to
+mandate a specific tool (e.g., "MUST use ruff, not flake8")
+can do so in `python-custom.md`.
+
+This also affects doctor checks (D5): the doctor should
+check for *any* of the equivalent tools, not mandate a
+single one.
+
+### D4: Detection priority preserves existing order
+
+New Python markers are added after `pyproject.toml` in the
+`detectLang()` marker list. The full priority order becomes:
+
+1. `go.mod` -> go
+2. `tsconfig.json` -> typescript
+3. `package.json` -> typescript
+4. `pyproject.toml` -> python
+5. `setup.py` -> python
+6. `setup.cfg` -> python
+7. `requirements.txt` -> python
+8. `tox.ini` -> python
+9. `Pipfile` -> python
+10. `Cargo.toml` -> rust
+
+**Rationale**: `pyproject.toml` is the modern standard and
+should be checked first. Legacy markers follow in decreasing
+specificity. Existing Go/TypeScript/Rust order is unchanged.
+
+### D5: Doctor checks use a separate check group
+
+Python tool checks are implemented as a new `CheckGroup`
+named "Python Tools", conditionally included when the
+detected language is `python`. This parallels how the
+DevPod check group is conditionally included.
+
+Per D3, doctor checks for formatting/linting/security tools
+check for *any* of the equivalent tools. If the project has
+ruff OR (black + flake8 + isort), the check passes. The
+check only warns when *none* of the equivalent tools are
+found.
+
+Tool checks and their severity:
+
+| Check | Severity | Binaries checked |
+|-------|----------|------------------|
+| python3 | required | `python3` |
+| pip/uv | recommended | `pip` or `uv` |
+| pytest | required | `pytest` |
+| formatter | recommended | `black` or `ruff` |
+| linter | recommended | `flake8` or `ruff` |
+| import sorter | recommended | `isort` or `ruff` |
+| security scanner | recommended | `bandit` or `ruff` |
+| mypy | optional | `mypy` |
+| tox | optional | `tox` |
+
+**Rationale**: `python3` and `pytest` are required because
+the convention pack mandates them ([MUST] rules). Other
+tools are recommended or optional because they enforce
+[SHOULD] rules. The severity model matches the existing
+`required` / `recommended` / `optional` pattern in
+`checkOneTool()`. Checking for tool alternatives (e.g.,
+ruff as a substitute for flake8) avoids false warnings on
+modern toolchains per D3.
+
+### D6: Doctor duplicates language detection inline
+
+The doctor system does not currently detect language. To
+gate the Python tools check group, `checkPythonTools()`
+checks for the same Python marker files that
+`scaffold.detectLang()` uses (`pyproject.toml`, `setup.py`,
+`setup.cfg`, `requirements.txt`, `tox.ini`, `Pipfile`).
+The detection is duplicated rather than importing
+`internal/scaffold` -- the doctor package should not
+depend on the scaffold package for a 10-line file-existence
+check.
+
+The function `isPythonProject(targetDir string) bool`
+returns true if any Python marker file exists. The check
+group is included only when `isPythonProject()` returns
+true.
+
+**Rationale**: Avoids a cross-package dependency for
+trivial logic. The marker file list is small and stable.
+If the lists diverge, the scaffold drift tests will
+surface the inconsistency because `uf init` will deploy
+Python packs but `uf doctor` will not check Python tools
+(or vice versa). Users can also suppress checks via
+`doctor.skip` config.
+
+### D7: SC-008 subprocess rule scoped to call sites
+
+The original draft of SC-008 said "Use `subprocess.run()`
+with `shell=False`. Never pass user input to `shell=True`
+subprocess calls." This is too absolute -- real-world
+codebases (e.g., SDEngine) have command execution utilities
+that use `shell=True` internally with controlled, non-user-
+supplied command strings. Requiring `shell=False` everywhere
+would force rewrites of foundational utilities with no
+security benefit when the inputs are developer-controlled.
+
+The revised rule narrows the prohibition:
+- [MUST] Never pass **user-supplied or external input** to
+  `shell=True` subprocess calls.
+- [SHOULD] Prefer `subprocess.run()` with list arguments
+  and `shell=False` for new code.
+- Internal utility wrappers that use `shell=True` with
+  hardcoded or developer-controlled commands are acceptable
+  when documented.
+
+**Rationale**: The security risk is shell injection from
+untrusted input, not the `shell=True` flag itself. A blanket
+prohibition would create friction for onboarding without
+improving security posture. SDEngine's `Cmd.run(shell=True)`
+is used with fixed command strings -- the risk is low.
+Projects that need stricter enforcement can override via
+`python-custom.md`.
+
+### D8: python-custom.md is an empty template
+
+The custom pack template contains only the YAML frontmatter
+and placeholder heading, identical in structure to
+`go-custom.md`. No default custom rules are included.
+
+**Rationale**: Custom rules are project-specific. Shipping
+default custom rules would violate the pack ownership model
+(canonical packs are tool-owned, custom packs are
+user-owned).
+
+## Risks / Trade-offs
+
+### R1: Convention pack rules may not fit all Python projects
+
+The Python pack mandates pytest (not unittest), requires
+auto-formatting and linting, and recommends specific
+architectural patterns. Projects using niche frameworks
+(e.g., Twisted, Tornado) or unconventional test runners
+may need to override rules in `python-custom.md`.
+
+**Mitigation**: Tool-specific rules use outcome-focused
+language per D3, so the pack is compatible with both
+traditional (black+flake8+isort) and modern (ruff)
+toolchains. Custom packs can override any rule. This
+matches how Go projects can customize the Go pack.
+
+### R2: Doctor checks may produce false warnings
+
+A valid Python project may not have all recommended tools
+installed globally (e.g., they live in a virtualenv).
+
+**Mitigation**: Doctor checks use `LookPath` which
+searches PATH. Activated virtualenvs add their bin to
+PATH. Users can suppress checks via `doctor.skip` or
+`doctor.tools` severity overrides in `.uf/config.yaml`.
+
+### R3: Additional Python markers may cause false detection
+
+A project with both `go.mod` and `requirements.txt` (e.g.,
+a Go project with Python tooling scripts) will be detected
+as Go due to priority order, which is correct. But a
+project with only `requirements.txt` and no clear primary
+language will be detected as Python.
+
+**Mitigation**: Users can set `scaffold.language` explicitly
+in `.uf/config.yaml` to override auto-detection. The
+detection priority order is documented in this design.

--- a/openspec/changes/python-convention-pack/proposal.md
+++ b/openspec/changes/python-convention-pack/proposal.md
@@ -1,0 +1,151 @@
+## Why
+
+Unbound Force currently ships convention packs for Go and
+TypeScript but not Python. The `scaffold.language` config
+already lists `python` as a valid value, and `detectLang()`
+recognizes `pyproject.toml`, but no Python convention pack
+exists to deploy. Running `uf init --lang python` or
+auto-detecting a Python project falls back to the default
+pack, losing all language-specific review criteria.
+
+This gap blocks onboarding Python projects (e.g., SDEngine,
+a 7-year-old Django monolith in Red Hat Product Security)
+to the UF toolchain. Divisor persona agents cannot enforce
+Python-specific coding standards, and `uf doctor` does not
+verify Python prerequisites.
+
+## What Changes
+
+Add first-class Python support to the scaffold and doctor
+systems:
+
+1. A canonical `python.md` convention pack with Python-
+   specific rules for coding style, architecture, security,
+   testing, type annotations, and documentation.
+
+2. An empty `python-custom.md` template for project-specific
+   rule extensions (following the `go-custom.md` pattern).
+
+3. Expanded language auto-detection to recognize additional
+   Python project markers (`setup.py`, `setup.cfg`,
+   `requirements.txt`, `tox.ini`, `Pipfile`).
+
+4. Python-specific `uf doctor` checks for the Python
+   toolchain (python3, pip/uv, pytest, black, flake8,
+   isort, bandit, mypy, tox).
+
+## Capabilities
+
+### New Capabilities
+- `python.md`: Canonical Python convention pack deployable
+  by `uf init` when the detected or configured language
+  is `python`. Covers 7 sections: Coding Style,
+  Architectural Patterns, Security Checks, Testing
+  Conventions, Type Annotations, Documentation
+  Requirements, and Custom Rules (empty placeholder).
+- `python-custom.md`: Empty template for project-specific
+  Python conventions, following the established custom pack
+  pattern.
+- Python doctor checks: `uf doctor` validates Python
+  toolchain prerequisites when the project language is
+  detected as Python (9 tool category checks with required /
+  recommended / optional severity levels). Tool-agnostic
+  where alternatives exist (e.g., passes if either `black`
+  or `ruff` is found for formatting).
+- Extended Python detection: `detectLang()` recognizes
+  `setup.py`, `setup.cfg`, `requirements.txt`, `tox.ini`,
+  and `Pipfile` in addition to the existing `pyproject.toml`
+  marker.
+
+### Modified Capabilities
+- `detectLang()`: Additional Python marker files checked
+  after `pyproject.toml` (which already exists). Priority
+  order preserved -- Go and TypeScript markers still take
+  precedence.
+- `uf doctor`: New "Python Tools" check group added when
+  a Python project is detected in the target directory.
+
+### Removed Capabilities
+- None.
+
+## Impact
+
+### Files Modified
+
+**Go source** (production):
+- `internal/scaffold/scaffold.go` -- `detectLang()` gains
+  5 additional Python marker entries.
+- `internal/doctor/checks.go` -- new `pythonToolSpecs`
+  slice, `checkPythonTools()` function, and
+  `isPythonProject()` detection function.
+- `internal/doctor/doctor.go` -- `Run()` conditionally
+  includes the Python tools check group when
+  `isPythonProject()` returns true.
+
+**Embedded assets** (new files):
+- `internal/scaffold/assets/opencode/uf/packs/python.md`
+- `internal/scaffold/assets/opencode/uf/packs/python-custom.md`
+
+**Live Markdown** (canonical sources, new files):
+- `.opencode/uf/packs/python.md`
+- `.opencode/uf/packs/python-custom.md`
+
+**Tests**:
+- `internal/scaffold/scaffold_test.go` -- `expectedAssetPaths`
+  updated, new test cases in `TestDetectLang`,
+  `TestShouldDeployPack`, `TestIsToolOwned`,
+  `TestIsDivisorAsset`.
+- `internal/doctor/doctor_test.go` -- new tests for Python
+  tool checks.
+
+### Cross-Repo Impact
+- None. This is additive -- no existing behavior changes.
+
+## Constitution Alignment
+
+Assessed against the Unbound Force org constitution.
+
+### I. Autonomous Collaboration
+
+**Assessment**: PASS
+
+Convention packs are self-describing Markdown artifacts with
+YAML frontmatter. The Python pack follows the same format as
+Go and TypeScript packs. Divisor persona agents consume packs
+dynamically at review time without runtime coupling. No
+inter-hero communication changes.
+
+### II. Composability First
+
+**Assessment**: PASS
+
+The Python pack is independently deployable. `uf init
+--lang python` works regardless of whether Gaze, Dewey, or
+any other hero is installed. The pack does not introduce
+mandatory dependencies -- it documents recommended tools
+(black, flake8, pytest, etc.) but does not require them to
+be installed for the pack itself to function. Doctor checks
+use the existing required/recommended/optional severity
+model.
+
+### III. Observable Quality
+
+**Assessment**: PASS
+
+The Python pack uses the same RFC 2119 severity indicators
+([MUST], [SHOULD], [MAY]) and numbered rule identifiers
+(CS-NNN, AP-NNN, etc.) as existing packs. Doctor check
+results are reported through the existing `CheckGroup` /
+`CheckResult` model with structured severity levels. All
+output is machine-parseable via the `--format json` flag.
+
+### IV. Testability
+
+**Assessment**: PASS
+
+All new code follows the established injectable-dependency
+pattern. `detectLang()` is tested via `t.TempDir()` with
+marker files. Pack deployment is tested through the existing
+`Run()` integration tests. Doctor checks use injected
+`LookPath` and `ExecCmd` functions. No external services
+or shared mutable state required.

--- a/openspec/changes/python-convention-pack/proposal.md
+++ b/openspec/changes/python-convention-pack/proposal.md
@@ -8,9 +8,9 @@ exists to deploy. Running `uf init --lang python` or
 auto-detecting a Python project falls back to the default
 pack, losing all language-specific review criteria.
 
-This gap blocks onboarding Python projects (e.g., SDEngine,
-a 7-year-old Django monolith in Red Hat Product Security)
-to the UF toolchain. Divisor persona agents cannot enforce
+This gap blocks onboarding Python projects (e.g., Django
+monoliths, pydantic-ai services) to the UF toolchain.
+Divisor persona agents cannot enforce
 Python-specific coding standards, and `uf doctor` does not
 verify Python prerequisites.
 

--- a/openspec/changes/python-convention-pack/tasks.md
+++ b/openspec/changes/python-convention-pack/tasks.md
@@ -12,7 +12,7 @@
 
 ## 1. Create Convention Pack Files
 
-- [ ] 1.1 [P] Create `.opencode/uf/packs/python.md` with
+- [x] 1.1 [P] Create `.opencode/uf/packs/python.md` with
   YAML frontmatter (`pack_id: python`, `language: Python`,
   `version: 1.0.0`) and 7 sections: Coding Style,
   Architectural Patterns, Security Checks, Testing
@@ -23,7 +23,7 @@
   identifiers (CS-NNN, AP-NNN, SC-NNN, TC-NNN, TA-NNN,
   DR-NNN).
 
-- [ ] 1.2 [P] Create `.opencode/uf/packs/python-custom.md`
+- [x] 1.2 [P] Create `.opencode/uf/packs/python-custom.md`
   with YAML frontmatter (`pack_id: python-custom`,
   `language: Python`, `version: 1.0.0`) and empty template
   matching `go-custom.md` format.
@@ -33,17 +33,17 @@
 Depends on Group 1. The embedded copies must be
 byte-identical to the canonical sources.
 
-- [ ] 2.1 Copy `.opencode/uf/packs/python.md` to
+- [x] 2.1 Copy `.opencode/uf/packs/python.md` to
   `internal/scaffold/assets/opencode/uf/packs/python.md`.
   Verify byte-identical with diff.
 
-- [ ] 2.2 Copy `.opencode/uf/packs/python-custom.md` to
+- [x] 2.2 Copy `.opencode/uf/packs/python-custom.md` to
   `internal/scaffold/assets/opencode/uf/packs/python-custom.md`.
   Verify byte-identical with diff.
 
 ## 3. Update Scaffold Language Detection
 
-- [ ] 3.1 Update `detectLang()` in
+- [x] 3.1 Update `detectLang()` in
   `internal/scaffold/scaffold.go`: add 5 new marker entries
   after the existing `pyproject.toml` entry:
   `setup.py` -> python, `setup.cfg` -> python,
@@ -56,12 +56,12 @@ byte-identical to the canonical sources.
 
 All changes in `internal/scaffold/scaffold_test.go`.
 
-- [ ] 4.1 Update `expectedAssetPaths`: add 2 new entries
+- [x] 4.1 Update `expectedAssetPaths`: add 2 new entries
   in sorted position:
   `"opencode/uf/packs/python-custom.md"` and
   `"opencode/uf/packs/python.md"`.
 
-- [ ] 4.2 Update `TestDetectLang`: add test cases for the
+- [x] 4.2 Update `TestDetectLang`: add test cases for the
   5 new Python markers (`setup.py`, `setup.cfg`,
   `requirements.txt`, `tox.ini`, `Pipfile`). Add a
   priority test case verifying `pyproject.toml` takes
@@ -69,7 +69,7 @@ All changes in `internal/scaffold/scaffold_test.go`.
   test verifying Go still takes priority over Python
   markers.
 
-- [ ] 4.3 Update `TestShouldDeployPack`: add test cases
+- [x] 4.3 Update `TestShouldDeployPack`: add test cases
   for Python pack deployment:
   `python.md` with lang=python -> true,
   `python-custom.md` with lang=python -> true,
@@ -77,17 +77,17 @@ All changes in `internal/scaffold/scaffold_test.go`.
   `python-custom.md` with lang=go -> false,
   `go.md` with lang=python -> false.
 
-- [ ] 4.4 Update `TestIsToolOwned`: add test cases:
+- [x] 4.4 Update `TestIsToolOwned`: add test cases:
   `opencode/uf/packs/python.md` -> true (canonical),
   `opencode/uf/packs/python-custom.md` -> false (custom).
 
-- [ ] 4.5 Update `TestIsDivisorAsset`: add test case:
+- [x] 4.5 Update `TestIsDivisorAsset`: add test case:
   `opencode/uf/packs/python.md` -> true (convention packs
   are Divisor assets).
 
 ## 5. Add Python Doctor Checks
 
-- [ ] 5.1 Add `checkPythonTools()` function to
+- [x] 5.1 Add `checkPythonTools()` function to
   `internal/doctor/checks.go` returning a `CheckGroup`
   named "Python Tools". Checks 9 tool categories:
   python3 (required), pip/uv (recommended, pass if either
@@ -102,7 +102,7 @@ All changes in `internal/scaffold/scaffold_test.go`.
   single-binary checks; implement a small
   `checkAnyTool()` helper for multi-binary categories.
 
-- [ ] 5.2 Add `isPythonProject(targetDir string) bool` to
+- [x] 5.2 Add `isPythonProject(targetDir string) bool` to
   `internal/doctor/checks.go` that checks for Python marker
   files (`pyproject.toml`, `setup.py`, `setup.cfg`,
   `requirements.txt`, `tox.ini`, `Pipfile`) via `os.Stat`.
@@ -110,7 +110,7 @@ All changes in `internal/scaffold/scaffold_test.go`.
   marker list from `scaffold.detectLang()` to avoid a
   cross-package import (per design D6).
 
-- [ ] 5.3 Update `Run()` in `internal/doctor/doctor.go` to
+- [x] 5.3 Update `Run()` in `internal/doctor/doctor.go` to
   conditionally include the Python tools check group. Call
   `isPythonProject(opts.TargetDir)` and include
   `checkPythonTools()` only when it returns true. Follow
@@ -118,21 +118,21 @@ All changes in `internal/scaffold/scaffold_test.go`.
 
 ## 6. Add Doctor Tests
 
-- [ ] 6.1 Add `TestCheckPythonTools_AllPresent` to
+- [x] 6.1 Add `TestCheckPythonTools_AllPresent` to
   `internal/doctor/doctor_test.go`: inject `LookPath` that
   finds all 9 Python tools, verify all results are Pass.
 
-- [ ] 6.2 Add `TestCheckPythonTools_NoneMissing` to
+- [x] 6.2 Add `TestCheckPythonTools_NoneMissing` to
   `internal/doctor/doctor_test.go`: inject `LookPath` that
   finds nothing, verify required tools are Fail,
   recommended are Warn, optional are Pass.
 
-- [ ] 6.3 Add `TestCheckPythonTools_Skipped` to
+- [x] 6.3 Add `TestCheckPythonTools_Skipped` to
   `internal/doctor/doctor_test.go`: verify Python tools
   group is NOT included when no Python marker files exist
   in the target directory.
 
-- [ ] 6.4 Add `TestIsPythonProject` to
+- [x] 6.4 Add `TestIsPythonProject` to
   `internal/doctor/doctor_test.go`: verify detection for
   each Python marker file individually (`pyproject.toml`,
   `setup.py`, `setup.cfg`, `requirements.txt`, `tox.ini`,
@@ -140,16 +140,16 @@ All changes in `internal/scaffold/scaffold_test.go`.
 
 ## 7. Build, Test, and Verify
 
-- [ ] 7.1 Run `go build ./...`. Fix any compilation errors.
-- [ ] 7.2 Run `go vet ./...`. Fix any vet warnings.
-- [ ] 7.3 Run `go test -race -count=1 ./...`. Fix any
+- [x] 7.1 Run `go build ./...`. Fix any compilation errors.
+- [x] 7.2 Run `go vet ./...`. Fix any vet warnings.
+- [x] 7.3 Run `go test -race -count=1 ./...`. Fix any
   test failures. Pay specific attention to:
   - `TestAssetPaths_MatchExpected` (asset count)
   - `TestEmbeddedAssets_MatchSource` (drift detection)
   - `TestCanonicalSources_AreEmbedded` (reverse drift)
   - `TestDetectLang` (new Python markers)
   - `TestShouldDeployPack` (Python pack filtering)
-- [ ] 7.4 Constitution alignment verification: confirm
+- [x] 7.4 Constitution alignment verification: confirm
   new pack files have YAML frontmatter (Observable
   Quality), detection is testable via TempDir
   (Testability), and no mandatory dependencies introduced

--- a/openspec/changes/python-convention-pack/tasks.md
+++ b/openspec/changes/python-convention-pack/tasks.md
@@ -1,0 +1,156 @@
+<!--
+  [P] marks tasks eligible for parallel execution.
+  Add [P] when a task: (a) touches different files from
+  other [P] tasks in the group, (b) has no dependency
+  on prior tasks in the group, (c) can safely execute
+  without ordering constraints.
+  Do NOT add [P] when tasks modify the same file —
+  parallel workers will cause merge conflicts.
+  Tasks without [P] run sequentially first, then [P]
+  tasks run in parallel.
+-->
+
+## 1. Create Convention Pack Files
+
+- [ ] 1.1 [P] Create `.opencode/uf/packs/python.md` with
+  YAML frontmatter (`pack_id: python`, `language: Python`,
+  `version: 1.0.0`) and 7 sections: Coding Style,
+  Architectural Patterns, Security Checks, Testing
+  Conventions, Type Annotations, Documentation
+  Requirements, Custom Rules (empty placeholder). Follow
+  the format of `go.md` and `typescript.md` exactly. Use
+  RFC 2119 severity indicators and numbered rule
+  identifiers (CS-NNN, AP-NNN, SC-NNN, TC-NNN, TA-NNN,
+  DR-NNN).
+
+- [ ] 1.2 [P] Create `.opencode/uf/packs/python-custom.md`
+  with YAML frontmatter (`pack_id: python-custom`,
+  `language: Python`, `version: 1.0.0`) and empty template
+  matching `go-custom.md` format.
+
+## 2. Create Embedded Asset Copies
+
+Depends on Group 1. The embedded copies must be
+byte-identical to the canonical sources.
+
+- [ ] 2.1 Copy `.opencode/uf/packs/python.md` to
+  `internal/scaffold/assets/opencode/uf/packs/python.md`.
+  Verify byte-identical with diff.
+
+- [ ] 2.2 Copy `.opencode/uf/packs/python-custom.md` to
+  `internal/scaffold/assets/opencode/uf/packs/python-custom.md`.
+  Verify byte-identical with diff.
+
+## 3. Update Scaffold Language Detection
+
+- [ ] 3.1 Update `detectLang()` in
+  `internal/scaffold/scaffold.go`: add 5 new marker entries
+  after the existing `pyproject.toml` entry:
+  `setup.py` -> python, `setup.cfg` -> python,
+  `requirements.txt` -> python, `tox.ini` -> python,
+  `Pipfile` -> python. Preserve existing marker order
+  (go.mod, tsconfig.json, package.json, pyproject.toml
+  remain unchanged; new entries before Cargo.toml).
+
+## 4. Update Scaffold Tests
+
+All changes in `internal/scaffold/scaffold_test.go`.
+
+- [ ] 4.1 Update `expectedAssetPaths`: add 2 new entries
+  in sorted position:
+  `"opencode/uf/packs/python-custom.md"` and
+  `"opencode/uf/packs/python.md"`.
+
+- [ ] 4.2 Update `TestDetectLang`: add test cases for the
+  5 new Python markers (`setup.py`, `setup.cfg`,
+  `requirements.txt`, `tox.ini`, `Pipfile`). Add a
+  priority test case verifying `pyproject.toml` takes
+  precedence when multiple Python markers exist. Add a
+  test verifying Go still takes priority over Python
+  markers.
+
+- [ ] 4.3 Update `TestShouldDeployPack`: add test cases
+  for Python pack deployment:
+  `python.md` with lang=python -> true,
+  `python-custom.md` with lang=python -> true,
+  `python.md` with lang=go -> false,
+  `python-custom.md` with lang=go -> false,
+  `go.md` with lang=python -> false.
+
+- [ ] 4.4 Update `TestIsToolOwned`: add test cases:
+  `opencode/uf/packs/python.md` -> true (canonical),
+  `opencode/uf/packs/python-custom.md` -> false (custom).
+
+- [ ] 4.5 Update `TestIsDivisorAsset`: add test case:
+  `opencode/uf/packs/python.md` -> true (convention packs
+  are Divisor assets).
+
+## 5. Add Python Doctor Checks
+
+- [ ] 5.1 Add `checkPythonTools()` function to
+  `internal/doctor/checks.go` returning a `CheckGroup`
+  named "Python Tools". Checks 9 tool categories:
+  python3 (required), pip/uv (recommended, pass if either
+  found), pytest (required), formatter (recommended, pass
+  if `black` or `ruff` found), linter (recommended, pass
+  if `flake8` or `ruff` found), import sorter (recommended,
+  pass if `isort` or `ruff` found), security scanner
+  (recommended, pass if `bandit` or `ruff` found), mypy
+  (optional), tox (optional). For categories with
+  alternatives, check all binaries via `LookPath` and pass
+  if any is found. Use the existing `checkOneTool()` for
+  single-binary checks; implement a small
+  `checkAnyTool()` helper for multi-binary categories.
+
+- [ ] 5.2 Add `isPythonProject(targetDir string) bool` to
+  `internal/doctor/checks.go` that checks for Python marker
+  files (`pyproject.toml`, `setup.py`, `setup.cfg`,
+  `requirements.txt`, `tox.ini`, `Pipfile`) via `os.Stat`.
+  Returns true if any marker exists. This duplicates the
+  marker list from `scaffold.detectLang()` to avoid a
+  cross-package import (per design D6).
+
+- [ ] 5.3 Update `Run()` in `internal/doctor/doctor.go` to
+  conditionally include the Python tools check group. Call
+  `isPythonProject(opts.TargetDir)` and include
+  `checkPythonTools()` only when it returns true. Follow
+  the DevPod conditional inclusion pattern.
+
+## 6. Add Doctor Tests
+
+- [ ] 6.1 Add `TestCheckPythonTools_AllPresent` to
+  `internal/doctor/doctor_test.go`: inject `LookPath` that
+  finds all 9 Python tools, verify all results are Pass.
+
+- [ ] 6.2 Add `TestCheckPythonTools_NoneMissing` to
+  `internal/doctor/doctor_test.go`: inject `LookPath` that
+  finds nothing, verify required tools are Fail,
+  recommended are Warn, optional are Pass.
+
+- [ ] 6.3 Add `TestCheckPythonTools_Skipped` to
+  `internal/doctor/doctor_test.go`: verify Python tools
+  group is NOT included when no Python marker files exist
+  in the target directory.
+
+- [ ] 6.4 Add `TestIsPythonProject` to
+  `internal/doctor/doctor_test.go`: verify detection for
+  each Python marker file individually (`pyproject.toml`,
+  `setup.py`, `setup.cfg`, `requirements.txt`, `tox.ini`,
+  `Pipfile`) and verify false when none exist.
+
+## 7. Build, Test, and Verify
+
+- [ ] 7.1 Run `go build ./...`. Fix any compilation errors.
+- [ ] 7.2 Run `go vet ./...`. Fix any vet warnings.
+- [ ] 7.3 Run `go test -race -count=1 ./...`. Fix any
+  test failures. Pay specific attention to:
+  - `TestAssetPaths_MatchExpected` (asset count)
+  - `TestEmbeddedAssets_MatchSource` (drift detection)
+  - `TestCanonicalSources_AreEmbedded` (reverse drift)
+  - `TestDetectLang` (new Python markers)
+  - `TestShouldDeployPack` (Python pack filtering)
+- [ ] 7.4 Constitution alignment verification: confirm
+  new pack files have YAML frontmatter (Observable
+  Quality), detection is testable via TempDir
+  (Testability), and no mandatory dependencies introduced
+  (Composability First).


### PR DESCRIPTION
## Summary

Add first-class Python support to the scaffold and doctor systems.

### Convention Packs
- `python.md`: canonical pack with 46 rules across 7 sections (Coding
  Style, Architectural Patterns, Security Checks, Testing Conventions,
  Type Annotations, Documentation Requirements, Custom Rules)
- `python-custom.md`: empty template for project-specific overrides
- Outcome-focused tool rules (D3): compatible with both traditional
  (black+flake8+isort) and modern (ruff) toolchains

### Scaffold
- `detectLang()` expanded with 5 additional Python markers (setup.py,
  setup.cfg, requirements.txt, tox.ini, Pipfile)

### Doctor
- `isPythonProject()` conditional detection
- `checkPythonTools()` with 9 tool categories (python3, pip/uv, pytest,
  formatter, linter, import sorter, security scanner, mypy, tox)
- `checkAnyTool()` helper for multi-binary categories with
  ToolSeverities config override support
- Tool-agnostic: ruff satisfies formatter, linter, import sorter, and
  security scanner categories

### Tests
- 8 new doctor tests (detection, all-present, none-present, ruff
  multi-role, Run() integration excluded/included, ToolSeverities
  override, first-binary-wins)
- 7 new scaffold test cases (detection, pack deploy, tool ownership,
  Divisor asset classification)

Spec: openspec/changes/python-convention-pack/
