### PR TITLE
fix: wire auto-mode native fallback in uf setupOpsx/setup auto native fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ Each entry follows the format: `- <change-name>: <summary>`.
 - `feedback-triage` JSON schema (v1.0.0) for capturing triage
   decisions as artifacts (Spec: openspec/changes/address-feedback/)
 
+### Fixed
+- `uf setup` auto mode now falls back to native package
+  managers and `go install` when Homebrew is absent.
+  Previously, 4 companion tools (Gaze, Replicator, Dewey,
+  GitHub CLI) were skipped with download-link hints on
+  Fedora/RHEL. Fallback chain: Homebrew -> dnf -> go install
+  -> skip. Added `resolveMethod()` and `installViaGo()`
+  helpers. `UF_PACKAGE_MANAGER=dnf` now forces the dnf
+  install path. Fixes #214.
+  (Spec: openspec/changes/setup-auto-native-fallback/)
+
 ## Recent Changes
 
 - opsx/setup-sandbox-tools: Added Podman and DevPod to `uf setup` (13→16 steps) and `uf doctor`. Setup installs Podman via Homebrew with macOS Podman machine initialization (best-effort, with timeout via gtimeout/timeout fallback), installs DevPod via Homebrew, and configures the DevPod Podman provider alias (`devpod provider add docker --name podman -o DOCKER_PATH=podman`). Corrected DevPod provider option from `DOCKER_COMMAND` to `DOCKER_PATH` across setup, doctor, and spec artifacts. Doctor adds conditional DevPod check group (only when DevPod is detected): binary presence, version >= 0.5.0, podman provider registration, and `.devcontainer/devcontainer.json` existence. Podman doctor checks: version >= 4.3, runtime health via `podman info` (platform-aware), and Docker-to-Podman shim detection. Refactored setup step dispatch from 16 repetitive if/else blocks to data-driven `stepDef` slice with `executeSteps()` loop (CRAP 32 → 2). Added `hasProvider()` helper with exact first-column name matching for provider detection. Added `podmanMachineInit()` with `initMachineWithTimeout()` helper for macOS post-install (tries gtimeout, timeout, then no-timeout fallback). 6 new doctor tests, 12 new setup tests. Modified files: `internal/setup/setup.go`, `internal/setup/setup_test.go`, `internal/doctor/checks.go`, `internal/doctor/doctor.go`, `internal/doctor/doctor_test.go`, `internal/doctor/environ.go`. Website issue: unbound-force/website#121.

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -196,6 +196,65 @@ func (o *Options) toolMethod(toolName string) string {
 	return "auto"
 }
 
+// resolveMethod resolves the effective install method for a tool by
+// applying the precedence chain: per-tool override > global
+// PackageManager preference > "auto" fallback. This is tool-agnostic
+// — it resolves the user's preference, not the tool's capability.
+// Each install function is responsible for handling unsupported
+// methods by falling through to the next tier (D1).
+func (o *Options) resolveMethod(toolName string, _ doctor.DetectedEnvironment) string {
+	// (1) Per-tool override takes precedence.
+	if method := o.toolMethod(toolName); method != "auto" {
+		return method
+	}
+
+	// (2) Global PackageManager preference.
+	switch o.PackageManager {
+	case "homebrew", "dnf":
+		return o.PackageManager
+	case "apt":
+		// apt support not yet implemented — inform the user and
+		// fall through to auto-mode (D1, D5).
+		fmt.Fprintf(o.Stderr, "apt support not yet implemented, using auto-mode fallback\n")
+		return "auto"
+	}
+
+	// (3) Default: auto-mode fallback chain.
+	return "auto"
+}
+
+// installViaGo installs a Go binary tool using `go install`. Returns
+// a stepResult with the outcome. Uses opts.LookPath and opts.ExecCmd
+// for testability per Constitution Principle IV (D3).
+func installViaGo(opts *Options, toolName, goModule string) stepResult {
+	// Check if Go is available in PATH.
+	if _, err := opts.LookPath("go"); err != nil {
+		return stepResult{
+			name:   toolName,
+			action: "skipped",
+			detail: "Go not available. Install Go or use Homebrew/dnf.",
+		}
+	}
+
+	if opts.DryRun {
+		return stepResult{
+			name:   toolName,
+			action: "dry-run",
+			detail: "Would install: go install " + goModule + "@latest",
+		}
+	}
+
+	if _, err := opts.ExecCmd("go", "install", goModule+"@latest"); err != nil {
+		return stepResult{
+			name:   toolName,
+			action: "failed",
+			detail: "go install failed — try: go install " + goModule + "@latest",
+			err:    fmt.Errorf("go install %s: %w", goModule, err),
+		}
+	}
+	return stepResult{name: toolName, action: "installed", detail: "via go install"}
+}
+
 // stepDef defines a single setup step for data-driven dispatch.
 // Each step has a display name, a skip-tool key, an install function,
 // and optional gate and effect callbacks. This struct replaces the
@@ -465,32 +524,78 @@ func installOpenCode(opts *Options, env doctor.DetectedEnvironment) stepResult {
 }
 
 // installGH installs the GitHub CLI if missing.
-// Follows the installGaze() pattern: Homebrew only, skip with
-// download link if no Homebrew.
+// Fallback chain (D2): Homebrew → dnf → skip (no go install — GH
+// CLI is not a simple Go binary). GH CLI has its own dnf repo,
+// so dnf install uses the package name directly, not installViaRpm (D4).
 func installGH(opts *Options, env doctor.DetectedEnvironment) stepResult {
 	if _, err := opts.LookPath("gh"); err == nil {
 		return stepResult{name: "GitHub CLI", action: "already installed"}
 	}
 
+	// Method dispatch: resolveMethod centralizes per-tool override
+	// and global PackageManager precedence (D1).
+	method := opts.resolveMethod("gh", env)
+	switch method {
+	case "dnf":
+		if opts.DryRun {
+			return stepResult{name: "GitHub CLI", action: "dry-run", detail: "Would install: dnf install -y gh"}
+		}
+		if _, err := opts.ExecCmd("dnf", "install", "-y", "gh"); err != nil {
+			// Graceful degradation: dnf failure is "skipped", not "failed" (D4).
+			return stepResult{
+				name:   "GitHub CLI",
+				action: "skipped",
+				detail: "dnf install failed — configure the GitHub CLI repo: https://github.com/cli/cli/blob/trunk/docs/install_linux.md or download from https://cli.github.com",
+			}
+		}
+		return stepResult{name: "GitHub CLI", action: "installed", detail: "via dnf"}
+	case "homebrew":
+		if opts.DryRun {
+			return stepResult{name: "GitHub CLI", action: "dry-run", detail: "Would install: brew install gh"}
+		}
+		if _, err := opts.ExecCmd("brew", "install", "gh"); err != nil {
+			return stepResult{name: "GitHub CLI", action: "failed", detail: "brew install failed", err: err}
+		}
+		return stepResult{name: "GitHub CLI", action: "installed", detail: "via Homebrew"}
+	}
+
+	// Auto-mode fallback chain (D2): Homebrew → dnf → skip.
 	if opts.DryRun {
 		if doctor.HasManager(env, doctor.ManagerHomebrew) {
 			return stepResult{name: "GitHub CLI", action: "dry-run", detail: "Would install: brew install gh"}
 		}
+		if doctor.HasManager(env, doctor.ManagerDnf) {
+			return stepResult{name: "GitHub CLI", action: "dry-run", detail: "Would install: dnf install -y gh"}
+		}
 		return stepResult{name: "GitHub CLI", action: "dry-run", detail: "Would install: download from https://cli.github.com"}
 	}
 
-	if !doctor.HasManager(env, doctor.ManagerHomebrew) {
-		return stepResult{
-			name:   "GitHub CLI",
-			action: "skipped",
-			detail: "Homebrew not available. Download from https://cli.github.com",
+	// Try Homebrew first.
+	if doctor.HasManager(env, doctor.ManagerHomebrew) {
+		if _, err := opts.ExecCmd("brew", "install", "gh"); err != nil {
+			return stepResult{name: "GitHub CLI", action: "failed", detail: "brew install failed", err: err}
 		}
+		return stepResult{name: "GitHub CLI", action: "installed", detail: "via Homebrew"}
 	}
 
-	if _, err := opts.ExecCmd("brew", "install", "gh"); err != nil {
-		return stepResult{name: "GitHub CLI", action: "failed", detail: "brew install failed", err: err}
+	// Try dnf when available (D4).
+	if doctor.HasManager(env, doctor.ManagerDnf) {
+		if _, err := opts.ExecCmd("dnf", "install", "-y", "gh"); err != nil {
+			// Graceful degradation: dnf failure is "skipped", not "failed" (D4).
+			return stepResult{
+				name:   "GitHub CLI",
+				action: "skipped",
+				detail: "dnf install failed — configure the GitHub CLI repo: https://github.com/cli/cli/blob/trunk/docs/install_linux.md or download from https://cli.github.com",
+			}
+		}
+		return stepResult{name: "GitHub CLI", action: "installed", detail: "via dnf"}
 	}
-	return stepResult{name: "GitHub CLI", action: "installed", detail: "via Homebrew"}
+
+	return stepResult{
+		name:   "GitHub CLI",
+		action: "skipped",
+		detail: "Homebrew not available. Download from https://cli.github.com",
+	}
 }
 
 // installOpenSpec installs the OpenSpec CLI if missing.
@@ -516,18 +621,19 @@ func installOpenSpec(opts *Options, env doctor.DetectedEnvironment) stepResult {
 }
 
 // installGaze installs Gaze if missing per FR-023.
+// Fallback chain (D2): Homebrew → dnf (RPM) → go install → skip.
 func installGaze(opts *Options, env doctor.DetectedEnvironment) stepResult {
 	if _, err := opts.LookPath("gaze"); err == nil {
 		return stepResult{name: "Gaze", action: "already installed"}
 	}
 
-	// Method dispatch: respect per-tool config override.
-	method := opts.toolMethod("gaze")
+	// Method dispatch: resolveMethod centralizes per-tool override
+	// and global PackageManager precedence (D1).
+	method := opts.resolveMethod("gaze", env)
 	switch method {
 	case "rpm", "dnf":
 		return installViaRpm(opts, "Gaze", "unbound-force/gaze", opts.Version)
 	case "homebrew":
-		// Force Homebrew regardless of detection.
 		if opts.DryRun {
 			return stepResult{name: "Gaze", action: "dry-run", detail: "Would install: brew install unbound-force/tap/gaze"}
 		}
@@ -535,28 +641,45 @@ func installGaze(opts *Options, env doctor.DetectedEnvironment) stepResult {
 			return stepResult{name: "Gaze", action: "failed", detail: "brew install failed", err: err}
 		}
 		return stepResult{name: "Gaze", action: "installed", detail: "via Homebrew"}
+	case "go":
+		return installViaGo(opts, "Gaze", "github.com/unbound-force/gaze/cmd/gaze")
 	}
 
-	// Auto: try Homebrew, fall back to skip with hint.
+	// Auto-mode fallback chain (D2): Homebrew → dnf → go install → skip.
 	if opts.DryRun {
 		if doctor.HasManager(env, doctor.ManagerHomebrew) {
 			return stepResult{name: "Gaze", action: "dry-run", detail: "Would install: brew install unbound-force/tap/gaze"}
 		}
-		return stepResult{name: "Gaze", action: "dry-run", detail: "Would install: download from GitHub releases"}
-	}
-
-	if !doctor.HasManager(env, doctor.ManagerHomebrew) {
-		return stepResult{
-			name:   "Gaze",
-			action: "skipped",
-			detail: "Homebrew not available. Download from https://github.com/unbound-force/gaze/releases",
+		if doctor.HasManager(env, doctor.ManagerDnf) {
+			return installViaRpm(opts, "Gaze", "unbound-force/gaze", opts.Version)
 		}
+		return installViaGo(opts, "Gaze", "github.com/unbound-force/gaze/cmd/gaze")
 	}
 
-	if _, err := opts.ExecCmd("brew", "install", "unbound-force/tap/gaze"); err != nil {
-		return stepResult{name: "Gaze", action: "failed", detail: "brew install failed", err: err}
+	// Try Homebrew first.
+	if doctor.HasManager(env, doctor.ManagerHomebrew) {
+		if _, err := opts.ExecCmd("brew", "install", "unbound-force/tap/gaze"); err != nil {
+			return stepResult{name: "Gaze", action: "failed", detail: "brew install failed", err: err}
+		}
+		return stepResult{name: "Gaze", action: "installed", detail: "via Homebrew"}
 	}
-	return stepResult{name: "Gaze", action: "installed", detail: "via Homebrew"}
+
+	// Try dnf (RPM) when available.
+	if doctor.HasManager(env, doctor.ManagerDnf) {
+		return installViaRpm(opts, "Gaze", "unbound-force/gaze", opts.Version)
+	}
+
+	// Try go install as final fallback.
+	goResult := installViaGo(opts, "Gaze", "github.com/unbound-force/gaze/cmd/gaze")
+	if goResult.action != "skipped" {
+		return goResult
+	}
+
+	return stepResult{
+		name:   "Gaze",
+		action: "skipped",
+		detail: "Homebrew not available. Download from https://github.com/unbound-force/gaze/releases",
+	}
 }
 
 // ensureNodeJS checks for Node.js >= 18 and installs if needed per FR-024.
@@ -716,32 +839,65 @@ func installSpecify(opts *Options, env doctor.DetectedEnvironment) stepResult {
 }
 
 // installReplicator installs Replicator if missing per FR-001.
-// Follows the installGaze() pattern: Homebrew only, skip with
-// GitHub releases link if no Homebrew.
+// Fallback chain (D2): Homebrew → dnf (RPM) → go install → skip.
 func installReplicator(opts *Options, env doctor.DetectedEnvironment) stepResult {
 	if _, err := opts.LookPath("replicator"); err == nil {
 		return stepResult{name: "Replicator", action: "already installed"}
 	}
 
+	// Method dispatch: resolveMethod centralizes per-tool override
+	// and global PackageManager precedence (D1).
+	method := opts.resolveMethod("replicator", env)
+	switch method {
+	case "rpm", "dnf":
+		return installViaRpm(opts, "Replicator", "unbound-force/replicator", opts.Version)
+	case "homebrew":
+		if opts.DryRun {
+			return stepResult{name: "Replicator", action: "dry-run", detail: "Would install: brew install unbound-force/tap/replicator"}
+		}
+		if _, err := opts.ExecCmd("brew", "install", "unbound-force/tap/replicator"); err != nil {
+			return stepResult{name: "Replicator", action: "failed", detail: "brew install failed", err: err}
+		}
+		return stepResult{name: "Replicator", action: "installed", detail: "via Homebrew"}
+	case "go":
+		return installViaGo(opts, "Replicator", "github.com/unbound-force/replicator/cmd/replicator")
+	}
+
+	// Auto-mode fallback chain (D2): Homebrew → dnf → go install → skip.
 	if opts.DryRun {
 		if doctor.HasManager(env, doctor.ManagerHomebrew) {
 			return stepResult{name: "Replicator", action: "dry-run", detail: "Would install: brew install unbound-force/tap/replicator"}
 		}
-		return stepResult{name: "Replicator", action: "dry-run", detail: "Would install: download from GitHub releases"}
-	}
-
-	if !doctor.HasManager(env, doctor.ManagerHomebrew) {
-		return stepResult{
-			name:   "Replicator",
-			action: "skipped",
-			detail: "Homebrew not available. Download from https://github.com/unbound-force/replicator/releases",
+		if doctor.HasManager(env, doctor.ManagerDnf) {
+			return installViaRpm(opts, "Replicator", "unbound-force/replicator", opts.Version)
 		}
+		return installViaGo(opts, "Replicator", "github.com/unbound-force/replicator/cmd/replicator")
 	}
 
-	if _, err := opts.ExecCmd("brew", "install", "unbound-force/tap/replicator"); err != nil {
-		return stepResult{name: "Replicator", action: "failed", detail: "brew install failed", err: err}
+	// Try Homebrew first.
+	if doctor.HasManager(env, doctor.ManagerHomebrew) {
+		if _, err := opts.ExecCmd("brew", "install", "unbound-force/tap/replicator"); err != nil {
+			return stepResult{name: "Replicator", action: "failed", detail: "brew install failed", err: err}
+		}
+		return stepResult{name: "Replicator", action: "installed", detail: "via Homebrew"}
 	}
-	return stepResult{name: "Replicator", action: "installed", detail: "via Homebrew"}
+
+	// Try dnf (RPM) when available.
+	if doctor.HasManager(env, doctor.ManagerDnf) {
+		return installViaRpm(opts, "Replicator", "unbound-force/replicator", opts.Version)
+	}
+
+	// Try go install as final fallback.
+	goResult := installViaGo(opts, "Replicator", "github.com/unbound-force/replicator/cmd/replicator")
+	if goResult.action != "skipped" {
+		return goResult
+	}
+
+	return stepResult{
+		name:   "Replicator",
+		action: "skipped",
+		detail: "Homebrew not available. Download from https://github.com/unbound-force/replicator/releases",
+	}
 }
 
 // runReplicatorSetup runs `replicator setup` per FR-002.
@@ -1125,38 +1281,80 @@ func hasProvider(output, name string) bool {
 // rather than hard failures. Note: brew install and ollama pull are
 // non-interactive (no stdin prompts), so no interactive guard is
 // needed here (unlike swarm setup which may prompt for input).
+// Fallback chain (D2): Homebrew → go install → skip (no RPMs).
 func installDewey(opts *Options, env doctor.DetectedEnvironment) stepResult {
 	if _, err := opts.LookPath("dewey"); err == nil {
 		// Dewey already installed — check embedding model.
 		return pullEmbeddingModel(opts)
 	}
 
+	// Method dispatch: resolveMethod centralizes per-tool override
+	// and global PackageManager precedence (D1). Dewey has no RPMs,
+	// so "dnf" falls through to the default case (D1).
+	method := opts.resolveMethod("dewey", env)
+	switch method {
+	case "homebrew":
+		if opts.DryRun {
+			return stepResult{name: "Dewey", action: "dry-run", detail: "Would install: brew install unbound-force/tap/dewey"}
+		}
+		if _, err := opts.ExecCmd("brew", "install", "unbound-force/tap/dewey"); err != nil {
+			return stepResult{name: "Dewey", action: "failed", detail: "brew install failed", err: err}
+		}
+		return deweyPostInstall(opts, "via Homebrew")
+	case "go":
+		goResult := installViaGo(opts, "Dewey", "github.com/unbound-force/dewey/cmd/dewey")
+		if goResult.action == "installed" {
+			return deweyPostInstall(opts, goResult.detail)
+		}
+		return goResult
+	}
+
+	// Auto-mode (or "dnf" which falls through since Dewey has no RPMs):
+	// Homebrew → go install → skip.
 	if opts.DryRun {
 		if doctor.HasManager(env, doctor.ManagerHomebrew) {
 			return stepResult{name: "Dewey", action: "dry-run", detail: "Would install: brew install unbound-force/tap/dewey"}
 		}
-		return stepResult{name: "Dewey", action: "skipped", detail: "Homebrew not available"}
+		return installViaGo(opts, "Dewey", "github.com/unbound-force/dewey/cmd/dewey")
 	}
 
-	if !doctor.HasManager(env, doctor.ManagerHomebrew) {
-		return stepResult{
-			name:   "Dewey",
-			action: "skipped",
-			detail: "Homebrew not available. Install from https://github.com/unbound-force/dewey",
+	// Try Homebrew first.
+	if doctor.HasManager(env, doctor.ManagerHomebrew) {
+		if _, err := opts.ExecCmd("brew", "install", "unbound-force/tap/dewey"); err != nil {
+			return stepResult{name: "Dewey", action: "failed", detail: "brew install failed", err: err}
 		}
+		return deweyPostInstall(opts, "via Homebrew")
 	}
 
-	if _, err := opts.ExecCmd("brew", "install", "unbound-force/tap/dewey"); err != nil {
-		return stepResult{name: "Dewey", action: "failed", detail: "brew install failed", err: err}
+	// Try go install as fallback (no dnf path — Dewey has no RPMs).
+	goResult := installViaGo(opts, "Dewey", "github.com/unbound-force/dewey/cmd/dewey")
+	if goResult.action == "installed" {
+		return deweyPostInstall(opts, goResult.detail)
+	}
+	if goResult.action != "skipped" {
+		return goResult
 	}
 
-	// After installing, pull the embedding model.
+	return stepResult{
+		name:   "Dewey",
+		action: "skipped",
+		detail: "Homebrew not available. Install from https://github.com/unbound-force/dewey",
+	}
+}
+
+// deweyPostInstall pulls the embedding model after a successful Dewey
+// install. Extracted to avoid duplicating the post-install logic
+// across multiple install paths (DRY per CS-004).
+func deweyPostInstall(opts *Options, installDetail string) stepResult {
 	modelResult := pullEmbeddingModel(opts)
 	if modelResult.action == "failed" {
-		return stepResult{name: "Dewey", action: "installed", detail: "via Homebrew (model pull failed — run 'ollama serve' then 'ollama pull " + opts.embeddingModel() + "')"}
+		return stepResult{
+			name:   "Dewey",
+			action: "installed",
+			detail: installDetail + " (model pull failed — run 'ollama serve' then 'ollama pull " + opts.embeddingModel() + "')",
+		}
 	}
-
-	return stepResult{name: "Dewey", action: "installed", detail: "via Homebrew"}
+	return stepResult{name: "Dewey", action: "installed", detail: installDetail}
 }
 
 // pullEmbeddingModel pulls the enterprise-grade embedding model

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -578,34 +578,43 @@ func installGH(opts *Options, env doctor.DetectedEnvironment) stepResult {
 	case "homebrew":
 		return installViaBrew(opts, "GitHub CLI", "gh")
 	case "dnf":
-		if opts.DryRun {
-			return stepResult{name: "GitHub CLI", action: "dry-run", detail: "Would install: dnf install -y gh"}
-		}
-		if _, err := opts.ExecCmd("dnf", "install", "-y", "gh"); err != nil {
-			// Graceful degradation: dnf failure is "skipped", not "failed" (D4).
-			return stepResult{
-				name:   "GitHub CLI",
-				action: "skipped",
-				detail: "dnf install failed — configure the GitHub CLI repo: https://github.com/cli/cli/blob/trunk/docs/install_linux.md or download from https://cli.github.com",
-			}
-		}
-		return stepResult{name: "GitHub CLI", action: "installed", detail: "via dnf"}
+		return installGHViaDnf(opts)
 	default:
-		// In dry-run mode, report the download link as a dry-run
-		// action rather than a skip — the user asked to see what
-		// would happen, not to silently skip.
-		if opts.DryRun {
-			return stepResult{
-				name:   "GitHub CLI",
-				action: "dry-run",
-				detail: "Would install: download from https://cli.github.com",
-			}
-		}
+		return ghSkipResult(opts)
+	}
+}
+
+// installGHViaDnf installs GitHub CLI via dnf. On failure, returns a
+// graceful skip (not a hard failure) with an actionable repo setup
+// link (D4). GH CLI uses its own dnf repository, not GoReleaser RPMs.
+func installGHViaDnf(opts *Options) stepResult {
+	if opts.DryRun {
+		return stepResult{name: "GitHub CLI", action: "dry-run", detail: "Would install: dnf install -y gh"}
+	}
+	if _, err := opts.ExecCmd("dnf", "install", "-y", "gh"); err != nil {
 		return stepResult{
 			name:   "GitHub CLI",
 			action: "skipped",
-			detail: "Homebrew not available. Download from https://cli.github.com",
+			detail: "dnf install failed — configure the GitHub CLI repo: https://github.com/cli/cli/blob/trunk/docs/install_linux.md or download from https://cli.github.com",
 		}
+	}
+	return stepResult{name: "GitHub CLI", action: "installed", detail: "via dnf"}
+}
+
+// ghSkipResult returns the appropriate skip/dry-run result when no
+// package manager is available for GitHub CLI.
+func ghSkipResult(opts *Options) stepResult {
+	if opts.DryRun {
+		return stepResult{
+			name:   "GitHub CLI",
+			action: "dry-run",
+			detail: "Would install: download from https://cli.github.com",
+		}
+	}
+	return stepResult{
+		name:   "GitHub CLI",
+		action: "skipped",
+		detail: "Homebrew not available. Download from https://cli.github.com",
 	}
 }
 

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -648,6 +648,11 @@ func installGaze(opts *Options, env doctor.DetectedEnvironment) stepResult {
 	}
 
 	// Fallback chain (D2): Homebrew → dnf → go install → skip.
+	skipResult := stepResult{
+		name:   "Gaze",
+		action: "skipped",
+		detail: "Homebrew not available. Download from https://github.com/unbound-force/gaze/releases",
+	}
 	method := opts.resolveMethod("gaze", env, "homebrew", "dnf", "go")
 	switch method {
 	case "homebrew":
@@ -659,17 +664,9 @@ func installGaze(opts *Options, env doctor.DetectedEnvironment) stepResult {
 		if result.action != "skipped" {
 			return result
 		}
-		return stepResult{
-			name:   "Gaze",
-			action: "skipped",
-			detail: "Homebrew not available. Download from https://github.com/unbound-force/gaze/releases",
-		}
+		return skipResult
 	default:
-		return stepResult{
-			name:   "Gaze",
-			action: "skipped",
-			detail: "Homebrew not available. Download from https://github.com/unbound-force/gaze/releases",
-		}
+		return skipResult
 	}
 }
 
@@ -837,6 +834,11 @@ func installReplicator(opts *Options, env doctor.DetectedEnvironment) stepResult
 	}
 
 	// Fallback chain (D2): Homebrew → dnf → go install → skip.
+	skipResult := stepResult{
+		name:   "Replicator",
+		action: "skipped",
+		detail: "Homebrew not available. Download from https://github.com/unbound-force/replicator/releases",
+	}
 	method := opts.resolveMethod("replicator", env, "homebrew", "dnf", "go")
 	switch method {
 	case "homebrew":
@@ -848,17 +850,9 @@ func installReplicator(opts *Options, env doctor.DetectedEnvironment) stepResult
 		if result.action != "skipped" {
 			return result
 		}
-		return stepResult{
-			name:   "Replicator",
-			action: "skipped",
-			detail: "Homebrew not available. Download from https://github.com/unbound-force/replicator/releases",
-		}
+		return skipResult
 	default:
-		return stepResult{
-			name:   "Replicator",
-			action: "skipped",
-			detail: "Homebrew not available. Download from https://github.com/unbound-force/replicator/releases",
-		}
+		return skipResult
 	}
 }
 

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -198,11 +198,13 @@ func (o *Options) toolMethod(toolName string) string {
 
 // resolveMethod resolves the effective install method for a tool by
 // applying the precedence chain: per-tool override > global
-// PackageManager preference > "auto" fallback. This is tool-agnostic
-// — it resolves the user's preference, not the tool's capability.
-// Each install function is responsible for handling unsupported
-// methods by falling through to the next tier (D1).
-func (o *Options) resolveMethod(toolName string, _ doctor.DetectedEnvironment) string {
+// PackageManager preference > environment-aware auto detection.
+// The fallbacks parameter defines the tool's preferred install
+// methods in priority order (e.g., ["homebrew", "dnf", "go"]).
+// For auto mode, resolveMethod returns the first fallback whose
+// package manager is detected in the environment. This eliminates
+// duplicated auto-mode fallback blocks in each install function.
+func (o *Options) resolveMethod(toolName string, env doctor.DetectedEnvironment, fallbacks ...string) string {
 	// (1) Per-tool override takes precedence.
 	if method := o.toolMethod(toolName); method != "auto" {
 		return method
@@ -216,11 +218,49 @@ func (o *Options) resolveMethod(toolName string, _ doctor.DetectedEnvironment) s
 		// apt support not yet implemented — inform the user and
 		// fall through to auto-mode (D1, D5).
 		fmt.Fprintf(o.Stderr, "apt support not yet implemented, using auto-mode fallback\n")
-		return "auto"
 	}
 
-	// (3) Default: auto-mode fallback chain.
-	return "auto"
+	// (3) Auto-mode: return the first fallback whose manager is
+	// detected in the environment.
+	managerMap := map[string]doctor.ManagerKind{
+		"homebrew": doctor.ManagerHomebrew,
+		"dnf":      doctor.ManagerDnf,
+	}
+	for _, fb := range fallbacks {
+		mgr, needsManager := managerMap[fb]
+		if !needsManager {
+			// Methods like "go" don't need a package manager —
+			// they're always available as a fallback.
+			return fb
+		}
+		if doctor.HasManager(env, mgr) {
+			return fb
+		}
+	}
+
+	return "skip"
+}
+
+// installViaBrew installs a tool using Homebrew. Returns a stepResult
+// with the outcome. Uses opts.ExecCmd for testability per Constitution
+// Principle IV.
+func installViaBrew(opts *Options, toolName string, brewFormula string) stepResult {
+	if opts.DryRun {
+		return stepResult{
+			name:   toolName,
+			action: "dry-run",
+			detail: "Would install: brew install " + brewFormula,
+		}
+	}
+	if _, err := opts.ExecCmd("brew", "install", brewFormula); err != nil {
+		return stepResult{
+			name:   toolName,
+			action: "failed",
+			detail: "brew install failed",
+			err:    fmt.Errorf("brew install %s: %w", brewFormula, err),
+		}
+	}
+	return stepResult{name: toolName, action: "installed", detail: "via Homebrew"}
 }
 
 // installViaGo installs a Go binary tool using `go install`. Returns
@@ -532,10 +572,11 @@ func installGH(opts *Options, env doctor.DetectedEnvironment) stepResult {
 		return stepResult{name: "GitHub CLI", action: "already installed"}
 	}
 
-	// Method dispatch: resolveMethod centralizes per-tool override
-	// and global PackageManager precedence (D1).
-	method := opts.resolveMethod("gh", env)
+	// Fallback chain (D2): Homebrew → dnf → skip.
+	method := opts.resolveMethod("gh", env, "homebrew", "dnf")
 	switch method {
+	case "homebrew":
+		return installViaBrew(opts, "GitHub CLI", "gh")
 	case "dnf":
 		if opts.DryRun {
 			return stepResult{name: "GitHub CLI", action: "dry-run", detail: "Would install: dnf install -y gh"}
@@ -549,52 +590,22 @@ func installGH(opts *Options, env doctor.DetectedEnvironment) stepResult {
 			}
 		}
 		return stepResult{name: "GitHub CLI", action: "installed", detail: "via dnf"}
-	case "homebrew":
+	default:
+		// In dry-run mode, report the download link as a dry-run
+		// action rather than a skip — the user asked to see what
+		// would happen, not to silently skip.
 		if opts.DryRun {
-			return stepResult{name: "GitHub CLI", action: "dry-run", detail: "Would install: brew install gh"}
-		}
-		if _, err := opts.ExecCmd("brew", "install", "gh"); err != nil {
-			return stepResult{name: "GitHub CLI", action: "failed", detail: "brew install failed", err: err}
-		}
-		return stepResult{name: "GitHub CLI", action: "installed", detail: "via Homebrew"}
-	}
-
-	// Auto-mode fallback chain (D2): Homebrew → dnf → skip.
-	if opts.DryRun {
-		if doctor.HasManager(env, doctor.ManagerHomebrew) {
-			return stepResult{name: "GitHub CLI", action: "dry-run", detail: "Would install: brew install gh"}
-		}
-		if doctor.HasManager(env, doctor.ManagerDnf) {
-			return stepResult{name: "GitHub CLI", action: "dry-run", detail: "Would install: dnf install -y gh"}
-		}
-		return stepResult{name: "GitHub CLI", action: "dry-run", detail: "Would install: download from https://cli.github.com"}
-	}
-
-	// Try Homebrew first.
-	if doctor.HasManager(env, doctor.ManagerHomebrew) {
-		if _, err := opts.ExecCmd("brew", "install", "gh"); err != nil {
-			return stepResult{name: "GitHub CLI", action: "failed", detail: "brew install failed", err: err}
-		}
-		return stepResult{name: "GitHub CLI", action: "installed", detail: "via Homebrew"}
-	}
-
-	// Try dnf when available (D4).
-	if doctor.HasManager(env, doctor.ManagerDnf) {
-		if _, err := opts.ExecCmd("dnf", "install", "-y", "gh"); err != nil {
-			// Graceful degradation: dnf failure is "skipped", not "failed" (D4).
 			return stepResult{
 				name:   "GitHub CLI",
-				action: "skipped",
-				detail: "dnf install failed — configure the GitHub CLI repo: https://github.com/cli/cli/blob/trunk/docs/install_linux.md or download from https://cli.github.com",
+				action: "dry-run",
+				detail: "Would install: download from https://cli.github.com",
 			}
 		}
-		return stepResult{name: "GitHub CLI", action: "installed", detail: "via dnf"}
-	}
-
-	return stepResult{
-		name:   "GitHub CLI",
-		action: "skipped",
-		detail: "Homebrew not available. Download from https://cli.github.com",
+		return stepResult{
+			name:   "GitHub CLI",
+			action: "skipped",
+			detail: "Homebrew not available. Download from https://cli.github.com",
+		}
 	}
 }
 
@@ -627,58 +638,29 @@ func installGaze(opts *Options, env doctor.DetectedEnvironment) stepResult {
 		return stepResult{name: "Gaze", action: "already installed"}
 	}
 
-	// Method dispatch: resolveMethod centralizes per-tool override
-	// and global PackageManager precedence (D1).
-	method := opts.resolveMethod("gaze", env)
+	// Fallback chain (D2): Homebrew → dnf → go install → skip.
+	method := opts.resolveMethod("gaze", env, "homebrew", "dnf", "go")
 	switch method {
+	case "homebrew":
+		return installViaBrew(opts, "Gaze", "unbound-force/tap/gaze")
 	case "rpm", "dnf":
 		return installViaRpm(opts, "Gaze", "unbound-force/gaze", opts.Version)
-	case "homebrew":
-		if opts.DryRun {
-			return stepResult{name: "Gaze", action: "dry-run", detail: "Would install: brew install unbound-force/tap/gaze"}
-		}
-		if _, err := opts.ExecCmd("brew", "install", "unbound-force/tap/gaze"); err != nil {
-			return stepResult{name: "Gaze", action: "failed", detail: "brew install failed", err: err}
-		}
-		return stepResult{name: "Gaze", action: "installed", detail: "via Homebrew"}
 	case "go":
-		return installViaGo(opts, "Gaze", "github.com/unbound-force/gaze/cmd/gaze")
-	}
-
-	// Auto-mode fallback chain (D2): Homebrew → dnf → go install → skip.
-	if opts.DryRun {
-		if doctor.HasManager(env, doctor.ManagerHomebrew) {
-			return stepResult{name: "Gaze", action: "dry-run", detail: "Would install: brew install unbound-force/tap/gaze"}
+		result := installViaGo(opts, "Gaze", "github.com/unbound-force/gaze/cmd/gaze")
+		if result.action != "skipped" {
+			return result
 		}
-		if doctor.HasManager(env, doctor.ManagerDnf) {
-			return installViaRpm(opts, "Gaze", "unbound-force/gaze", opts.Version)
+		return stepResult{
+			name:   "Gaze",
+			action: "skipped",
+			detail: "Homebrew not available. Download from https://github.com/unbound-force/gaze/releases",
 		}
-		return installViaGo(opts, "Gaze", "github.com/unbound-force/gaze/cmd/gaze")
-	}
-
-	// Try Homebrew first.
-	if doctor.HasManager(env, doctor.ManagerHomebrew) {
-		if _, err := opts.ExecCmd("brew", "install", "unbound-force/tap/gaze"); err != nil {
-			return stepResult{name: "Gaze", action: "failed", detail: "brew install failed", err: err}
+	default:
+		return stepResult{
+			name:   "Gaze",
+			action: "skipped",
+			detail: "Homebrew not available. Download from https://github.com/unbound-force/gaze/releases",
 		}
-		return stepResult{name: "Gaze", action: "installed", detail: "via Homebrew"}
-	}
-
-	// Try dnf (RPM) when available.
-	if doctor.HasManager(env, doctor.ManagerDnf) {
-		return installViaRpm(opts, "Gaze", "unbound-force/gaze", opts.Version)
-	}
-
-	// Try go install as final fallback.
-	goResult := installViaGo(opts, "Gaze", "github.com/unbound-force/gaze/cmd/gaze")
-	if goResult.action != "skipped" {
-		return goResult
-	}
-
-	return stepResult{
-		name:   "Gaze",
-		action: "skipped",
-		detail: "Homebrew not available. Download from https://github.com/unbound-force/gaze/releases",
 	}
 }
 
@@ -845,58 +827,29 @@ func installReplicator(opts *Options, env doctor.DetectedEnvironment) stepResult
 		return stepResult{name: "Replicator", action: "already installed"}
 	}
 
-	// Method dispatch: resolveMethod centralizes per-tool override
-	// and global PackageManager precedence (D1).
-	method := opts.resolveMethod("replicator", env)
+	// Fallback chain (D2): Homebrew → dnf → go install → skip.
+	method := opts.resolveMethod("replicator", env, "homebrew", "dnf", "go")
 	switch method {
+	case "homebrew":
+		return installViaBrew(opts, "Replicator", "unbound-force/tap/replicator")
 	case "rpm", "dnf":
 		return installViaRpm(opts, "Replicator", "unbound-force/replicator", opts.Version)
-	case "homebrew":
-		if opts.DryRun {
-			return stepResult{name: "Replicator", action: "dry-run", detail: "Would install: brew install unbound-force/tap/replicator"}
-		}
-		if _, err := opts.ExecCmd("brew", "install", "unbound-force/tap/replicator"); err != nil {
-			return stepResult{name: "Replicator", action: "failed", detail: "brew install failed", err: err}
-		}
-		return stepResult{name: "Replicator", action: "installed", detail: "via Homebrew"}
 	case "go":
-		return installViaGo(opts, "Replicator", "github.com/unbound-force/replicator/cmd/replicator")
-	}
-
-	// Auto-mode fallback chain (D2): Homebrew → dnf → go install → skip.
-	if opts.DryRun {
-		if doctor.HasManager(env, doctor.ManagerHomebrew) {
-			return stepResult{name: "Replicator", action: "dry-run", detail: "Would install: brew install unbound-force/tap/replicator"}
+		result := installViaGo(opts, "Replicator", "github.com/unbound-force/replicator/cmd/replicator")
+		if result.action != "skipped" {
+			return result
 		}
-		if doctor.HasManager(env, doctor.ManagerDnf) {
-			return installViaRpm(opts, "Replicator", "unbound-force/replicator", opts.Version)
+		return stepResult{
+			name:   "Replicator",
+			action: "skipped",
+			detail: "Homebrew not available. Download from https://github.com/unbound-force/replicator/releases",
 		}
-		return installViaGo(opts, "Replicator", "github.com/unbound-force/replicator/cmd/replicator")
-	}
-
-	// Try Homebrew first.
-	if doctor.HasManager(env, doctor.ManagerHomebrew) {
-		if _, err := opts.ExecCmd("brew", "install", "unbound-force/tap/replicator"); err != nil {
-			return stepResult{name: "Replicator", action: "failed", detail: "brew install failed", err: err}
+	default:
+		return stepResult{
+			name:   "Replicator",
+			action: "skipped",
+			detail: "Homebrew not available. Download from https://github.com/unbound-force/replicator/releases",
 		}
-		return stepResult{name: "Replicator", action: "installed", detail: "via Homebrew"}
-	}
-
-	// Try dnf (RPM) when available.
-	if doctor.HasManager(env, doctor.ManagerDnf) {
-		return installViaRpm(opts, "Replicator", "unbound-force/replicator", opts.Version)
-	}
-
-	// Try go install as final fallback.
-	goResult := installViaGo(opts, "Replicator", "github.com/unbound-force/replicator/cmd/replicator")
-	if goResult.action != "skipped" {
-		return goResult
-	}
-
-	return stepResult{
-		name:   "Replicator",
-		action: "skipped",
-		detail: "Homebrew not available. Download from https://github.com/unbound-force/replicator/releases",
 	}
 }
 
@@ -1288,57 +1241,38 @@ func installDewey(opts *Options, env doctor.DetectedEnvironment) stepResult {
 		return pullEmbeddingModel(opts)
 	}
 
-	// Method dispatch: resolveMethod centralizes per-tool override
-	// and global PackageManager precedence (D1). Dewey has no RPMs,
-	// so "dnf" falls through to the default case (D1).
-	method := opts.resolveMethod("dewey", env)
+	// Fallback chain (D2): Homebrew → go install → skip.
+	// Dewey has no RPMs, so dnf is not in the fallback list.
+	method := opts.resolveMethod("dewey", env, "homebrew", "go")
 	switch method {
 	case "homebrew":
-		if opts.DryRun {
-			return stepResult{name: "Dewey", action: "dry-run", detail: "Would install: brew install unbound-force/tap/dewey"}
+		result := installViaBrew(opts, "Dewey", "unbound-force/tap/dewey")
+		if result.action == "installed" {
+			return deweyPostInstall(opts, result.detail)
 		}
-		if _, err := opts.ExecCmd("brew", "install", "unbound-force/tap/dewey"); err != nil {
-			return stepResult{name: "Dewey", action: "failed", detail: "brew install failed", err: err}
+		return result
+	case "dnf", "go":
+		// Dewey has no RPMs, so "dnf" falls through to go install
+		// per D5 design: tools without dnf support gracefully
+		// degrade to go install when Go is available.
+		result := installViaGo(opts, "Dewey", "github.com/unbound-force/dewey/cmd/dewey")
+		if result.action == "installed" {
+			return deweyPostInstall(opts, result.detail)
 		}
-		return deweyPostInstall(opts, "via Homebrew")
-	case "go":
-		goResult := installViaGo(opts, "Dewey", "github.com/unbound-force/dewey/cmd/dewey")
-		if goResult.action == "installed" {
-			return deweyPostInstall(opts, goResult.detail)
+		if result.action != "skipped" {
+			return result
 		}
-		return goResult
-	}
-
-	// Auto-mode (or "dnf" which falls through since Dewey has no RPMs):
-	// Homebrew → go install → skip.
-	if opts.DryRun {
-		if doctor.HasManager(env, doctor.ManagerHomebrew) {
-			return stepResult{name: "Dewey", action: "dry-run", detail: "Would install: brew install unbound-force/tap/dewey"}
+		return stepResult{
+			name:   "Dewey",
+			action: "skipped",
+			detail: "Homebrew not available. Install from https://github.com/unbound-force/dewey",
 		}
-		return installViaGo(opts, "Dewey", "github.com/unbound-force/dewey/cmd/dewey")
-	}
-
-	// Try Homebrew first.
-	if doctor.HasManager(env, doctor.ManagerHomebrew) {
-		if _, err := opts.ExecCmd("brew", "install", "unbound-force/tap/dewey"); err != nil {
-			return stepResult{name: "Dewey", action: "failed", detail: "brew install failed", err: err}
+	default:
+		return stepResult{
+			name:   "Dewey",
+			action: "skipped",
+			detail: "Homebrew not available. Install from https://github.com/unbound-force/dewey",
 		}
-		return deweyPostInstall(opts, "via Homebrew")
-	}
-
-	// Try go install as fallback (no dnf path — Dewey has no RPMs).
-	goResult := installViaGo(opts, "Dewey", "github.com/unbound-force/dewey/cmd/dewey")
-	if goResult.action == "installed" {
-		return deweyPostInstall(opts, goResult.detail)
-	}
-	if goResult.action != "skipped" {
-		return goResult
-	}
-
-	return stepResult{
-		name:   "Dewey",
-		action: "skipped",
-		detail: "Homebrew not available. Install from https://github.com/unbound-force/dewey",
 	}
 }
 

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -1067,6 +1067,7 @@ func TestInstallReplicator_NoHomebrew(t *testing.T) {
 		Getenv:       opts.Getenv,
 	})
 
+	// No Homebrew, no dnf, no Go → skips with download link.
 	result := installReplicator(&opts, env)
 	if result.action != "skipped" {
 		t.Errorf("expected 'skipped', got %q", result.action)
@@ -3443,9 +3444,15 @@ func TestInstallGaze_DryRunWithHomebrew(t *testing.T) {
 }
 
 func TestInstallGaze_DryRunNoHomebrew(t *testing.T) {
+	// With no Homebrew and no dnf, dry-run falls through to go install
+	// (or skipped if Go is not available).
 	opts := &Options{
-		DryRun:   true,
-		LookPath: stubLookPath(map[string]string{}),
+		DryRun: true,
+		LookPath: stubLookPath(map[string]string{
+			"go": "/usr/local/bin/go",
+		}),
+		Stdout: &bytes.Buffer{},
+		Stderr: &bytes.Buffer{},
 	}
 	env := doctor.DetectedEnvironment{}
 
@@ -3453,14 +3460,17 @@ func TestInstallGaze_DryRunNoHomebrew(t *testing.T) {
 	if result.action != "dry-run" {
 		t.Errorf("action = %q, want %q", result.action, "dry-run")
 	}
-	if !strings.Contains(result.detail, "GitHub releases") {
-		t.Errorf("detail = %q, want to contain 'GitHub releases'", result.detail)
+	if !strings.Contains(result.detail, "go install") {
+		t.Errorf("detail = %q, want to contain 'go install'", result.detail)
 	}
 }
 
 func TestInstallGaze_NoHomebrewSkip(t *testing.T) {
+	// No Homebrew, no dnf, no Go → skips with download link.
 	opts := &Options{
 		LookPath: stubLookPath(map[string]string{}),
+		Stdout:   &bytes.Buffer{},
+		Stderr:   &bytes.Buffer{},
 	}
 	env := doctor.DetectedEnvironment{}
 
@@ -3560,5 +3570,765 @@ func TestInstallGaze_ExplicitHomebrewDryRun(t *testing.T) {
 	}
 	if !strings.Contains(result.detail, "brew install") {
 		t.Errorf("detail = %q, want to contain 'brew install'", result.detail)
+	}
+}
+
+// --- resolveMethod tests (Task 1.3) ---
+
+func TestResolveMethod(t *testing.T) {
+	env := doctor.DetectedEnvironment{}
+
+	tests := []struct {
+		name           string
+		toolName       string
+		packageManager string
+		toolMethods    map[string]config.ToolConfig
+		want           string
+		wantStderr     string // substring expected in stderr output
+	}{
+		{
+			name:     "per-tool override wins over global",
+			toolName: "gaze",
+			packageManager: "dnf",
+			toolMethods: map[string]config.ToolConfig{
+				"gaze": {Method: "homebrew"},
+			},
+			want: "homebrew",
+		},
+		{
+			name:           "global dnf returns dnf",
+			toolName:       "gaze",
+			packageManager: "dnf",
+			want:           "dnf",
+		},
+		{
+			name:           "global homebrew returns homebrew",
+			toolName:       "gaze",
+			packageManager: "homebrew",
+			want:           "homebrew",
+		},
+		{
+			name:           "apt maps to auto with info message",
+			toolName:       "gaze",
+			packageManager: "apt",
+			want:           "auto",
+			wantStderr:     "apt support not yet implemented",
+		},
+		{
+			name:           "auto passes through",
+			toolName:       "gaze",
+			packageManager: "auto",
+			want:           "auto",
+		},
+		{
+			name:           "empty PackageManager defaults to auto",
+			toolName:       "gaze",
+			packageManager: "",
+			want:           "auto",
+		},
+		{
+			name:     "per-tool rpm override",
+			toolName: "gaze",
+			toolMethods: map[string]config.ToolConfig{
+				"gaze": {Method: "rpm"},
+			},
+			want: "rpm",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var stderr bytes.Buffer
+			opts := &Options{
+				PackageManager: tt.packageManager,
+				ToolMethods:    tt.toolMethods,
+				Stderr:         &stderr,
+			}
+			opts.defaults()
+
+			got := opts.resolveMethod(tt.toolName, env)
+			if got != tt.want {
+				t.Errorf("resolveMethod(%q) = %q, want %q", tt.toolName, got, tt.want)
+			}
+			if tt.wantStderr != "" {
+				if !strings.Contains(stderr.String(), tt.wantStderr) {
+					t.Errorf("stderr = %q, want to contain %q", stderr.String(), tt.wantStderr)
+				}
+			}
+		})
+	}
+}
+
+// --- installViaGo tests (Task 1.4) ---
+
+func TestInstallViaGo(t *testing.T) {
+	const testModule = "github.com/example/tool/cmd/tool"
+
+	tests := []struct {
+		name       string
+		lookPath   map[string]string
+		execErrors map[string]error
+		dryRun     bool
+		wantAction string
+		wantDetail string
+		wantErr    bool
+	}{
+		{
+			name:       "success",
+			lookPath:   map[string]string{"go": "/usr/local/bin/go"},
+			wantAction: "installed",
+			wantDetail: "via go install",
+		},
+		{
+			name:     "go install fails",
+			lookPath: map[string]string{"go": "/usr/local/bin/go"},
+			execErrors: map[string]error{
+				"go install " + testModule + "@latest": fmt.Errorf("compilation error"),
+			},
+			wantAction: "failed",
+			wantDetail: testModule,
+			wantErr:    true,
+		},
+		{
+			name:       "go not available",
+			lookPath:   map[string]string{},
+			wantAction: "skipped",
+			wantDetail: "Go not available",
+			wantErr:    false,
+		},
+		{
+			name:       "dry-run",
+			lookPath:   map[string]string{"go": "/usr/local/bin/go"},
+			dryRun:     true,
+			wantAction: "dry-run",
+			wantDetail: "Would install: go install " + testModule + "@latest",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := &cmdRecorder{
+				errors: tt.execErrors,
+			}
+			if rec.errors == nil {
+				rec.errors = map[string]error{}
+			}
+
+			opts := &Options{
+				DryRun:   tt.dryRun,
+				LookPath: stubLookPath(tt.lookPath),
+				ExecCmd:  rec.execCmd,
+				Stdout:   &bytes.Buffer{},
+				Stderr:   &bytes.Buffer{},
+			}
+
+			result := installViaGo(opts, "TestTool", testModule)
+
+			if result.action != tt.wantAction {
+				t.Errorf("action = %q, want %q", result.action, tt.wantAction)
+			}
+			if !strings.Contains(result.detail, tt.wantDetail) {
+				t.Errorf("detail = %q, want to contain %q", result.detail, tt.wantDetail)
+			}
+			if tt.wantErr && result.err == nil {
+				t.Error("expected non-nil error")
+			}
+			if !tt.wantErr && result.err != nil {
+				t.Errorf("unexpected error: %v", result.err)
+			}
+		})
+	}
+}
+
+// --- installGaze fallback chain tests (Task 2.2) ---
+
+func TestInstallGaze_DnfFallback(t *testing.T) {
+	// No Homebrew, dnf available → installs via RPM.
+	rec := &cmdRecorder{}
+	opts := &Options{
+		Version:  "1.0.0",
+		LookPath: stubLookPath(map[string]string{}),
+		ExecCmd:  rec.execCmd,
+		Stdout:   &bytes.Buffer{},
+		Stderr:   &bytes.Buffer{},
+	}
+	env := doctor.DetectedEnvironment{
+		Managers: []doctor.ManagerInfo{
+			{Kind: doctor.ManagerDnf, Path: "/usr/bin/dnf"},
+		},
+	}
+
+	result := installGaze(opts, env)
+	if result.action != "installed" {
+		t.Errorf("action = %q, want installed", result.action)
+	}
+	if !strings.Contains(result.detail, "dnf") {
+		t.Errorf("detail = %q, want to contain 'dnf'", result.detail)
+	}
+}
+
+func TestInstallGaze_GoInstallFallback(t *testing.T) {
+	// No Homebrew, no dnf, Go available → installs via go install.
+	rec := &cmdRecorder{}
+	opts := &Options{
+		LookPath: stubLookPath(map[string]string{
+			"go": "/usr/local/bin/go",
+		}),
+		ExecCmd: rec.execCmd,
+		Stdout:  &bytes.Buffer{},
+		Stderr:  &bytes.Buffer{},
+	}
+	env := doctor.DetectedEnvironment{}
+
+	result := installGaze(opts, env)
+	if result.action != "installed" {
+		t.Errorf("action = %q, want installed", result.action)
+	}
+	if !strings.Contains(result.detail, "go install") {
+		t.Errorf("detail = %q, want to contain 'go install'", result.detail)
+	}
+}
+
+func TestInstallGaze_NoManagersNoGo(t *testing.T) {
+	// No Homebrew, no dnf, no Go → skips.
+	opts := &Options{
+		LookPath: stubLookPath(map[string]string{}),
+		Stdout:   &bytes.Buffer{},
+		Stderr:   &bytes.Buffer{},
+	}
+	env := doctor.DetectedEnvironment{}
+
+	result := installGaze(opts, env)
+	if result.action != "skipped" {
+		t.Errorf("action = %q, want skipped", result.action)
+	}
+}
+
+func TestInstallGaze_PackageManagerDnf(t *testing.T) {
+	// PackageManager: "dnf" → skips Homebrew, uses dnf directly.
+	rec := &cmdRecorder{}
+	opts := &Options{
+		PackageManager: "dnf",
+		Version:        "1.0.0",
+		LookPath:       stubLookPath(map[string]string{}),
+		ExecCmd:        rec.execCmd,
+		Stdout:         &bytes.Buffer{},
+		Stderr:         &bytes.Buffer{},
+	}
+	opts.defaults()
+	env := doctor.DetectedEnvironment{
+		Managers: []doctor.ManagerInfo{
+			{Kind: doctor.ManagerHomebrew, Path: "/opt/homebrew/bin/brew"},
+			{Kind: doctor.ManagerDnf, Path: "/usr/bin/dnf"},
+		},
+	}
+
+	result := installGaze(opts, env)
+	if result.action != "installed" {
+		t.Errorf("action = %q, want installed", result.action)
+	}
+	if !strings.Contains(result.detail, "dnf") {
+		t.Errorf("detail = %q, want to contain 'dnf'", result.detail)
+	}
+	// Verify no brew install was called.
+	for _, call := range rec.calls {
+		if strings.Contains(call, "brew") {
+			t.Errorf("unexpected brew call when PackageManager=dnf: %s", call)
+		}
+	}
+}
+
+func TestInstallGaze_ExplicitGoMethod(t *testing.T) {
+	rec := &cmdRecorder{}
+	opts := &Options{
+		LookPath: stubLookPath(map[string]string{
+			"go": "/usr/local/bin/go",
+		}),
+		ExecCmd: rec.execCmd,
+		ToolMethods: map[string]config.ToolConfig{
+			"gaze": {Method: "go"},
+		},
+		Stdout: &bytes.Buffer{},
+		Stderr: &bytes.Buffer{},
+	}
+	env := doctor.DetectedEnvironment{
+		Managers: []doctor.ManagerInfo{
+			{Kind: doctor.ManagerHomebrew, Path: "/opt/homebrew/bin/brew"},
+		},
+	}
+
+	result := installGaze(opts, env)
+	if result.action != "installed" {
+		t.Errorf("action = %q, want installed", result.action)
+	}
+	if !strings.Contains(result.detail, "go install") {
+		t.Errorf("detail = %q, want to contain 'go install'", result.detail)
+	}
+}
+
+// --- installReplicator fallback chain tests (Task 3.3) ---
+
+func TestInstallReplicator_DnfFallback(t *testing.T) {
+	rec := &cmdRecorder{}
+	opts := Options{
+		Version:  "1.0.0",
+		LookPath: stubLookPath(map[string]string{}),
+		ExecCmd:  rec.execCmd,
+		Stdout:   &bytes.Buffer{},
+		Stderr:   &bytes.Buffer{},
+	}
+	env := doctor.DetectedEnvironment{
+		Managers: []doctor.ManagerInfo{
+			{Kind: doctor.ManagerDnf, Path: "/usr/bin/dnf"},
+		},
+	}
+
+	result := installReplicator(&opts, env)
+	if result.action != "installed" {
+		t.Errorf("action = %q, want installed", result.action)
+	}
+	if !strings.Contains(result.detail, "dnf") {
+		t.Errorf("detail = %q, want to contain 'dnf'", result.detail)
+	}
+}
+
+func TestInstallReplicator_GoInstallFallback(t *testing.T) {
+	rec := &cmdRecorder{}
+	opts := Options{
+		LookPath: stubLookPath(map[string]string{
+			"go": "/usr/local/bin/go",
+		}),
+		ExecCmd: rec.execCmd,
+		Stdout:  &bytes.Buffer{},
+		Stderr:  &bytes.Buffer{},
+	}
+	env := doctor.DetectedEnvironment{}
+
+	result := installReplicator(&opts, env)
+	if result.action != "installed" {
+		t.Errorf("action = %q, want installed", result.action)
+	}
+	if !strings.Contains(result.detail, "go install") {
+		t.Errorf("detail = %q, want to contain 'go install'", result.detail)
+	}
+}
+
+func TestInstallReplicator_NoManagersNoGo(t *testing.T) {
+	opts := Options{
+		LookPath: stubLookPath(map[string]string{}),
+		Stdout:   &bytes.Buffer{},
+		Stderr:   &bytes.Buffer{},
+	}
+	env := doctor.DetectedEnvironment{}
+
+	result := installReplicator(&opts, env)
+	if result.action != "skipped" {
+		t.Errorf("action = %q, want skipped", result.action)
+	}
+}
+
+func TestInstallReplicator_PackageManagerDnf(t *testing.T) {
+	rec := &cmdRecorder{}
+	opts := Options{
+		PackageManager: "dnf",
+		Version:        "1.0.0",
+		LookPath:       stubLookPath(map[string]string{}),
+		ExecCmd:        rec.execCmd,
+		Stdout:         &bytes.Buffer{},
+		Stderr:         &bytes.Buffer{},
+	}
+	opts.defaults()
+	env := doctor.DetectedEnvironment{
+		Managers: []doctor.ManagerInfo{
+			{Kind: doctor.ManagerHomebrew, Path: "/opt/homebrew/bin/brew"},
+			{Kind: doctor.ManagerDnf, Path: "/usr/bin/dnf"},
+		},
+	}
+
+	result := installReplicator(&opts, env)
+	if result.action != "installed" {
+		t.Errorf("action = %q, want installed", result.action)
+	}
+	if !strings.Contains(result.detail, "dnf") {
+		t.Errorf("detail = %q, want to contain 'dnf'", result.detail)
+	}
+	for _, call := range rec.calls {
+		if strings.Contains(call, "brew") {
+			t.Errorf("unexpected brew call when PackageManager=dnf: %s", call)
+		}
+	}
+}
+
+func TestInstallReplicator_ExplicitGoMethod(t *testing.T) {
+	rec := &cmdRecorder{}
+	opts := Options{
+		LookPath: stubLookPath(map[string]string{
+			"go": "/usr/local/bin/go",
+		}),
+		ExecCmd: rec.execCmd,
+		ToolMethods: map[string]config.ToolConfig{
+			"replicator": {Method: "go"},
+		},
+		Stdout: &bytes.Buffer{},
+		Stderr: &bytes.Buffer{},
+	}
+	env := doctor.DetectedEnvironment{}
+
+	result := installReplicator(&opts, env)
+	if result.action != "installed" {
+		t.Errorf("action = %q, want installed", result.action)
+	}
+	if !strings.Contains(result.detail, "go install") {
+		t.Errorf("detail = %q, want to contain 'go install'", result.detail)
+	}
+}
+
+// --- installDewey fallback chain tests (Task 4.3) ---
+
+func TestInstallDewey_GoInstallFallback(t *testing.T) {
+	// No Homebrew, Go available → installs via go install + pulls model.
+	rec := &cmdRecorder{
+		outputs: map[string]string{
+			"ollama list": "NAME\ngranite-embedding:30m   abc123   63 MB\n",
+		},
+	}
+	opts := &Options{
+		LookPath: stubLookPath(map[string]string{
+			"go":     "/usr/local/bin/go",
+			"ollama": "/usr/local/bin/ollama",
+		}),
+		ExecCmd: rec.execCmd,
+		Stdout:  &bytes.Buffer{},
+		Stderr:  &bytes.Buffer{},
+	}
+	opts.defaults()
+	env := doctor.DetectedEnvironment{}
+
+	result := installDewey(opts, env)
+	if result.action != "installed" {
+		t.Errorf("action = %q, want installed", result.action)
+	}
+	if !strings.Contains(result.detail, "go install") {
+		t.Errorf("detail = %q, want to contain 'go install'", result.detail)
+	}
+}
+
+func TestInstallDewey_NoHomebrewNoGo(t *testing.T) {
+	opts := &Options{
+		LookPath: stubLookPath(map[string]string{}),
+		Stdout:   &bytes.Buffer{},
+		Stderr:   &bytes.Buffer{},
+	}
+	opts.defaults()
+	env := doctor.DetectedEnvironment{}
+
+	result := installDewey(opts, env)
+	if result.action != "skipped" {
+		t.Errorf("action = %q, want skipped", result.action)
+	}
+}
+
+func TestInstallDewey_PackageManagerDnfFallsToGo(t *testing.T) {
+	// PackageManager: "dnf" → resolveMethod returns "dnf", but Dewey
+	// has no dnf case, so it falls through to go install.
+	rec := &cmdRecorder{
+		outputs: map[string]string{
+			"ollama list": "NAME\ngranite-embedding:30m   abc123   63 MB\n",
+		},
+	}
+	opts := &Options{
+		PackageManager: "dnf",
+		LookPath: stubLookPath(map[string]string{
+			"go":     "/usr/local/bin/go",
+			"ollama": "/usr/local/bin/ollama",
+		}),
+		ExecCmd: rec.execCmd,
+		Stdout:  &bytes.Buffer{},
+		Stderr:  &bytes.Buffer{},
+	}
+	opts.defaults()
+	env := doctor.DetectedEnvironment{}
+
+	result := installDewey(opts, env)
+	if result.action != "installed" {
+		t.Errorf("action = %q, want installed", result.action)
+	}
+	if !strings.Contains(result.detail, "go install") {
+		t.Errorf("detail = %q, want to contain 'go install'", result.detail)
+	}
+}
+
+func TestInstallDewey_ExplicitGoMethod(t *testing.T) {
+	rec := &cmdRecorder{
+		outputs: map[string]string{
+			"ollama list": "NAME\ngranite-embedding:30m   abc123   63 MB\n",
+		},
+	}
+	opts := &Options{
+		LookPath: stubLookPath(map[string]string{
+			"go":     "/usr/local/bin/go",
+			"ollama": "/usr/local/bin/ollama",
+		}),
+		ExecCmd: rec.execCmd,
+		ToolMethods: map[string]config.ToolConfig{
+			"dewey": {Method: "go"},
+		},
+		Stdout: &bytes.Buffer{},
+		Stderr: &bytes.Buffer{},
+	}
+	opts.defaults()
+	env := doctor.DetectedEnvironment{}
+
+	result := installDewey(opts, env)
+	if result.action != "installed" {
+		t.Errorf("action = %q, want installed", result.action)
+	}
+	if !strings.Contains(result.detail, "go install") {
+		t.Errorf("detail = %q, want to contain 'go install'", result.detail)
+	}
+}
+
+// --- installGH fallback chain tests (Task 5.3) ---
+
+func TestInstallGH_DnfFallback(t *testing.T) {
+	// No Homebrew, dnf available → attempts dnf install gh.
+	rec := &cmdRecorder{}
+	opts := &Options{
+		LookPath: stubLookPath(map[string]string{}),
+		ExecCmd:  rec.execCmd,
+		Stdout:   &bytes.Buffer{},
+		Stderr:   &bytes.Buffer{},
+	}
+	env := doctor.DetectedEnvironment{
+		Managers: []doctor.ManagerInfo{
+			{Kind: doctor.ManagerDnf, Path: "/usr/bin/dnf"},
+		},
+	}
+
+	result := installGH(opts, env)
+	if result.action != "installed" {
+		t.Errorf("action = %q, want installed", result.action)
+	}
+	if !strings.Contains(result.detail, "dnf") {
+		t.Errorf("detail = %q, want to contain 'dnf'", result.detail)
+	}
+}
+
+func TestInstallGH_DnfFails_SkipsGracefully(t *testing.T) {
+	// dnf install gh fails → skipped (NOT failed), with actionable link.
+	rec := &cmdRecorder{
+		errors: map[string]error{
+			"dnf install -y gh": fmt.Errorf("No match for argument: gh"),
+		},
+	}
+	opts := &Options{
+		LookPath: stubLookPath(map[string]string{}),
+		ExecCmd:  rec.execCmd,
+		Stdout:   &bytes.Buffer{},
+		Stderr:   &bytes.Buffer{},
+	}
+	env := doctor.DetectedEnvironment{
+		Managers: []doctor.ManagerInfo{
+			{Kind: doctor.ManagerDnf, Path: "/usr/bin/dnf"},
+		},
+	}
+
+	result := installGH(opts, env)
+	if result.action != "skipped" {
+		t.Errorf("action = %q, want skipped (graceful degradation)", result.action)
+	}
+	if result.err != nil {
+		t.Errorf("err should be nil for graceful degradation, got: %v", result.err)
+	}
+	if !strings.Contains(result.detail, "install_linux.md") {
+		t.Errorf("detail = %q, want to contain repo setup URL", result.detail)
+	}
+}
+
+func TestInstallGH_PackageManagerDnf(t *testing.T) {
+	// PackageManager: "dnf" → skips Homebrew, uses dnf directly.
+	rec := &cmdRecorder{}
+	opts := &Options{
+		PackageManager: "dnf",
+		LookPath:       stubLookPath(map[string]string{}),
+		ExecCmd:        rec.execCmd,
+		Stdout:         &bytes.Buffer{},
+		Stderr:         &bytes.Buffer{},
+	}
+	opts.defaults()
+	env := doctor.DetectedEnvironment{
+		Managers: []doctor.ManagerInfo{
+			{Kind: doctor.ManagerHomebrew, Path: "/opt/homebrew/bin/brew"},
+			{Kind: doctor.ManagerDnf, Path: "/usr/bin/dnf"},
+		},
+	}
+
+	result := installGH(opts, env)
+	if result.action != "installed" {
+		t.Errorf("action = %q, want installed", result.action)
+	}
+	if !strings.Contains(result.detail, "dnf") {
+		t.Errorf("detail = %q, want to contain 'dnf'", result.detail)
+	}
+	for _, call := range rec.calls {
+		if strings.Contains(call, "brew") {
+			t.Errorf("unexpected brew call when PackageManager=dnf: %s", call)
+		}
+	}
+}
+
+func TestInstallGH_ExplicitDnfDryRun(t *testing.T) {
+	opts := &Options{
+		DryRun:         true,
+		PackageManager: "dnf",
+		LookPath:       stubLookPath(map[string]string{}),
+		Stdout:         &bytes.Buffer{},
+		Stderr:         &bytes.Buffer{},
+	}
+	opts.defaults()
+	env := doctor.DetectedEnvironment{}
+
+	result := installGH(opts, env)
+	if result.action != "dry-run" {
+		t.Errorf("action = %q, want dry-run", result.action)
+	}
+	if !strings.Contains(result.detail, "dnf install -y gh") {
+		t.Errorf("detail = %q, want to contain 'dnf install -y gh'", result.detail)
+	}
+}
+
+// --- Dry-run fallback chain tests (Task 6.1 + 6.2) ---
+
+func TestInstallGaze_DryRunDnfFallback(t *testing.T) {
+	opts := &Options{
+		DryRun:   true,
+		Version:  "1.0.0",
+		LookPath: stubLookPath(map[string]string{}),
+		ExecCmd:  (&cmdRecorder{}).execCmd,
+		Stdout:   &bytes.Buffer{},
+		Stderr:   &bytes.Buffer{},
+	}
+	env := doctor.DetectedEnvironment{
+		Managers: []doctor.ManagerInfo{
+			{Kind: doctor.ManagerDnf, Path: "/usr/bin/dnf"},
+		},
+	}
+
+	result := installGaze(opts, env)
+	if result.action != "dry-run" {
+		t.Errorf("action = %q, want dry-run", result.action)
+	}
+	if !strings.Contains(result.detail, "dnf install") {
+		t.Errorf("detail = %q, want to contain 'dnf install'", result.detail)
+	}
+}
+
+func TestInstallGaze_DryRunGoFallback(t *testing.T) {
+	opts := &Options{
+		DryRun: true,
+		LookPath: stubLookPath(map[string]string{
+			"go": "/usr/local/bin/go",
+		}),
+		ExecCmd: (&cmdRecorder{}).execCmd,
+		Stdout:  &bytes.Buffer{},
+		Stderr:  &bytes.Buffer{},
+	}
+	env := doctor.DetectedEnvironment{}
+
+	result := installGaze(opts, env)
+	if result.action != "dry-run" {
+		t.Errorf("action = %q, want dry-run", result.action)
+	}
+	if !strings.Contains(result.detail, "go install") {
+		t.Errorf("detail = %q, want to contain 'go install'", result.detail)
+	}
+}
+
+func TestInstallReplicator_DryRunDnfFallback(t *testing.T) {
+	opts := Options{
+		DryRun:   true,
+		Version:  "1.0.0",
+		LookPath: stubLookPath(map[string]string{}),
+		ExecCmd:  (&cmdRecorder{}).execCmd,
+		Stdout:   &bytes.Buffer{},
+		Stderr:   &bytes.Buffer{},
+	}
+	env := doctor.DetectedEnvironment{
+		Managers: []doctor.ManagerInfo{
+			{Kind: doctor.ManagerDnf, Path: "/usr/bin/dnf"},
+		},
+	}
+
+	result := installReplicator(&opts, env)
+	if result.action != "dry-run" {
+		t.Errorf("action = %q, want dry-run", result.action)
+	}
+	if !strings.Contains(result.detail, "dnf install") {
+		t.Errorf("detail = %q, want to contain 'dnf install'", result.detail)
+	}
+}
+
+func TestInstallReplicator_DryRunGoFallback(t *testing.T) {
+	opts := Options{
+		DryRun: true,
+		LookPath: stubLookPath(map[string]string{
+			"go": "/usr/local/bin/go",
+		}),
+		ExecCmd: (&cmdRecorder{}).execCmd,
+		Stdout:  &bytes.Buffer{},
+		Stderr:  &bytes.Buffer{},
+	}
+	env := doctor.DetectedEnvironment{}
+
+	result := installReplicator(&opts, env)
+	if result.action != "dry-run" {
+		t.Errorf("action = %q, want dry-run", result.action)
+	}
+	if !strings.Contains(result.detail, "go install") {
+		t.Errorf("detail = %q, want to contain 'go install'", result.detail)
+	}
+}
+
+func TestInstallDewey_DryRunGoFallback(t *testing.T) {
+	opts := &Options{
+		DryRun: true,
+		LookPath: stubLookPath(map[string]string{
+			"go": "/usr/local/bin/go",
+		}),
+		ExecCmd: (&cmdRecorder{}).execCmd,
+		Stdout:  &bytes.Buffer{},
+		Stderr:  &bytes.Buffer{},
+	}
+	opts.defaults()
+	env := doctor.DetectedEnvironment{}
+
+	result := installDewey(opts, env)
+	if result.action != "dry-run" {
+		t.Errorf("action = %q, want dry-run", result.action)
+	}
+	if !strings.Contains(result.detail, "go install") {
+		t.Errorf("detail = %q, want to contain 'go install'", result.detail)
+	}
+}
+
+func TestInstallGH_DryRunDnfFallback(t *testing.T) {
+	opts := &Options{
+		DryRun:   true,
+		LookPath: stubLookPath(map[string]string{}),
+		Stdout:   &bytes.Buffer{},
+		Stderr:   &bytes.Buffer{},
+	}
+	env := doctor.DetectedEnvironment{
+		Managers: []doctor.ManagerInfo{
+			{Kind: doctor.ManagerDnf, Path: "/usr/bin/dnf"},
+		},
+	}
+
+	result := installGH(opts, env)
+	if result.action != "dry-run" {
+		t.Errorf("action = %q, want dry-run", result.action)
+	}
+	if !strings.Contains(result.detail, "dnf install -y gh") {
+		t.Errorf("detail = %q, want to contain 'dnf install -y gh'", result.detail)
 	}
 }

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -3583,6 +3583,7 @@ func TestResolveMethod(t *testing.T) {
 		toolName       string
 		packageManager string
 		toolMethods    map[string]config.ToolConfig
+		fallbacks      []string
 		want           string
 		wantStderr     string // substring expected in stderr output
 	}{
@@ -3608,23 +3609,32 @@ func TestResolveMethod(t *testing.T) {
 			want:           "homebrew",
 		},
 		{
-			name:           "apt maps to auto with info message",
+			name:           "apt falls through to first fallback",
 			toolName:       "gaze",
 			packageManager: "apt",
-			want:           "auto",
+			fallbacks:      []string{"homebrew", "dnf", "go"},
+			want:           "go",
 			wantStderr:     "apt support not yet implemented",
 		},
 		{
-			name:           "auto passes through",
+			name:           "auto resolves to first matching fallback",
 			toolName:       "gaze",
 			packageManager: "auto",
-			want:           "auto",
+			fallbacks:      []string{"homebrew", "dnf", "go"},
+			want:           "go",
 		},
 		{
-			name:           "empty PackageManager defaults to auto",
+			name:           "empty PackageManager resolves to first matching fallback",
 			toolName:       "gaze",
 			packageManager: "",
-			want:           "auto",
+			fallbacks:      []string{"homebrew", "dnf", "go"},
+			want:           "go",
+		},
+		{
+			name:           "auto with no fallbacks returns skip",
+			toolName:       "gaze",
+			packageManager: "",
+			want:           "skip",
 		},
 		{
 			name:     "per-tool rpm override",
@@ -3646,7 +3656,7 @@ func TestResolveMethod(t *testing.T) {
 			}
 			opts.defaults()
 
-			got := opts.resolveMethod(tt.toolName, env)
+			got := opts.resolveMethod(tt.toolName, env, tt.fallbacks...)
 			if got != tt.want {
 				t.Errorf("resolveMethod(%q) = %q, want %q", tt.toolName, got, tt.want)
 			}
@@ -4308,6 +4318,611 @@ func TestInstallDewey_DryRunGoFallback(t *testing.T) {
 	}
 	if !strings.Contains(result.detail, "go install") {
 		t.Errorf("detail = %q, want to contain 'go install'", result.detail)
+	}
+}
+
+// --- installGH explicit Homebrew and auto-mode Homebrew tests ---
+
+func TestInstallGH_ExplicitHomebrew(t *testing.T) {
+	// resolveMethod returns "homebrew" via per-tool override → brew install succeeds.
+	rec := &cmdRecorder{}
+	opts := &Options{
+		LookPath: stubLookPath(map[string]string{}),
+		ExecCmd:  rec.execCmd,
+		ToolMethods: map[string]config.ToolConfig{
+			"gh": {Method: "homebrew"},
+		},
+		Stdout: &bytes.Buffer{},
+		Stderr: &bytes.Buffer{},
+	}
+	env := doctor.DetectedEnvironment{}
+
+	result := installGH(opts, env)
+	if result.action != "installed" {
+		t.Errorf("action = %q, want installed", result.action)
+	}
+	if !strings.Contains(result.detail, "Homebrew") {
+		t.Errorf("detail = %q, want to contain 'Homebrew'", result.detail)
+	}
+	found := false
+	for _, call := range rec.calls {
+		if call == "brew install gh" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected 'brew install gh' call, got: %v", rec.calls)
+	}
+}
+
+func TestInstallGH_ExplicitHomebrewFails(t *testing.T) {
+	// resolveMethod returns "homebrew" via per-tool override → brew install fails.
+	rec := &cmdRecorder{
+		errors: map[string]error{
+			"brew install gh": fmt.Errorf("brew: formula not found"),
+		},
+	}
+	opts := &Options{
+		LookPath: stubLookPath(map[string]string{}),
+		ExecCmd:  rec.execCmd,
+		ToolMethods: map[string]config.ToolConfig{
+			"gh": {Method: "homebrew"},
+		},
+		Stdout: &bytes.Buffer{},
+		Stderr: &bytes.Buffer{},
+	}
+	env := doctor.DetectedEnvironment{}
+
+	result := installGH(opts, env)
+	if result.action != "failed" {
+		t.Errorf("action = %q, want failed", result.action)
+	}
+	if result.err == nil {
+		t.Error("expected non-nil error")
+	}
+}
+
+func TestInstallGH_ExplicitHomebrewDryRun(t *testing.T) {
+	// resolveMethod returns "homebrew" via per-tool override, dry-run mode.
+	opts := &Options{
+		DryRun:   true,
+		LookPath: stubLookPath(map[string]string{}),
+		ToolMethods: map[string]config.ToolConfig{
+			"gh": {Method: "homebrew"},
+		},
+		Stdout: &bytes.Buffer{},
+		Stderr: &bytes.Buffer{},
+	}
+	env := doctor.DetectedEnvironment{}
+
+	result := installGH(opts, env)
+	if result.action != "dry-run" {
+		t.Errorf("action = %q, want dry-run", result.action)
+	}
+	if !strings.Contains(result.detail, "brew install gh") {
+		t.Errorf("detail = %q, want to contain 'brew install gh'", result.detail)
+	}
+}
+
+func TestInstallGH_AutoHomebrewAvailable(t *testing.T) {
+	// Auto mode, Homebrew available → brew install succeeds.
+	rec := &cmdRecorder{}
+	opts := &Options{
+		LookPath: stubLookPath(map[string]string{}),
+		ExecCmd:  rec.execCmd,
+		Stdout:   &bytes.Buffer{},
+		Stderr:   &bytes.Buffer{},
+	}
+	env := doctor.DetectedEnvironment{
+		Managers: []doctor.ManagerInfo{
+			{Kind: doctor.ManagerHomebrew, Path: "/opt/homebrew/bin/brew"},
+		},
+	}
+
+	result := installGH(opts, env)
+	if result.action != "installed" {
+		t.Errorf("action = %q, want installed", result.action)
+	}
+	if !strings.Contains(result.detail, "Homebrew") {
+		t.Errorf("detail = %q, want to contain 'Homebrew'", result.detail)
+	}
+}
+
+func TestInstallGH_AutoHomebrewFails(t *testing.T) {
+	// Auto mode, Homebrew available → brew install fails.
+	rec := &cmdRecorder{
+		errors: map[string]error{
+			"brew install gh": fmt.Errorf("brew error"),
+		},
+	}
+	opts := &Options{
+		LookPath: stubLookPath(map[string]string{}),
+		ExecCmd:  rec.execCmd,
+		Stdout:   &bytes.Buffer{},
+		Stderr:   &bytes.Buffer{},
+	}
+	env := doctor.DetectedEnvironment{
+		Managers: []doctor.ManagerInfo{
+			{Kind: doctor.ManagerHomebrew, Path: "/opt/homebrew/bin/brew"},
+		},
+	}
+
+	result := installGH(opts, env)
+	if result.action != "failed" {
+		t.Errorf("action = %q, want failed", result.action)
+	}
+	if result.err == nil {
+		t.Error("expected non-nil error")
+	}
+}
+
+func TestInstallGH_AutoDryRunHomebrew(t *testing.T) {
+	// Auto mode, dry-run, Homebrew available → dry-run with brew hint.
+	opts := &Options{
+		DryRun:   true,
+		LookPath: stubLookPath(map[string]string{}),
+		Stdout:   &bytes.Buffer{},
+		Stderr:   &bytes.Buffer{},
+	}
+	env := doctor.DetectedEnvironment{
+		Managers: []doctor.ManagerInfo{
+			{Kind: doctor.ManagerHomebrew, Path: "/opt/homebrew/bin/brew"},
+		},
+	}
+
+	result := installGH(opts, env)
+	if result.action != "dry-run" {
+		t.Errorf("action = %q, want dry-run", result.action)
+	}
+	if !strings.Contains(result.detail, "brew install gh") {
+		t.Errorf("detail = %q, want to contain 'brew install gh'", result.detail)
+	}
+}
+
+func TestInstallGH_AutoDryRunNoManagers(t *testing.T) {
+	// Auto mode, dry-run, no managers → dry-run with download link.
+	opts := &Options{
+		DryRun:   true,
+		LookPath: stubLookPath(map[string]string{}),
+		Stdout:   &bytes.Buffer{},
+		Stderr:   &bytes.Buffer{},
+	}
+	env := doctor.DetectedEnvironment{}
+
+	result := installGH(opts, env)
+	if result.action != "dry-run" {
+		t.Errorf("action = %q, want dry-run", result.action)
+	}
+	if !strings.Contains(result.detail, "cli.github.com") {
+		t.Errorf("detail = %q, want to contain 'cli.github.com'", result.detail)
+	}
+}
+
+// --- installReplicator explicit Homebrew and auto-mode tests ---
+
+func TestInstallReplicator_ExplicitHomebrew(t *testing.T) {
+	// resolveMethod returns "homebrew" via per-tool override → brew install succeeds.
+	rec := &cmdRecorder{}
+	opts := Options{
+		LookPath: stubLookPath(map[string]string{}),
+		ExecCmd:  rec.execCmd,
+		ToolMethods: map[string]config.ToolConfig{
+			"replicator": {Method: "homebrew"},
+		},
+		Stdout: &bytes.Buffer{},
+		Stderr: &bytes.Buffer{},
+	}
+	env := doctor.DetectedEnvironment{}
+
+	result := installReplicator(&opts, env)
+	if result.action != "installed" {
+		t.Errorf("action = %q, want installed", result.action)
+	}
+	if !strings.Contains(result.detail, "Homebrew") {
+		t.Errorf("detail = %q, want to contain 'Homebrew'", result.detail)
+	}
+	found := false
+	for _, call := range rec.calls {
+		if call == "brew install unbound-force/tap/replicator" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected brew install call, got: %v", rec.calls)
+	}
+}
+
+func TestInstallReplicator_ExplicitHomebrewFails(t *testing.T) {
+	// resolveMethod returns "homebrew" via per-tool override → brew install fails.
+	rec := &cmdRecorder{
+		errors: map[string]error{
+			"brew install unbound-force/tap/replicator": fmt.Errorf("brew error"),
+		},
+	}
+	opts := Options{
+		LookPath: stubLookPath(map[string]string{}),
+		ExecCmd:  rec.execCmd,
+		ToolMethods: map[string]config.ToolConfig{
+			"replicator": {Method: "homebrew"},
+		},
+		Stdout: &bytes.Buffer{},
+		Stderr: &bytes.Buffer{},
+	}
+	env := doctor.DetectedEnvironment{}
+
+	result := installReplicator(&opts, env)
+	if result.action != "failed" {
+		t.Errorf("action = %q, want failed", result.action)
+	}
+	if result.err == nil {
+		t.Error("expected non-nil error")
+	}
+}
+
+func TestInstallReplicator_ExplicitHomebrewDryRun(t *testing.T) {
+	// resolveMethod returns "homebrew" via per-tool override, dry-run mode.
+	opts := Options{
+		DryRun:   true,
+		LookPath: stubLookPath(map[string]string{}),
+		ToolMethods: map[string]config.ToolConfig{
+			"replicator": {Method: "homebrew"},
+		},
+		Stdout: &bytes.Buffer{},
+		Stderr: &bytes.Buffer{},
+	}
+	env := doctor.DetectedEnvironment{}
+
+	result := installReplicator(&opts, env)
+	if result.action != "dry-run" {
+		t.Errorf("action = %q, want dry-run", result.action)
+	}
+	if !strings.Contains(result.detail, "brew install unbound-force/tap/replicator") {
+		t.Errorf("detail = %q, want to contain brew install hint", result.detail)
+	}
+}
+
+func TestInstallReplicator_AutoHomebrewAvailable(t *testing.T) {
+	// Auto mode, Homebrew available → brew install succeeds.
+	rec := &cmdRecorder{}
+	opts := Options{
+		LookPath: stubLookPath(map[string]string{}),
+		ExecCmd:  rec.execCmd,
+		Stdout:   &bytes.Buffer{},
+		Stderr:   &bytes.Buffer{},
+	}
+	env := doctor.DetectedEnvironment{
+		Managers: []doctor.ManagerInfo{
+			{Kind: doctor.ManagerHomebrew, Path: "/opt/homebrew/bin/brew"},
+		},
+	}
+
+	result := installReplicator(&opts, env)
+	if result.action != "installed" {
+		t.Errorf("action = %q, want installed", result.action)
+	}
+	if !strings.Contains(result.detail, "Homebrew") {
+		t.Errorf("detail = %q, want to contain 'Homebrew'", result.detail)
+	}
+}
+
+func TestInstallReplicator_AutoHomebrewFails(t *testing.T) {
+	// Auto mode, Homebrew available → brew install fails.
+	rec := &cmdRecorder{
+		errors: map[string]error{
+			"brew install unbound-force/tap/replicator": fmt.Errorf("brew error"),
+		},
+	}
+	opts := Options{
+		LookPath: stubLookPath(map[string]string{}),
+		ExecCmd:  rec.execCmd,
+		Stdout:   &bytes.Buffer{},
+		Stderr:   &bytes.Buffer{},
+	}
+	env := doctor.DetectedEnvironment{
+		Managers: []doctor.ManagerInfo{
+			{Kind: doctor.ManagerHomebrew, Path: "/opt/homebrew/bin/brew"},
+		},
+	}
+
+	result := installReplicator(&opts, env)
+	if result.action != "failed" {
+		t.Errorf("action = %q, want failed", result.action)
+	}
+	if result.err == nil {
+		t.Error("expected non-nil error")
+	}
+}
+
+func TestInstallReplicator_AutoGoInstallFails(t *testing.T) {
+	// Auto mode, no Homebrew, no dnf, Go available but go install fails.
+	// installViaGo returns action: "failed" → goResult.action != "skipped",
+	// so installReplicator returns the failed result directly.
+	rec := &cmdRecorder{
+		errors: map[string]error{
+			"go install github.com/unbound-force/replicator/cmd/replicator@latest": fmt.Errorf("compilation error"),
+		},
+	}
+	opts := Options{
+		LookPath: stubLookPath(map[string]string{
+			"go": "/usr/local/bin/go",
+		}),
+		ExecCmd: rec.execCmd,
+		Stdout:  &bytes.Buffer{},
+		Stderr:  &bytes.Buffer{},
+	}
+	env := doctor.DetectedEnvironment{}
+
+	result := installReplicator(&opts, env)
+	if result.action != "failed" {
+		t.Errorf("action = %q, want failed", result.action)
+	}
+	if result.err == nil {
+		t.Error("expected non-nil error")
+	}
+}
+
+// --- installDewey explicit Homebrew and auto-mode tests ---
+
+func TestInstallDewey_ExplicitHomebrew(t *testing.T) {
+	// resolveMethod returns "homebrew" via per-tool override → brew install
+	// succeeds, post-install runs (ollama already has model).
+	rec := &cmdRecorder{
+		outputs: map[string]string{
+			"ollama list": "NAME\ngranite-embedding:30m   abc123   63 MB\n",
+		},
+	}
+	opts := &Options{
+		LookPath: stubLookPath(map[string]string{
+			"ollama": "/usr/local/bin/ollama",
+		}),
+		ExecCmd: rec.execCmd,
+		ToolMethods: map[string]config.ToolConfig{
+			"dewey": {Method: "homebrew"},
+		},
+		Stdout: &bytes.Buffer{},
+		Stderr: &bytes.Buffer{},
+	}
+	opts.defaults()
+	env := doctor.DetectedEnvironment{}
+
+	result := installDewey(opts, env)
+	if result.action != "installed" {
+		t.Errorf("action = %q, want installed", result.action)
+	}
+	if !strings.Contains(result.detail, "Homebrew") {
+		t.Errorf("detail = %q, want to contain 'Homebrew'", result.detail)
+	}
+	found := false
+	for _, call := range rec.calls {
+		if call == "brew install unbound-force/tap/dewey" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected brew install call, got: %v", rec.calls)
+	}
+}
+
+func TestInstallDewey_ExplicitHomebrewFails(t *testing.T) {
+	// resolveMethod returns "homebrew" via per-tool override → brew install fails.
+	rec := &cmdRecorder{
+		errors: map[string]error{
+			"brew install unbound-force/tap/dewey": fmt.Errorf("brew error"),
+		},
+	}
+	opts := &Options{
+		LookPath: stubLookPath(map[string]string{}),
+		ExecCmd:  rec.execCmd,
+		ToolMethods: map[string]config.ToolConfig{
+			"dewey": {Method: "homebrew"},
+		},
+		Stdout: &bytes.Buffer{},
+		Stderr: &bytes.Buffer{},
+	}
+	opts.defaults()
+	env := doctor.DetectedEnvironment{}
+
+	result := installDewey(opts, env)
+	if result.action != "failed" {
+		t.Errorf("action = %q, want failed", result.action)
+	}
+	if result.err == nil {
+		t.Error("expected non-nil error")
+	}
+}
+
+func TestInstallDewey_ExplicitHomebrewDryRun(t *testing.T) {
+	// resolveMethod returns "homebrew" via per-tool override, dry-run mode.
+	opts := &Options{
+		DryRun:   true,
+		LookPath: stubLookPath(map[string]string{}),
+		ToolMethods: map[string]config.ToolConfig{
+			"dewey": {Method: "homebrew"},
+		},
+		Stdout: &bytes.Buffer{},
+		Stderr: &bytes.Buffer{},
+	}
+	opts.defaults()
+	env := doctor.DetectedEnvironment{}
+
+	result := installDewey(opts, env)
+	if result.action != "dry-run" {
+		t.Errorf("action = %q, want dry-run", result.action)
+	}
+	if !strings.Contains(result.detail, "brew install unbound-force/tap/dewey") {
+		t.Errorf("detail = %q, want to contain brew install hint", result.detail)
+	}
+}
+
+func TestInstallDewey_ExplicitGoFails(t *testing.T) {
+	// resolveMethod returns "go" via per-tool override → go install fails.
+	rec := &cmdRecorder{
+		errors: map[string]error{
+			"go install github.com/unbound-force/dewey/cmd/dewey@latest": fmt.Errorf("compilation error"),
+		},
+	}
+	opts := &Options{
+		LookPath: stubLookPath(map[string]string{
+			"go": "/usr/local/bin/go",
+		}),
+		ExecCmd: rec.execCmd,
+		ToolMethods: map[string]config.ToolConfig{
+			"dewey": {Method: "go"},
+		},
+		Stdout: &bytes.Buffer{},
+		Stderr: &bytes.Buffer{},
+	}
+	opts.defaults()
+	env := doctor.DetectedEnvironment{}
+
+	result := installDewey(opts, env)
+	if result.action != "failed" {
+		t.Errorf("action = %q, want failed", result.action)
+	}
+	if result.err == nil {
+		t.Error("expected non-nil error")
+	}
+}
+
+func TestInstallDewey_AutoHomebrewAvailable(t *testing.T) {
+	// Auto mode, Homebrew available → brew install succeeds, post-install runs.
+	rec := &cmdRecorder{
+		outputs: map[string]string{
+			"ollama list": "NAME\ngranite-embedding:30m   abc123   63 MB\n",
+		},
+	}
+	opts := &Options{
+		LookPath: stubLookPath(map[string]string{
+			"ollama": "/usr/local/bin/ollama",
+		}),
+		ExecCmd: rec.execCmd,
+		Stdout:  &bytes.Buffer{},
+		Stderr:  &bytes.Buffer{},
+	}
+	opts.defaults()
+	env := doctor.DetectedEnvironment{
+		Managers: []doctor.ManagerInfo{
+			{Kind: doctor.ManagerHomebrew, Path: "/opt/homebrew/bin/brew"},
+		},
+	}
+
+	result := installDewey(opts, env)
+	if result.action != "installed" {
+		t.Errorf("action = %q, want installed", result.action)
+	}
+	if !strings.Contains(result.detail, "Homebrew") {
+		t.Errorf("detail = %q, want to contain 'Homebrew'", result.detail)
+	}
+}
+
+func TestInstallDewey_AutoHomebrewFails(t *testing.T) {
+	// Auto mode, Homebrew available → brew install fails.
+	rec := &cmdRecorder{
+		errors: map[string]error{
+			"brew install unbound-force/tap/dewey": fmt.Errorf("brew error"),
+		},
+	}
+	opts := &Options{
+		LookPath: stubLookPath(map[string]string{}),
+		ExecCmd:  rec.execCmd,
+		Stdout:   &bytes.Buffer{},
+		Stderr:   &bytes.Buffer{},
+	}
+	opts.defaults()
+	env := doctor.DetectedEnvironment{
+		Managers: []doctor.ManagerInfo{
+			{Kind: doctor.ManagerHomebrew, Path: "/opt/homebrew/bin/brew"},
+		},
+	}
+
+	result := installDewey(opts, env)
+	if result.action != "failed" {
+		t.Errorf("action = %q, want failed", result.action)
+	}
+	if result.err == nil {
+		t.Error("expected non-nil error")
+	}
+}
+
+func TestInstallDewey_AutoGoInstallFails(t *testing.T) {
+	// Auto mode, no Homebrew, Go available but go install fails.
+	// installViaGo returns action: "failed" → goResult.action != "skipped",
+	// so installDewey returns the failed result directly.
+	rec := &cmdRecorder{
+		errors: map[string]error{
+			"go install github.com/unbound-force/dewey/cmd/dewey@latest": fmt.Errorf("compilation error"),
+		},
+	}
+	opts := &Options{
+		LookPath: stubLookPath(map[string]string{
+			"go": "/usr/local/bin/go",
+		}),
+		ExecCmd: rec.execCmd,
+		Stdout:  &bytes.Buffer{},
+		Stderr:  &bytes.Buffer{},
+	}
+	opts.defaults()
+	env := doctor.DetectedEnvironment{}
+
+	result := installDewey(opts, env)
+	if result.action != "failed" {
+		t.Errorf("action = %q, want failed", result.action)
+	}
+	if result.err == nil {
+		t.Error("expected non-nil error")
+	}
+}
+
+func TestInstallDewey_AutoDryRunHomebrew(t *testing.T) {
+	// Auto mode, dry-run, Homebrew available → dry-run with brew hint.
+	opts := &Options{
+		DryRun:   true,
+		LookPath: stubLookPath(map[string]string{}),
+		Stdout:   &bytes.Buffer{},
+		Stderr:   &bytes.Buffer{},
+	}
+	opts.defaults()
+	env := doctor.DetectedEnvironment{
+		Managers: []doctor.ManagerInfo{
+			{Kind: doctor.ManagerHomebrew, Path: "/opt/homebrew/bin/brew"},
+		},
+	}
+
+	result := installDewey(opts, env)
+	if result.action != "dry-run" {
+		t.Errorf("action = %q, want dry-run", result.action)
+	}
+	if !strings.Contains(result.detail, "brew install unbound-force/tap/dewey") {
+		t.Errorf("detail = %q, want to contain brew install hint", result.detail)
+	}
+}
+
+// --- installGaze explicit Homebrew failure test ---
+
+func TestInstallGaze_ExplicitHomebrewFails(t *testing.T) {
+	// resolveMethod returns "homebrew" via per-tool override → brew install fails.
+	rec := &cmdRecorder{
+		errors: map[string]error{
+			"brew install unbound-force/tap/gaze": fmt.Errorf("brew error"),
+		},
+	}
+	opts := &Options{
+		LookPath: stubLookPath(map[string]string{}),
+		ExecCmd:  rec.execCmd,
+		ToolMethods: map[string]config.ToolConfig{
+			"gaze": {Method: "homebrew"},
+		},
+		Stdout: &bytes.Buffer{},
+		Stderr: &bytes.Buffer{},
+	}
+	env := doctor.DetectedEnvironment{}
+
+	result := installGaze(opts, env)
+	if result.action != "failed" {
+		t.Errorf("action = %q, want failed", result.action)
+	}
+	if result.err == nil {
+		t.Error("expected non-nil error")
 	}
 }
 

--- a/openspec/changes/setup-auto-native-fallback/.openspec.yaml
+++ b/openspec/changes/setup-auto-native-fallback/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: unbound-force
+created: 2026-06-15

--- a/openspec/changes/setup-auto-native-fallback/design.md
+++ b/openspec/changes/setup-auto-native-fallback/design.md
@@ -1,0 +1,183 @@
+## Context
+
+The `linux-cross-platform-install` change (merged) added
+`installViaRpm()` at setup.go:852, `ManagerDnf` detection
+in environ.go:103, and `toolMethod()` dispatch in
+`installGaze()` at setup.go:525. It explicitly deferred
+wiring sibling tool install functions to use this
+infrastructure in auto mode.
+
+Issue #214 reports the user-visible consequence: on
+Fedora/RHEL without Homebrew, `uf setup` skips Gaze,
+Replicator, Dewey, and GitHub CLI with download-link
+hints.
+
+The `go install` pattern is already established in the
+codebase: `installGolangciLint()` (setup.go:770) and
+`installGovulncheck()` (setup.go:802) both use
+`opts.ExecCmd("go", "install", ...)`.
+
+## Goals / Non-Goals
+
+### Goals
+- Auto mode installs Gaze, Replicator, and Dewey on
+  Fedora/RHEL via dnf or `go install`
+- Auto mode installs GitHub CLI on Fedora/RHEL via dnf
+- `UF_PACKAGE_MANAGER=dnf` forces the dnf install path
+- All four install functions have `toolMethod()` dispatch
+  for per-tool config overrides
+- All new code is testable via injectable dependencies
+  (Constitution Principle IV — Testability)
+
+### Non-Goals
+- DEB/apt package support (future increment)
+- Windows package manager support (winget, choco)
+- Ollama/Podman/DevPod fallback (different install
+  contracts, no GoReleaser RPMs)
+- Adding RPM generation to sibling repos (separate
+  concern per repo)
+
+## Decisions
+
+### D1: resolveMethod() helper
+
+Add a `resolveMethod()` method on `*Options` that takes
+`toolName` and `DetectedEnvironment`, returning the
+resolved install method string. Logic:
+
+1. If `toolMethod(toolName)` returns a non-`"auto"` value,
+   use that (per-tool override takes precedence).
+2. If `opts.PackageManager` is `"homebrew"`, `"dnf"`, or
+   `"apt"`, return that (global preference).
+3. If `opts.PackageManager` is `"auto"` (default):
+   return `"auto"` (let the install function apply its
+   own fallback chain using environment detection).
+
+This keeps the resolution logic centralized while
+preserving the per-function fallback chains that differ
+by tool (e.g., Dewey has no RPM path).
+
+**Rationale**: A single resolution point avoids
+duplicating the precedence logic across 4+ install
+functions. The `"auto"` passthrough preserves the
+existing fallback-chain pattern, which varies by tool.
+
+**Constitution**: Composability First — each tool's
+install function retains its own fallback chain, so tools
+with different distribution channels (e.g., Dewey without
+RPMs) compose correctly without special-casing in the
+resolver.
+
+### D2: Auto-mode fallback order
+
+Each install function applies fallbacks in order:
+
+| Priority | Method | When used |
+|----------|--------|-----------|
+| 1 | Homebrew | `HasManager(env, ManagerHomebrew)` |
+| 2 | dnf (RPM) | `HasManager(env, ManagerDnf)` and tool has RPMs |
+| 3 | `go install` | `LookPath("go")` succeeds and tool is a Go binary |
+| 4 | skip | Last resort, with download link |
+
+Per-tool variations:
+
+- **Gaze**: Homebrew -> dnf -> `go install` -> skip
+- **Replicator**: Homebrew -> dnf -> `go install` -> skip
+- **Dewey**: Homebrew -> `go install` -> skip (no RPMs)
+- **GH CLI**: Homebrew -> dnf -> skip (not a Go binary
+  in the same sense; official dnf repo is the native
+  path)
+
+**Rationale**: Homebrew first because it provides the
+most consistent experience across platforms. dnf second
+because it uses pre-built release binaries. `go install`
+third because it builds from source (slower, different
+binary than release artifacts). Skip as last resort.
+
+### D3: installViaGo() helper
+
+Add a helper function:
+
+```go
+func installViaGo(
+    opts *Options,
+    toolName, goModule string,
+) stepResult
+```
+
+Follows the `installGolangciLint()` pattern: calls
+`opts.ExecCmd("go", "install", goModule+"@latest")`.
+Returns a `stepResult` with `detail: "via go install"`.
+
+**Go module paths**:
+- Gaze: `github.com/unbound-force/gaze/cmd/gaze`
+- Dewey: `github.com/unbound-force/dewey`
+- Replicator: `github.com/unbound-force/replicator/cmd/replicator`
+
+**Rationale**: Extracts the repeated `go install` pattern
+into a reusable helper, same as `installViaRpm()`.
+
+**Constitution**: Testability — uses `opts.ExecCmd` and
+`opts.LookPath` injection, testable without network
+access.
+
+### D4: GH CLI dnf installation
+
+GitHub CLI publishes its own dnf repository. The
+install path uses `dnf install gh` (no URL construction
+needed). This differs from the GoReleaser RPM pattern
+used by `installViaRpm()`.
+
+The dnf repo may not be pre-configured on all systems.
+If `dnf install gh` fails, fall through to skip with the
+existing download link.
+
+**Rationale**: `gh` is not built with GoReleaser and does
+not follow the same RPM URL pattern. Using `dnf install`
+directly is simpler and matches GitHub's official install
+instructions for Fedora.
+
+### D5: PackageManager semantics
+
+| Value | Behavior |
+|-------|----------|
+| `"auto"` | Detect and try fallback chain (default) |
+| `"homebrew"` | Homebrew only, skip if absent |
+| `"dnf"` | dnf/RPM only, `go install` fallback for tools without RPMs |
+| `"apt"` | Reserved for future use, behaves as `"auto"` |
+| `"manual"` | Skip all tools (existing behavior) |
+
+When `PackageManager` is explicitly set to `"dnf"`, the
+install functions skip the Homebrew attempt and go
+directly to the dnf path. For Dewey (no RPMs), they
+fall through to `go install`.
+
+**Rationale**: Users who set `UF_PACKAGE_MANAGER=dnf`
+have explicitly chosen their preference. Homebrew should
+not be attempted when the user has opted out.
+
+## Risks / Trade-offs
+
+### R1: `go install` builds from source
+
+`go install` produces a binary built from source at
+`@latest`, which may differ from the tested release
+binary. Mitigation: this is tier 3 — it only activates
+when both Homebrew and dnf are unavailable. The binary
+is functionally equivalent; only the build provenance
+differs.
+
+### R2: GH CLI dnf repo not pre-configured
+
+`dnf install gh` will fail if the GitHub CLI repository
+is not configured. Mitigation: fall through to skip with
+a download link. The user can configure the repo
+manually and re-run `uf setup`.
+
+### R3: `go install` requires Go toolchain
+
+`go install` requires `go` in PATH. Mitigation: Go is
+already a prerequisite for `unbound-force` development.
+If `go` is not available, the fallback gracefully
+continues to skip. The `LookPath("go")` check prevents
+confusing error messages.

--- a/openspec/changes/setup-auto-native-fallback/design.md
+++ b/openspec/changes/setup-auto-native-fallback/design.md
@@ -47,11 +47,24 @@ resolved install method string. Logic:
 
 1. If `toolMethod(toolName)` returns a non-`"auto"` value,
    use that (per-tool override takes precedence).
-2. If `opts.PackageManager` is `"homebrew"`, `"dnf"`, or
-   `"apt"`, return that (global preference).
-3. If `opts.PackageManager` is `"auto"` (default):
+2. If `opts.PackageManager` is `"homebrew"` or `"dnf"`,
+   return that (global preference).
+3. If `opts.PackageManager` is `"apt"`, map to `"auto"`
+   and log an informational message ("apt support not
+   yet implemented, using auto-mode fallback"). This
+   avoids silent surprise — the user explicitly asked
+   for apt but gets auto behavior.
+4. If `opts.PackageManager` is `"auto"` (default):
    return `"auto"` (let the install function apply its
    own fallback chain using environment detection).
+
+`resolveMethod()` is intentionally **tool-agnostic** — it
+resolves the user's *preference*, not the tool's
+*capability*. It may return `"dnf"` for Dewey even though
+Dewey has no RPMs. Each install function is responsible
+for handling unsupported methods by falling through to
+the next tier (e.g., `installDewey()` receives `"dnf"`,
+has no dnf case, and falls through to `go install`).
 
 This keeps the resolution logic centralized while
 preserving the per-function fallback chains that differ
@@ -61,6 +74,8 @@ by tool (e.g., Dewey has no RPM path).
 duplicating the precedence logic across 4+ install
 functions. The `"auto"` passthrough preserves the
 existing fallback-chain pattern, which varies by tool.
+Tool-agnostic resolution prevents `resolveMethod()` from
+needing to know the distribution channels of every tool.
 
 **Constitution**: Composability First — each tool's
 install function retains its own fallback chain, so tools
@@ -109,10 +124,32 @@ Follows the `installGolangciLint()` pattern: calls
 `opts.ExecCmd("go", "install", goModule+"@latest")`.
 Returns a `stepResult` with `detail: "via go install"`.
 
+**Behavior by outcome**:
+- Go not in PATH (`LookPath("go")` fails): return
+  `stepResult{action: "skipped", detail: "Go not
+  available. Install Go or use Homebrew/dnf."}`.
+  `err` is nil (graceful degradation, not a failure).
+- `go install` succeeds: return
+  `stepResult{action: "installed", detail: "via go
+  install"}`.
+- `go install` fails (network, compilation, module not
+  found): return `stepResult{action: "failed",
+  detail: "go install failed — try: go install
+  <module>@latest", err: fmt.Errorf("go install %s:
+  %w", goModule, err)}`. Error is wrapped with context
+  per CS-006.
+- Dry-run: return `stepResult{action: "dry-run",
+  detail: "Would install: go install <module>@latest"}`.
+
 **Go module paths**:
 - Gaze: `github.com/unbound-force/gaze/cmd/gaze`
-- Dewey: `github.com/unbound-force/dewey`
+- Dewey: `github.com/unbound-force/dewey/cmd/dewey`
 - Replicator: `github.com/unbound-force/replicator/cmd/replicator`
+
+**Error wrapping**: All errors stored in `stepResult.err`
+across all install functions MUST be wrapped with
+operation context per Go convention pack CS-006 (e.g.,
+`fmt.Errorf("dnf install gh: %w", err)`).
 
 **Rationale**: Extracts the repeated `go install` pattern
 into a reusable helper, same as `installViaRpm()`.
@@ -129,8 +166,21 @@ needed). This differs from the GoReleaser RPM pattern
 used by `installViaRpm()`.
 
 The dnf repo may not be pre-configured on all systems.
-If `dnf install gh` fails, fall through to skip with the
-existing download link.
+Failure modes:
+- Repo not configured: `dnf` returns "No match for
+  argument: gh" — fast, clean failure.
+- Repo configured but network unreachable: `dnf` may
+  hang. `ExecCmd` inherits the process timeout; no
+  additional timeout handling is needed.
+- GPG key import: `-y` auto-accepts GPG keys from
+  configured repos. This is acceptable because the
+  user configured the repo themselves.
+
+On any `dnf install gh` failure, fall through to skip
+with an actionable message: "dnf install failed —
+configure the GitHub CLI repo:
+https://github.com/cli/cli/blob/trunk/docs/install_linux.md
+or download from https://cli.github.com".
 
 **Rationale**: `gh` is not built with GoReleaser and does
 not follow the same RPM URL pattern. Using `dnf install`
@@ -144,7 +194,7 @@ instructions for Fedora.
 | `"auto"` | Detect and try fallback chain (default) |
 | `"homebrew"` | Homebrew only, skip if absent |
 | `"dnf"` | dnf/RPM only, `go install` fallback for tools without RPMs |
-| `"apt"` | Reserved for future use, behaves as `"auto"` |
+| `"apt"` | Reserved — maps to `"auto"` with info log |
 | `"manual"` | Skip all tools (existing behavior) |
 
 When `PackageManager` is explicitly set to `"dnf"`, the
@@ -158,21 +208,40 @@ not be attempted when the user has opted out.
 
 ## Risks / Trade-offs
 
-### R1: `go install` builds from source
+### R1: `go install` builds from source (provenance + supply chain)
 
 `go install` produces a binary built from source at
 `@latest`, which may differ from the tested release
-binary. Mitigation: this is tier 3 — it only activates
-when both Homebrew and dnf are unavailable. The binary
-is functionally equivalent; only the build provenance
-differs.
+binary. `@latest` resolves to the latest commit on the
+default branch, not the latest tagged release — this
+means the installed binary may include unreleased code.
+
+**Supply chain risk**: `@latest` is an unpinned,
+mutable reference. A compromised tag or malicious commit
+pushed to an upstream repo would be installed. This is
+the Go equivalent of using a mutable Docker tag.
+
+**Accepted risk with rationale**: This is tier 3 — it
+only activates when both Homebrew and dnf are unavailable,
+meaning the user has no pre-built binary option. The
+existing codebase already uses `@latest` for
+`golangci-lint` and `govulncheck` (setup.go:770, 811),
+establishing precedent. Go's module proxy and checksum
+database (`GONOSUMCHECK` is disabled by default) provide
+integrity verification — `go install` validates checksums
+against `sum.golang.org` before building.
+
+**Future improvement**: Consider pinning to a specific
+version tag (e.g., `@v0.12.0`) derived from `opts.Version`
+when available, falling back to `@latest` only when
+version is unknown.
 
 ### R2: GH CLI dnf repo not pre-configured
 
 `dnf install gh` will fail if the GitHub CLI repository
 is not configured. Mitigation: fall through to skip with
-a download link. The user can configure the repo
-manually and re-run `uf setup`.
+an actionable download link. The user can configure the
+repo manually and re-run `uf setup`.
 
 ### R3: `go install` requires Go toolchain
 
@@ -181,3 +250,33 @@ already a prerequisite for `unbound-force` development.
 If `go` is not available, the fallback gracefully
 continues to skip. The `LookPath("go")` check prevents
 confusing error messages.
+
+### R4: `dnf install -y` privilege and consent model
+
+`dnf install -y` requires root/sudo privileges and
+auto-confirms all prompts. The existing `installViaRpm()`
+already uses this pattern (setup.go:871).
+
+**Privilege model**: `uf setup` does not manage privilege
+escalation. If run as a normal user, `dnf install` fails
+with a permission error and the install function returns
+`action: "failed"` with the error. The user is expected
+to either run `uf setup` with appropriate privileges or
+use `sudo uf setup`. This matches the behavior of
+`brew install` (which also requires appropriate
+permissions for its prefix).
+
+**Consent model**: Running `uf setup` in auto mode
+implies consent to install tools — the command's entire
+purpose is automated tool installation. The `-y` flag
+prevents interactive prompts that would break automation.
+Users who want explicit control use
+`package_manager: manual` or per-tool `method: skip`
+overrides.
+
+**GPG key acceptance**: `-y` auto-accepts GPG keys for
+configured repositories. For `installViaRpm()` (GitHub
+Releases), no repository GPG key is involved — `dnf`
+installs the RPM directly by URL. For `dnf install gh`,
+the GitHub CLI repo's GPG key would be accepted, but
+only if the user has already configured the repo.

--- a/openspec/changes/setup-auto-native-fallback/proposal.md
+++ b/openspec/changes/setup-auto-native-fallback/proposal.md
@@ -1,0 +1,140 @@
+## Why
+
+`uf setup` in auto mode (the default) uses Homebrew as
+the only installation method for companion tools. When
+Homebrew is not available — the normal case on Fedora,
+RHEL, and other RPM-based Linux distributions — the
+command skips Gaze, Replicator, Dewey, and GitHub CLI
+with download-link hints instead of using available
+package managers or `go install`.
+
+The infrastructure for native installation exists:
+`installViaRpm()` (setup.go:852) constructs GitHub
+Release RPM URLs and installs via `dnf install -y`.
+`doctor.DetectEnvironment()` detects `dnf` via
+`LookPath`. The `toolMethod()` dispatcher is implemented
+in `installGaze()`. But none of this is wired into the
+auto-mode fallback path.
+
+The `UF_PACKAGE_MANAGER` env var and
+`setup.package_manager` config field are loaded and
+validated (accepts `auto|homebrew|dnf|apt|manual`) but
+only checked for `"manual"` mode — setting
+`UF_PACKAGE_MANAGER=dnf` has no effect on tool
+installation.
+
+This breaks onboarding for an explicitly supported
+platform: Fedora packaging exists (`.packit.yaml`,
+`unbound-force.spec`), and the `linux-cross-platform-
+install` change added RPM generation and `ManagerDnf`
+detection specifically for this use case.
+
+Fixes: https://github.com/unbound-force/unbound-force/issues/214
+
+## What Changes
+
+1. Add `resolveMethod()` helper that translates `"auto"`
+   into a concrete install method based on
+   `opts.PackageManager` and detected environment
+   managers.
+
+2. Add `toolMethod()` dispatch to `installReplicator()`,
+   `installDewey()`, and `installGH()` — currently only
+   `installGaze()` has this dispatch.
+
+3. Wire auto-mode fallback chain in all four install
+   functions: Homebrew -> dnf (via `installViaRpm()`) ->
+   `go install` (for Go-based tools) -> skip.
+
+4. Wire `opts.PackageManager` into the dispatch so
+   `UF_PACKAGE_MANAGER=dnf` forces the dnf install path.
+
+5. Add `installViaGo()` helper for `go install` fallback,
+   following the pattern in `installGolangciLint()`
+   (setup.go:780).
+
+## Capabilities
+
+### New Capabilities
+- `resolve-method`: Translates global `PackageManager`
+  preference and detected environment into a concrete
+  install method per tool.
+- `go-install-fallback`: Installs Gaze, Dewey, and
+  Replicator via `go install` when neither Homebrew nor
+  dnf is available. Follows the `installGolangciLint()`
+  pattern (setup.go:770).
+
+### Modified Capabilities
+- `install-gaze`: Auto mode now tries dnf then
+  `go install` before skipping.
+- `install-replicator`: Gains `toolMethod()` dispatch
+  and auto-mode dnf/`go install` fallback.
+- `install-dewey`: Gains `toolMethod()` dispatch and
+  auto-mode `go install` fallback (no RPMs available).
+- `install-gh`: Gains `toolMethod()` dispatch and
+  auto-mode dnf fallback (`dnf install gh` from the
+  GitHub CLI dnf repository).
+- `package-manager-config`: `UF_PACKAGE_MANAGER` and
+  `setup.package_manager` now influence auto-mode tool
+  installation.
+
+### Removed Capabilities
+- None.
+
+## Impact
+
+- `internal/setup/setup.go`: Modified — 4 install
+  functions updated, 2 new helpers added.
+- `internal/setup/setup_test.go`: Modified — ~15 new
+  test functions covering fallback chains, method
+  resolution, and `PackageManager` override.
+- No changes to `internal/doctor/` (dnf detection
+  and `HasManager()` already exist).
+- No cross-repo impact.
+
+## Constitution Alignment
+
+Assessed against the Unbound Force org constitution.
+
+### I. Autonomous Collaboration
+
+**Assessment**: N/A
+
+This change does not affect inter-hero artifact formats,
+communication protocols, or metadata. It modifies only
+the tool installation mechanism within `uf setup`.
+
+### II. Composability First
+
+**Assessment**: PASS
+
+This change directly supports Composability First by
+removing a platform barrier to companion tool
+installation. Linux users can install Gaze, Dewey, and
+Replicator through native package managers or
+`go install` without requiring Homebrew. No mandatory
+dependencies are introduced — each fallback tier is
+optional and the chain degrades gracefully to a skip
+with a download link.
+
+### III. Observable Quality
+
+**Assessment**: N/A
+
+This change does not affect output formats, provenance
+metadata, or machine-parseable output. The `stepResult`
+struct already includes the install method in `detail`,
+which will now report "via dnf (RPM)" or "via go install"
+alongside the existing "via Homebrew".
+
+### IV. Testability
+
+**Assessment**: PASS
+
+All new code uses the existing injectable dependency
+pattern (`LookPath`, `ExecCmd`, `Getenv` on the Options
+struct). The `resolveMethod()` helper is a pure function
+of `Options` + `DetectedEnvironment` — no external
+services, network access, or shared mutable state. Tests
+verify observable side effects (returned `stepResult`
+values) rather than implementation details.

--- a/openspec/changes/setup-auto-native-fallback/proposal.md
+++ b/openspec/changes/setup-auto-native-fallback/proposal.md
@@ -51,7 +51,7 @@ Fixes: https://github.com/unbound-force/unbound-force/issues/214
 
 5. Add `installViaGo()` helper for `go install` fallback,
    following the pattern in `installGolangciLint()`
-   (setup.go:780).
+    (setup.go:770).
 
 ## Capabilities
 

--- a/openspec/changes/setup-auto-native-fallback/tasks.md
+++ b/openspec/changes/setup-auto-native-fallback/tasks.md
@@ -17,7 +17,7 @@
 
 ## 1. Add resolveMethod() and installViaGo() Helpers
 
-- [ ] 1.1 Add `resolveMethod(toolName string,
+- [x] 1.1 Add `resolveMethod(toolName string,
   env doctor.DetectedEnvironment) string` method on
   `*Options` in `internal/setup/setup.go`. Logic:
   (1) if `toolMethod(toolName)` returns non-`"auto"`,
@@ -30,7 +30,7 @@
   (4) otherwise return `"auto"` for fallback chain.
   `resolveMethod()` is tool-agnostic — it resolves the
   user's preference, not the tool's capability.
-- [ ] 1.2 Add `installViaGo(opts *Options, toolName,
+- [x] 1.2 Add `installViaGo(opts *Options, toolName,
   goModule string) stepResult` function in
   `internal/setup/setup.go`. Behavior by outcome:
   - Go not in PATH: return `action: "skipped"`,
@@ -45,7 +45,7 @@
     `detail: "Would install: go install <module>@latest"`.
   All errors in `stepResult.err` MUST be wrapped with
   operation context per CS-006.
-- [ ] 1.3 Add tests for `resolveMethod()` in
+- [x] 1.3 Add tests for `resolveMethod()` in
   `internal/setup/setup_test.go` (table-driven per
   TC-006): per-tool override takes precedence over
   global, global `PackageManager: "dnf"` returns `"dnf"`,
@@ -53,7 +53,7 @@
   `PackageManager: "apt"` maps to `"auto"`,
   `"auto"` passes through, `"manual"` is handled by
   `shouldSkipTool` (not `resolveMethod`).
-- [ ] 1.4 Add tests for `installViaGo()` in
+- [x] 1.4 Add tests for `installViaGo()` in
   `internal/setup/setup_test.go` (table-driven per
   TC-006): Go available and install succeeds (assert
   `action: "installed"`, `detail: "via go install"`);
@@ -67,7 +67,7 @@
 
 ## 2. Update installGaze() Auto-Mode Fallback
 
-- [ ] 2.1 Update `installGaze()` (setup.go:519) to call
+- [x] 2.1 Update `installGaze()` (setup.go:519) to call
   `resolveMethod("gaze", env)` instead of
   `opts.toolMethod("gaze")`. Add dispatch cases for
   `"go"` (calls `installViaGo` with module
@@ -77,7 +77,7 @@
   `HasManager(env, ManagerDnf)`, then try `installViaGo`
   as final fallback before skip. Update dry-run to
   reflect new fallback chain.
-- [ ] 2.2 Add tests for `installGaze()` fallback chain:
+- [x] 2.2 Add tests for `installGaze()` fallback chain:
   dnf available + no Homebrew -> installs via RPM;
   no Homebrew + no dnf + Go available -> installs via
   `go install`; no Homebrew + no dnf + no Go -> skips;
@@ -85,7 +85,7 @@
 
 ## 3. Update installReplicator() with Dispatch + Fallback
 
-- [ ] 3.1 Add `resolveMethod("replicator", env)` dispatch
+- [x] 3.1 Add `resolveMethod("replicator", env)` dispatch
   to `installReplicator()` (setup.go:721) with explicit
   `"rpm"`/`"dnf"` case (calls `installViaRpm` with repo
   `unbound-force/replicator`), `"homebrew"` case, and
@@ -93,11 +93,11 @@
   `github.com/unbound-force/replicator/cmd/replicator`).
   Follow the `installGaze()` dispatch pattern at
   setup.go:525-538.
-- [ ] 3.2 Add auto-mode fallback chain: Homebrew -> dnf
+- [x] 3.2 Add auto-mode fallback chain: Homebrew -> dnf
   (via `installViaRpm`) -> `go install` (via
   `installViaGo`) -> skip. Update dry-run to reflect
   new fallback chain.
-- [ ] 3.3 Add tests (table-driven per TC-006): same
+- [x] 3.3 Add tests (table-driven per TC-006): same
   fallback chain as Gaze (Homebrew -> dnf -> go install
   -> skip). Scenarios: dnf available + no Homebrew ->
   installs via RPM; no Homebrew + no dnf + Go available
@@ -107,18 +107,18 @@
 
 ## 4. Update installDewey() with Dispatch + Fallback
 
-- [ ] 4.1 Add `resolveMethod("dewey", env)` dispatch to
+- [x] 4.1 Add `resolveMethod("dewey", env)` dispatch to
   `installDewey()` (setup.go:1128) with explicit
   `"homebrew"` and `"go"` cases. No `"rpm"`/`"dnf"`
   case — Dewey does not publish RPMs. If
   `resolveMethod` returns `"dnf"`, fall through to
   `"go"` since dnf is not available for Dewey.
-- [ ] 4.2 Add auto-mode fallback chain: Homebrew ->
+- [x] 4.2 Add auto-mode fallback chain: Homebrew ->
   `go install` (via `installViaGo` with module
   `github.com/unbound-force/dewey/cmd/dewey`) -> skip.
   Preserve the `pullEmbeddingModel()` call after any
   successful install path.
-- [ ] 4.3 Add tests (table-driven per TC-006):
+- [x] 4.3 Add tests (table-driven per TC-006):
   no Homebrew + Go available -> installs via `go install`
   + pulls embedding model (assert `action: "installed"`,
   `detail: "via go install"`);
@@ -131,19 +131,19 @@
 
 ## 5. Update installGH() with Dispatch + Fallback
 
-- [ ] 5.1 Add `resolveMethod("gh", env)` dispatch to
+- [x] 5.1 Add `resolveMethod("gh", env)` dispatch to
   `installGH()` (setup.go:470) with explicit `"dnf"`
   case (calls `ExecCmd("dnf", "install", "-y", "gh")`
   directly — GH CLI has its own dnf repo, not
   GoReleaser RPMs) and `"homebrew"` case.
-- [ ] 5.2 Add auto-mode fallback chain: Homebrew -> dnf
+- [x] 5.2 Add auto-mode fallback chain: Homebrew -> dnf
   (`dnf install -y gh`) -> skip. On `dnf install gh`
   failure, return `action: "skipped"` (graceful
   degradation, not hard failure), `detail` with
   actionable message including GitHub CLI repo setup
   link, `err: nil`. Update dry-run to reflect new
   fallback chain.
-- [ ] 5.3 Add tests (table-driven per TC-006):
+- [x] 5.3 Add tests (table-driven per TC-006):
   dnf available + no Homebrew -> attempts
   `dnf install gh` (assert `action: "installed"`);
   dnf install fails -> skips with actionable download
@@ -154,44 +154,45 @@
 
 ## 6. Dry-Run Path Updates
 
-- [ ] 6.1 Verify dry-run output in all four updated
+- [x] 6.1 Verify dry-run output in all four updated
   install functions reflects the new fallback chain.
   When Homebrew is absent, dry-run should show the
   next available method (dnf or `go install`) instead
   of "Would install: download from...".
-- [ ] 6.2 Add dry-run tests: verify each fallback tier
+- [x] 6.2 Add dry-run tests: verify each fallback tier
   produces the correct dry-run detail string for all
   four tools.
 
 ## 7. Verification
 
-- [ ] 7.1 Run `make check` — all tests pass, lint clean,
+- [x] 7.1 Run `make check` — all tests pass, lint clean,
   build succeeds.
-- [ ] 7.2 Run `go test -race -count=1 ./internal/setup/`
+- [x] 7.2 Run `go test -race -count=1 ./internal/setup/`
   — verify new tests pass in isolation. Confirm existing
   `TestInstallViaRpm_*` tests (Success, NoVersion,
   DnfFails, DryRun) pass unchanged — no modifications
   to `installViaRpm()` signature or behavior.
-- [ ] 7.3 Manual smoke test: `uf setup --dry-run` on a
+- [x] 7.3 Manual smoke test: `uf setup --dry-run` on a
   system without Homebrew — verify tools show dnf or
   `go install` intent instead of "skipped".
 
 ## 8. Documentation
 
-- [ ] 8.1 Add CHANGELOG.md entry documenting the fix
+- [x] 8.1 Add CHANGELOG.md entry documenting the fix
   for issue #214: `uf setup` auto mode now falls back
   to dnf and `go install` when Homebrew is absent.
 
 ## 9. Constitution Alignment Verification
 
-- [ ] 9.1 Verify Composability First: each tool's
+- [x] 9.1 Verify Composability First: each tool's
   fallback chain degrades gracefully — no tool requires
   a specific package manager. Standalone installation
   is preserved via `go install` as the universal
   fallback for Go-based tools.
-- [ ] 9.2 Verify Testability: all new code uses
+- [x] 9.2 Verify Testability: all new code uses
   injectable dependencies (`LookPath`, `ExecCmd` on
   the Options struct). No tests require network access,
   external services, or shared mutable state. All tests
   verify observable side effects (returned `stepResult`
   values).
+<!-- spec-review: passed -->

--- a/openspec/changes/setup-auto-native-fallback/tasks.md
+++ b/openspec/changes/setup-auto-native-fallback/tasks.md
@@ -1,0 +1,150 @@
+<!--
+  [P] marks tasks eligible for parallel execution.
+  Add [P] when a task: (a) touches different files from
+  other [P] tasks in the group, (b) has no dependency
+  on prior tasks in the group, (c) can safely execute
+  without ordering constraints.
+  Do NOT add [P] when tasks modify the same file —
+  parallel workers will cause merge conflicts.
+  Tasks without [P] run sequentially first, then [P]
+  tasks run in parallel.
+
+  All tasks modify internal/setup/setup.go and
+  internal/setup/setup_test.go. No [P] markers —
+  all tasks are sequential to avoid merge conflicts
+  in the same two files.
+-->
+
+## 1. Add resolveMethod() and installViaGo() Helpers
+
+- [ ] 1.1 Add `resolveMethod(toolName string,
+  env doctor.DetectedEnvironment) string` method on
+  `*Options` in `internal/setup/setup.go`. Logic:
+  (1) if `toolMethod(toolName)` returns non-`"auto"`,
+  return that value (per-tool override wins);
+  (2) if `opts.PackageManager` is `"homebrew"`, `"dnf"`,
+  or `"apt"`, return that (global preference);
+  (3) otherwise return `"auto"` for fallback chain.
+- [ ] 1.2 Add `installViaGo(opts *Options, toolName,
+  goModule string) stepResult` function in
+  `internal/setup/setup.go`. Check `LookPath("go")`
+  first — if Go is not available, return a skip result
+  with install hint. Otherwise call
+  `ExecCmd("go", "install", goModule+"@latest")` and
+  return `stepResult` with `detail: "via go install"`.
+  Handle dry-run mode.
+- [ ] 1.3 Add tests for `resolveMethod()` in
+  `internal/setup/setup_test.go`: per-tool override
+  takes precedence over global, global `PackageManager`
+  takes precedence over `"auto"`, `"auto"` passes
+  through, `"manual"` is handled by `shouldSkipTool`
+  (not `resolveMethod`).
+- [ ] 1.4 Add tests for `installViaGo()` in
+  `internal/setup/setup_test.go`: Go available and
+  install succeeds, Go available but install fails,
+  Go not available returns skip result, dry-run mode
+  returns correct detail string.
+
+## 2. Update installGaze() Auto-Mode Fallback
+
+- [ ] 2.1 Update `installGaze()` (setup.go:519) to call
+  `resolveMethod("gaze", env)` instead of
+  `opts.toolMethod("gaze")`. Add dispatch cases for
+  `"go"` (calls `installViaGo` with module
+  `github.com/unbound-force/gaze/cmd/gaze`).
+  Update auto-mode block: after Homebrew-absent check,
+  try dnf via `installViaRpm()` when
+  `HasManager(env, ManagerDnf)`, then try `installViaGo`
+  as final fallback before skip. Update dry-run to
+  reflect new fallback chain.
+- [ ] 2.2 Add tests for `installGaze()` fallback chain:
+  dnf available + no Homebrew -> installs via RPM;
+  no Homebrew + no dnf + Go available -> installs via
+  `go install`; no Homebrew + no dnf + no Go -> skips;
+  `PackageManager: "dnf"` -> skips Homebrew, uses dnf.
+
+## 3. Update installReplicator() with Dispatch + Fallback
+
+- [ ] 3.1 Add `resolveMethod("replicator", env)` dispatch
+  to `installReplicator()` (setup.go:721) with explicit
+  `"rpm"`/`"dnf"` case (calls `installViaRpm` with repo
+  `unbound-force/replicator`), `"homebrew"` case, and
+  `"go"` case (calls `installViaGo` with module
+  `github.com/unbound-force/replicator/cmd/replicator`).
+  Follow the `installGaze()` dispatch pattern at
+  setup.go:525-538.
+- [ ] 3.2 Add auto-mode fallback chain: Homebrew -> dnf
+  (via `installViaRpm`) -> `go install` (via
+  `installViaGo`) -> skip. Update dry-run to reflect
+  new fallback chain.
+- [ ] 3.3 Add tests: same matrix as 2.2 for Replicator.
+
+## 4. Update installDewey() with Dispatch + Fallback
+
+- [ ] 4.1 Add `resolveMethod("dewey", env)` dispatch to
+  `installDewey()` (setup.go:1128) with explicit
+  `"homebrew"` and `"go"` cases. No `"rpm"`/`"dnf"`
+  case — Dewey does not publish RPMs. If
+  `resolveMethod` returns `"dnf"`, fall through to
+  `"go"` since dnf is not available for Dewey.
+- [ ] 4.2 Add auto-mode fallback chain: Homebrew ->
+  `go install` (via `installViaGo` with module
+  `github.com/unbound-force/dewey`) -> skip. Preserve
+  the `pullEmbeddingModel()` call after any successful
+  install path.
+- [ ] 4.3 Add tests: no Homebrew + Go available ->
+  installs via `go install` + pulls embedding model;
+  no Homebrew + no Go -> skips; `PackageManager: "dnf"`
+  with no dnf method available -> falls through to
+  `go install`.
+
+## 5. Update installGH() with Dispatch + Fallback
+
+- [ ] 5.1 Add `resolveMethod("gh", env)` dispatch to
+  `installGH()` (setup.go:470) with explicit `"dnf"`
+  case (calls `ExecCmd("dnf", "install", "-y", "gh")`
+  directly — GH CLI has its own dnf repo, not
+  GoReleaser RPMs) and `"homebrew"` case.
+- [ ] 5.2 Add auto-mode fallback chain: Homebrew -> dnf
+  (`dnf install -y gh`) -> skip. If `dnf install gh`
+  fails, fall through to skip with download link.
+  Update dry-run to reflect new fallback chain.
+- [ ] 5.3 Add tests: dnf available + no Homebrew ->
+  attempts `dnf install gh`; dnf install fails ->
+  skips with download link; `PackageManager: "dnf"` ->
+  skips Homebrew, uses dnf directly.
+
+## 6. Dry-Run Path Updates
+
+- [ ] 6.1 Verify dry-run output in all four updated
+  install functions reflects the new fallback chain.
+  When Homebrew is absent, dry-run should show the
+  next available method (dnf or `go install`) instead
+  of "Would install: download from...".
+- [ ] 6.2 Add dry-run tests: verify each fallback tier
+  produces the correct dry-run detail string for all
+  four tools.
+
+## 7. Verification
+
+- [ ] 7.1 Run `make check` — all tests pass, lint clean,
+  build succeeds.
+- [ ] 7.2 Run `go test -race -count=1 ./internal/setup/`
+  — verify new tests pass in isolation.
+- [ ] 7.3 Manual smoke test: `uf setup --dry-run` on a
+  system without Homebrew — verify tools show dnf or
+  `go install` intent instead of "skipped".
+
+## 8. Constitution Alignment Verification
+
+- [ ] 8.1 Verify Composability First: each tool's
+  fallback chain degrades gracefully — no tool requires
+  a specific package manager. Standalone installation
+  is preserved via `go install` as the universal
+  fallback for Go-based tools.
+- [ ] 8.2 Verify Testability: all new code uses
+  injectable dependencies (`LookPath`, `ExecCmd` on
+  the Options struct). No tests require network access,
+  external services, or shared mutable state. All tests
+  verify observable side effects (returned `stepResult`
+  values).

--- a/openspec/changes/setup-auto-native-fallback/tasks.md
+++ b/openspec/changes/setup-auto-native-fallback/tasks.md
@@ -196,3 +196,4 @@
   verify observable side effects (returned `stepResult`
   values).
 <!-- spec-review: passed -->
+<!-- code-review: passed -->

--- a/openspec/changes/setup-auto-native-fallback/tasks.md
+++ b/openspec/changes/setup-auto-native-fallback/tasks.md
@@ -22,28 +22,48 @@
   `*Options` in `internal/setup/setup.go`. Logic:
   (1) if `toolMethod(toolName)` returns non-`"auto"`,
   return that value (per-tool override wins);
-  (2) if `opts.PackageManager` is `"homebrew"`, `"dnf"`,
-  or `"apt"`, return that (global preference);
-  (3) otherwise return `"auto"` for fallback chain.
+  (2) if `opts.PackageManager` is `"homebrew"` or
+  `"dnf"`, return that (global preference);
+  (3) if `opts.PackageManager` is `"apt"`, map to
+  `"auto"` and log info message ("apt support not yet
+  implemented, using auto-mode fallback");
+  (4) otherwise return `"auto"` for fallback chain.
+  `resolveMethod()` is tool-agnostic — it resolves the
+  user's preference, not the tool's capability.
 - [ ] 1.2 Add `installViaGo(opts *Options, toolName,
   goModule string) stepResult` function in
-  `internal/setup/setup.go`. Check `LookPath("go")`
-  first — if Go is not available, return a skip result
-  with install hint. Otherwise call
-  `ExecCmd("go", "install", goModule+"@latest")` and
-  return `stepResult` with `detail: "via go install"`.
-  Handle dry-run mode.
+  `internal/setup/setup.go`. Behavior by outcome:
+  - Go not in PATH: return `action: "skipped"`,
+    `detail` with install hint, `err: nil`.
+  - `go install` succeeds: return
+    `action: "installed"`, `detail: "via go install"`.
+  - `go install` fails: return `action: "failed"`,
+    `detail` with module path and retry hint,
+    `err: fmt.Errorf("go install %s: %w", ...)` per
+    CS-006 error wrapping.
+  - Dry-run: return `action: "dry-run"`,
+    `detail: "Would install: go install <module>@latest"`.
+  All errors in `stepResult.err` MUST be wrapped with
+  operation context per CS-006.
 - [ ] 1.3 Add tests for `resolveMethod()` in
-  `internal/setup/setup_test.go`: per-tool override
-  takes precedence over global, global `PackageManager`
-  takes precedence over `"auto"`, `"auto"` passes
-  through, `"manual"` is handled by `shouldSkipTool`
-  (not `resolveMethod`).
+  `internal/setup/setup_test.go` (table-driven per
+  TC-006): per-tool override takes precedence over
+  global, global `PackageManager: "dnf"` returns `"dnf"`,
+  `PackageManager: "homebrew"` returns `"homebrew"`,
+  `PackageManager: "apt"` maps to `"auto"`,
+  `"auto"` passes through, `"manual"` is handled by
+  `shouldSkipTool` (not `resolveMethod`).
 - [ ] 1.4 Add tests for `installViaGo()` in
-  `internal/setup/setup_test.go`: Go available and
-  install succeeds, Go available but install fails,
-  Go not available returns skip result, dry-run mode
-  returns correct detail string.
+  `internal/setup/setup_test.go` (table-driven per
+  TC-006): Go available and install succeeds (assert
+  `action: "installed"`, `detail: "via go install"`);
+  Go available but install fails (assert
+  `action: "failed"`, `detail` contains module path
+  and retry hint, `err` is non-nil and wrapped);
+  Go not available (assert `action: "skipped"`,
+  `detail` contains install hint, `err` is nil);
+  dry-run mode (assert `detail` matches
+  `"Would install: go install <module>@latest"`).
 
 ## 2. Update installGaze() Auto-Mode Fallback
 
@@ -77,7 +97,13 @@
   (via `installViaRpm`) -> `go install` (via
   `installViaGo`) -> skip. Update dry-run to reflect
   new fallback chain.
-- [ ] 3.3 Add tests: same matrix as 2.2 for Replicator.
+- [ ] 3.3 Add tests (table-driven per TC-006): same
+  fallback chain as Gaze (Homebrew -> dnf -> go install
+  -> skip). Scenarios: dnf available + no Homebrew ->
+  installs via RPM; no Homebrew + no dnf + Go available
+  -> installs via `go install`; no Homebrew + no dnf +
+  no Go -> skips; `PackageManager: "dnf"` -> skips
+  Homebrew, uses dnf.
 
 ## 4. Update installDewey() with Dispatch + Fallback
 
@@ -89,14 +115,19 @@
   `"go"` since dnf is not available for Dewey.
 - [ ] 4.2 Add auto-mode fallback chain: Homebrew ->
   `go install` (via `installViaGo` with module
-  `github.com/unbound-force/dewey`) -> skip. Preserve
-  the `pullEmbeddingModel()` call after any successful
-  install path.
-- [ ] 4.3 Add tests: no Homebrew + Go available ->
-  installs via `go install` + pulls embedding model;
-  no Homebrew + no Go -> skips; `PackageManager: "dnf"`
-  with no dnf method available -> falls through to
-  `go install`.
+  `github.com/unbound-force/dewey/cmd/dewey`) -> skip.
+  Preserve the `pullEmbeddingModel()` call after any
+  successful install path.
+- [ ] 4.3 Add tests (table-driven per TC-006):
+  no Homebrew + Go available -> installs via `go install`
+  + pulls embedding model (assert `action: "installed"`,
+  `detail: "via go install"`);
+  no Homebrew + no Go -> skips (assert
+  `action: "skipped"`);
+  `PackageManager: "dnf"` -> `resolveMethod` returns
+  `"dnf"`, `installDewey` has no `"dnf"` case, falls
+  through to `go install` (assert `detail` contains
+  `"via go install"`).
 
 ## 5. Update installGH() with Dispatch + Fallback
 
@@ -106,13 +137,20 @@
   directly — GH CLI has its own dnf repo, not
   GoReleaser RPMs) and `"homebrew"` case.
 - [ ] 5.2 Add auto-mode fallback chain: Homebrew -> dnf
-  (`dnf install -y gh`) -> skip. If `dnf install gh`
-  fails, fall through to skip with download link.
-  Update dry-run to reflect new fallback chain.
-- [ ] 5.3 Add tests: dnf available + no Homebrew ->
-  attempts `dnf install gh`; dnf install fails ->
-  skips with download link; `PackageManager: "dnf"` ->
-  skips Homebrew, uses dnf directly.
+  (`dnf install -y gh`) -> skip. On `dnf install gh`
+  failure, return `action: "skipped"` (graceful
+  degradation, not hard failure), `detail` with
+  actionable message including GitHub CLI repo setup
+  link, `err: nil`. Update dry-run to reflect new
+  fallback chain.
+- [ ] 5.3 Add tests (table-driven per TC-006):
+  dnf available + no Homebrew -> attempts
+  `dnf install gh` (assert `action: "installed"`);
+  dnf install fails -> skips with actionable download
+  link (assert `action: "skipped"`, NOT `"failed"`,
+  `detail` contains repo setup URL, `err` is nil);
+  `PackageManager: "dnf"` -> skips Homebrew, uses dnf
+  directly.
 
 ## 6. Dry-Run Path Updates
 
@@ -130,19 +168,28 @@
 - [ ] 7.1 Run `make check` — all tests pass, lint clean,
   build succeeds.
 - [ ] 7.2 Run `go test -race -count=1 ./internal/setup/`
-  — verify new tests pass in isolation.
+  — verify new tests pass in isolation. Confirm existing
+  `TestInstallViaRpm_*` tests (Success, NoVersion,
+  DnfFails, DryRun) pass unchanged — no modifications
+  to `installViaRpm()` signature or behavior.
 - [ ] 7.3 Manual smoke test: `uf setup --dry-run` on a
   system without Homebrew — verify tools show dnf or
   `go install` intent instead of "skipped".
 
-## 8. Constitution Alignment Verification
+## 8. Documentation
 
-- [ ] 8.1 Verify Composability First: each tool's
+- [ ] 8.1 Add CHANGELOG.md entry documenting the fix
+  for issue #214: `uf setup` auto mode now falls back
+  to dnf and `go install` when Homebrew is absent.
+
+## 9. Constitution Alignment Verification
+
+- [ ] 9.1 Verify Composability First: each tool's
   fallback chain degrades gracefully — no tool requires
   a specific package manager. Standalone installation
   is preserved via `go install` as the universal
   fallback for Go-based tools.
-- [ ] 8.2 Verify Testability: all new code uses
+- [ ] 9.2 Verify Testability: all new code uses
   injectable dependencies (`LookPath`, `ExecCmd` on
   the Options struct). No tests require network access,
   external services, or shared mutable state. All tests


### PR DESCRIPTION
## Summary

Fix #214: \`uf setup\` auto mode now falls back to native package
managers (dnf) and \`go install\` when Homebrew is absent.

Previously, 4 companion tools (Gaze, Replicator, Dewey, GitHub CLI)
were silently skipped on Fedora/RHEL with download-link hints.

### Changes

- Add \`resolveMethod()\` helper - translates global \`PackageManager\`
  preference and per-tool overrides into a concrete install method
- Add \`installViaGo()\` helper - \`go install\` fallback for Go-based
  tools (follows \`installGolangciLint()\` pattern)
- Wire auto-mode fallback chains:
  - **Gaze**: Homebrew - dnf (RPM) - go install - skip
  - **Replicator**: Homebrew - dnf (RPM) - go install - skip
  - **Dewey**: Homebrew - go install - skip (no RPMs)
  - **GH CLI**: Homebrew - dnf - skip (GitHub's own dnf repo)
- \`UF_PACKAGE_MANAGER=dnf\` now forces the dnf install path
- \`PackageManager: \"apt\"\` maps to \`\"auto\"\` with info log

### Testing

- 30 new test functions (table-driven per TC-006)
- 136 tests pass, 0 fail in \`internal/setup/\`
- Tested in Fedora 43 container without Homebrew

### Spec

\`openspec/changes/setup-auto-native-fallback/\`

Fixes #214