### PR TITLE
feat: add dnf/RPM and binary download fallbacks to uf setup

### DIFF
--- a/.gaze/baseline.json
+++ b/.gaze/baseline.json
@@ -1751,9 +1751,9 @@
       "function": "managerInstallCmd",
       "file": "internal/doctor/environ.go",
       "line": 228,
-      "complexity": 11,
-      "line_coverage": 91.66666666666667,
-      "crap": 11.070023148148149
+      "complexity": 12,
+      "line_coverage": 92.3076923076923,
+      "crap": 12.071005917159763
     },
     {
       "package": "doctor",
@@ -4728,7 +4728,7 @@
       "package": "setup",
       "function": "installOllama",
       "file": "internal/setup/setup.go",
-      "line": 897,
+      "line": 1010,
       "complexity": 6,
       "line_coverage": 100,
       "crap": 6
@@ -4764,7 +4764,7 @@
       "package": "setup",
       "function": "installDevPod",
       "file": "internal/setup/setup.go",
-      "line": 1029,
+      "line": 1210,
       "complexity": 6,
       "line_coverage": 90.9090909090909,
       "crap": 6.027047332832457
@@ -5035,6 +5035,33 @@
       "contract_coverage": 100,
       "gaze_crap": 1,
       "quadrant": "Q1_Safe"
+    },
+    {
+      "package": "doctor",
+      "function": "dnfOrGenericCmd",
+      "file": "internal/doctor/environ.go",
+      "line": 296,
+      "complexity": 2,
+      "line_coverage": 100,
+      "crap": 2
+    },
+    {
+      "package": "setup",
+      "function": "installOllamaViaCurl",
+      "file": "internal/setup/setup.go",
+      "line": 1038,
+      "complexity": 4,
+      "line_coverage": 100,
+      "crap": 4
+    },
+    {
+      "package": "setup",
+      "function": "installDevPodViaBinary",
+      "file": "internal/setup/setup.go",
+      "line": 1241,
+      "complexity": 4,
+      "line_coverage": 100,
+      "crap": 4
     }
   ],
   "summary": {

--- a/.opencode/agents/cobalt-crush-dev.md
+++ b/.opencode/agents/cobalt-crush-dev.md
@@ -99,7 +99,7 @@ After writing code, check for Gaze quality feedback:
 
 4. **Re-validate**: After addressing all findings, run the project's test suite. Proceed to review only when all tests pass and quality metrics are acceptable.
 
-5. **No Gaze available**: If Gaze is not installed or no artifacts exist, note this: "Quality validation is not available — Gaze is not installed. Recommend running `brew install unbound-force/tap/gaze` for automated quality feedback." Proceed with implementation using best-effort test coverage.
+5. **No Gaze available**: If Gaze is not installed or no artifacts exist, note this: "Quality validation is not available — Gaze is not installed. Recommend running `brew install unbound-force/tap/gaze` (or on Fedora/RHEL: `go install github.com/unbound-force/gaze/cmd/gaze@latest`) for automated quality feedback." Proceed with implementation using best-effort test coverage.
 
 ## Divisor Review Preparation
 

--- a/.opencode/agents/gaze-reporter.md
+++ b/.opencode/agents/gaze-reporter.md
@@ -80,6 +80,7 @@ Before running any gaze command, locate the `gaze` binary:
 
 If all three methods fail, report the error clearly and suggest
 the developer install gaze via `brew install unbound-force/tap/gaze`
+(or on Fedora/RHEL: `sudo dnf install <RPM URL>`)
 or `go install github.com/unbound-force/gaze/cmd/gaze@latest`.
 
 ## Mode Parsing

--- a/.opencode/commands/review-council.md
+++ b/.opencode/commands/review-council.md
@@ -167,9 +167,11 @@ Review the current codebase for compliance with the Behavioral Constraints in `A
 
    c. **If `gaze` is NOT available**: skip with an
       informational note:
-      > "Gaze not installed -- skipping quality
-      > analysis. Install with
-      > `brew install unbound-force/tap/gaze`."
+       > "Gaze not installed -- skipping quality
+       > analysis. Install with
+       > `brew install unbound-force/tap/gaze`
+       > (or on Fedora/RHEL:
+       > `go install github.com/unbound-force/gaze/cmd/gaze@latest`)."
 
       Proceed to step 2 without Gaze data.
 

--- a/.opencode/commands/uf-init.md
+++ b/.opencode/commands/uf-init.md
@@ -664,6 +664,7 @@ Re-run `/uf-init` after:
 - Running `uf init` or `uf setup` (new tool versions
   may reset third-party files)
 - Updating the OpenSpec CLI (`npm update`)
-- Upgrading the `uf` binary (`brew upgrade unbound-force`
-  — new versions may add scaffold files that need
-  customization)
+- Upgrading the `uf` binary (`brew upgrade unbound-force`,
+   or on Fedora/RHEL: `sudo dnf upgrade unbound-force`
+   — new versions may add scaffold files that need
+   customization)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,16 @@ Each entry follows the format: `- <change-name>: <summary>`.
   (Spec: openspec/changes/parallel-subtool-init/)
 
 ### Fixed
+- `uf setup` DevPod now falls back to binary download from GitHub
+  Releases when Homebrew is absent, gated by `--yes` flag or
+  interactive terminal (#268)
+- `uf setup` auto mode now falls back to `dnf install`
+  for Podman and curl installer for Ollama when Homebrew
+  is absent on Fedora/RHEL (#268)
+- Doctor hints now show `dnf install` commands on Fedora
+  systems instead of `brew install`
+- Fixed `genericInstallCmd("replicator")` returning
+  `brew install` in the no-package-manager codepath
 - `uf setup` auto mode now falls back to native package
   managers and `go install` when Homebrew is absent.
   Previously, 4 companion tools (Gaze, Replicator, Dewey,

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -162,6 +162,11 @@ uf setup        # installs recommended tools
 uf doctor       # verify everything works
 ```
 
+On Fedora/RHEL: `uf setup` automatically uses `dnf install`
+for tools with RPM packages (e.g., Podman) and `go install`
+for Go-based tools when Homebrew is absent. No extra
+configuration needed.
+
 Preview what `uf setup` will install before running:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -27,8 +27,20 @@ All hero repositories must maintain constitutions that align with (and never con
 
 ## Getting Started
 
+### macOS (Homebrew)
+
 ```bash
 brew install unbound-force/tap/unbound-force
+```
+
+### Fedora / RHEL (dnf)
+
+```bash
+sudo dnf install -y "$(
+  curl -fsSL \
+    https://api.github.com/repos/unbound-force/unbound-force/releases/latest |
+  grep -o 'https://[^"]*linux_amd64\.rpm'
+)"
 ```
 
 See **[QUICKSTART.md](QUICKSTART.md)** for full installation instructions (macOS and Fedora/RHEL), first-use walkthrough, and platform-specific guidance. See **[Usage Guide](docs/usage.md)** for common workflows and command reference.

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -4354,3 +4354,107 @@ func TestCheckAnyTool_FirstBinaryWins(t *testing.T) {
 		t.Errorf("message = %q, want %q (first binary wins)", result.Message, "black installed")
 	}
 }
+
+// --- dnfInstallCmd tests ---
+
+func TestDnfInstallCmd_ToolMapping(t *testing.T) {
+	tests := []struct {
+		tool string
+		want string
+	}{
+		{"go", "dnf install -y golang"},
+		{"node", "dnf install -y nodejs"},
+		{"gh", "dnf install -y gh"},
+		{"podman", "dnf install -y podman"},
+		{"gaze", "sudo dnf install <gaze RPM from https://github.com/unbound-force/gaze/releases>"},
+		{"replicator", "sudo dnf install <replicator RPM from https://github.com/unbound-force/replicator/releases>"},
+		{"opencode", "dnf install -y opencode"},
+		// Tools NOT in Fedora repos return empty string.
+		{"ollama", ""},
+		{"devpod", ""},
+		{"dewey", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.tool, func(t *testing.T) {
+			got := dnfInstallCmd(tt.tool)
+			if got != tt.want {
+				t.Errorf("dnfInstallCmd(%q) = %q, want %q", tt.tool, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestInstallHint_DnfDetected_NoHomebrew(t *testing.T) {
+	// When only ManagerDnf is detected, installHint should return
+	// dnf commands for tools in Fedora repos and generic download
+	// links for tools not in Fedora repos.
+	env := DetectedEnvironment{
+		Managers: []ManagerInfo{
+			{Kind: ManagerDnf, Path: "/usr/bin/dnf", Manages: []string{"packages"}},
+		},
+	}
+
+	tests := []struct {
+		tool     string
+		contains string
+	}{
+		{"podman", "dnf install -y podman"},
+		{"gh", "dnf install -y gh"},
+		{"gaze", "dnf install"},
+		{"replicator", "dnf install"},
+		// Tools not in Fedora repos fall through to genericInstallCmd.
+		{"ollama", "Download from https://ollama.com/download"},
+		{"devpod", "Download from https://devpod.sh/docs/getting-started/install"},
+		{"dewey", "Install dewey"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.tool, func(t *testing.T) {
+			hint := installHint(tt.tool, env)
+			if !strings.Contains(hint, tt.contains) {
+				t.Errorf("installHint(%q) = %q, want to contain %q", tt.tool, hint, tt.contains)
+			}
+		})
+	}
+}
+
+func TestInstallHint_BothManagers_HomebrewPreferred(t *testing.T) {
+	// When both Homebrew and dnf are detected, Homebrew takes
+	// priority because it appears first in the manager iteration
+	// (Homebrew is detected before dnf in DetectEnvironment).
+	env := DetectedEnvironment{
+		Managers: []ManagerInfo{
+			{Kind: ManagerHomebrew, Path: "/opt/homebrew/bin/brew", Manages: []string{"packages"}},
+			{Kind: ManagerDnf, Path: "/usr/bin/dnf", Manages: []string{"packages"}},
+		},
+	}
+
+	tests := []struct {
+		tool     string
+		contains string
+	}{
+		{"podman", "brew install podman"},
+		{"gaze", "brew install unbound-force/tap/gaze"},
+		{"gh", "brew install gh"},
+		{"ollama", "brew install"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.tool, func(t *testing.T) {
+			hint := installHint(tt.tool, env)
+			if !strings.Contains(hint, tt.contains) {
+				t.Errorf("installHint(%q) = %q, want to contain %q", tt.tool, hint, tt.contains)
+			}
+		})
+	}
+}
+
+func TestGenericInstallCmd_ReplicatorFixed(t *testing.T) {
+	// Verify the replicator bug fix: genericInstallCmd should return
+	// a download link, not a brew command.
+	got := genericInstallCmd("replicator")
+	if strings.Contains(got, "brew") {
+		t.Errorf("genericInstallCmd(replicator) = %q, must not contain brew command", got)
+	}
+	if !strings.Contains(got, "https://github.com/unbound-force/replicator/releases") {
+		t.Errorf("genericInstallCmd(replicator) = %q, want download URL", got)
+	}
+}

--- a/internal/doctor/environ.go
+++ b/internal/doctor/environ.go
@@ -251,6 +251,8 @@ func managerInstallCmd(toolName string, manager ManagerKind) string {
 		}
 	case ManagerHomebrew:
 		return homebrewInstallCmd(toolName)
+	case ManagerDnf:
+		return dnfOrGenericCmd(toolName)
 	}
 	return homebrewInstallCmd(toolName)
 }
@@ -287,6 +289,44 @@ func homebrewInstallCmd(toolName string) string {
 	}
 }
 
+// dnfOrGenericCmd returns the dnf install command for a tool if
+// available in Fedora repos, otherwise falls through to generic
+// download instructions. This avoids returning Homebrew hints on
+// Fedora systems for tools without native packages.
+func dnfOrGenericCmd(toolName string) string {
+	if cmd := dnfInstallCmd(toolName); cmd != "" {
+		return cmd
+	}
+	return genericInstallCmd(toolName)
+}
+
+// dnfInstallCmd returns the dnf install command for a tool.
+// Returns empty string for tools not available in Fedora repos
+// (ollama, devpod, dewey), signaling fall-through to
+// genericInstallCmd. Parallel to homebrewInstallCmd per D5.
+func dnfInstallCmd(toolName string) string {
+	switch toolName {
+	case "go":
+		return "dnf install -y golang"
+	case "node":
+		return "dnf install -y nodejs"
+	case "gh":
+		return "dnf install -y gh"
+	case "podman":
+		return "dnf install -y podman"
+	case "gaze":
+		return "sudo dnf install <gaze RPM from https://github.com/unbound-force/gaze/releases>"
+	case "replicator":
+		return "sudo dnf install <replicator RPM from https://github.com/unbound-force/replicator/releases>"
+	case "ollama", "devpod", "dewey":
+		// Not available in Fedora repos — fall through to
+		// genericInstallCmd for download links.
+		return ""
+	default:
+		return "dnf install -y " + toolName
+	}
+}
+
 // genericInstallCmd returns generic install instructions when
 // no package manager is detected.
 func genericInstallCmd(toolName string) string {
@@ -300,7 +340,7 @@ func genericInstallCmd(toolName string) string {
 	case "node":
 		return "Download from https://nodejs.org/"
 	case "replicator":
-		return "brew install unbound-force/tap/replicator"
+		return "Download from https://github.com/unbound-force/replicator/releases"
 	case "gh":
 		return "Download from https://cli.github.com/"
 	case "ollama":

--- a/internal/scaffold/assets/opencode/agents/cobalt-crush-dev.md
+++ b/internal/scaffold/assets/opencode/agents/cobalt-crush-dev.md
@@ -99,7 +99,7 @@ After writing code, check for Gaze quality feedback:
 
 4. **Re-validate**: After addressing all findings, run the project's test suite. Proceed to review only when all tests pass and quality metrics are acceptable.
 
-5. **No Gaze available**: If Gaze is not installed or no artifacts exist, note this: "Quality validation is not available — Gaze is not installed. Recommend running `brew install unbound-force/tap/gaze` for automated quality feedback." Proceed with implementation using best-effort test coverage.
+5. **No Gaze available**: If Gaze is not installed or no artifacts exist, note this: "Quality validation is not available — Gaze is not installed. Recommend running `brew install unbound-force/tap/gaze` (or on Fedora/RHEL: `go install github.com/unbound-force/gaze/cmd/gaze@latest`) for automated quality feedback." Proceed with implementation using best-effort test coverage.
 
 ## Divisor Review Preparation
 

--- a/internal/scaffold/assets/opencode/commands/review-council.md
+++ b/internal/scaffold/assets/opencode/commands/review-council.md
@@ -167,9 +167,11 @@ Review the current codebase for compliance with the Behavioral Constraints in `A
 
    c. **If `gaze` is NOT available**: skip with an
       informational note:
-      > "Gaze not installed -- skipping quality
-      > analysis. Install with
-      > `brew install unbound-force/tap/gaze`."
+       > "Gaze not installed -- skipping quality
+       > analysis. Install with
+       > `brew install unbound-force/tap/gaze`
+       > (or on Fedora/RHEL:
+       > `go install github.com/unbound-force/gaze/cmd/gaze@latest`)."
 
       Proceed to step 2 without Gaze data.
 

--- a/internal/scaffold/assets/opencode/commands/uf-init.md
+++ b/internal/scaffold/assets/opencode/commands/uf-init.md
@@ -664,6 +664,7 @@ Re-run `/uf-init` after:
 - Running `uf init` or `uf setup` (new tool versions
   may reset third-party files)
 - Updating the OpenSpec CLI (`npm update`)
-- Upgrading the `uf` binary (`brew upgrade unbound-force`
-  — new versions may add scaffold files that need
-  customization)
+- Upgrading the `uf` binary (`brew upgrade unbound-force`,
+   or on Fedora/RHEL: `sudo dnf upgrade unbound-force`
+   — new versions may add scaffold files that need
+   customization)

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -1016,36 +1016,54 @@ func ollamaBrew(goos string) []string {
 // installOllama installs Ollama if missing. Ollama is the local
 // model runtime used by both Dewey (semantic search embeddings)
 // and Replicator (semantic memory). OS-aware: uses cask on macOS,
-// formula on Linux. Skips with download link if no Homebrew.
+// formula on Linux. Falls back to the official curl installer when
+// Homebrew is absent, gated by YesFlag/IsTTY per FR-DNF-003.
 func installOllama(opts *Options, env doctor.DetectedEnvironment) stepResult {
 	if _, err := opts.LookPath("ollama"); err == nil {
 		return stepResult{name: "Ollama", action: "already installed"}
 	}
 
-	// Determine the Homebrew install method based on OS.
-	// macOS: cask (ollama-app) for .app bundle with auto-updates.
-	// Linux: formula (ollama) — casks are macOS-only.
 	brewArgs := ollamaBrew(opts.GOOS)
 
 	if opts.DryRun {
 		if doctor.HasManager(env, doctor.ManagerHomebrew) {
 			return stepResult{name: "Ollama", action: "dry-run", detail: "Would install: brew install " + strings.Join(brewArgs[1:], " ")}
 		}
-		return stepResult{name: "Ollama", action: "dry-run", detail: "Would install: download from https://ollama.com/download"}
+		return stepResult{name: "Ollama", action: "dry-run", detail: "Would install via: curl -fsSL https://ollama.com/install.sh | sh"}
 	}
 
-	if !doctor.HasManager(env, doctor.ManagerHomebrew) {
+	// Try Homebrew first.
+	if doctor.HasManager(env, doctor.ManagerHomebrew) {
+		if out, err := opts.ExecCmd(brewArgs[0], brewArgs[1:]...); err != nil {
+			return stepResult{name: "Ollama", action: "failed", detail: "brew install failed", err: err, output: out}
+		}
+		return stepResult{name: "Ollama", action: "installed", detail: "via Homebrew"}
+	}
+
+	return installOllamaViaCurl(opts)
+}
+
+// installOllamaViaCurl installs Ollama via the official curl installer.
+// Requires --yes or TTY confirmation (FR-DNF-003). Matches the
+// installOpenCode() YesFlag/IsTTY pattern.
+//
+// Constitution V trade-off: the install script is fetched over HTTPS
+// from the official domain without content-hash verification. Hash
+// pinning is impractical — the script changes with each release.
+// The YesFlag/IsTTY gate ensures no unattended execution.
+func installOllamaViaCurl(opts *Options) stepResult {
+	if !opts.YesFlag && !opts.IsTTY() {
 		return stepResult{
 			name:   "Ollama",
 			action: "skipped",
-			detail: "Homebrew not available. Download from https://ollama.com/download",
+			detail: "curl|bash install requires --yes flag or interactive terminal",
 		}
 	}
 
-	if out, err := opts.ExecCmd(brewArgs[0], brewArgs[1:]...); err != nil {
-		return stepResult{name: "Ollama", action: "failed", detail: "brew install failed", err: err, output: out}
+	if out, err := opts.ExecCmd("bash", "-c", "curl -fsSL https://ollama.com/install.sh | sh"); err != nil {
+		return stepResult{name: "Ollama", action: "failed", detail: "curl install failed", err: err, output: out}
 	}
-	return stepResult{name: "Ollama", action: "installed", detail: "via Homebrew"}
+	return stepResult{name: "Ollama", action: "installed", detail: "via curl installer"}
 }
 
 // podmanMachineTimeout is the timeout for podman machine init,
@@ -1055,38 +1073,85 @@ func installOllama(opts *Options, env doctor.DetectedEnvironment) stepResult {
 const podmanMachineTimeout = "180"
 
 // installPodman installs Podman if missing. Podman is the container
-// runtime used by the sandbox for isolated agent sessions. On macOS,
-// after installation, a Podman machine is initialized and started
-// (best-effort — failures are reported but do not block the step).
-// A smoke test via `podman info` verifies the installation is
+// runtime used by the sandbox for isolated agent sessions.
+// Fallback chain (D2): Homebrew → dnf → skip with download link.
+// On macOS, after installation, a Podman machine is initialized and
+// started (best-effort — failures are reported but do not block the
+// step). A smoke test via `podman info` verifies the installation is
 // functional.
 func installPodman(opts *Options, env doctor.DetectedEnvironment) stepResult {
 	if _, err := opts.LookPath("podman"); err == nil {
 		return stepResult{name: "Podman", action: "already installed"}
 	}
 
-	if opts.DryRun {
-		if doctor.HasManager(env, doctor.ManagerHomebrew) {
-			return stepResult{name: "Podman", action: "dry-run", detail: "Would install: brew install podman"}
-		}
-		return stepResult{name: "Podman", action: "dry-run", detail: "Would install: download from https://podman.io/docs/installation"}
+	// Fallback chain (D2): Homebrew → dnf → skip.
+	method := opts.resolveMethod("podman", env, "homebrew", "dnf")
+	switch method {
+	case "homebrew":
+		return installPodmanViaBrew(opts, env)
+	case "dnf":
+		return installPodmanViaDnf(opts, env)
+	default:
+		return podmanSkipResult(opts)
 	}
+}
 
-	if !doctor.HasManager(env, doctor.ManagerHomebrew) {
-		return stepResult{
-			name:   "Podman",
-			action: "skipped",
-			detail: "Homebrew not available. Download from https://podman.io/docs/installation",
-		}
+// installPodmanViaBrew installs Podman via Homebrew. Handles dry-run,
+// macOS machine init, and smoke test.
+func installPodmanViaBrew(opts *Options, env doctor.DetectedEnvironment) stepResult {
+	if opts.DryRun {
+		return stepResult{name: "Podman", action: "dry-run", detail: "Would install: brew install podman"}
 	}
 
 	if out, err := opts.ExecCmd("brew", "install", "podman"); err != nil {
 		return stepResult{name: "Podman", action: "failed", detail: "brew install failed", err: err, output: out}
 	}
 
+	return podmanPostInstall(opts, "via Homebrew")
+}
+
+// installPodmanViaDnf installs Podman via dnf. On failure, returns
+// an actionable error with sudo guidance per FR-DNF-002.
+func installPodmanViaDnf(opts *Options, env doctor.DetectedEnvironment) stepResult {
+	if opts.DryRun {
+		return stepResult{name: "Podman", action: "dry-run", detail: "Would install: dnf install -y podman"}
+	}
+
+	if out, err := opts.ExecCmd("dnf", "install", "-y", "podman"); err != nil {
+		return stepResult{
+			name:   "Podman",
+			action: "failed",
+			detail: "dnf install requires root — run with sudo or install manually: sudo dnf install -y podman",
+			err:    err,
+			output: out,
+		}
+	}
+
+	return podmanPostInstall(opts, "via dnf")
+}
+
+// podmanSkipResult returns the appropriate skip/dry-run result when
+// no package manager is available for Podman.
+func podmanSkipResult(opts *Options) stepResult {
+	if opts.DryRun {
+		return stepResult{
+			name:   "Podman",
+			action: "dry-run",
+			detail: "Would install: download from https://podman.io/docs/installation",
+		}
+	}
+	return stepResult{
+		name:   "Podman",
+		action: "skipped",
+		detail: "Homebrew not available. Download from https://podman.io/docs/installation",
+	}
+}
+
+// podmanPostInstall handles macOS machine init and smoke test after
+// a successful Podman installation. Shared between brew and dnf paths.
+func podmanPostInstall(opts *Options, detail string) stepResult {
 	// macOS post-install: initialize and start a Podman machine.
 	// Podman on macOS requires a VM to run Linux containers.
-	detail := "via Homebrew"
 	if opts.GOOS == "darwin" {
 		detail = podmanMachineInit(opts, detail)
 	}
@@ -1145,10 +1210,20 @@ func initMachineWithTimeout(opts *Options) ([]byte, error) {
 	return opts.ExecCmd("podman", "machine", "init")
 }
 
+// devpodBinaryURL returns the GitHub Releases download URL for the
+// DevPod CLI binary matching the current architecture. DevPod does
+// not provide a curl|sh installer or native packages — the CLI is
+// distributed as a standalone binary download (D4).
+func devpodBinaryURL() string {
+	return fmt.Sprintf(
+		"https://github.com/loft-sh/devpod/releases/latest/download/devpod-linux-%s",
+		rpmArch(),
+	)
+}
+
 // installDevPod installs DevPod if missing. DevPod provides
-// persistent workspace management on top of Podman. Follows the
-// installGaze() pattern: Homebrew only, skip with download URL
-// if no Homebrew.
+// persistent workspace management on top of Podman. Fallback chain:
+// Homebrew → binary download (gated by YesFlag/IsTTY) → skip.
 func installDevPod(opts *Options, env doctor.DetectedEnvironment) stepResult {
 	if _, err := opts.LookPath("devpod"); err == nil {
 		return stepResult{name: "DevPod", action: "already installed"}
@@ -1158,21 +1233,59 @@ func installDevPod(opts *Options, env doctor.DetectedEnvironment) stepResult {
 		if doctor.HasManager(env, doctor.ManagerHomebrew) {
 			return stepResult{name: "DevPod", action: "dry-run", detail: "Would install: brew install devpod"}
 		}
-		return stepResult{name: "DevPod", action: "dry-run", detail: "Would install: download from https://devpod.sh/docs/getting-started/install"}
-	}
-
-	if !doctor.HasManager(env, doctor.ManagerHomebrew) {
 		return stepResult{
 			name:   "DevPod",
-			action: "skipped",
-			detail: "Homebrew not available. Download from https://devpod.sh/docs/getting-started/install",
+			action: "dry-run",
+			detail: "Would install via: curl -L -o devpod " + devpodBinaryURL(),
 		}
 	}
 
-	if out, err := opts.ExecCmd("brew", "install", "devpod"); err != nil {
-		return stepResult{name: "DevPod", action: "failed", detail: "brew install failed", err: err, output: out}
+	// Try Homebrew first.
+	if doctor.HasManager(env, doctor.ManagerHomebrew) {
+		if out, err := opts.ExecCmd("brew", "install", "devpod"); err != nil {
+			return stepResult{name: "DevPod", action: "failed", detail: "brew install failed", err: err, output: out}
+		}
+		return stepResult{name: "DevPod", action: "installed", detail: "via Homebrew"}
 	}
-	return stepResult{name: "DevPod", action: "installed", detail: "via Homebrew"}
+
+	return installDevPodViaBinary(opts)
+}
+
+// installDevPodViaBinary downloads and installs the DevPod CLI binary
+// from GitHub Releases. Follows the official DevPod install method:
+// curl the binary, then use install(1) to place it with 0755 perms.
+// Requires --yes or TTY confirmation (FR-DNF-004).
+//
+// Constitution V trade-off: the binary is fetched over HTTPS from
+// GitHub Releases without content-hash verification. The download
+// URL uses /releases/latest/ which resolves to the newest version,
+// making hash pinning impractical. The YesFlag/IsTTY gate ensures
+// no unattended execution. Uses mktemp for the temporary file to
+// avoid TOCTOU on multi-user systems.
+func installDevPodViaBinary(opts *Options) stepResult {
+	if !opts.YesFlag && !opts.IsTTY() {
+		return stepResult{
+			name:   "DevPod",
+			action: "skipped",
+			detail: "curl|bash install requires --yes flag or interactive terminal",
+		}
+	}
+
+	url := devpodBinaryURL()
+	cmd := fmt.Sprintf(
+		"tmpfile=$(mktemp) && curl -L -o \"$tmpfile\" %q && sudo install -c -m 0755 \"$tmpfile\" /usr/local/bin/devpod && rm -f \"$tmpfile\"",
+		url,
+	)
+	if out, err := opts.ExecCmd("bash", "-c", cmd); err != nil {
+		return stepResult{
+			name:   "DevPod",
+			action: "failed",
+			detail: "binary download failed — try: " + url,
+			err:    fmt.Errorf("devpod binary download: %w", err),
+			output: out,
+		}
+	}
+	return stepResult{name: "DevPod", action: "installed", detail: "via binary download"}
 }
 
 // configureDevPodProvider configures the DevPod Podman provider

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -1554,10 +1554,11 @@ func TestSetupRun_OllamaNoHomebrew(t *testing.T) {
 		}
 	}
 
-	// Verify output contains download link.
+	// Verify output contains the curl|bash skip message (FR-DNF-003:
+	// non-interactive without --yes skips the curl installer).
 	output := buf.String()
-	if !strings.Contains(output, "ollama.com/download") {
-		t.Error("expected download link in output when Homebrew is not available")
+	if !strings.Contains(output, "curl|bash install requires --yes flag or interactive terminal") {
+		t.Errorf("expected curl|bash skip message in output when Homebrew is not available, got: %s", output)
 	}
 }
 
@@ -3077,31 +3078,140 @@ func TestInstallDevPod_BrewInstall(t *testing.T) {
 	}
 }
 
-func TestInstallDevPod_NoHomebrew(t *testing.T) {
+func TestInstallDevPod_NoHomebrew_NonInteractive(t *testing.T) {
+	// No Homebrew + non-interactive → skipped with YesFlag/IsTTY message.
 	rec := &cmdRecorder{}
 
-	opts := Options{
-		Stdout:       &bytes.Buffer{},
-		Stderr:       &bytes.Buffer{},
-		LookPath:     stubLookPath(map[string]string{}),
-		ExecCmd:      rec.execCmd,
-		EvalSymlinks: stubEvalSymlinks(nil),
-		Getenv:       stubGetenv(map[string]string{}),
+	opts := &Options{
+		GOOS:     "linux",
+		YesFlag:  false,
+		IsTTY:    func() bool { return false },
+		LookPath: stubLookPath(map[string]string{}),
+		ExecCmd:  rec.execCmd,
+		Stdout:   &bytes.Buffer{},
+		Stderr:   &bytes.Buffer{},
 	}
-	opts.defaults()
+	env := doctor.DetectedEnvironment{
+		Managers: []doctor.ManagerInfo{},
+	}
 
-	env := doctor.DetectEnvironment(&doctor.Options{
-		LookPath:     opts.LookPath,
-		EvalSymlinks: opts.EvalSymlinks,
-		Getenv:       opts.Getenv,
-	})
-
-	result := installDevPod(&opts, env)
+	result := installDevPod(opts, env)
 	if result.action != "skipped" {
 		t.Errorf("expected 'skipped', got %q", result.action)
 	}
-	if !strings.Contains(result.detail, "devpod.sh/docs/getting-started/install") {
-		t.Errorf("expected download URL in detail, got %q", result.detail)
+	if !strings.Contains(result.detail, "requires --yes flag") {
+		t.Errorf("expected YesFlag hint in detail, got %q", result.detail)
+	}
+}
+
+func TestInstallDevPod_BinaryDownload_YesFlag(t *testing.T) {
+	// YesFlag true + no Homebrew → installs via binary download.
+	rec := &cmdRecorder{}
+	opts := &Options{
+		GOOS:     "linux",
+		YesFlag:  true,
+		IsTTY:    func() bool { return false },
+		LookPath: stubLookPath(map[string]string{}),
+		ExecCmd:  rec.execCmd,
+		Stdout:   &bytes.Buffer{},
+		Stderr:   &bytes.Buffer{},
+	}
+	env := doctor.DetectedEnvironment{
+		Managers: []doctor.ManagerInfo{},
+	}
+
+	result := installDevPod(opts, env)
+	if result.action != "installed" {
+		t.Errorf("action = %q, want installed", result.action)
+	}
+	if result.detail != "via binary download" {
+		t.Errorf("detail = %q, want 'via binary download'", result.detail)
+	}
+	found := false
+	for _, call := range rec.calls {
+		if strings.Contains(call, "curl -L -o") && strings.Contains(call, "devpod-linux") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected curl binary download call, got: %v", rec.calls)
+	}
+}
+
+func TestInstallDevPod_BinaryDownload_IsTTY(t *testing.T) {
+	// IsTTY true + no Homebrew → installs via binary download.
+	rec := &cmdRecorder{}
+	opts := &Options{
+		GOOS:     "linux",
+		YesFlag:  false,
+		IsTTY:    func() bool { return true },
+		LookPath: stubLookPath(map[string]string{}),
+		ExecCmd:  rec.execCmd,
+		Stdout:   &bytes.Buffer{},
+		Stderr:   &bytes.Buffer{},
+	}
+	env := doctor.DetectedEnvironment{
+		Managers: []doctor.ManagerInfo{},
+	}
+
+	result := installDevPod(opts, env)
+	if result.action != "installed" {
+		t.Errorf("action = %q, want installed", result.action)
+	}
+	if result.detail != "via binary download" {
+		t.Errorf("detail = %q, want 'via binary download'", result.detail)
+	}
+}
+
+func TestInstallDevPod_BinaryDownloadFails(t *testing.T) {
+	// Binary download fails → returns failed with URL hint.
+	opts := &Options{
+		GOOS:     "linux",
+		YesFlag:  true,
+		IsTTY:    func() bool { return false },
+		LookPath: stubLookPath(map[string]string{}),
+		ExecCmd: func(cmd string, args ...string) ([]byte, error) {
+			return nil, fmt.Errorf("curl failed")
+		},
+		Stdout: &bytes.Buffer{},
+		Stderr: &bytes.Buffer{},
+	}
+	env := doctor.DetectedEnvironment{
+		Managers: []doctor.ManagerInfo{},
+	}
+
+	result := installDevPod(opts, env)
+	if result.action != "failed" {
+		t.Errorf("action = %q, want failed", result.action)
+	}
+	if !strings.Contains(result.detail, "binary download failed") {
+		t.Errorf("detail = %q, want 'binary download failed'", result.detail)
+	}
+	if result.err == nil {
+		t.Error("expected non-nil error")
+	}
+}
+
+func TestInstallDevPod_DryRun_NoBrew(t *testing.T) {
+	// Dry-run + no Homebrew → shows binary download URL.
+	opts := &Options{
+		GOOS:     "linux",
+		DryRun:   true,
+		LookPath: stubLookPath(map[string]string{}),
+		ExecCmd:  (&cmdRecorder{}).execCmd,
+		Stdout:   &bytes.Buffer{},
+		Stderr:   &bytes.Buffer{},
+	}
+	env := doctor.DetectedEnvironment{
+		Managers: []doctor.ManagerInfo{},
+	}
+
+	result := installDevPod(opts, env)
+	if result.action != "dry-run" {
+		t.Errorf("action = %q, want dry-run", result.action)
+	}
+	if !strings.Contains(result.detail, "curl -L -o devpod") {
+		t.Errorf("detail = %q, want curl download URL", result.detail)
 	}
 }
 
@@ -4923,6 +5033,299 @@ func TestInstallGaze_ExplicitHomebrewFails(t *testing.T) {
 	}
 	if result.err == nil {
 		t.Error("expected non-nil error")
+	}
+}
+
+// --- Ollama curl installer tests (FR-DNF-003) ---
+
+func TestInstallOllama_CurlInstall_YesFlag(t *testing.T) {
+	// YesFlag true + no Homebrew → installs via curl installer.
+	rec := &cmdRecorder{}
+	opts := &Options{
+		GOOS:     "linux",
+		YesFlag:  true,
+		IsTTY:    func() bool { return false },
+		LookPath: stubLookPath(map[string]string{}),
+		ExecCmd:  rec.execCmd,
+		Stdout:   &bytes.Buffer{},
+		Stderr:   &bytes.Buffer{},
+	}
+	env := doctor.DetectedEnvironment{
+		Managers: []doctor.ManagerInfo{},
+	}
+
+	result := installOllama(opts, env)
+	if result.action != "installed" {
+		t.Errorf("action = %q, want installed", result.action)
+	}
+	if result.detail != "via curl installer" {
+		t.Errorf("detail = %q, want 'via curl installer'", result.detail)
+	}
+	found := false
+	for _, call := range rec.calls {
+		if strings.Contains(call, "curl -fsSL https://ollama.com/install.sh") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected curl install call, got: %v", rec.calls)
+	}
+}
+
+func TestInstallOllama_CurlInstall_IsTTY(t *testing.T) {
+	// IsTTY true + YesFlag false + no Homebrew → installs via curl.
+	rec := &cmdRecorder{}
+	opts := &Options{
+		GOOS:     "linux",
+		YesFlag:  false,
+		IsTTY:    func() bool { return true },
+		LookPath: stubLookPath(map[string]string{}),
+		ExecCmd:  rec.execCmd,
+		Stdout:   &bytes.Buffer{},
+		Stderr:   &bytes.Buffer{},
+	}
+	env := doctor.DetectedEnvironment{
+		Managers: []doctor.ManagerInfo{},
+	}
+
+	result := installOllama(opts, env)
+	if result.action != "installed" {
+		t.Errorf("action = %q, want installed", result.action)
+	}
+	if result.detail != "via curl installer" {
+		t.Errorf("detail = %q, want 'via curl installer'", result.detail)
+	}
+}
+
+func TestInstallOllama_Skipped_NonInteractive(t *testing.T) {
+	// IsTTY false + YesFlag false + no Homebrew → skips.
+	opts := &Options{
+		GOOS:     "linux",
+		YesFlag:  false,
+		IsTTY:    func() bool { return false },
+		LookPath: stubLookPath(map[string]string{}),
+		ExecCmd:  (&cmdRecorder{}).execCmd,
+		Stdout:   &bytes.Buffer{},
+		Stderr:   &bytes.Buffer{},
+	}
+	env := doctor.DetectedEnvironment{
+		Managers: []doctor.ManagerInfo{},
+	}
+
+	result := installOllama(opts, env)
+	if result.action != "skipped" {
+		t.Errorf("action = %q, want skipped", result.action)
+	}
+	if !strings.Contains(result.detail, "requires --yes flag or interactive terminal") {
+		t.Errorf("detail = %q, want to contain '--yes flag or interactive terminal'", result.detail)
+	}
+}
+
+func TestInstallOllama_CurlFails(t *testing.T) {
+	// Curl command fails → returns failed.
+	rec := &cmdRecorder{
+		errors: map[string]error{
+			"bash -c curl -fsSL https://ollama.com/install.sh | sh": fmt.Errorf("network error"),
+		},
+	}
+	opts := &Options{
+		GOOS:     "linux",
+		YesFlag:  true,
+		IsTTY:    func() bool { return false },
+		LookPath: stubLookPath(map[string]string{}),
+		ExecCmd:  rec.execCmd,
+		Stdout:   &bytes.Buffer{},
+		Stderr:   &bytes.Buffer{},
+	}
+	env := doctor.DetectedEnvironment{
+		Managers: []doctor.ManagerInfo{},
+	}
+
+	result := installOllama(opts, env)
+	if result.action != "failed" {
+		t.Errorf("action = %q, want failed", result.action)
+	}
+	if result.detail != "curl install failed" {
+		t.Errorf("detail = %q, want 'curl install failed'", result.detail)
+	}
+	if result.err == nil {
+		t.Error("expected non-nil error")
+	}
+}
+
+func TestInstallOllama_DryRun_NoBrew(t *testing.T) {
+	// Dry-run + no Homebrew → shows curl command.
+	opts := &Options{
+		DryRun:   true,
+		GOOS:     "linux",
+		LookPath: stubLookPath(map[string]string{}),
+		Stdout:   &bytes.Buffer{},
+		Stderr:   &bytes.Buffer{},
+	}
+	env := doctor.DetectedEnvironment{
+		Managers: []doctor.ManagerInfo{},
+	}
+
+	result := installOllama(opts, env)
+	if result.action != "dry-run" {
+		t.Errorf("action = %q, want dry-run", result.action)
+	}
+	if !strings.Contains(result.detail, "curl -fsSL https://ollama.com/install.sh") {
+		t.Errorf("detail = %q, want to contain curl install command", result.detail)
+	}
+}
+
+// --- Podman dnf fallback tests (FR-DNF-002) ---
+
+func TestInstallPodman_DnfFallback(t *testing.T) {
+	// No Homebrew, dnf available → installs via dnf.
+	rec := &cmdRecorder{
+		outputs: map[string]string{
+			"podman info": "host:\n  os: linux\n",
+		},
+	}
+	opts := &Options{
+		GOOS:     "linux",
+		LookPath: stubLookPath(map[string]string{}),
+		ExecCmd:  rec.execCmd,
+		Stdout:   &bytes.Buffer{},
+		Stderr:   &bytes.Buffer{},
+	}
+	env := doctor.DetectedEnvironment{
+		Managers: []doctor.ManagerInfo{
+			{Kind: doctor.ManagerDnf, Path: "/usr/bin/dnf"},
+		},
+	}
+
+	result := installPodman(opts, env)
+	if result.action != "installed" {
+		t.Errorf("action = %q, want installed", result.action)
+	}
+	if !strings.Contains(result.detail, "via dnf") {
+		t.Errorf("detail = %q, want to contain 'via dnf'", result.detail)
+	}
+}
+
+func TestInstallPodman_DnfFails_SudoGuidance(t *testing.T) {
+	// dnf install fails → failed with actionable sudo guidance.
+	rec := &cmdRecorder{
+		errors: map[string]error{
+			"dnf install -y podman": fmt.Errorf("Error: This command has to be run with superuser privileges"),
+		},
+	}
+	opts := &Options{
+		GOOS:     "linux",
+		LookPath: stubLookPath(map[string]string{}),
+		ExecCmd:  rec.execCmd,
+		Stdout:   &bytes.Buffer{},
+		Stderr:   &bytes.Buffer{},
+	}
+	env := doctor.DetectedEnvironment{
+		Managers: []doctor.ManagerInfo{
+			{Kind: doctor.ManagerDnf, Path: "/usr/bin/dnf"},
+		},
+	}
+
+	result := installPodman(opts, env)
+	if result.action != "failed" {
+		t.Errorf("action = %q, want failed", result.action)
+	}
+	if !strings.Contains(result.detail, "sudo") {
+		t.Errorf("detail = %q, want to contain sudo guidance", result.detail)
+	}
+	if result.err == nil {
+		t.Error("expected non-nil error")
+	}
+}
+
+func TestInstallPodman_PackageManagerDnf(t *testing.T) {
+	// PackageManager: "dnf" + Homebrew available → uses dnf, not Homebrew.
+	rec := &cmdRecorder{
+		outputs: map[string]string{
+			"podman info": "host:\n  os: linux\n",
+		},
+	}
+	opts := &Options{
+		GOOS:           "linux",
+		PackageManager: "dnf",
+		LookPath:       stubLookPath(map[string]string{}),
+		ExecCmd:        rec.execCmd,
+		Stdout:         &bytes.Buffer{},
+		Stderr:         &bytes.Buffer{},
+	}
+	opts.defaults()
+	env := doctor.DetectedEnvironment{
+		Managers: []doctor.ManagerInfo{
+			{Kind: doctor.ManagerHomebrew, Path: "/opt/homebrew/bin/brew"},
+			{Kind: doctor.ManagerDnf, Path: "/usr/bin/dnf"},
+		},
+	}
+
+	result := installPodman(opts, env)
+	if result.action != "installed" {
+		t.Errorf("action = %q, want installed", result.action)
+	}
+	if !strings.Contains(result.detail, "via dnf") {
+		t.Errorf("detail = %q, want to contain 'via dnf'", result.detail)
+	}
+	for _, call := range rec.calls {
+		if strings.Contains(call, "brew") {
+			t.Errorf("unexpected brew call when PackageManager=dnf: %s", call)
+		}
+	}
+}
+
+func TestInstallPodman_BothManagers_AutoUsesHomebrew(t *testing.T) {
+	// Both managers in auto mode → uses Homebrew (first in fallback chain).
+	rec := &cmdRecorder{
+		outputs: map[string]string{
+			"podman info": "host:\n  os: linux\n",
+		},
+	}
+	opts := &Options{
+		GOOS:     "linux",
+		LookPath: stubLookPath(map[string]string{}),
+		ExecCmd:  rec.execCmd,
+		Stdout:   &bytes.Buffer{},
+		Stderr:   &bytes.Buffer{},
+	}
+	env := doctor.DetectedEnvironment{
+		Managers: []doctor.ManagerInfo{
+			{Kind: doctor.ManagerHomebrew, Path: "/opt/homebrew/bin/brew"},
+			{Kind: doctor.ManagerDnf, Path: "/usr/bin/dnf"},
+		},
+	}
+
+	result := installPodman(opts, env)
+	if result.action != "installed" {
+		t.Errorf("action = %q, want installed", result.action)
+	}
+	if !strings.Contains(result.detail, "via Homebrew") {
+		t.Errorf("detail = %q, want to contain 'via Homebrew'", result.detail)
+	}
+}
+
+func TestInstallPodman_DryRunDnfFallback(t *testing.T) {
+	// Dry-run + dnf detected → shows dnf command.
+	opts := &Options{
+		DryRun:   true,
+		GOOS:     "linux",
+		LookPath: stubLookPath(map[string]string{}),
+		Stdout:   &bytes.Buffer{},
+		Stderr:   &bytes.Buffer{},
+	}
+	env := doctor.DetectedEnvironment{
+		Managers: []doctor.ManagerInfo{
+			{Kind: doctor.ManagerDnf, Path: "/usr/bin/dnf"},
+		},
+	}
+
+	result := installPodman(opts, env)
+	if result.action != "dry-run" {
+		t.Errorf("action = %q, want dry-run", result.action)
+	}
+	if !strings.Contains(result.detail, "dnf install -y podman") {
+		t.Errorf("detail = %q, want to contain 'dnf install -y podman'", result.detail)
 	}
 }
 

--- a/openspec/changes/linux-dnf-rpm-setup/.openspec.yaml
+++ b/openspec/changes/linux-dnf-rpm-setup/.openspec.yaml
@@ -1,0 +1,4 @@
+schema: unbound-force
+status: drafting
+created: "2026-06-16"
+issue: https://github.com/unbound-force/unbound-force/issues/268

--- a/openspec/changes/linux-dnf-rpm-setup/design.md
+++ b/openspec/changes/linux-dnf-rpm-setup/design.md
@@ -1,0 +1,223 @@
+## Context
+
+The `setup-auto-native-fallback` change added
+`resolveMethod()`, `installViaGo()`, and dnf/go-install
+fallbacks for Gaze, Replicator, Dewey, and GH CLI. The
+`linux-cross-platform-install` change added
+`installViaRpm()`, `ManagerDnf` detection, and RPM
+packaging. Two tools remain without native Linux
+fallbacks: Podman and Ollama. DevPod has no automated
+Linux installer (verified: `https://devpod.sh/install.sh`
+returns 404). Additionally, the doctor hint system still
+returns Homebrew commands on Fedora systems because
+`managerInstallCmd()` has no `ManagerDnf` case.
+
+## Goals / Non-Goals
+
+### Goals
+- Fix doctor hints to return dnf commands on Fedora
+- Add `dnf install -y podman` fallback to
+  `installPodman()`
+- Add curl-installer fallback with `YesFlag`/`IsTTY`
+  gate to `installOllama()`
+- Fix `genericInstallCmd("replicator")` bug
+- Update documentation to show dnf alongside brew
+
+### Non-Goals
+- apt/Debian support (deferred)
+- COPR repository setup
+- Standalone installer script
+- DevPod curl installer (does not exist — 404)
+- New injectable fields on Options (reuse existing
+  `YesFlag`/`IsTTY` pattern)
+- Changes to Gaze/Replicator/Dewey/GH CLI install
+  functions (already handled by prior changes)
+- Changes to RPM packaging (already handled)
+
+## Decisions
+
+### D1: Reuse YesFlag/IsTTY for Ollama Curl Gate
+
+The Ollama curl installer fallback uses the existing
+`YesFlag bool` + `IsTTY func() bool` guard pattern on
+`setup.Options`, matching `installOpenCode()` (line
+552) and `installUV()` (line 782):
+
+```go
+if !opts.YesFlag && !opts.IsTTY() {
+    return stepResult{..., action: "skipped",
+        detail: "curl|bash install requires --yes flag or interactive terminal"}
+}
+```
+
+**Rationale**: This pattern is established in the
+codebase for exactly this purpose. Adding a new
+`PromptUser` injectable would create a competing
+abstraction. `YesFlag` means "auto-confirm" (proceed
+without prompting). Non-TTY without `--yes` means
+"skip" (CI safety).
+
+### D2: Podman dnf Install — Direct Package Name
+
+Podman is in Fedora's base repos. Use
+`dnf install -y podman` directly (not `installViaRpm`
+with a GitHub Release URL). This is simpler and
+handles version management through the distro's
+package lifecycle.
+
+The auto-mode cascade for Podman uses `resolveMethod`
+following the `installGH()` pattern:
+
+```go
+method := opts.resolveMethod("podman", env, "homebrew", "dnf")
+switch method {
+case "homebrew": // brew install podman
+case "dnf":      // dnf install -y podman
+default:         // skip with download link
+}
+```
+
+No `go install` fallback — Podman is not a Go CLI
+tool distributable via `go install`.
+
+### D3: Ollama Curl Installer
+
+Ollama provides an official install script at
+`https://ollama.com/install.sh`. This is the documented
+installation method for Linux. The YesFlag/IsTTY gate
+(D1) controls whether this script runs.
+
+The auto-mode cascade for Ollama:
+1. Homebrew if detected
+2. `YesFlag`/`IsTTY` gate, then
+   `bash -c "curl -fsSL https://ollama.com/install.sh | sh"`
+3. Skip with download link
+
+Implementation: use `opts.ExecCmd("bash", "-c",
+"curl -fsSL https://ollama.com/install.sh | sh")`,
+matching the `installOpenCode()` pattern (line 560).
+
+**Supply chain trade-off**: Constitution V requires
+content-hash verification for downloads outside a
+package manager. The Ollama install script content
+changes with each release, making hash pinning
+impractical. Mitigations: HTTPS transport, official
+domain, user-confirmation gate, non-interactive skip.
+This trade-off is documented in the proposal's
+Constitution Alignment section.
+
+### D4: DevPod — Binary Download Fallback
+
+DevPod does NOT provide a `curl | sh` installer
+(`https://devpod.sh/install.sh` returns HTTP 404).
+However, DevPod provides a CLI binary download with
+an explicit install command for Linux:
+
+```bash
+curl -L -o devpod "https://github.com/loft-sh/devpod/releases/latest/download/devpod-linux-amd64" \
+  && sudo install -c -m 0755 devpod /usr/local/bin \
+  && rm -f devpod
+```
+
+This downloads a known binary (not an opaque script),
+which is better from a supply chain perspective than
+`curl | sh`. The pattern is: download binary to a temp
+path, then use `install` to place it with correct
+permissions.
+
+The auto-mode cascade for DevPod becomes:
+1. Homebrew if detected
+2. `YesFlag`/`IsTTY` gate, then binary download via
+   curl + install
+3. Skip with download link
+
+Use the same `YesFlag`/`IsTTY` guard as Ollama since
+this still runs curl and sudo. Architecture detection
+uses `runtime.GOARCH` (mapped via `rpmArch()` which
+returns `amd64` or `arm64`).
+
+### D5: dnfInstallCmd Helper for Doctor Hints
+
+Add a `dnfInstallCmd(toolName string) string` function
+parallel to `homebrewInstallCmd()`. This function MUST
+only return actual `dnf` commands for tools that are
+installable via dnf:
+
+| Tool | Command |
+|------|---------|
+| `go` | `dnf install -y golang` |
+| `node` | `dnf install -y nodejs` |
+| `gh` | `dnf install -y gh` |
+| `podman` | `dnf install -y podman` |
+| `gaze` | `sudo dnf install <RPM URL>` |
+| `replicator` | `sudo dnf install <RPM URL>` |
+| (default) | `dnf install -y <toolName>` |
+
+For tools NOT in Fedora repos and without RPMs (ollama,
+devpod, dewey), `dnfInstallCmd` returns empty string
+and `managerInstallCmd` falls through to
+`genericInstallCmd()`.
+
+Wire this into `managerInstallCmd()` under
+`case ManagerDnf:`.
+
+### D6: resolveMethod Reuse
+
+The `resolveMethod()` helper added by
+`setup-auto-native-fallback` handles per-tool method
+overrides and global `PackageManager` preference.
+Reuse it in `installPodman()` with fallbacks
+`"homebrew", "dnf"`, following the `installGH()`
+pattern.
+
+Do NOT route `installOllama()` through `resolveMethod`
+— the curl installer is gated by `YesFlag`/`IsTTY`,
+not by package manager detection. Use the
+`installOpenCode()` pattern instead.
+
+### D7: Documentation Scope
+
+Update brew-only references in:
+- `internal/doctor/environ.go` (bug fixes)
+- `README.md` (add Fedora section)
+- `QUICKSTART.md` (add Linux-native path)
+- `CHANGELOG.md` (change entry)
+- Embedded assets and deployed agent/command files
+
+## Risks / Trade-offs
+
+### R1: Curl|sh Supply Chain Risk
+
+Running `curl | sh` from Ollama introduces a supply
+chain risk. Mitigated by the `YesFlag`/`IsTTY` gate:
+non-interactive mode (CI without `--yes`) skips the
+installer entirely. `--yes` flag means the user has
+explicitly opted in to automated installation.
+Same pattern as `installOpenCode()` and `installUV()`.
+
+### R2: dnf Requires Root/Sudo
+
+`dnf install -y` requires root privileges. If the
+user is not root, the command will fail. The
+`stepResult` reports the failure with an actionable
+message including guidance to run with elevated
+privileges. This is consistent with how
+`installViaRpm()` already behaves.
+
+### R3: Podman Version Differences
+
+Fedora repos may have a different Podman version than
+Homebrew. The minimum version requirement (>= 4.3) is
+checked by `uf doctor`, not by setup. This is
+acceptable because doctor runs after setup.
+
+### R4: Ollama Install Script Requires Sudo
+
+The Ollama install script internally uses `sudo` to
+install the binary and set up a systemd service.
+When run via `ExecCmd`, the script's internal sudo
+prompts may not reach the user's terminal. This
+matches the existing behavior of `installOpenCode()`
+which runs `curl | bash` via `ExecCmd`. If sudo
+fails, the script returns a non-zero exit code which
+is captured as a `"failed"` result.

--- a/openspec/changes/linux-dnf-rpm-setup/proposal.md
+++ b/openspec/changes/linux-dnf-rpm-setup/proposal.md
@@ -1,0 +1,184 @@
+## Why
+
+On Fedora/RHEL without Homebrew, `uf setup` fails to install
+7 of 11 tools. Each either skips with an unhelpful download
+link or — worse — prints a `brew install` hint on a system
+where brew is not present. The infrastructure for native
+Linux installation partially exists (`installViaRpm()`,
+`ManagerDnf` detection, `toolMethod()` dispatch) but is
+not wired into the auto-mode fallback for most tools.
+
+Four bugs compound the problem:
+
+1. `genericInstallCmd("replicator")` returns a `brew install`
+   command even in the "no package manager" codepath.
+2. `managerInstallCmd()` has no `case ManagerDnf:` — dnf
+   detection falls through to Homebrew hints.
+3. `installHint()` detects dnf but dispatches to brew hints
+   because `managerInstallCmd` has no dnf case.
+4. Only `installGaze()` has `toolMethod()` dispatch — the
+   other install functions skip it entirely.
+
+The `setup-auto-native-fallback` change (issue #214) added
+`resolveMethod()`, `installViaGo()`, and dnf/go-install
+fallbacks for Gaze, Replicator, Dewey, and GH CLI. But
+two tools remain broken on Linux without brew: Podman and
+Ollama. DevPod has no automated Linux installer (no curl
+script, no Fedora package). And the doctor hint bugs (#2
+and #3 above) were not addressed by that change.
+
+Fixes: https://github.com/unbound-force/unbound-force/issues/268
+
+## What Changes
+
+1. Fix `genericInstallCmd("replicator")` to return a GitHub
+   releases download link instead of `brew install`.
+
+2. Add `case ManagerDnf:` to `managerInstallCmd()` with
+   dnf-appropriate install hints for tools available in
+   Fedora repos (`gh`, `podman`, `nodejs`, `golang`) and
+   GitHub Release RPM URLs for UF tools.
+
+3. Add dnf fallback to `installPodman()`: when Homebrew is
+   absent and dnf is detected, run `dnf install -y podman`.
+
+4. Add curl-installer fallback to `installOllama()`: when
+   Homebrew is absent, use the existing `YesFlag`/`IsTTY`
+   guard pattern to confirm before running the official
+   Ollama install script.
+
+5. Add binary-download fallback to `installDevPod()`:
+   DevPod has no `curl | sh` script, but provides a
+   direct CLI binary download for Linux. Use the
+   `YesFlag`/`IsTTY` guard pattern before downloading
+   and installing the binary.
+
+6. Update documentation and embedded scaffold assets to
+   show dnf install commands alongside brew commands
+   for Linux users.
+
+## Capabilities
+
+### New Capabilities
+- `dnf-install-hints`: Doctor hints show `dnf install`
+  commands on Fedora/RHEL systems instead of brew
+  commands for tools in Fedora repos.
+- `install-podman-dnf`: `installPodman()` falls back to
+  `dnf install -y podman` when brew is absent and dnf
+  is detected.
+- `install-ollama-curl`: `installOllama()` falls back to
+  the official Ollama curl installer with `YesFlag`/
+  `IsTTY` confirmation gate when brew is absent.
+- `install-devpod-binary`: `installDevPod()` falls back
+  to downloading the DevPod CLI binary from GitHub
+  Releases with `YesFlag`/`IsTTY` confirmation gate.
+
+### Modified Capabilities
+- `generic-install-cmd`: Fixed replicator entry to return
+  GitHub releases link instead of brew command.
+- `manager-install-cmd`: Added ManagerDnf case with
+  tool-specific dnf commands.
+- `install-podman`: Gains dnf fallback in auto mode.
+- `install-ollama`: Gains curl-installer fallback in
+  auto mode using existing `YesFlag`/`IsTTY` pattern.
+- `install-devpod`: Gains binary-download fallback in
+  auto mode using `YesFlag`/`IsTTY` gate.
+
+### Removed Capabilities
+- None.
+
+## Impact
+
+- `internal/doctor/environ.go`: Modified — add dnf case
+  to `managerInstallCmd()`, fix `genericInstallCmd`.
+- `internal/setup/setup.go`: Modified — update
+  `installPodman()` and `installOllama()`.
+- `internal/setup/setup_test.go`: Modified — new tests
+  for dnf and curl fallback paths.
+- `internal/doctor/environ_test.go`: Modified — tests for
+  dnf hint dispatch.
+- Documentation files: Updated brew-only references with
+  dnf alternatives.
+- No cross-repo impact (RPMs for gaze, dewey, replicator
+  are already produced per `setup-auto-native-fallback`
+  and `linux-cross-platform-install` changes).
+
+## Constitution Alignment
+
+Assessed against the Unbound Force org constitution.
+
+### I. Autonomous Collaboration
+
+**Assessment**: N/A
+
+This change does not affect inter-hero artifact formats,
+communication protocols, or metadata. It modifies only
+the tool installation mechanism within `uf setup` and
+doctor hint generation.
+
+### II. Composability First
+
+**Assessment**: PASS
+
+This change directly supports Composability First by
+removing platform barriers. Podman and Ollama become
+installable on Linux without requiring Homebrew. Each
+fallback tier is optional and degrades gracefully:
+dnf -> curl installer (with user confirmation) -> skip
+with download link. No mandatory dependencies are
+introduced.
+
+### III. Observable Quality
+
+**Assessment**: N/A
+
+This change does not affect output formats, provenance
+metadata, or machine-parseable output. The `stepResult`
+struct already reports the install method in `detail`,
+which will now report "via dnf" or "via curl installer"
+alongside existing methods.
+
+### IV. Testability
+
+**Assessment**: PASS
+
+All new code uses the existing injectable dependency
+pattern (`LookPath`, `ExecCmd`, `YesFlag`, `IsTTY` on
+the Options struct). No new injectable fields are added.
+No tests require network access, external services, or
+shared mutable state.
+
+### V. Security by Default
+
+**Assessment**: PASS WITH TRADE-OFF
+
+This change introduces `curl -fsSL https://ollama.com/install.sh | sh`
+execution for Ollama installation. Constitution V
+requires: "Dependencies MUST be verified by content
+hash (SHA256 or equivalent) when downloaded outside a
+package manager's built-in verification."
+
+The curl|sh pattern cannot satisfy strict hash
+verification because the Ollama install script content
+changes with each release — there is no stable hash to
+pin against. This is a documented trade-off:
+
+**Mitigations in place**:
+- HTTPS transport (TLS verification)
+- Script is from the tool's official domain
+  (ollama.com)
+- User must explicitly confirm via `--yes` flag or
+  interactive TTY prompt — non-interactive mode
+  (CI without `--yes`) skips the installer entirely
+- Same pattern already used by `installOpenCode()` and
+  `installUV()` in the existing codebase
+
+**Justification**: Hash pinning is impractical for
+third-party install scripts that change with each
+release. The user-confirmation gate ensures no
+unattended execution of unverified scripts. This
+matches the precedent set by OpenCode and uv
+installers.
+
+This trade-off is accepted per the constitution's
+Conflict Resolution clause.

--- a/openspec/changes/linux-dnf-rpm-setup/specs/linux-dnf-rpm-setup.md
+++ b/openspec/changes/linux-dnf-rpm-setup/specs/linux-dnf-rpm-setup.md
@@ -1,0 +1,206 @@
+## ADDED Requirements
+
+### Requirement: FR-DNF-001 — dnf Install Hints
+
+The doctor MUST return dnf-appropriate install hints
+when `ManagerDnf` is detected and the tool is available
+in Fedora repos or has a known RPM on GitHub Releases.
+
+The `managerInstallCmd()` function MUST include a
+`case ManagerDnf:` that dispatches to a
+`dnfInstallCmd()` helper. The helper MUST only return
+actual dnf commands for tools available via dnf. For
+tools not in Fedora repos (ollama, devpod, dewey),
+the function MUST fall through to `genericInstallCmd()`
+which returns download links or alternative install
+methods.
+
+#### Scenario: Fedora system with dnf, no Homebrew
+
+- **GIVEN** the detected environment has `ManagerDnf`
+  and does not have `ManagerHomebrew`
+- **WHEN** `installHint("podman", env)` is called
+- **THEN** the returned string is `dnf install -y podman`
+
+#### Scenario: dnf hint for UF tool with RPM
+
+- **GIVEN** the detected environment has `ManagerDnf`
+- **WHEN** `installHint("gaze", env)` is called
+- **THEN** the returned string contains
+  `dnf install` and a GitHub Release RPM URL
+
+#### Scenario: Both managers detected, Homebrew preferred
+
+- **GIVEN** the detected environment has both
+  `ManagerHomebrew` and `ManagerDnf`
+- **WHEN** `installHint("podman", env)` is called
+- **THEN** the returned string is `brew install podman`
+  (Homebrew takes priority in the manager iteration)
+
+### Requirement: FR-DNF-002 — Podman dnf Fallback
+
+`installPodman()` MUST attempt `dnf install -y podman`
+when Homebrew is absent and `ManagerDnf` is detected,
+before skipping with a download link. The function
+MUST use `resolveMethod("podman", env, "homebrew",
+"dnf")` for method dispatch, following the existing
+pattern in `installGH()`.
+
+#### Scenario: Podman install via dnf
+
+- **GIVEN** Podman is not in PATH, Homebrew is absent,
+  and `ManagerDnf` is detected
+- **WHEN** `installPodman()` runs in auto mode
+- **THEN** it calls `dnf install -y podman`
+- **AND** returns `action: "installed"`,
+  `detail: "via dnf"`
+
+#### Scenario: Podman dnf install fails
+
+- **GIVEN** Podman is not in PATH, Homebrew is absent,
+  and `ManagerDnf` is detected
+- **WHEN** `installPodman()` runs and `dnf install`
+  fails
+- **THEN** it returns `action: "failed"` with an
+  actionable error message
+
+#### Scenario: Podman dnf fails — permission denied
+
+- **GIVEN** non-root user, `ManagerDnf` is detected,
+  Homebrew is absent
+- **WHEN** `installPodman()` runs and `dnf install`
+  fails with a permission error
+- **THEN** the error detail includes guidance:
+  "dnf install requires root — run with sudo or
+  install manually: sudo dnf install -y podman"
+
+#### Scenario: Explicit PackageManager override
+
+- **GIVEN** `PackageManager` is set to `"dnf"` and
+  Homebrew is available
+- **WHEN** `installPodman()` runs
+- **THEN** it uses dnf, not Homebrew
+
+#### Scenario: Both managers available, auto mode
+
+- **GIVEN** both Homebrew and `ManagerDnf` are detected
+- **WHEN** `installPodman()` runs in auto mode
+- **THEN** it uses Homebrew (first in fallback chain)
+
+### Requirement: FR-DNF-003 — Ollama Curl Installer
+
+`installOllama()` MUST offer the official Ollama curl
+installer as a fallback when Homebrew is absent. The
+function MUST use the existing `YesFlag`/`IsTTY` guard
+pattern (matching `installOpenCode()` and `installUV()`)
+to gate execution of the third-party script.
+
+#### Scenario: Ollama curl install with --yes flag
+
+- **GIVEN** Ollama is not in PATH, Homebrew is absent,
+  and `YesFlag` is true
+- **WHEN** `installOllama()` runs in auto mode
+- **THEN** it executes
+  `bash -c "curl -fsSL https://ollama.com/install.sh | sh"`
+  without prompting
+- **AND** returns `action: "installed"`,
+  `detail: "via curl installer"`
+
+#### Scenario: Ollama curl install with interactive TTY
+
+- **GIVEN** Ollama is not in PATH, Homebrew is absent,
+  `YesFlag` is false, and `IsTTY()` returns true
+- **WHEN** `installOllama()` runs in auto mode
+- **THEN** it executes the curl installer
+- **AND** returns `action: "installed"`,
+  `detail: "via curl installer"`
+
+#### Scenario: Ollama skipped — non-interactive
+
+- **GIVEN** Ollama is not in PATH, Homebrew is absent,
+  `YesFlag` is false, and `IsTTY()` returns false
+- **WHEN** `installOllama()` runs
+- **THEN** it returns `action: "skipped"`,
+  `detail` containing "curl|bash install requires
+  --yes flag or interactive terminal"
+
+#### Scenario: Ollama curl install fails
+
+- **GIVEN** Ollama is not in PATH, Homebrew is absent,
+  `YesFlag` is true
+- **WHEN** `installOllama()` runs and the curl command
+  fails (network error, script error)
+- **THEN** it returns `action: "failed"`,
+  `detail: "curl install failed"` with the error
+
+### Requirement: FR-DNF-004 — DevPod Binary Download
+
+DevPod does NOT have a `curl | sh` installer script.
+Instead, DevPod provides a CLI binary download for
+Linux. `installDevPod()` MUST offer the binary download
+as a fallback when Homebrew is absent. The function
+MUST use the existing `YesFlag`/`IsTTY` guard pattern
+to gate execution since it runs curl and sudo.
+
+The binary download command is architecture-aware:
+`https://github.com/loft-sh/devpod/releases/latest/download/devpod-linux-{amd64|arm64}`
+
+#### Scenario: DevPod binary download with --yes
+
+- **GIVEN** DevPod is not in PATH, Homebrew is absent,
+  and `YesFlag` is true
+- **WHEN** `installDevPod()` runs in auto mode
+- **THEN** it downloads the DevPod binary via curl,
+  installs it to `/usr/local/bin` with mode 0755,
+  and returns `action: "installed"`,
+  `detail: "via binary download"`
+
+#### Scenario: DevPod binary download with TTY
+
+- **GIVEN** DevPod is not in PATH, Homebrew is absent,
+  `YesFlag` is false, and `IsTTY()` returns true
+- **WHEN** `installDevPod()` runs in auto mode
+- **THEN** it downloads and installs the DevPod binary
+
+#### Scenario: DevPod skipped — non-interactive
+
+- **GIVEN** DevPod is not in PATH, Homebrew is absent,
+  `YesFlag` is false, and `IsTTY()` returns false
+- **WHEN** `installDevPod()` runs
+- **THEN** it returns `action: "skipped"`,
+  `detail` containing "curl|bash install requires
+  --yes flag or interactive terminal"
+
+#### Scenario: DevPod download fails
+
+- **GIVEN** DevPod is not in PATH, Homebrew is absent,
+  `YesFlag` is true
+- **WHEN** the curl download command fails
+- **THEN** it returns `action: "failed"`,
+  `detail: "binary download failed"` with the error
+
+## MODIFIED Requirements
+
+### Requirement: genericInstallCmd replicator fix
+
+`genericInstallCmd("replicator")` MUST return
+`"Download from https://github.com/unbound-force/replicator/releases"`
+instead of `"brew install unbound-force/tap/replicator"`.
+
+Previously: returned a Homebrew command even in the
+"no package manager detected" codepath.
+
+### Requirement: managerInstallCmd dnf case
+
+`managerInstallCmd()` MUST include a `case ManagerDnf:`
+that returns dnf-appropriate commands for tools in
+Fedora repos and falls through to `genericInstallCmd()`
+for tools not in Fedora repos (ollama, devpod, dewey).
+
+Previously: no ManagerDnf case existed; dnf detection
+fell through to `homebrewInstallCmd()` as the default
+return.
+
+## REMOVED Requirements
+
+None.

--- a/openspec/changes/linux-dnf-rpm-setup/tasks.md
+++ b/openspec/changes/linux-dnf-rpm-setup/tasks.md
@@ -1,0 +1,188 @@
+<!--
+  [P] marks tasks eligible for parallel execution.
+  Add [P] when a task: (a) touches different files from
+  other [P] tasks in the group, (b) has no dependency
+  on prior tasks in the group, (c) can safely execute
+  without ordering constraints.
+  Do NOT add [P] when tasks modify the same file —
+  parallel workers will cause merge conflicts.
+  Tasks without [P] run sequentially first, then [P]
+  tasks run in parallel.
+-->
+
+## 1. Fix Doctor Hint Bugs
+
+- [x] 1.1 Fix `genericInstallCmd("replicator")` in
+  `internal/doctor/environ.go` — change return value
+  from `"brew install unbound-force/tap/replicator"`
+  to `"Download from https://github.com/unbound-force/replicator/releases"`.
+- [x] 1.2 Add `dnfInstallCmd(toolName string) string`
+  function to `internal/doctor/environ.go`, parallel
+  to `homebrewInstallCmd()`. Return dnf commands ONLY
+  for tools installable via dnf:
+  `go` -> `dnf install -y golang`,
+  `node` -> `dnf install -y nodejs`,
+  `gh` -> `dnf install -y gh`,
+  `podman` -> `dnf install -y podman`,
+  `gaze` -> `sudo dnf install <RPM URL hint>`,
+  `replicator` -> `sudo dnf install <RPM URL hint>`,
+  default -> `dnf install -y <toolName>`.
+  For tools NOT in Fedora repos (ollama, devpod,
+  dewey), return empty string to fall through to
+  `genericInstallCmd()`.
+- [x] 1.3 Add `case ManagerDnf:` to
+  `managerInstallCmd()` in `internal/doctor/environ.go`
+  — call `dnfInstallCmd(toolName)`. If the result is
+  empty, fall through to `genericInstallCmd(toolName)`.
+- [x] 1.4 Add tests in `internal/doctor/environ_test.go`.
+  Table-driven: verify each tool returns the expected
+  dnf command via `dnfInstallCmd()`. Verify
+  `installHint()` returns dnf hints when `ManagerDnf`
+  is detected and `ManagerHomebrew` is absent. Verify
+  that when both `ManagerHomebrew` and `ManagerDnf`
+  are detected, `installHint()` returns Homebrew hints
+  (Homebrew takes priority).
+
+## 2. Add dnf Fallback to installPodman()
+
+- [x] 2.1 Add `resolveMethod("podman", env, "homebrew",
+  "dnf")` dispatch to `installPodman()` in
+  `internal/setup/setup.go`, following the `installGH()`
+  pattern. Switch on the result:
+  `"homebrew"` -> existing brew install path.
+  `"dnf"` -> `opts.ExecCmd("dnf", "install", "-y",
+  "podman")`. On success, proceed to macOS machine
+  init (skipped on Linux via `opts.GOOS`) and smoke
+  test. On failure, return `action: "failed"` with
+  actionable message including sudo guidance.
+  default -> skip with download link.
+  Update dry-run to reflect the new dispatch.
+- [x] 2.2 Add tests for `installPodman()` dnf fallback
+  in `internal/setup/setup_test.go`. Table-driven:
+  dnf detected + no Homebrew -> installs via dnf
+  (assert `action: "installed"`, `detail: "via dnf"`);
+  dnf install fails -> returns failed with actionable
+  message (assert `action: "failed"`, detail contains
+  sudo guidance);
+  `PackageManager: "dnf"` + Homebrew available ->
+  uses dnf, not Homebrew;
+  both managers available in auto mode -> uses
+  Homebrew (first in fallback chain);
+  dry-run + dnf detected -> shows dnf command.
+
+## 3. Add Curl Installer Fallback to installOllama()
+
+- [x] 3.1 Update `installOllama()` in
+  `internal/setup/setup.go`: after the
+  `!HasManager(env, ManagerHomebrew)` check, add the
+  `YesFlag`/`IsTTY` guard matching `installOpenCode()`
+  pattern (line 552):
+  ```
+  if !opts.YesFlag && !opts.IsTTY() {
+      return stepResult{..., action: "skipped",
+          detail: "curl|bash install requires --yes flag or interactive terminal"}
+  }
+  ```
+  Then execute:
+  `opts.ExecCmd("bash", "-c", "curl -fsSL https://ollama.com/install.sh | sh")`.
+  On success, return `action: "installed"`,
+  `detail: "via curl installer"`. On failure, return
+  `action: "failed"`, `detail: "curl install failed"`.
+  Update dry-run path: when Homebrew is absent, show
+  `"Would install via: curl -fsSL https://ollama.com/install.sh | sh"`.
+- [x] 3.2 Add tests for `installOllama()` curl fallback
+  in `internal/setup/setup_test.go`. Table-driven:
+  YesFlag true + no Homebrew -> installs via curl
+  (assert `action: "installed"`,
+  `detail: "via curl installer"`);
+  IsTTY true + YesFlag false + no Homebrew -> installs
+  via curl;
+  IsTTY false + YesFlag false + no Homebrew -> skips
+  (assert `action: "skipped"`, detail contains
+  "requires --yes flag or interactive terminal");
+  curl command fails -> returns failed (assert
+  `action: "failed"`, `detail: "curl install failed"`);
+  dry-run + no Homebrew -> shows curl command.
+
+## 4. Add Binary Download Fallback to installDevPod()
+
+- [x] 4.1 Add `devpodBinaryURL()` helper to
+  `internal/setup/setup.go` that constructs the GitHub
+  Releases download URL for the DevPod CLI binary
+  using `rpmArch()` for architecture detection.
+- [x] 4.2 Update `installDevPod()` in
+  `internal/setup/setup.go`: after the Homebrew check,
+  add `YesFlag`/`IsTTY` guard (matching Ollama pattern).
+  If confirmed, download binary via curl, install with
+  `sudo install -c -m 0755`, clean up temp file.
+  On failure, return actionable error with URL.
+  Update dry-run to show binary download URL.
+- [x] 4.3 Add tests for `installDevPod()` binary
+  download fallback: YesFlag true -> downloads binary;
+  IsTTY true -> downloads binary; both false -> skips;
+  download fails -> returns failed; dry-run shows URL.
+
+## 5. Documentation Updates
+
+- [x] 5.1 [P] Update `README.md` — add Fedora/RHEL
+  install section showing `dnf install` for the RPM
+  alongside the existing `brew install` instructions.
+- [x] 5.2 [P] Update `QUICKSTART.md` — add Linux-native
+  instructions for `uf setup` explaining that dnf
+  is used automatically on Fedora when Homebrew is
+  absent.
+- [x] 5.3 [P] Update embedded scaffold asset
+  `internal/scaffold/assets/opencode/commands/review-council.md`
+  — change Gaze install hint from brew-only to include
+  dnf alternative.
+- [x] 5.4 [P] Update embedded scaffold asset
+  `internal/scaffold/assets/opencode/commands/uf-init.md`
+  — change upgrade hint from brew-only to include
+  dnf alternative.
+- [x] 5.5 [P] Update embedded scaffold asset
+  `internal/scaffold/assets/opencode/agents/cobalt-crush-dev.md`
+  — change Gaze install hint to include dnf.
+- [x] 5.6 [P] Update deployed files:
+  `.opencode/agents/cobalt-crush-dev.md`,
+  `.opencode/agents/gaze-reporter.md`,
+  `.opencode/commands/review-council.md`,
+  `.opencode/commands/uf-init.md` — same hint changes.
+  Note: `.opencode/agents/gaze-reporter.md` is not
+  scaffolded from an embedded asset — it is a
+  direct edit.
+- [x] 5.7 [P] Add CHANGELOG.md entry documenting the
+  fix for issue #268: `uf setup` auto mode now falls
+  back to dnf for Podman and curl installer for Ollama
+  when Homebrew is absent. Doctor hints now show
+  dnf commands on Fedora systems.
+
+## 6. Verification
+
+- [x] 6.1 Run `make check` — all tests pass, lint
+  clean, build succeeds.
+- [x] 6.2 Run `go test -race -count=1 ./internal/setup/`
+  — verify new tests pass in isolation.
+- [x] 6.3 Run `go test -race -count=1 ./internal/doctor/`
+  — verify new tests pass in isolation.
+- [x] 6.4 Manual smoke test: `uf setup --dry-run` on a
+  system without Homebrew — verify Podman shows dnf,
+  Ollama shows curl installer intent.
+
+## 7. Constitution Alignment Verification
+
+- [x] 7.1 Verify Composability First: each tool's
+  fallback chain degrades gracefully — Podman via
+  dnf, Ollama via YesFlag/IsTTY-gated curl, DevPod
+  skip with download link. No mandatory dependencies.
+- [x] 7.2 Verify Testability: all new code uses
+  injectable dependencies (`LookPath`, `ExecCmd`,
+  `YesFlag`, `IsTTY` on the Options struct). No new
+  injectable fields added. No tests require network
+  access or stdin interaction.
+- [x] 7.3 Verify Security by Default: Ollama curl
+  installer is gated by YesFlag/IsTTY. Non-interactive
+  mode without --yes skips the installer. Trade-off
+  documented in proposal Constitution Alignment
+  section.
+<!-- spec-review: passed -->
+<!-- code-review: passed -->


### PR DESCRIPTION
## Summary

Fixes #268

On Fedora/RHEL without Homebrew, `uf setup` failed to install 7 of 11
tools. This change adds native Linux fallbacks so setup works without
brew:

- **Podman**: falls back to `dnf install -y podman` when brew is absent
- **Ollama**: falls back to official curl installer (`ollama.com/install.sh`)
  gated by `--yes` flag or interactive TTY
- **DevPod**: falls back to binary download from GitHub Releases, also
  gated by `--yes`/TTY

### Bug fixes
- `genericInstallCmd("replicator")` no longer returns `brew install` in
  the no-package-manager codepath
- `managerInstallCmd()` now has a `case ManagerDnf:` so doctor hints
  show `dnf install` on Fedora instead of `brew install`

### Documentation
- README, QUICKSTART, CHANGELOG updated with Fedora/dnf install paths
- Agent and command files updated with dnf alternatives for Gaze hints

### Tests
- 19 new tests covering dnf fallback, curl installer, binary download,
  dry-run, non-interactive skip, and failure paths
- All 19 packages pass with `-race -count=1`