### PR TITLE
fix: update CRAP baseline for checkPodmanRuntimeDarwin on Linux CI

### DIFF
--- a/.gaze/baseline.json
+++ b/.gaze/baseline.json
@@ -1309,8 +1309,8 @@
       "file": "internal/doctor/checks.go",
       "line": 216,
       "complexity": 4,
-      "line_coverage": 71.42857142857143,
-      "crap": 4.373177842565598
+      "line_coverage": 0,
+      "crap": 20
     },
     {
       "package": "doctor",


### PR DESCRIPTION
## Summary

`checkPodmanRuntimeDarwin` is gated by `runtime.GOOS == "darwin"` and gets 0% line coverage on Linux CI. The CRAP baseline was generated on macOS where 71.4% coverage was achievable, causing the baseline CRAP score (4.37) to be much lower than what CI measures (20.0). This makes every Go-touching PR fail the CRAP regression check.

### Fix

Update `.gaze/baseline.json` to set `checkPodmanRuntimeDarwin` to 0% coverage / CRAP 20, matching Linux CI reality.

This is a platform parity fix, not a code change.
