### PR TITLE
feat: add /triage-issue slash command for multi-agent issue triage

### DIFF
--- a/.opencode/commands/triage-issue.md
+++ b/.opencode/commands/triage-issue.md
@@ -141,7 +141,7 @@ Each agent MUST return a **structured assessment** with these fields:
 | **category** | `bug`, `feature`, `enhancement`, `question`, `opinion`, `duplicate`, or `needs-clarification` |
 | **objectivity** | `objective` (verifiable evidence exists) or `subjective` (preference-based) |
 | **reasoning** | Evidence-based explanation for the verdict and category |
-| **split_recommendation** | `null` or an object with `reason` and `proposed_children` (array of `{title, body}`) |
+| **split_recommendation** | `null` or an array of `{title, description}` — each item is a proposed child issue |
 
 Use the following focus areas when prompting each agent:
 

--- a/.opencode/commands/triage-issue.md
+++ b/.opencode/commands/triage-issue.md
@@ -1,0 +1,463 @@
+---
+description: "Triage a GitHub issue using the Divisor review panel"
+---
+<!-- scaffolded by uf vdev -->
+
+
+# Triage Issue
+
+You are a token-efficient issue analyst. The user provides a GitHub issue number. Fetch the issue, fan out to the Divisor review panel for multi-agent assessment, consolidate verdicts into a classification, then execute triage actions (labels, comments, child issues) with user confirmation. Produce a JSON artifact for every invocation.
+
+The command follows four sequential phases (Ingest → Assess → Classify → Act). Phases are not independently invocable — run all four in sequence every invocation.
+
+## Arguments
+
+- **Issue number** (required): The GitHub issue number to triage (e.g., `42`).
+
+**Argument parsing** (before any tool calls): Check the user's message for an issue number argument. Validate that it matches `^[1-9][0-9]*$` (positive integer, no leading zeros). If the argument is missing, invalid, zero, negative, or contains non-numeric characters: **STOP** with error:
+> "Invalid issue number. Must be a positive integer."
+
+No `gh` CLI commands are permitted until the argument passes validation. Set `ISSUE_NUMBER` to the validated value. All subsequent steps use `<ISSUE_NUMBER>`.
+
+---
+
+## Phase 1: Ingest
+
+Fetch the issue, repository context, and duplicate candidates.
+
+### 1.0 Prerequisites
+
+Verify the `gh` CLI is available and authenticated:
+
+```bash
+which gh
+```
+
+If not found: **STOP** with error:
+> "GitHub CLI (gh) is not installed. Install from https://cli.github.com/"
+
+```bash
+gh auth status
+```
+
+If not authenticated: **STOP** with error:
+> "GitHub CLI not authenticated. Run `gh auth login` to authenticate."
+
+Detect the current repository:
+
+```bash
+gh repo view --json nameWithOwner --jq '.nameWithOwner'
+```
+
+Record `{owner}/{repo}` for all subsequent API calls. Repository identifiers MUST NOT be hardcoded.
+
+### 1.1 Fetch Issue
+
+```bash
+gh issue view <ISSUE_NUMBER> --json number,title,body,labels,author,comments,assignees,createdAt,state
+```
+
+**If the issue does not exist**: **STOP** with the `gh` error output.
+
+**If the issue is closed**: **STOP** with error:
+> "Issue #<ISSUE_NUMBER> is closed. Triage applies to open issues only."
+
+Record the full issue data for agent consumption.
+
+### 1.2 Re-Run Detection
+
+Check for previous triage actions on this issue to support idempotent re-runs:
+
+1. **Existing labels**: Extract the `labels` array from the issue data fetched in 1.1. Record which triage-relevant labels are already applied (`bug`, `enhancement`, `question`, `design-discussion`, `duplicate`, `needs-info`).
+
+2. **Previous triage comment**: Check the `comments` array for any comment containing the footer `_This triage was performed by the Divisor review panel._`. If found, note that a previous triage comment exists.
+
+3. **Existing artifact**: Check if `.uf/artifacts/issue-triage/issue-<ISSUE_NUMBER>.json` exists. If so, the new artifact will use a round number (e.g., `issue-<ISSUE_NUMBER>-2.json`).
+
+### 1.3 Fetch Repository Context
+
+Read project context files to provide agents with design philosophy:
+
+1. Read `README.md` (if it exists) — project description and purpose
+2. Read `AGENTS.md` — coding conventions, project structure, behavioral rules
+
+These provide agents with the context needed to assess whether an issue aligns with project goals and conventions.
+
+### 1.4 Duplicate Check
+
+Extract keywords from the issue title and first paragraph of the body for duplicate search:
+
+1. **Extract keywords**: Take the issue title and the first paragraph of the body. Select 5-10 meaningful keywords (nouns, verbs, technical terms). Exclude common stop words.
+
+2. **Sanitize keywords**: Remove shell metacharacters (`;`, `|`, `` ` ``, `$`, `(`, `)`, `"`) and strip any strings starting with `--` to prevent CLI flag injection.
+
+3. **Search for duplicates**:
+
+```bash
+gh issue list --search "<sanitized-keywords>" --state open --json number,title,url --limit 10
+```
+
+4. **Filter results**: Exclude the current issue from the results. Record any remaining candidates as `duplicate_candidates` for agent evaluation.
+
+---
+
+## Phase 2: Assess (Parallel Fan-Out)
+
+Fan out to the Divisor review panel for multi-agent assessment.
+
+### 2.1 Discover Available Agents
+
+1. **Read the `.opencode/agents/` directory** using the Read tool to list all entries.
+
+2. **Filter for triage panel agents**: From the directory listing, select only entries matching these five target agents:
+   - `divisor-adversary.md`
+   - `divisor-architect.md`
+   - `divisor-guard.md`
+   - `divisor-sre.md`
+   - `divisor-testing.md`
+
+   Note: `divisor-curator` is excluded from the triage panel. Its domain (documentation gap detection and content pipeline triage) is not relevant to issue classification.
+
+3. **Extract agent names**: For each matching file, strip the `.md` extension to get the agent name (e.g., `divisor-adversary.md` → `divisor-adversary`).
+
+4. **Guard clause**: If zero triage panel agents are discovered: **STOP** with error:
+   > "No Divisor agents found. At least one agent is required for triage."
+
+5. **Note absent agents**: Compare discovered agents against the five target agents. Any target agent not discovered is noted as absent. Absent agents are informational only — they do not block triage.
+
+### 2.2 Fan Out to Agents
+
+Delegate assessment to all discovered agents **in parallel** using the Task tool. For each agent, provide:
+
+- Full issue text (title, body, comments, author, labels, creation date)
+- Repository context (README.md and AGENTS.md summaries)
+- Duplicate candidates from Phase 1
+
+Each agent MUST return a **structured assessment** with these fields:
+
+| Field | Values |
+|---|---|
+| **verdict** | `VALID`, `INVALID`, or `NEEDS-CLARIFICATION` |
+| **category** | `bug`, `feature`, `enhancement`, `question`, `opinion`, `duplicate`, or `needs-clarification` |
+| **objectivity** | `objective` (verifiable evidence exists) or `subjective` (preference-based) |
+| **reasoning** | Evidence-based explanation for the verdict and category |
+| **split_recommendation** | `null` or an object with `reason` and `proposed_children` (array of `{title, body}`) |
+
+Use the following focus areas when prompting each agent:
+
+| Agent | Focus |
+|---|---|
+| `divisor-adversary` | Security implications, attack surface, error handling gaps, dependency risks, injection vectors |
+| `divisor-architect` | Architectural alignment, design patterns, scope fit, technical feasibility, convention adherence |
+| `divisor-guard` | Intent alignment with project goals, constitution compliance, scope discipline, user value |
+| `divisor-sre` | Operational impact, performance implications, deployment concerns, monitoring gaps, reliability |
+| `divisor-testing` | Testability, reproducibility, test coverage implications, regression risk, acceptance criteria clarity |
+
+For any discovered agent not in this table, use a generic prompt: "Assess this GitHub issue for validity, category, and objectivity. Return your structured assessment."
+
+### 2.3 Collect Assessments
+
+Collect all agent responses. If an agent fails to respond or returns an unparseable response, record the failure and proceed with the remaining assessments. The command SHOULD proceed with as few as one successful assessment.
+
+---
+
+## Phase 3: Classify (Consolidation)
+
+Consolidate individual agent assessments into a single classification.
+
+### 3.1 Verdict Resolution
+
+Apply the three-rule majority in order:
+
+1. **NEEDS-CLARIFICATION majority**: If NEEDS-CLARIFICATION verdicts constitute a majority of all agents (>50%), the overall verdict is **NEEDS-CLARIFICATION**.
+
+2. **Exclude NEEDS-CLARIFICATION**: Otherwise, exclude NEEDS-CLARIFICATION verdicts. If VALID or INVALID has a majority of the remaining votes, that verdict wins.
+
+3. **Tie-breaking**: If the remaining votes tie (equal VALID and INVALID after excluding NEEDS-CLARIFICATION), the overall verdict defaults to **NEEDS-CLARIFICATION**.
+
+When fewer than 5 agents are available, majority of available agents applies.
+
+### 3.2 Category Resolution
+
+Resolve category disagreements using the specificity hierarchy:
+
+```
+bug > feature > enhancement > needs-clarification > opinion > question
+```
+
+When agents disagree, the most specific category wins.
+
+**Duplicate resolution** (independent of hierarchy): An issue is classified as `duplicate` only when BOTH conditions are met:
+1. Phase 1 duplicate search found matching candidates
+2. At least two agents independently classify the issue as `duplicate`
+
+When both conditions are met, `duplicate` takes precedence over the specificity hierarchy.
+
+### 3.3 Objectivity Classification
+
+- **Objective**: At least ONE agent provides verifiable evidence (reproducible bug, measurable performance issue, documented behavior contradiction)
+- **Subjective**: ALL agents agree the issue is preference-based
+
+### 3.4 Record Dissent
+
+Record all dissenting agents (those whose verdict differs from the consolidated verdict) with their agent name and reasoning. These are included in the artifact for provenance tracing.
+
+### 3.5 Synthesize Split Recommendations
+
+If two or more agents recommend splitting the issue, synthesize their recommendations into a unified set of proposed child issues. Deduplicate overlapping proposals and merge complementary ones.
+
+---
+
+## Phase 4: Act (Interactive)
+
+Present the analysis and execute triage actions with user confirmation.
+
+### 4.1 Present Analysis Summary
+
+Display the consolidated classification to the user:
+
+```
+─── Issue Triage Summary ─────────────────
+Issue:        #<ISSUE_NUMBER>: <title>
+Verdict:      <VALID|INVALID|NEEDS-CLARIFICATION>
+Category:     <category>
+Objectivity:  <objective|subjective>
+Agents:       <N> consulted, <N> available
+Dissent:      <agent names and brief reasons, or "none">
+Duplicates:   <candidate issue numbers, or "none found">
+Split:        <"recommended" with count, or "not recommended">
+──────────────────────────────────────────
+
+── Agent Assessments ──
+<For each agent: name, verdict, category, brief reasoning>
+
+── Proposed Actions ──
+• Label: <label> (auto-apply / requires confirmation)
+• Comment: <tone tier> (requires confirmation)
+• Split: <N child issues> (requires confirmation, if applicable)
+──────────────────────────────────────────
+```
+
+### 4.2 Label Application
+
+Labels are applied **automatically without user confirmation**, with one exception: the `duplicate` label requires user confirmation because it carries implicit "close" semantics.
+
+**Label mapping**:
+
+| Category | Label |
+|---|---|
+| `bug` | `bug` |
+| `feature` | `enhancement` |
+| `enhancement` | `enhancement` |
+| `question` | `question` |
+| `opinion` | `design-discussion` |
+| `duplicate` | `duplicate` |
+| `needs-clarification` | `needs-info` |
+
+**Re-run check**: If the target label is already applied (detected in Phase 1.2), skip label application and note "label already present."
+
+**Label existence check**: Before applying, verify the label exists in the repository. If it does not exist, create it:
+
+```bash
+gh label create "<label>" --description "<description>" --color "<color>"
+```
+
+If label creation fails due to insufficient permissions, report the specific label that could not be created, skip that label, and continue with remaining actions. Record the failure in `actions_taken`.
+
+**Apply the label**:
+
+```bash
+gh issue edit <ISSUE_NUMBER> --add-label "<label>"
+```
+
+**For `duplicate` label only**: Present to the user for confirmation before applying:
+> "The `duplicate` label will be applied to issue #<ISSUE_NUMBER>. This signals the issue should be closed. Confirm? (yes/no)"
+
+### 4.3 Comment Composition and Posting
+
+Compose a triage comment based on the consolidated classification. The comment tone follows three tiers:
+
+| Verdict | Tone |
+|---|---|
+| VALID | Factual analysis: classification, recommendations, next steps |
+| INVALID / OPINION | Warm, non-dismissive: acknowledge reporter effort, explain reasoning with specific references, offer alternatives, invite continued engagement |
+| NEEDS-CLARIFICATION | Specific questions: what information would help, what to reproduce, what context is missing |
+
+**All comments MUST include the footer**:
+```
+_This triage was performed by the Divisor review panel._
+```
+
+**If duplicate candidates were found** (but not classified as duplicate): mention similar issues in the comment for the reporter's awareness.
+
+**Re-run check**: If a previous triage comment was detected in Phase 1.2, warn the user:
+> "A previous triage comment was detected on this issue. Posting another comment may cause confusion. Proceed?"
+
+**Present the composed comment to the user for confirmation**:
+
+| Decision | Action |
+|---|---|
+| **APPROVE** | Post the comment as-is |
+| **MODIFY** | User provides adjusted comment text; post the adjusted version |
+| **ABORT** | Do not post any comment; record `comment_posted: false` in artifact |
+
+**Post the comment** (on APPROVE or MODIFY):
+
+Write the comment body to a temporary file and post via `gh api --input`. NEVER interpolate comment text into shell arguments.
+
+```bash
+# Write comment body to temp file (never interpolate into shell args)
+COMMENT_FILE=$(mktemp)
+chmod 600 "$COMMENT_FILE"
+cat > "$COMMENT_FILE" << 'COMMENT_EOF'
+{"body": "<comment content as JSON-escaped string>"}
+COMMENT_EOF
+
+# Post the comment
+gh api repos/{owner}/{repo}/issues/<ISSUE_NUMBER>/comments \
+  --method POST --input "$COMMENT_FILE"
+
+# Clean up temp file in ALL paths (success, failure, abort)
+rm -f "$COMMENT_FILE"
+```
+
+**On API failure**: Report the error, do NOT retry. Record the failure in `actions_taken`. Clean up the temp file.
+
+### 4.4 Child Issue Creation (If Splitting)
+
+This section applies only when Phase 3.5 produced split recommendations.
+
+For each proposed child issue:
+
+1. **Present to user**: Show the proposed title and body. The user confirms each child issue individually.
+
+2. **Duplicate check**: Before creating, search for existing issues matching the proposed title:
+
+```bash
+gh issue list --search "<sanitized-child-title>" --state open --json number,title --limit 5
+```
+
+If a close match is found, warn the user and ask whether to proceed.
+
+3. **Create the child issue** (on confirmation):
+
+Each child issue body MUST include a cross-reference: `Split from #<ISSUE_NUMBER>`.
+
+Write the child issue payload to a temporary file and create via `gh api --input`:
+
+```bash
+CHILD_FILE=$(mktemp)
+chmod 600 "$CHILD_FILE"
+cat > "$CHILD_FILE" << 'CHILD_EOF'
+{"title": "<child title>", "body": "<child body with Split from #N>"}
+CHILD_EOF
+
+gh api repos/{owner}/{repo}/issues \
+  --method POST --input "$CHILD_FILE"
+
+rm -f "$CHILD_FILE"
+```
+
+Record each created child issue number and title.
+
+4. **Post parent comment**: After all confirmed child issues are created, post a comment on the parent issue listing the created children:
+
+```
+This issue has been split into the following child issues:
+- #<child_number>: <child_title>
+- #<child_number>: <child_title>
+
+_This triage was performed by the Divisor review panel._
+```
+
+Post this comment using the same temp file + `--input` pattern from 4.3.
+
+5. **Parent issue remains open**: The parent issue MUST NOT be auto-closed after splitting.
+
+### 4.5 Produce Triage Artifact
+
+Write the artifact for **every invocation**, regardless of outcome (success, user abort, partial failure).
+
+**Artifact path**: `.uf/artifacts/issue-triage/issue-<ISSUE_NUMBER>.json`
+
+**Round number**: If the file already exists, scan for the highest existing round number and increment (e.g., `issue-42.json` exists → write `issue-42-2.json`; `issue-42-2.json` exists → write `issue-42-3.json`).
+
+**Atomic write**: Write to a temp file first, then rename to the final path.
+
+**Envelope wrapper** (standard schema):
+
+```json
+{
+  "hero": "the-divisor",
+  "version": "1.0.0",
+  "timestamp": "<ISO 8601>",
+  "artifact_type": "issue-triage",
+  "schema_version": "1.0.0",
+  "context": {
+    "repository": "<owner/repo>",
+    "issue_number": "<ISSUE_NUMBER>"
+  },
+  "payload": {
+    "issue_number": 42,
+    "issue_url": "https://github.com/<owner>/<repo>/issues/<ISSUE_NUMBER>",
+    "repo": "<owner>/<repo>",
+    "title": "<issue title>",
+    "author": "<issue author login>",
+    "category": "bug",
+    "validity": "valid",
+    "objectivity": "objective",
+    "duplicate_of": null,
+    "split_issues": [],
+    "assessments": [
+      {
+        "agent": "divisor-adversary",
+        "verdict": "valid",
+        "category": "bug",
+        "objectivity": "objective",
+        "reasoning": "...",
+        "split_recommendation": null
+      }
+    ],
+    "actions_taken": {
+      "labels_applied": ["bug"],
+      "comment_posted": true,
+      "child_issues_created": [],
+      "label_creation_failed": false
+    },
+    "summary": {
+      "agents_consulted": 5,
+      "agents_available": 5,
+      "consensus": "4/5 valid",
+      "dissenting_agents": [
+        {"agent": "divisor-sre", "reasoning": "..."}
+      ]
+    }
+  }
+}
+```
+
+Fields may be `null` when not applicable (e.g., `duplicate_of` when the issue is not a duplicate). Use lowercase enum values in the payload (`valid`, `invalid`, `needs-clarification`, `bug`, `feature`, etc.) matching the schema definitions. Use UPPERCASE (`VALID`, `INVALID`, etc.) only in display/summary output to the user.
+
+**On partial failure**: The `actions_taken` section MUST reflect the actual state — which actions completed and which failed. Set `label_creation_failed` to `true` if label creation failed due to permissions. Set `comment_posted` to `false` if the user aborted or the API call failed.
+
+---
+
+## Guardrails
+
+1. **No auto-close**: MUST NOT close or lock any issue under any circumstances. The parent issue remains open even after splitting. The `duplicate` label is applied only with user confirmation.
+
+2. **No comments without confirmation**: Every issue comment is shown to the user before posting. No autonomous public communication.
+
+3. **No child issues without confirmation**: Every proposed child issue is presented to the user before creation. No autonomous issue creation.
+
+4. **Single issue per invocation**: The command processes exactly one issue. If the user provides multiple issue numbers, use only the first and ignore the rest with a warning.
+
+5. **gh CLI verification before API calls**: `which gh` and `gh auth status` MUST succeed before any GitHub API call. Specific error messages per prerequisite failure.
+
+6. **API failure handling**: When any `gh` CLI or API call fails (network error, HTTP 403 rate limit, HTTP 5xx), report the specific error, indicate which phase failed, and list any actions already completed. MUST NOT proceed with subsequent GitHub mutations after a failure. MUST still produce the artifact with `actions_taken` reflecting partial state.
+
+7. **Idempotent re-run**: On re-invocation for the same issue, detect previously applied labels (from issue data) to avoid duplication. Detect previously posted triage comments by checking for the Divisor review panel footer. Use round numbers for artifacts to preserve history.
+
+8. **Shell injection prevention**: All untrusted text (issue content, agent output, synthesized comments, child issue content) MUST be written to temporary files and passed via `--input` for all `gh api` calls. Untrusted text MUST NOT be interpolated into shell arguments. Temp files MUST use restrictive permissions (`chmod 600`) and be cleaned up in all exit paths (success, failure, abort).
+
+9. **Safe artifact paths**: The issue number is validated as a positive integer (matching `^[1-9][0-9]*$`) before use in any file path. This validation occurs in the Arguments section before any other processing.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,7 +65,7 @@ unbound-force/
 ├── .specify/                         # Speckit framework (templates, scripts, memory)
 ├── .opencode/
 │   ├── agents/                       # Hero persona agents (18 active)
-│   ├── commands/                     # Slash commands (47 files)
+│   ├── commands/                     # Slash commands (48 files)
 │   ├── skill/                        # Swarm skills packages
 │   ├── skills/                       # Additional skills packages
 │   └── uf/packs/                     # Convention packs
@@ -93,7 +93,8 @@ unbound-force/
 ├── specs/                            # Architectural specs (001-035)
 ├── openspec/                         # OpenSpec tactical workflow
 ├── schemas/                          # JSON Schema registry
-│   └── feedback-triage/              # Feedback triage schemas
+│   ├── feedback-triage/              # Feedback triage schemas
+│   └── issue-triage/                 # Issue triage schemas
 ├── go.mod                            # Go module (1.25+)
 ├── opencode.json                     # MCP server configuration
 ├── .goreleaser.yaml                  # Release configuration
@@ -186,6 +187,12 @@ These rules are non-negotiable. Violations are CRITICAL severity.
 | `/review-council` | Pre-PR (local) | 5+ Divisor agents |
 | `/review-pr [N]` | Post-PR (GitHub) | Single agent, CI analysis |
 | `/address-feedback [N]` | Post-PR (GitHub) | Triage + address reviewer feedback |
+
+### Issue Triage Commands
+
+| Command | When | Scope |
+|---------|------|-------|
+| `/triage-issue <N>` | Issue triage | 5 Divisor agents, classify + comment |
 
 `/review-pr` key capabilities: PR walkthrough, issue
 linking (`Fixes #N`), suggestion blocks, verdict-aligned

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ Each entry follows the format: `- <change-name>: <summary>`.
 ## Unreleased
 
 ### Added
+- `/triage-issue` slash command for multi-agent GitHub issue
+  triage using the Divisor review panel. Classifies issues
+  (bug, feature, enhancement, question, opinion, duplicate,
+  needs-clarification), determines validity via majority
+  consensus, checks for duplicates, recommends splitting
+  compound issues, and posts tone-appropriate comments.
+  (Spec: openspec/changes/triage-issue/)
+- `issue-triage` JSON schema (v1.0.0) for capturing triage
+  decisions as artifacts with per-agent assessment provenance
+  (Spec: openspec/changes/triage-issue/)
 - `python-convention-pack`: Added Python convention pack
   (`python.md`, `python-custom.md`) with 46 rules across 7
   sections (Coding Style, Architectural Patterns, Security

--- a/cmd/unbound-force/main_test.go
+++ b/cmd/unbound-force/main_test.go
@@ -30,12 +30,11 @@ func TestRunInit_FreshDir(t *testing.T) {
 	}
 
 	// Verify the summary includes a non-trivial file count
-	// 38 = 36 prior + 2 Python convention pack files
-	// (python.md + python-custom.md).
+	// 39 = 38 prior + 1 triage-issue command.
 	// (devcontainer excluded — OS-specific, generated
 	// per-user by uf sandbox init).
-	if !strings.Contains(output, "38 files processed") {
-		t.Errorf("expected '38 files processed' in output, got:\n%s", output)
+	if !strings.Contains(output, "39 files processed") {
+		t.Errorf("expected '39 files processed' in output, got:\n%s", output)
 	}
 
 	// Verify a user-owned file was created

--- a/internal/scaffold/assets/opencode/commands/triage-issue.md
+++ b/internal/scaffold/assets/opencode/commands/triage-issue.md
@@ -1,0 +1,463 @@
+---
+description: "Triage a GitHub issue using the Divisor review panel"
+---
+
+<!-- scaffolded by uf vdev -->
+
+# Triage Issue
+
+You are a token-efficient issue analyst. The user provides a GitHub issue number. Fetch the issue, fan out to the Divisor review panel for multi-agent assessment, consolidate verdicts into a classification, then execute triage actions (labels, comments, child issues) with user confirmation. Produce a JSON artifact for every invocation.
+
+The command follows four sequential phases (Ingest → Assess → Classify → Act). Phases are not independently invocable — run all four in sequence every invocation.
+
+## Arguments
+
+- **Issue number** (required): The GitHub issue number to triage (e.g., `42`).
+
+**Argument parsing** (before any tool calls): Check the user's message for an issue number argument. Validate that it matches `^[1-9][0-9]*$` (positive integer, no leading zeros). If the argument is missing, invalid, zero, negative, or contains non-numeric characters: **STOP** with error:
+> "Invalid issue number. Must be a positive integer."
+
+No `gh` CLI commands are permitted until the argument passes validation. Set `ISSUE_NUMBER` to the validated value. All subsequent steps use `<ISSUE_NUMBER>`.
+
+---
+
+## Phase 1: Ingest
+
+Fetch the issue, repository context, and duplicate candidates.
+
+### 1.0 Prerequisites
+
+Verify the `gh` CLI is available and authenticated:
+
+```bash
+which gh
+```
+
+If not found: **STOP** with error:
+> "GitHub CLI (gh) is not installed. Install from https://cli.github.com/"
+
+```bash
+gh auth status
+```
+
+If not authenticated: **STOP** with error:
+> "GitHub CLI not authenticated. Run `gh auth login` to authenticate."
+
+Detect the current repository:
+
+```bash
+gh repo view --json nameWithOwner --jq '.nameWithOwner'
+```
+
+Record `{owner}/{repo}` for all subsequent API calls. Repository identifiers MUST NOT be hardcoded.
+
+### 1.1 Fetch Issue
+
+```bash
+gh issue view <ISSUE_NUMBER> --json number,title,body,labels,author,comments,assignees,createdAt,state
+```
+
+**If the issue does not exist**: **STOP** with the `gh` error output.
+
+**If the issue is closed**: **STOP** with error:
+> "Issue #<ISSUE_NUMBER> is closed. Triage applies to open issues only."
+
+Record the full issue data for agent consumption.
+
+### 1.2 Re-Run Detection
+
+Check for previous triage actions on this issue to support idempotent re-runs:
+
+1. **Existing labels**: Extract the `labels` array from the issue data fetched in 1.1. Record which triage-relevant labels are already applied (`bug`, `enhancement`, `question`, `design-discussion`, `duplicate`, `needs-info`).
+
+2. **Previous triage comment**: Check the `comments` array for any comment containing the footer `_This triage was performed by the Divisor review panel._`. If found, note that a previous triage comment exists.
+
+3. **Existing artifact**: Check if `.uf/artifacts/issue-triage/issue-<ISSUE_NUMBER>.json` exists. If so, the new artifact will use a round number (e.g., `issue-<ISSUE_NUMBER>-2.json`).
+
+### 1.3 Fetch Repository Context
+
+Read project context files to provide agents with design philosophy:
+
+1. Read `README.md` (if it exists) — project description and purpose
+2. Read `AGENTS.md` — coding conventions, project structure, behavioral rules
+
+These provide agents with the context needed to assess whether an issue aligns with project goals and conventions.
+
+### 1.4 Duplicate Check
+
+Extract keywords from the issue title and first paragraph of the body for duplicate search:
+
+1. **Extract keywords**: Take the issue title and the first paragraph of the body. Select 5-10 meaningful keywords (nouns, verbs, technical terms). Exclude common stop words.
+
+2. **Sanitize keywords**: Remove shell metacharacters (`;`, `|`, `` ` ``, `$`, `(`, `)`, `"`) and strip any strings starting with `--` to prevent CLI flag injection.
+
+3. **Search for duplicates**:
+
+```bash
+gh issue list --search "<sanitized-keywords>" --state open --json number,title,url --limit 10
+```
+
+4. **Filter results**: Exclude the current issue from the results. Record any remaining candidates as `duplicate_candidates` for agent evaluation.
+
+---
+
+## Phase 2: Assess (Parallel Fan-Out)
+
+Fan out to the Divisor review panel for multi-agent assessment.
+
+### 2.1 Discover Available Agents
+
+1. **Read the `.opencode/agents/` directory** using the Read tool to list all entries.
+
+2. **Filter for triage panel agents**: From the directory listing, select only entries matching these five target agents:
+   - `divisor-adversary.md`
+   - `divisor-architect.md`
+   - `divisor-guard.md`
+   - `divisor-sre.md`
+   - `divisor-testing.md`
+
+   Note: `divisor-curator` is excluded from the triage panel. Its domain (documentation gap detection and content pipeline triage) is not relevant to issue classification.
+
+3. **Extract agent names**: For each matching file, strip the `.md` extension to get the agent name (e.g., `divisor-adversary.md` → `divisor-adversary`).
+
+4. **Guard clause**: If zero triage panel agents are discovered: **STOP** with error:
+   > "No Divisor agents found. At least one agent is required for triage."
+
+5. **Note absent agents**: Compare discovered agents against the five target agents. Any target agent not discovered is noted as absent. Absent agents are informational only — they do not block triage.
+
+### 2.2 Fan Out to Agents
+
+Delegate assessment to all discovered agents **in parallel** using the Task tool. For each agent, provide:
+
+- Full issue text (title, body, comments, author, labels, creation date)
+- Repository context (README.md and AGENTS.md summaries)
+- Duplicate candidates from Phase 1
+
+Each agent MUST return a **structured assessment** with these fields:
+
+| Field | Values |
+|---|---|
+| **verdict** | `VALID`, `INVALID`, or `NEEDS-CLARIFICATION` |
+| **category** | `bug`, `feature`, `enhancement`, `question`, `opinion`, `duplicate`, or `needs-clarification` |
+| **objectivity** | `objective` (verifiable evidence exists) or `subjective` (preference-based) |
+| **reasoning** | Evidence-based explanation for the verdict and category |
+| **split_recommendation** | `null` or an object with `reason` and `proposed_children` (array of `{title, body}`) |
+
+Use the following focus areas when prompting each agent:
+
+| Agent | Focus |
+|---|---|
+| `divisor-adversary` | Security implications, attack surface, error handling gaps, dependency risks, injection vectors |
+| `divisor-architect` | Architectural alignment, design patterns, scope fit, technical feasibility, convention adherence |
+| `divisor-guard` | Intent alignment with project goals, constitution compliance, scope discipline, user value |
+| `divisor-sre` | Operational impact, performance implications, deployment concerns, monitoring gaps, reliability |
+| `divisor-testing` | Testability, reproducibility, test coverage implications, regression risk, acceptance criteria clarity |
+
+For any discovered agent not in this table, use a generic prompt: "Assess this GitHub issue for validity, category, and objectivity. Return your structured assessment."
+
+### 2.3 Collect Assessments
+
+Collect all agent responses. If an agent fails to respond or returns an unparseable response, record the failure and proceed with the remaining assessments. The command SHOULD proceed with as few as one successful assessment.
+
+---
+
+## Phase 3: Classify (Consolidation)
+
+Consolidate individual agent assessments into a single classification.
+
+### 3.1 Verdict Resolution
+
+Apply the three-rule majority in order:
+
+1. **NEEDS-CLARIFICATION majority**: If NEEDS-CLARIFICATION verdicts constitute a majority of all agents (>50%), the overall verdict is **NEEDS-CLARIFICATION**.
+
+2. **Exclude NEEDS-CLARIFICATION**: Otherwise, exclude NEEDS-CLARIFICATION verdicts. If VALID or INVALID has a majority of the remaining votes, that verdict wins.
+
+3. **Tie-breaking**: If the remaining votes tie (equal VALID and INVALID after excluding NEEDS-CLARIFICATION), the overall verdict defaults to **NEEDS-CLARIFICATION**.
+
+When fewer than 5 agents are available, majority of available agents applies.
+
+### 3.2 Category Resolution
+
+Resolve category disagreements using the specificity hierarchy:
+
+```
+bug > feature > enhancement > needs-clarification > opinion > question
+```
+
+When agents disagree, the most specific category wins.
+
+**Duplicate resolution** (independent of hierarchy): An issue is classified as `duplicate` only when BOTH conditions are met:
+1. Phase 1 duplicate search found matching candidates
+2. At least two agents independently classify the issue as `duplicate`
+
+When both conditions are met, `duplicate` takes precedence over the specificity hierarchy.
+
+### 3.3 Objectivity Classification
+
+- **Objective**: At least ONE agent provides verifiable evidence (reproducible bug, measurable performance issue, documented behavior contradiction)
+- **Subjective**: ALL agents agree the issue is preference-based
+
+### 3.4 Record Dissent
+
+Record all dissenting agents (those whose verdict differs from the consolidated verdict) with their agent name and reasoning. These are included in the artifact for provenance tracing.
+
+### 3.5 Synthesize Split Recommendations
+
+If two or more agents recommend splitting the issue, synthesize their recommendations into a unified set of proposed child issues. Deduplicate overlapping proposals and merge complementary ones.
+
+---
+
+## Phase 4: Act (Interactive)
+
+Present the analysis and execute triage actions with user confirmation.
+
+### 4.1 Present Analysis Summary
+
+Display the consolidated classification to the user:
+
+```
+─── Issue Triage Summary ─────────────────
+Issue:        #<ISSUE_NUMBER>: <title>
+Verdict:      <VALID|INVALID|NEEDS-CLARIFICATION>
+Category:     <category>
+Objectivity:  <objective|subjective>
+Agents:       <N> consulted, <N> available
+Dissent:      <agent names and brief reasons, or "none">
+Duplicates:   <candidate issue numbers, or "none found">
+Split:        <"recommended" with count, or "not recommended">
+──────────────────────────────────────────
+
+── Agent Assessments ──
+<For each agent: name, verdict, category, brief reasoning>
+
+── Proposed Actions ──
+• Label: <label> (auto-apply / requires confirmation)
+• Comment: <tone tier> (requires confirmation)
+• Split: <N child issues> (requires confirmation, if applicable)
+──────────────────────────────────────────
+```
+
+### 4.2 Label Application
+
+Labels are applied **automatically without user confirmation**, with one exception: the `duplicate` label requires user confirmation because it carries implicit "close" semantics.
+
+**Label mapping**:
+
+| Category | Label |
+|---|---|
+| `bug` | `bug` |
+| `feature` | `enhancement` |
+| `enhancement` | `enhancement` |
+| `question` | `question` |
+| `opinion` | `design-discussion` |
+| `duplicate` | `duplicate` |
+| `needs-clarification` | `needs-info` |
+
+**Re-run check**: If the target label is already applied (detected in Phase 1.2), skip label application and note "label already present."
+
+**Label existence check**: Before applying, verify the label exists in the repository. If it does not exist, create it:
+
+```bash
+gh label create "<label>" --description "<description>" --color "<color>"
+```
+
+If label creation fails due to insufficient permissions, report the specific label that could not be created, skip that label, and continue with remaining actions. Record the failure in `actions_taken`.
+
+**Apply the label**:
+
+```bash
+gh issue edit <ISSUE_NUMBER> --add-label "<label>"
+```
+
+**For `duplicate` label only**: Present to the user for confirmation before applying:
+> "The `duplicate` label will be applied to issue #<ISSUE_NUMBER>. This signals the issue should be closed. Confirm? (yes/no)"
+
+### 4.3 Comment Composition and Posting
+
+Compose a triage comment based on the consolidated classification. The comment tone follows three tiers:
+
+| Verdict | Tone |
+|---|---|
+| VALID | Factual analysis: classification, recommendations, next steps |
+| INVALID / OPINION | Warm, non-dismissive: acknowledge reporter effort, explain reasoning with specific references, offer alternatives, invite continued engagement |
+| NEEDS-CLARIFICATION | Specific questions: what information would help, what to reproduce, what context is missing |
+
+**All comments MUST include the footer**:
+```
+_This triage was performed by the Divisor review panel._
+```
+
+**If duplicate candidates were found** (but not classified as duplicate): mention similar issues in the comment for the reporter's awareness.
+
+**Re-run check**: If a previous triage comment was detected in Phase 1.2, warn the user:
+> "A previous triage comment was detected on this issue. Posting another comment may cause confusion. Proceed?"
+
+**Present the composed comment to the user for confirmation**:
+
+| Decision | Action |
+|---|---|
+| **APPROVE** | Post the comment as-is |
+| **MODIFY** | User provides adjusted comment text; post the adjusted version |
+| **ABORT** | Do not post any comment; record `comment_posted: false` in artifact |
+
+**Post the comment** (on APPROVE or MODIFY):
+
+Write the comment body to a temporary file and post via `gh api --input`. NEVER interpolate comment text into shell arguments.
+
+```bash
+# Write comment body to temp file (never interpolate into shell args)
+COMMENT_FILE=$(mktemp)
+chmod 600 "$COMMENT_FILE"
+cat > "$COMMENT_FILE" << 'COMMENT_EOF'
+{"body": "<comment content as JSON-escaped string>"}
+COMMENT_EOF
+
+# Post the comment
+gh api repos/{owner}/{repo}/issues/<ISSUE_NUMBER>/comments \
+  --method POST --input "$COMMENT_FILE"
+
+# Clean up temp file in ALL paths (success, failure, abort)
+rm -f "$COMMENT_FILE"
+```
+
+**On API failure**: Report the error, do NOT retry. Record the failure in `actions_taken`. Clean up the temp file.
+
+### 4.4 Child Issue Creation (If Splitting)
+
+This section applies only when Phase 3.5 produced split recommendations.
+
+For each proposed child issue:
+
+1. **Present to user**: Show the proposed title and body. The user confirms each child issue individually.
+
+2. **Duplicate check**: Before creating, search for existing issues matching the proposed title:
+
+```bash
+gh issue list --search "<sanitized-child-title>" --state open --json number,title --limit 5
+```
+
+If a close match is found, warn the user and ask whether to proceed.
+
+3. **Create the child issue** (on confirmation):
+
+Each child issue body MUST include a cross-reference: `Split from #<ISSUE_NUMBER>`.
+
+Write the child issue payload to a temporary file and create via `gh api --input`:
+
+```bash
+CHILD_FILE=$(mktemp)
+chmod 600 "$CHILD_FILE"
+cat > "$CHILD_FILE" << 'CHILD_EOF'
+{"title": "<child title>", "body": "<child body with Split from #N>"}
+CHILD_EOF
+
+gh api repos/{owner}/{repo}/issues \
+  --method POST --input "$CHILD_FILE"
+
+rm -f "$CHILD_FILE"
+```
+
+Record each created child issue number and title.
+
+4. **Post parent comment**: After all confirmed child issues are created, post a comment on the parent issue listing the created children:
+
+```
+This issue has been split into the following child issues:
+- #<child_number>: <child_title>
+- #<child_number>: <child_title>
+
+_This triage was performed by the Divisor review panel._
+```
+
+Post this comment using the same temp file + `--input` pattern from 4.3.
+
+5. **Parent issue remains open**: The parent issue MUST NOT be auto-closed after splitting.
+
+### 4.5 Produce Triage Artifact
+
+Write the artifact for **every invocation**, regardless of outcome (success, user abort, partial failure).
+
+**Artifact path**: `.uf/artifacts/issue-triage/issue-<ISSUE_NUMBER>.json`
+
+**Round number**: If the file already exists, scan for the highest existing round number and increment (e.g., `issue-42.json` exists → write `issue-42-2.json`; `issue-42-2.json` exists → write `issue-42-3.json`).
+
+**Atomic write**: Write to a temp file first, then rename to the final path.
+
+**Envelope wrapper** (standard schema):
+
+```json
+{
+  "hero": "the-divisor",
+  "version": "1.0.0",
+  "timestamp": "<ISO 8601>",
+  "artifact_type": "issue-triage",
+  "schema_version": "1.0.0",
+  "context": {
+    "repository": "<owner/repo>",
+    "issue_number": "<ISSUE_NUMBER>"
+  },
+  "payload": {
+    "issue_number": 42,
+    "issue_url": "https://github.com/<owner>/<repo>/issues/<ISSUE_NUMBER>",
+    "repo": "<owner>/<repo>",
+    "title": "<issue title>",
+    "author": "<issue author login>",
+    "category": "bug",
+    "validity": "valid",
+    "objectivity": "objective",
+    "duplicate_of": null,
+    "split_issues": [],
+    "assessments": [
+      {
+        "agent": "divisor-adversary",
+        "verdict": "valid",
+        "category": "bug",
+        "objectivity": "objective",
+        "reasoning": "...",
+        "split_recommendation": null
+      }
+    ],
+    "actions_taken": {
+      "labels_applied": ["bug"],
+      "comment_posted": true,
+      "child_issues_created": [],
+      "label_creation_failed": false
+    },
+    "summary": {
+      "agents_consulted": 5,
+      "agents_available": 5,
+      "consensus": "4/5 valid",
+      "dissenting_agents": [
+        {"agent": "divisor-sre", "reasoning": "..."}
+      ]
+    }
+  }
+}
+```
+
+Fields may be `null` when not applicable (e.g., `duplicate_of` when the issue is not a duplicate). Use lowercase enum values in the payload (`valid`, `invalid`, `needs-clarification`, `bug`, `feature`, etc.) matching the schema definitions. Use UPPERCASE (`VALID`, `INVALID`, etc.) only in display/summary output to the user.
+
+**On partial failure**: The `actions_taken` section MUST reflect the actual state — which actions completed and which failed. Set `label_creation_failed` to `true` if label creation failed due to permissions. Set `comment_posted` to `false` if the user aborted or the API call failed.
+
+---
+
+## Guardrails
+
+1. **No auto-close**: MUST NOT close or lock any issue under any circumstances. The parent issue remains open even after splitting. The `duplicate` label is applied only with user confirmation.
+
+2. **No comments without confirmation**: Every issue comment is shown to the user before posting. No autonomous public communication.
+
+3. **No child issues without confirmation**: Every proposed child issue is presented to the user before creation. No autonomous issue creation.
+
+4. **Single issue per invocation**: The command processes exactly one issue. If the user provides multiple issue numbers, use only the first and ignore the rest with a warning.
+
+5. **gh CLI verification before API calls**: `which gh` and `gh auth status` MUST succeed before any GitHub API call. Specific error messages per prerequisite failure.
+
+6. **API failure handling**: When any `gh` CLI or API call fails (network error, HTTP 403 rate limit, HTTP 5xx), report the specific error, indicate which phase failed, and list any actions already completed. MUST NOT proceed with subsequent GitHub mutations after a failure. MUST still produce the artifact with `actions_taken` reflecting partial state.
+
+7. **Idempotent re-run**: On re-invocation for the same issue, detect previously applied labels (from issue data) to avoid duplication. Detect previously posted triage comments by checking for the Divisor review panel footer. Use round numbers for artifacts to preserve history.
+
+8. **Shell injection prevention**: All untrusted text (issue content, agent output, synthesized comments, child issue content) MUST be written to temporary files and passed via `--input` for all `gh api` calls. Untrusted text MUST NOT be interpolated into shell arguments. Temp files MUST use restrictive permissions (`chmod 600`) and be cleaned up in all exit paths (success, failure, abort).
+
+9. **Safe artifact paths**: The issue number is validated as a positive integer (matching `^[1-9][0-9]*$`) before use in any file path. This validation occurs in the Arguments section before any other processing.

--- a/internal/scaffold/assets/opencode/commands/triage-issue.md
+++ b/internal/scaffold/assets/opencode/commands/triage-issue.md
@@ -141,7 +141,7 @@ Each agent MUST return a **structured assessment** with these fields:
 | **category** | `bug`, `feature`, `enhancement`, `question`, `opinion`, `duplicate`, or `needs-clarification` |
 | **objectivity** | `objective` (verifiable evidence exists) or `subjective` (preference-based) |
 | **reasoning** | Evidence-based explanation for the verdict and category |
-| **split_recommendation** | `null` or an object with `reason` and `proposed_children` (array of `{title, body}`) |
+| **split_recommendation** | `null` or an array of `{title, description}` — each item is a proposed child issue |
 
 Use the following focus areas when prompting each agent:
 

--- a/internal/scaffold/assets/opencode/commands/triage-issue.md
+++ b/internal/scaffold/assets/opencode/commands/triage-issue.md
@@ -1,8 +1,8 @@
 ---
 description: "Triage a GitHub issue using the Divisor review panel"
 ---
-
 <!-- scaffolded by uf vdev -->
+
 
 # Triage Issue
 

--- a/internal/scaffold/scaffold_test.go
+++ b/internal/scaffold/scaffold_test.go
@@ -130,7 +130,7 @@ func mapAssetToSource(relPath string) string {
 // expectedAssetPaths is the canonical list of embedded assets.
 // Update this list when adding or removing assets.
 var expectedAssetPaths = []string{
-	// OpenCode commands (9) — UF-custom only; speckit.*.md externalized to specify init + /uf-init
+	// OpenCode commands (10) — UF-custom only; speckit.*.md externalized to specify init + /uf-init
 	"opencode/commands/address-feedback.md",
 	"opencode/commands/agent-brief.md",
 	"opencode/commands/cobalt-crush.md",
@@ -138,6 +138,7 @@ var expectedAssetPaths = []string{
 	"opencode/commands/finale.md",
 	"opencode/commands/review-council.md",
 	"opencode/commands/review-pr.md",
+	"opencode/commands/triage-issue.md",
 	"opencode/commands/uf-init.md",
 	"opencode/commands/unleash.md",
 	// OpenCode agents — Divisor personas (6) + Cobalt-Crush (1) + Mx F coach (1) + constitution-check (1)

--- a/internal/schemas/ci_test.go
+++ b/internal/schemas/ci_test.go
@@ -173,6 +173,7 @@ func TestSchemaRegistry_NoDrift(t *testing.T) {
 // tests since they are not covered by the registry-based tests.
 var handAuthoredSchemas = []string{
 	"feedback-triage",
+	"issue-triage",
 }
 
 // TestHandAuthoredSchemas_SampleValidates validates the positive

--- a/openspec/changes/triage-issue/.openspec.yaml
+++ b/openspec/changes/triage-issue/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: unbound-force
+created: 2026-06-16

--- a/openspec/changes/triage-issue/design.md
+++ b/openspec/changes/triage-issue/design.md
@@ -1,0 +1,288 @@
+## Context
+
+Maintainers manually triage GitHub issues today. The
+Divisor review panel (adversary, architect, guard, sre,
+testing) already evaluates PRs through specialized lenses.
+This design extends that pattern to issue triage via a new
+`/triage-issue` slash command.
+
+The design follows three established patterns:
+- `/review-council` for multi-agent parallel fan-out and
+  verdict consolidation
+- `/address-feedback` for interactive user confirmation
+  before GitHub actions
+- `divisor-curator` for `gh` CLI issue operations and
+  duplicate checking
+
+## Goals / Non-Goals
+
+### Goals
+- Structured multi-agent issue classification with
+  per-agent provenance
+- Duplicate detection before any action
+- Compound issue splitting with cross-references
+- Tone-appropriate commenting (warm for rejections,
+  factual for valid issues)
+- Machine-parseable triage artifact for downstream
+  consumption
+- Graceful degradation when fewer than five agents
+  are available
+
+### Non-Goals
+- Batch triage (multiple issues per invocation)
+- Cross-repo triage (only current repo)
+- Auto-closing issues (never, by design)
+- Modifying existing agent files
+- Creating new Divisor agents
+
+## Decisions
+
+### D1: Four-Phase Pipeline
+
+**Decision**: Follow the address-feedback four-phase
+pattern: Ingest, Assess, Classify, Act.
+
+**Rationale**: Proven pattern in the codebase. Separates
+data gathering (Ingest) from analysis (Assess/Classify)
+from side effects (Act). Each phase has clear inputs and
+outputs. The Act phase gates all GitHub mutations behind
+user confirmation.
+
+### D2: Majority Verdict (3/5) Not Unanimous
+
+**Decision**: Use majority consensus (3 of 5 agents)
+for validity determination, not the unanimous gate used
+by review-council.
+
+**Rationale**: Issues are more nuanced than code review.
+A single dissenting agent should not block the entire
+panel. The review-council uses unanimous APPROVE because
+merging bad code is costly and irreversible. Issue
+classification is lower-stakes and reversible (labels can
+be changed, comments edited). Dissenting opinions are
+recorded in the artifact for transparency.
+
+### D3: Category Taxonomy
+
+**Decision**: Seven categories with deterministic label
+mapping.
+
+| Category             | GitHub Label         |
+|----------------------|----------------------|
+| `bug`                | `bug`                |
+| `feature`            | `enhancement`        |
+| `enhancement`        | `enhancement`        |
+| `question`           | `question`           |
+| `opinion`            | `design-discussion`  |
+| `duplicate`          | `duplicate`          |
+| `needs-clarification`| `needs-info`         |
+
+**Rationale**: Categories map to standard GitHub labels
+where possible. `feature` and `enhancement` both map to
+`enhancement` (GitHub convention). `opinion` gets a new
+`design-discussion` label to distinguish philosophical
+disagreements from invalid issues. `needs-clarification`
+uses `needs-info` to signal the reporter should provide
+more context.
+
+### D4: Labels Applied Without Confirmation (with Exception)
+
+**Decision**: Labels are applied automatically without
+user confirmation. Exception: the `duplicate` label
+requires user confirmation because it carries implicit
+"close" semantics. Comments and child issues also
+require user confirmation.
+
+**Rationale**: Most labels are low-risk and reversible
+(one `gh issue edit --remove-label` away). The
+`duplicate` label is different -- it signals to the
+community that the issue should be closed, which is
+a higher-stakes action. Comments are public-facing and
+irreversible in practice. Child issues create new work
+items. The risk/reversibility gradient drives the
+confirmation policy.
+
+### D5: Objectivity Classification
+
+**Decision**: Binary classification (objective vs.
+subjective) based on agent consensus.
+
+- **Objective**: At least one agent provides verifiable
+  evidence (reproducible bug, measurable performance
+  issue, documented behavior contradiction)
+- **Subjective**: All agents agree the issue is
+  preference-based (naming, style, philosophy)
+
+**Rationale**: This mirrors the address-feedback
+`data-driven` vs. `subjective` classification. The
+threshold is deliberately low for objective (any single
+agent can elevate) because false negatives (dismissing a
+real issue as subjective) are more costly than false
+positives.
+
+### D6: Comment Tone Tiers
+
+**Decision**: Three comment tone tiers composed by the
+command itself, not by individual agents.
+
+| Validity        | Tone                                                                        |
+|-----------------|-----------------------------------------------------------------------------|
+| Valid            | Factual analysis, recommendations                                           |
+| Invalid/Opinion  | Warm acknowledgment; design rationale; alternatives; invite engagement       |
+| Needs-Clarify    | Specific questions; what info would help                                    |
+
+**Rationale**: Individual Divisor agents are blunt by
+design (adversarial reviewers). Public-facing issue
+comments require a different register. The command
+synthesizes agent findings into a unified comment with
+appropriate tone. This separation of concerns keeps
+agents honest and comments kind.
+
+### D7: Artifact Schema with Envelope Wrapping
+
+**Decision**: Produce a JSON artifact at
+`.uf/artifacts/issue-triage/issue-<N>.json` wrapped in
+the standard envelope format.
+
+**Rationale**: Aligns with Principle III (Observable
+Quality). The envelope provides provenance metadata
+(hero, version, timestamp). The payload schema
+(`schemas/issue-triage/v1.0.0.schema.json`) enables
+schema validation and cross-hero consumption. Mx F can
+track triage patterns, Muti-Mind can detect recurring
+gaps.
+
+### D8: Dynamic Agent Discovery
+
+**Decision**: Discover available triage agents at runtime
+by reading `.opencode/agents/` and filtering for the five
+target agent files.
+
+**Rationale**: Follows the review-council pattern.
+Avoids hardcoding agent availability. Supports graceful
+degradation (Principle II: Composability First) -- the
+command works with any subset of the five agents.
+Note: `divisor-curator` is excluded from the triage
+panel because its domain (documentation gap detection
+and content pipeline triage) is not relevant to issue
+classification.
+
+### D9: Duplicate Check Strategy
+
+**Decision**: Two-layer duplicate detection.
+
+1. **Phase 1 (Ingest)**: Extract keywords from issue
+   title and body, search via
+   `gh issue list --search "<keywords>" --state open`
+2. **Phase 2 (Assess)**: Agents independently evaluate
+   whether the issue is a duplicate based on the
+   candidate list from Phase 1
+
+If Phase 1 finds candidates AND 2+ agents classify as
+duplicate, the issue is marked `duplicate`.
+
+**Rationale**: Keyword search alone produces false
+positives. Agent assessment alone lacks search reach.
+The two-layer approach combines broad search with
+expert judgment.
+
+### D10: Split Issue Cross-Referencing
+
+**Decision**: When splitting, each child issue body
+includes a reference to the parent issue
+(`Split from #N`). The parent issue receives a comment
+listing all created child issues with their numbers
+and titles.
+
+**Rationale**: Maintains traceability. The parent issue
+is never auto-closed -- the reporter confirms the split
+addresses their concerns.
+
+### D11: Idempotent Re-Run
+
+**Decision**: The command is safely re-runnable. On
+re-invocation, it detects previously applied labels and
+posted comments to avoid duplication. Artifacts use
+round numbers to preserve history.
+
+**Rationale**: Follows the address-feedback pattern
+(round-numbered artifacts). The Act phase performs
+multiple sequential GitHub mutations (label, comment,
+child issues). If any step fails, the user should be
+able to re-run without duplicating completed actions.
+Label application is inherently idempotent
+(`--add-label` on an already-labeled issue is a no-op).
+Comment duplication is detected by checking for the
+Divisor panel footer.
+
+### D12: Keyword Sanitization for Duplicate Search
+
+**Decision**: Keywords extracted from issue content are
+sanitized before use in `gh issue list --search`.
+Shell metacharacters and CLI flag prefixes are stripped.
+
+**Rationale**: Issue content is attacker-controlled
+(any GitHub user can create an issue). Keywords flow
+into a shell command. Without sanitization, a malicious
+issue title could inject shell commands or `gh` CLI
+flags. This follows the same principle as FR-018
+(temp file + `--input`) but applied to search queries.
+
+## Risks / Trade-offs
+
+### R1: Agent Disagreement on Category
+
+**Risk**: Five agents may return five different
+categories for the same issue.
+
+**Mitigation**: Category resolution uses a specificity
+hierarchy (bug > feature > enhancement >
+needs-clarification > opinion > question). `duplicate`
+is resolved independently by FR-013. Disagreements
+are recorded in the artifact and surfaced to the user
+during the Act phase. The user can override via MODIFY.
+
+### R2: False Duplicate Detection
+
+**Risk**: Keyword search may surface unrelated issues
+as duplicates.
+
+**Mitigation**: Duplicate classification requires both
+keyword match AND 2+ agent agreement. Per D4, the
+`duplicate` label is the one label that requires user
+confirmation before application (it carries implicit
+"close" semantics). Keywords extracted from issue
+content are sanitized before use in search queries
+(FR-012).
+
+### R3: Tone Mismatch for Edge Cases
+
+**Risk**: The three-tier tone model may not cover all
+cases (e.g., a valid bug report with an aggressive tone
+from the reporter).
+
+**Mitigation**: The user reviews and can MODIFY the
+comment before posting. The command never posts
+autonomously. Edge cases are handled by human judgment
+in the confirmation step.
+
+### R4: Rate Limiting
+
+**Risk**: Five parallel agent invocations plus multiple
+`gh` API calls could hit rate limits on large repos.
+
+**Mitigation**: Agent calls use the Task tool (managed
+concurrency). GitHub API calls are sequential within
+each phase. The command does not retry on rate limit
+errors -- it reports the error and stops.
+
+### R5: Label Creation
+
+**Risk**: The `design-discussion` label may not exist
+in the target repository.
+
+**Mitigation**: The command checks for label existence
+before applying. If the label does not exist, it creates
+it via `gh label create "design-discussion"
+--description "Subjective design philosophy discussion"
+--color "d4c5f9"`. Same pattern for any missing labels.

--- a/openspec/changes/triage-issue/proposal.md
+++ b/openspec/changes/triage-issue/proposal.md
@@ -1,0 +1,142 @@
+## Why
+
+GitHub issues arrive in many forms: genuine bugs, feature
+requests mislabeled as bugs, subjective disagreements with
+design philosophy, questions that belong in discussions, and
+compound issues that should be split. Today maintainers
+manually read, classify, and respond to each one. This is
+time-consuming, inconsistent, and prone to tone missteps
+when declining an issue.
+
+The Divisor review panel already has the domain expertise
+to evaluate issues across security, architecture,
+governance, operations, and testing. This change extends
+their reach from PR review to issue triage, bringing
+structured multi-agent assessment to the issue lifecycle.
+
+## What Changes
+
+A new `/triage-issue` slash command that accepts a GitHub
+issue number and runs a five-agent Divisor panel to:
+
+1. Classify the issue (bug, feature, enhancement,
+   question, opinion, duplicate)
+2. Determine validity (valid, invalid, needs
+   clarification)
+3. Assess objectivity (objective defect vs. subjective
+   preference)
+4. Check for duplicates against open issues
+5. Recommend splitting compound issues into focused
+   child issues
+6. Post a triage comment with the analysis and
+   recommendations
+7. Apply appropriate labels automatically
+
+A new `issue-triage` JSON Schema captures the triage
+artifact for consumption by Mx F, Muti-Mind, and future
+analytics.
+
+## Capabilities
+
+### New Capabilities
+- `/triage-issue <N>`: Multi-agent issue triage with
+  structured classification, duplicate detection, split
+  recommendations, and tone-appropriate commenting
+- `issue-triage` schema (v1.0.0): Machine-parseable
+  artifact for triage outcomes with full agent assessment
+  provenance
+
+### Modified Capabilities
+- None
+
+### Removed Capabilities
+- None
+
+## Impact
+
+- **New files**:
+  - `.opencode/commands/triage-issue.md` (slash command)
+  - `schemas/issue-triage/v1.0.0.schema.json` (payload
+    schema)
+  - `schemas/issue-triage/README.md` (schema docs)
+  - `schemas/issue-triage/samples/sample-issue-triage.json`
+    (valid sample)
+  - `schemas/issue-triage/samples/invalid-extra-property.json`
+    (invalid sample for validation testing)
+- **No modified files**: The command is self-contained.
+  Agents discover commands by filename. The schema
+  directory is a flat registry.
+- **GitHub interactions**: Reads issues via `gh issue view`,
+  searches for duplicates via `gh issue list --search`,
+  applies labels via `gh issue edit --add-label`, posts
+  comments via `gh api`, creates child issues via
+  `gh issue create`
+- **New GitHub label**: `design-discussion` for issues
+  classified as subjective opinion/philosophy differences
+
+## Constitution Alignment
+
+Assessed against the Unbound Force org constitution v1.2.0.
+
+### I. Autonomous Collaboration
+
+**Assessment**: PASS
+
+The command produces a self-describing JSON artifact
+(`.uf/artifacts/issue-triage/issue-<N>.json`) wrapped in
+the standard envelope format with full provenance metadata.
+Each agent assessment is recorded independently. Mx F can
+consume triage artifacts for trend analysis without
+consulting the producing agents. The five Divisor agents
+operate asynchronously via parallel Task tool fan-out,
+with no synchronous inter-agent coupling.
+
+### II. Composability First
+
+**Assessment**: PASS
+
+The command gracefully degrades when fewer than five
+Divisor agents are available. If only three agents are
+deployed, the command proceeds with those three and notes
+which are missing. The command requires no other heroes
+(Muti-Mind, Mx F, Gaze) to function. Those heroes
+benefit from consuming the artifact but are not
+prerequisites.
+
+### III. Observable Quality
+
+**Assessment**: PASS
+
+The triage artifact is JSON with a formal schema
+(`schemas/issue-triage/v1.0.0.schema.json`), includes
+provenance metadata (producing hero, timestamp, repo
+context), and is validated against the schema. Valid
+and invalid samples enable automated regression testing.
+The artifact includes per-agent assessments so every
+classification decision is traceable to its source.
+
+### IV. Testability
+
+**Assessment**: PASS
+
+The schema includes valid and invalid samples for
+validation testing. The command uses `gh` CLI exclusively
+(testable via mock runners, consistent with
+`internal/sync/sync.go` patterns). Agent assessments
+are independently verifiable. The slash command is a
+declarative instruction file with no compiled code,
+so testability concerns are limited to schema validation
+and integration testing of the `gh` CLI interactions.
+
+### V. Security by Default
+
+**Assessment**: PASS
+
+All GitHub comment text is written to temporary files
+and posted via `--input`, preventing shell injection
+(consistent with `address-feedback` and `review-pr`
+guardrails). The command uses dynamic repo detection
+(`gh repo view --json nameWithOwner`) rather than
+hardcoded values. No new dependencies are introduced.
+Labels are applied via `gh issue edit`, which respects
+the authenticated user's permissions.

--- a/openspec/changes/triage-issue/specs/triage-issue.md
+++ b/openspec/changes/triage-issue/specs/triage-issue.md
@@ -1,0 +1,459 @@
+## ADDED Requirements
+
+### Requirement: Issue Triage Command
+
+FR-001: The `/triage-issue` command MUST accept a single
+GitHub issue number as a required argument. The argument
+MUST be validated as a positive integer (matching
+`^[1-9][0-9]*$`) before any `gh` CLI invocation.
+Non-integer, negative, zero, or excessively large values
+MUST be rejected with an error message.
+
+FR-002: The command MUST validate that the issue exists
+and is in an open state before proceeding. If the issue
+is closed, the command MUST stop with an error message.
+
+FR-003: The command MUST detect the current repository
+dynamically via `gh repo view --json nameWithOwner`.
+Repository identifiers MUST NOT be hardcoded.
+
+#### Scenario: Triage a valid open issue
+
+- **GIVEN** the user invokes `/triage-issue 42`
+- **AND** issue #42 exists and is open
+- **WHEN** the command completes all four phases
+- **THEN** the issue has an appropriate label applied
+- **AND** a triage comment is posted (after user
+  confirmation)
+- **AND** a JSON artifact is produced at
+  `.uf/artifacts/issue-triage/issue-42.json`
+- **AND** the artifact validates against
+  `schemas/issue-triage/v1.0.0.schema.json`
+
+#### Scenario: Triage a closed issue
+
+- **GIVEN** the user invokes `/triage-issue 99`
+- **AND** issue #99 is closed
+- **WHEN** the command validates the issue state
+- **THEN** the command stops with an error:
+  "Issue #99 is closed. Triage applies to open issues
+  only."
+
+#### Scenario: Triage a nonexistent issue
+
+- **GIVEN** the user invokes `/triage-issue 9999`
+- **AND** issue #9999 does not exist
+- **WHEN** the command fetches the issue
+- **THEN** the command stops with the `gh` error output
+
+#### Scenario: Invalid issue number argument
+
+- **GIVEN** the user invokes `/triage-issue "42; echo pwned"`
+- **WHEN** the command validates the argument
+- **THEN** the command stops with an error:
+  "Invalid issue number. Must be a positive integer."
+- **AND** no `gh` CLI commands are executed
+
+---
+
+### Requirement: Multi-Agent Assessment
+
+FR-004: The command MUST fan out to the following five
+Divisor agents in parallel via the Task tool:
+`divisor-adversary`, `divisor-architect`,
+`divisor-guard`, `divisor-sre`, `divisor-testing`.
+
+FR-005: Each agent MUST return a structured assessment
+containing: verdict (VALID, INVALID, or
+NEEDS-CLARIFICATION), category, objectivity
+classification, evidence-based reasoning, and an
+optional split recommendation.
+
+FR-006: Agent discovery MUST be dynamic (read
+`.opencode/agents/` directory). If an agent file is
+missing, the command MUST proceed with available agents
+and note which agents were unavailable.
+
+FR-007: The command SHOULD proceed with as few as one
+available agent. Zero available agents MUST cause the
+command to stop with an error.
+
+#### Scenario: All five agents available
+
+- **GIVEN** all five Divisor agent files exist
+- **WHEN** the command fans out to agents
+- **THEN** all five agents are invoked in parallel
+- **AND** five assessments are collected
+
+#### Scenario: Graceful degradation with missing agents
+
+- **GIVEN** only `divisor-adversary` and
+  `divisor-architect` agent files exist
+- **WHEN** the command discovers available agents
+- **THEN** the command proceeds with two agents
+- **AND** the artifact `summary.agents_available` is 2
+- **AND** the artifact `summary.agents_consulted` is 2
+- **AND** missing agents are noted in the output
+
+#### Scenario: No agents available
+
+- **GIVEN** no `divisor-*.md` files exist in
+  `.opencode/agents/`
+- **WHEN** the command attempts agent discovery
+- **THEN** the command stops with an error:
+  "No Divisor agents found. At least one agent is
+  required for triage."
+
+---
+
+### Requirement: Verdict Consolidation
+
+FR-008: The command MUST use majority consensus (3 of 5
+agents) to determine issue validity. When fewer than 5
+agents are available, majority of available agents
+applies. Verdict resolution follows three rules in
+order:
+1. If NEEDS-CLARIFICATION verdicts constitute a majority
+   of all agents (>50%), the overall verdict is
+   NEEDS-CLARIFICATION.
+2. Otherwise, NEEDS-CLARIFICATION verdicts are excluded.
+   If VALID or INVALID has a majority of the remaining
+   votes, that verdict wins.
+3. If the remaining votes tie (equal VALID and INVALID
+   after excluding NEEDS-CLARIFICATION), the overall
+   verdict defaults to NEEDS-CLARIFICATION.
+
+FR-009: Category resolution MUST use a specificity
+hierarchy for non-meta categories:
+bug > feature > enhancement > needs-clarification >
+opinion > question. When agents disagree, the most
+specific category wins. `duplicate` is resolved by
+FR-013 independently of this hierarchy and takes
+precedence when its conditions are met.
+
+FR-010: Objectivity MUST be classified as `objective`
+if ANY agent provides verifiable evidence. Objectivity
+MUST be classified as `subjective` only when ALL agents
+agree the issue is preference-based.
+
+FR-011: Dissenting agent verdicts MUST be recorded in
+the artifact with the agent name and reasoning.
+
+#### Scenario: Majority verdict determines validity
+
+- **GIVEN** three agents return VALID and two return
+  INVALID
+- **WHEN** verdicts are consolidated
+- **THEN** the issue validity is VALID
+- **AND** the two dissenting agents are recorded in
+  `summary.dissenting_agents`
+
+#### Scenario: Category specificity resolution
+
+- **GIVEN** two agents classify as `bug`, two as
+  `enhancement`, one as `question`
+- **WHEN** categories are consolidated
+- **THEN** the final category is `bug` (most specific)
+
+#### Scenario: NEEDS-CLARIFICATION verdict
+
+- **GIVEN** three agents return NEEDS-CLARIFICATION
+  and two return VALID
+- **WHEN** verdicts are consolidated
+- **THEN** the issue validity is NEEDS-CLARIFICATION
+  (NEEDS-CLARIFICATION has majority of all agents)
+- **AND** the comment uses the needs-clarification tone
+- **AND** the `needs-info` label is applied
+
+#### Scenario: Tie-breaking with even agent count
+
+- **GIVEN** four agents are available
+- **AND** two return VALID and two return INVALID
+- **WHEN** verdicts are consolidated
+- **THEN** the issue validity defaults to
+  NEEDS-CLARIFICATION
+
+---
+
+### Requirement: Duplicate Detection
+
+FR-012: The command MUST search for potential duplicates
+during the Ingest phase using
+`gh issue list --search "<keywords>" --state open`.
+Keywords extracted from issue titles and bodies MUST be
+sanitized before use: shell metacharacters (`;`, `|`,
+`` ` ``, `$()`, `"`) MUST be removed, and strings
+starting with `--` MUST be stripped to prevent CLI flag
+injection. Keyword extraction SHOULD prioritize the
+issue title and first paragraph of the body, limited
+to 5-10 keywords.
+
+FR-013: An issue MUST be classified as `duplicate` only
+when Phase 1 search finds matching candidates AND at
+least two agents independently classify it as duplicate.
+
+FR-014: Before creating child issues (during splitting),
+the command MUST search for existing issues that match
+each proposed child issue title.
+
+#### Scenario: Duplicate detected
+
+- **GIVEN** the issue title contains "timeout on large
+  files"
+- **AND** an open issue #30 titled "Upload timeout for
+  large files" exists
+- **AND** three agents classify the issue as duplicate
+- **WHEN** verdicts are consolidated
+- **THEN** the category is `duplicate`
+- **AND** `duplicate_of` references issue #30
+
+#### Scenario: Similar but not duplicate
+
+- **GIVEN** keyword search returns candidate issues
+- **BUT** only one agent classifies as duplicate
+- **WHEN** verdicts are consolidated
+- **THEN** the category is NOT `duplicate`
+- **AND** the similar issues are mentioned in the
+  comment for the reporter's awareness
+
+---
+
+### Requirement: Label Application
+
+FR-015: The command MUST apply GitHub labels
+automatically without user confirmation, using this
+mapping. Exception: the `duplicate` label MUST require
+user confirmation before application because it carries
+implicit "close" semantics.
+
+| Category              | Label              |
+|-----------------------|--------------------|
+| `bug`                 | `bug`              |
+| `feature`             | `enhancement`      |
+| `enhancement`         | `enhancement`      |
+| `question`            | `question`         |
+| `opinion`             | `design-discussion`|
+| `duplicate`           | `duplicate`        |
+| `needs-clarification` | `needs-info`       |
+
+FR-016: If a required label does not exist in the
+repository, the command MUST create it via
+`gh label create` before applying it. If label creation
+fails due to insufficient permissions, the command MUST
+report the specific label that could not be created,
+skip that label, and continue with remaining triage
+actions. The artifact MUST record the failure in
+`actions_taken`.
+
+#### Scenario: Label applied automatically
+
+- **GIVEN** the consolidated category is `bug`
+- **WHEN** the Act phase applies labels
+- **THEN** the `bug` label is applied to the issue
+  via `gh issue edit <N> --add-label bug`
+- **AND** no user confirmation is required
+
+#### Scenario: Missing label created
+
+- **GIVEN** the `design-discussion` label does not
+  exist in the repository
+- **AND** the consolidated category is `opinion`
+- **WHEN** the Act phase applies labels
+- **THEN** the label is created via `gh label create`
+- **AND** the label is then applied to the issue
+
+---
+
+### Requirement: Comment Posting
+
+FR-017: The command MUST compose a triage comment and
+present it to the user for confirmation before posting.
+
+FR-018: Comment text MUST be written to a temporary
+file and posted via `gh api --input <file>`. Comment
+text MUST NOT be interpolated into shell arguments.
+Temporary files MUST be cleaned up in all exit paths
+(success, user abort, API failure). Temp files MUST
+use the system temp directory (`mktemp`) with
+restrictive permissions (0o600).
+
+FR-019: Comments for invalid or opinion-classified
+issues MUST use a warm, non-dismissive tone that:
+acknowledges the reporter's effort, explains the
+reasoning with specific references, offers alternatives
+when possible, and invites continued engagement.
+
+FR-020: Comments for valid issues MUST be factual and
+concise, presenting the classification and any
+recommendations.
+
+FR-021: Comments MUST include a footer:
+`_This triage was performed by the Divisor review
+panel._`
+
+#### Scenario: User confirms comment
+
+- **GIVEN** the command has composed a triage comment
+- **WHEN** the user approves the comment
+- **THEN** the comment is posted to the issue
+- **AND** the temp file is deleted
+
+#### Scenario: User modifies comment
+
+- **GIVEN** the command has composed a triage comment
+- **WHEN** the user chooses MODIFY
+- **THEN** the user provides an adjusted comment
+- **AND** the adjusted comment is posted
+
+#### Scenario: User aborts comment
+
+- **GIVEN** the command has composed a triage comment
+- **WHEN** the user chooses ABORT
+- **THEN** no comment is posted
+- **AND** the artifact records
+  `actions_taken.comment_posted` as false
+
+---
+
+### Requirement: Issue Splitting
+
+FR-022: If two or more agents recommend splitting the
+issue, the command MUST synthesize their recommendations
+into proposed child issues.
+
+FR-023: Each proposed child issue MUST be presented to
+the user for confirmation before creation.
+
+FR-024: Each child issue body MUST include a
+cross-reference to the parent issue (`Split from #N`).
+Child issue titles and bodies MUST be written to
+temporary files and created via `gh api --input <file>`
+or equivalent. Child issue content MUST NOT be
+interpolated into shell arguments.
+
+FR-025: After creating child issues, the command MUST
+post a comment on the parent issue listing all created
+child issues with their numbers and titles.
+
+FR-026: The parent issue MUST NOT be auto-closed after
+splitting.
+
+#### Scenario: Issue split into two child issues
+
+- **GIVEN** three agents recommend splitting issue #42
+  into "Fix timeout handling" and "Add retry
+  configuration"
+- **AND** the user confirms both child issues
+- **WHEN** the Act phase creates child issues
+- **THEN** two new issues are created with
+  cross-references to #42
+- **AND** a comment is posted on #42 listing the new
+  issues
+- **AND** issue #42 remains open
+
+---
+
+### Requirement: Triage Artifact
+
+FR-027: The command MUST produce a JSON artifact at
+`.uf/artifacts/issue-triage/issue-<N>.json` for every
+invocation, regardless of outcome.
+
+FR-028: The artifact MUST be wrapped in the standard
+envelope format with `artifact_type: "issue-triage"`.
+
+FR-029: The artifact payload MUST conform to the
+`schemas/issue-triage/v1.0.0.schema.json` schema.
+
+FR-030: The artifact MUST include per-agent assessments
+with full reasoning, enabling provenance tracing of
+every classification decision.
+
+#### Scenario: Artifact produced on successful triage
+
+- **GIVEN** the command completes all four phases
+- **WHEN** the artifact is written
+- **THEN** the file exists at
+  `.uf/artifacts/issue-triage/issue-<N>.json`
+- **AND** the payload validates against the schema
+- **AND** the envelope contains `hero`, `version`,
+  `timestamp`, `artifact_type`, `schema_version`,
+  and `context`
+
+#### Scenario: Artifact produced on abort
+
+- **GIVEN** the user aborts during the Act phase
+- **WHEN** the artifact is written
+- **THEN** `actions_taken.comment_posted` is false
+- **AND** `actions_taken.child_issues_created` is empty
+- **AND** the assessments are still recorded
+
+---
+
+### Requirement: Guardrails
+
+FR-031: The command MUST NOT close or lock any issue
+under any circumstances.
+
+FR-032: The command MUST NOT post comments without
+explicit user confirmation.
+
+FR-033: The command MUST NOT create child issues without
+explicit user confirmation.
+
+FR-034: The command MUST process exactly one issue per
+invocation.
+
+FR-035: The command MUST verify `gh` CLI installation
+(via `which gh`) and authentication (via
+`gh auth status`) before any GitHub API calls. If `gh`
+is not installed: "GitHub CLI (gh) is not installed.
+Install from https://cli.github.com/". If not
+authenticated: "GitHub CLI not authenticated. Run
+`gh auth login` to authenticate."
+
+FR-036: When any `gh` CLI or API call fails during any
+phase (network error, HTTP 403 rate limit, HTTP 5xx),
+the command MUST report the specific error, indicate
+which phase failed, and list any actions already
+completed. The command MUST NOT proceed with subsequent
+GitHub mutations after a failure but MUST still produce
+the artifact with `actions_taken` reflecting partial
+state.
+
+FR-037: The command MUST be safely re-runnable. On
+re-invocation for the same issue, the command MUST
+detect previously applied labels (via `gh issue view
+--json labels`) to avoid duplication. Previously posted
+triage comments SHOULD be detected by checking for the
+Divisor review panel footer. If an artifact already
+exists for the issue, the command MUST append a round
+number (e.g., `issue-42-2.json`) to preserve history.
+
+FR-038: All untrusted text (issue content, agent
+output, synthesized comments, child issue content)
+MUST be written to temporary files and passed via
+`--input` for all `gh api` and `gh issue create` calls.
+Untrusted text MUST NOT be interpolated into shell
+arguments. Temp files MUST use restrictive permissions
+(0o600) and be cleaned up in all exit paths.
+
+FR-039: Artifact file paths MUST be constructed safely.
+The issue number MUST be validated as a positive integer
+(FR-001) before use in any file path.
+
+#### Scenario: No auto-close
+
+- **GIVEN** the consolidated verdict is INVALID
+- **WHEN** the Act phase completes
+- **THEN** the issue remains open
+- **AND** only a label and comment (if confirmed) are
+  applied
+
+## MODIFIED Requirements
+
+None.
+
+## REMOVED Requirements
+
+None.

--- a/openspec/changes/triage-issue/tasks.md
+++ b/openspec/changes/triage-issue/tasks.md
@@ -1,0 +1,185 @@
+<!--
+  [P] marks tasks eligible for parallel execution.
+  Add [P] when a task: (a) touches different files from
+  other [P] tasks in the group, (b) has no dependency
+  on prior tasks in the group, (c) can safely execute
+  without ordering constraints.
+  Do NOT add [P] when tasks modify the same file —
+  parallel workers will cause merge conflicts.
+  Tasks without [P] run sequentially first, then [P]
+  tasks run in parallel.
+-->
+
+## 1. JSON Schema
+
+Create the `issue-triage` schema, samples, and
+documentation. All files in `schemas/issue-triage/`
+are independent of each other and touch different
+files.
+
+- [x] 1.1 [P] Create `schemas/issue-triage/v1.0.0.schema.json`
+  Define the issue-triage payload schema following
+  JSON Schema draft 2020-12. Include all fields from
+  the design (D7): `issue_number`, `issue_url`, `repo`,
+  `title`, `author`, `category` (enum), `validity`
+  (enum), `objectivity` (enum), `assessments` (array
+  of agent results), `duplicate_of` (integer|null),
+  `split_issues` (array), `actions_taken` (object),
+  `summary` (object). Set `additionalProperties: false`
+  at every level. Use `$id` following the existing
+  pattern: `https://github.com/unbound-force/unbound-force/internal/schemas/issue-triage-payload`.
+  Refs: FR-027, FR-028, FR-029, FR-030.
+
+- [x] 1.2 [P] Create `schemas/issue-triage/README.md`
+  Follow the `schemas/feedback-triage/README.md`
+  pattern. Producer: The Divisor (panel) via
+  `/triage-issue`. Consumers: Mx F (triage pattern
+  trends), Muti-Mind (backlog health), Cobalt-Crush
+  (learns from past triage). Include required/optional
+  field tables, schema evolution policy, and version
+  history.
+
+- [x] 1.3 [P] Create `schemas/issue-triage/samples/sample-issue-triage.json`
+  Valid sample showing a bug triage with five agent
+  assessments, one dissenting, label applied, comment
+  posted, no split. Must validate against the schema
+  from 1.1.
+
+- [x] 1.4 [P] Create `schemas/issue-triage/samples/invalid-extra-property.json`
+  Invalid sample with an extra `priority` property on
+  an assessment item. Must fail validation due to
+  `additionalProperties: false`.
+
+- [x] 1.5 [P] Create `schemas/issue-triage/samples/invalid-missing-required.json`
+  Invalid sample with a required field omitted (e.g.,
+  missing `assessments`). Must fail validation due to
+  missing required field.
+
+- [x] 1.6 [P] Create `schemas/issue-triage/samples/invalid-bad-enum.json`
+  Invalid sample with an invalid enum value (e.g.,
+  `category: "urgent"`). Must fail validation due to
+  enum constraint violation.
+
+- [x] 1.7 Add `"issue-triage"` to `handAuthoredSchemas`
+  in `internal/schemas/ci_test.go`. This enables
+  automated CI validation of all samples (positive
+  and negative) against the schema. Single-line change.
+  Refs: FR-029.
+
+## 2. Slash Command
+
+Create the `/triage-issue` command file. This is a
+single file with no parallel opportunities.
+
+- [x] 2.1 Create `.opencode/commands/triage-issue.md`
+  Implement the four-phase pipeline (Ingest, Assess,
+  Classify, Act) as described in the design. Include:
+  - YAML frontmatter with description
+  - Arguments section (issue number, required)
+  - Prerequisites (gh CLI, auth, repo detection)
+  - Phase 1: Ingest
+    - Input validation (FR-001)
+    - Fetch issue, validate open state (FR-002)
+    - Repo detection (FR-003)
+    - Duplicate check with keyword sanitization (FR-012)
+    - gh CLI verification (FR-035)
+  - Phase 2: Assess
+    - Dynamic agent discovery (FR-006)
+    - Parallel fan-out to 5 Divisor agents (FR-004)
+    - Structured assessment return format (FR-005)
+    - Graceful degradation (FR-007)
+  - Phase 3: Classify
+    - Majority verdict 3/5 with NEEDS-CLARIFICATION
+      and tie-breaking rules (FR-008)
+    - Category specificity hierarchy (FR-009)
+    - Objectivity classification (FR-010)
+    - Dissent recording (FR-011)
+    - Duplicate resolution (FR-013)
+    - Split synthesis (FR-022)
+  - Phase 4: Act
+    - Present analysis to user
+    - Duplicate pre-check for child issues (FR-014)
+    - Label application without confirmation,
+      except `duplicate` (FR-015, FR-016)
+    - Comment posting with confirmation via
+      temp file + --input (FR-017, FR-018,
+      FR-019, FR-020, FR-021)
+    - Child issue creation with confirmation
+      and shell injection prevention (FR-022,
+      FR-023, FR-024, FR-025, FR-026)
+    - Artifact production (FR-027, FR-028,
+      FR-029, FR-030)
+  - Comment tone tiers (valid, invalid/opinion,
+    needs-clarification) per design D6.
+  - Guardrails section covering:
+    - No auto-close (FR-031)
+    - No comments without confirmation (FR-032)
+    - No child issues without confirmation (FR-033)
+    - Single issue per invocation (FR-034)
+    - gh CLI verification (FR-035)
+    - API failure handling (FR-036)
+    - Idempotent re-run (FR-037)
+    - Shell injection prevention (FR-038)
+    - Safe artifact paths (FR-039)
+
+## 3. Scaffold Asset
+
+- [x] 3.1 [P] Copy `.opencode/commands/triage-issue.md`
+  to `internal/scaffold/assets/opencode/commands/triage-issue.md`
+  so the command is deployed by `uf init`.
+
+- [x] 3.2 [P] Update `expectedAssetPaths` in
+  `internal/scaffold/scaffold_test.go` to include
+  the new command file. This ensures scaffold drift
+  tests detect if the embedded copy diverges from
+  the canonical source.
+
+## 4. Documentation
+
+- [x] 4.1 [P] Update AGENTS.md project structure to
+  list `schemas/issue-triage/` alongside
+  `feedback-triage/`. Add `/triage-issue` to an
+  "Issue Triage Commands" reference section.
+
+- [x] 4.2 [P] Add CHANGELOG.md entry for the new
+  `/triage-issue` command and `issue-triage` schema.
+
+- [x] 4.3 File a `docs`-labeled issue in
+  `unbound-force/website` for the new `/triage-issue`
+  command documentation. Include coverage for:
+  command usage, examples, the issue-triage artifact
+  format, and The Divisor team page update.
+  Constitution requirement: Cross-Repo Documentation.
+
+- [x] 4.4 File a `blog`-labeled issue in
+  `unbound-force/website` for a blog post covering
+  the multi-agent issue triage capability.
+
+## 5. Verification
+
+- [x] 5.1 Run `make check` to verify build, test,
+  vet, and lint all pass with the new schema and
+  scaffold asset.
+
+- [x] 5.2 Validate schema samples by running
+  `go test -race -count=1 ./internal/schemas/...`
+  to confirm the valid sample passes and all three
+  invalid samples are rejected.
+
+- [x] 5.3 Verify constitution alignment
+  Confirm the implementation aligns with all five
+  constitution principles:
+  - I. Autonomous Collaboration: artifact produced with
+    envelope, no synchronous inter-agent coupling
+  - II. Composability First: graceful degradation with
+    missing agents, no hero prerequisites
+  - III. Observable Quality: JSON schema, provenance
+    metadata, per-agent assessment provenance
+  - IV. Testability: valid/invalid samples with CI
+    regression testing via `handAuthoredSchemas`
+  - V. Security by Default: shell injection prevention
+    via temp files, input validation, keyword
+    sanitization, dynamic repo detection
+
+<!-- spec-review: passed -->
+<!-- code-review: passed -->

--- a/schemas/issue-triage/README.md
+++ b/schemas/issue-triage/README.md
@@ -1,0 +1,52 @@
+# Issue Triage Schema
+
+The issue triage payload captures the Divisor review panel's
+assessment of a GitHub issue: per-agent classification, validity
+determination, objectivity analysis, and actions taken.
+
+## Producer
+
+**The Divisor** (review panel) — executing the `/triage-issue` slash command.
+
+## Consumers
+
+- **Mx F** — tracks triage pattern trends, classification accuracy, tone consistency
+- **Muti-Mind** — detects recurring issue categories for backlog health analysis
+- **Cobalt-Crush** — learns from past triage decisions to improve issue quality
+
+## Required Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `issue_number` | integer | GitHub issue number |
+| `issue_url` | string | Full GitHub issue URL |
+| `repo` | string | Repository in owner/repo format |
+| `title` | string | Issue title |
+| `author` | string | Issue author GitHub login |
+| `category` | string (enum) | Classification: bug, feature, enhancement, question, opinion, duplicate, needs-clarification |
+| `validity` | string (enum) | Panel verdict: valid, invalid, needs-clarification |
+| `objectivity` | string (enum) | Assessment: objective, subjective |
+| `assessments` | array | Per-agent assessment records (agent, verdict, category, objectivity, reasoning, split_recommendation) |
+| `actions_taken` | object | Actions performed (labels_applied, comment_posted, child_issues_created, label_creation_failed) |
+| `summary` | object | Aggregate statistics (agents_consulted, agents_available, consensus, dissenting_agents) |
+
+## Optional Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `duplicate_of` | integer or null | Issue number this duplicates (null if not duplicate) |
+| `split_issues` | array | Child issues created from splitting (number, title, url) |
+| `assessments[].split_recommendation` | array or null | Proposed child issues from agent (null if no split) |
+
+## Schema Evolution
+
+Minor versions add optional fields and may relax
+`additionalProperties` constraints. Major versions may remove
+or rename fields. Consumers should handle unknown fields
+gracefully when consuming artifacts from newer minor versions.
+
+## Version History
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 1.0.0 | 2026-06-16 | Initial release |

--- a/schemas/issue-triage/samples/invalid-bad-enum.json
+++ b/schemas/issue-triage/samples/invalid-bad-enum.json
@@ -1,0 +1,34 @@
+{
+  "issue_number": 55,
+  "issue_url": "https://github.com/unbound-force/unbound-force/issues/55",
+  "repo": "unbound-force/unbound-force",
+  "title": "Something urgent",
+  "author": "user-dave",
+  "category": "urgent",
+  "validity": "valid",
+  "objectivity": "objective",
+  "duplicate_of": null,
+  "split_issues": [],
+  "assessments": [
+    {
+      "agent": "divisor-adversary",
+      "verdict": "valid",
+      "category": "urgent",
+      "objectivity": "objective",
+      "reasoning": "Urgent matter.",
+      "split_recommendation": null
+    }
+  ],
+  "actions_taken": {
+    "labels_applied": [],
+    "comment_posted": false,
+    "child_issues_created": [],
+    "label_creation_failed": false
+  },
+  "summary": {
+    "agents_consulted": 1,
+    "agents_available": 5,
+    "consensus": "1/1 valid",
+    "dissenting_agents": []
+  }
+}

--- a/schemas/issue-triage/samples/invalid-extra-property.json
+++ b/schemas/issue-triage/samples/invalid-extra-property.json
@@ -1,0 +1,35 @@
+{
+  "issue_number": 99,
+  "issue_url": "https://github.com/unbound-force/unbound-force/issues/99",
+  "repo": "unbound-force/unbound-force",
+  "title": "Add dark mode support",
+  "author": "user-bob",
+  "category": "feature",
+  "validity": "valid",
+  "objectivity": "subjective",
+  "duplicate_of": null,
+  "split_issues": [],
+  "assessments": [
+    {
+      "agent": "divisor-architect",
+      "verdict": "valid",
+      "category": "feature",
+      "objectivity": "subjective",
+      "reasoning": "Valid feature request for dark mode.",
+      "split_recommendation": null,
+      "priority": "high"
+    }
+  ],
+  "actions_taken": {
+    "labels_applied": ["enhancement"],
+    "comment_posted": true,
+    "child_issues_created": [],
+    "label_creation_failed": false
+  },
+  "summary": {
+    "agents_consulted": 1,
+    "agents_available": 5,
+    "consensus": "1/1 valid",
+    "dissenting_agents": []
+  }
+}

--- a/schemas/issue-triage/samples/invalid-missing-required.json
+++ b/schemas/issue-triage/samples/invalid-missing-required.json
@@ -1,0 +1,24 @@
+{
+  "issue_number": 77,
+  "issue_url": "https://github.com/unbound-force/unbound-force/issues/77",
+  "repo": "unbound-force/unbound-force",
+  "title": "Improve error messages",
+  "author": "user-charlie",
+  "category": "enhancement",
+  "validity": "valid",
+  "objectivity": "objective",
+  "duplicate_of": null,
+  "split_issues": [],
+  "actions_taken": {
+    "labels_applied": ["enhancement"],
+    "comment_posted": false,
+    "child_issues_created": [],
+    "label_creation_failed": false
+  },
+  "summary": {
+    "agents_consulted": 3,
+    "agents_available": 5,
+    "consensus": "3/3 valid",
+    "dissenting_agents": []
+  }
+}

--- a/schemas/issue-triage/samples/sample-issue-triage-split.json
+++ b/schemas/issue-triage/samples/sample-issue-triage-split.json
@@ -1,0 +1,111 @@
+{
+  "issue_number": 85,
+  "issue_url": "https://github.com/unbound-force/unbound-force/issues/85",
+  "repo": "unbound-force/unbound-force",
+  "title": "Gateway timeout handling and retry configuration",
+  "author": "contributor-eve",
+  "category": "feature",
+  "validity": "valid",
+  "objectivity": "objective",
+  "duplicate_of": null,
+  "split_issues": [
+    {
+      "number": 86,
+      "title": "Fix gateway timeout handling for large payloads",
+      "url": "https://github.com/unbound-force/unbound-force/issues/86"
+    },
+    {
+      "number": 87,
+      "title": "Add configurable retry policy for gateway proxy",
+      "url": "https://github.com/unbound-force/unbound-force/issues/87"
+    }
+  ],
+  "assessments": [
+    {
+      "agent": "divisor-adversary",
+      "verdict": "valid",
+      "category": "bug",
+      "objectivity": "objective",
+      "reasoning": "The timeout issue is a reliability defect. Large payloads exceed the default timeout, causing silent failures.",
+      "split_recommendation": [
+        {
+          "title": "Fix gateway timeout handling for large payloads",
+          "description": "The proxy uses a hardcoded 30s timeout that is insufficient for large payloads. Add size-aware timeout scaling."
+        }
+      ]
+    },
+    {
+      "agent": "divisor-architect",
+      "verdict": "valid",
+      "category": "feature",
+      "objectivity": "objective",
+      "reasoning": "The issue conflates two distinct concerns: timeout handling (bug) and retry configuration (feature). These should be separate issues.",
+      "split_recommendation": [
+        {
+          "title": "Fix gateway timeout handling for large payloads",
+          "description": "Address the timeout defect with size-aware scaling."
+        },
+        {
+          "title": "Add configurable retry policy for gateway proxy",
+          "description": "New feature: expose retry count, backoff, and jitter as configuration options."
+        }
+      ]
+    },
+    {
+      "agent": "divisor-guard",
+      "verdict": "valid",
+      "category": "feature",
+      "objectivity": "objective",
+      "reasoning": "Both concerns are valid. The timeout is a defect; the retry config is a feature request. Splitting improves traceability.",
+      "split_recommendation": [
+        {
+          "title": "Fix gateway timeout handling for large payloads",
+          "description": "Bug fix for the hardcoded timeout."
+        },
+        {
+          "title": "Add configurable retry policy for gateway proxy",
+          "description": "Feature request for retry configuration."
+        }
+      ]
+    },
+    {
+      "agent": "divisor-sre",
+      "verdict": "valid",
+      "category": "feature",
+      "objectivity": "objective",
+      "reasoning": "Both concerns affect operational reliability. The timeout fix is urgent; the retry config is important but can follow.",
+      "split_recommendation": null
+    },
+    {
+      "agent": "divisor-testing",
+      "verdict": "valid",
+      "category": "feature",
+      "objectivity": "objective",
+      "reasoning": "Splitting allows independent test strategies. Timeout fix needs regression tests; retry config needs integration tests.",
+      "split_recommendation": null
+    }
+  ],
+  "actions_taken": {
+    "labels_applied": ["enhancement"],
+    "comment_posted": true,
+    "child_issues_created": [
+      {
+        "number": 86,
+        "title": "Fix gateway timeout handling for large payloads",
+        "url": "https://github.com/unbound-force/unbound-force/issues/86"
+      },
+      {
+        "number": 87,
+        "title": "Add configurable retry policy for gateway proxy",
+        "url": "https://github.com/unbound-force/unbound-force/issues/87"
+      }
+    ],
+    "label_creation_failed": false
+  },
+  "summary": {
+    "agents_consulted": 5,
+    "agents_available": 5,
+    "consensus": "5/5 valid",
+    "dissenting_agents": []
+  }
+}

--- a/schemas/issue-triage/samples/sample-issue-triage.json
+++ b/schemas/issue-triage/samples/sample-issue-triage.json
@@ -1,0 +1,71 @@
+{
+  "issue_number": 42,
+  "issue_url": "https://github.com/unbound-force/unbound-force/issues/42",
+  "repo": "unbound-force/unbound-force",
+  "title": "Gateway proxy panics on nil response body",
+  "author": "contributor-alice",
+  "category": "bug",
+  "validity": "valid",
+  "objectivity": "objective",
+  "duplicate_of": null,
+  "split_issues": [],
+  "assessments": [
+    {
+      "agent": "divisor-adversary",
+      "verdict": "valid",
+      "category": "bug",
+      "objectivity": "objective",
+      "reasoning": "Nil pointer dereference on response body is a crash-level defect. The proxy does not check for nil before reading.",
+      "split_recommendation": null
+    },
+    {
+      "agent": "divisor-architect",
+      "verdict": "valid",
+      "category": "bug",
+      "objectivity": "objective",
+      "reasoning": "The nil check is missing in the proxy handler. This violates the error handling convention (CS-006) which requires checking all return values.",
+      "split_recommendation": null
+    },
+    {
+      "agent": "divisor-guard",
+      "verdict": "invalid",
+      "category": "opinion",
+      "objectivity": "subjective",
+      "reasoning": "The reporter expects the proxy to handle upstream failures gracefully, but the current design intentionally surfaces upstream errors. This is a design philosophy difference.",
+      "split_recommendation": null
+    },
+    {
+      "agent": "divisor-sre",
+      "verdict": "valid",
+      "category": "bug",
+      "objectivity": "objective",
+      "reasoning": "A panic in production crashes the process without cleanup. This is an operational reliability issue regardless of design intent.",
+      "split_recommendation": null
+    },
+    {
+      "agent": "divisor-testing",
+      "verdict": "valid",
+      "category": "bug",
+      "objectivity": "objective",
+      "reasoning": "No test covers the nil response body path. This is a test coverage gap that allowed a crash-level defect to ship.",
+      "split_recommendation": null
+    }
+  ],
+  "actions_taken": {
+    "labels_applied": ["bug"],
+    "comment_posted": true,
+    "child_issues_created": [],
+    "label_creation_failed": false
+  },
+  "summary": {
+    "agents_consulted": 5,
+    "agents_available": 5,
+    "consensus": "4/5 valid",
+    "dissenting_agents": [
+      {
+        "agent": "divisor-guard",
+        "reasoning": "Considers this a design philosophy difference rather than a defect"
+      }
+    ]
+  }
+}

--- a/schemas/issue-triage/v1.0.0.schema.json
+++ b/schemas/issue-triage/v1.0.0.schema.json
@@ -1,0 +1,287 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/unbound-force/unbound-force/internal/schemas/issue-triage-payload",
+  "properties": {
+    "issue_number": {
+      "type": "integer",
+      "description": "GitHub issue number"
+    },
+    "issue_url": {
+      "type": "string",
+      "description": "Full GitHub URL for the issue"
+    },
+    "repo": {
+      "type": "string",
+      "description": "Repository in owner/repo format"
+    },
+    "title": {
+      "type": "string",
+      "description": "Issue title"
+    },
+    "author": {
+      "type": "string",
+      "description": "Issue author GitHub login"
+    },
+    "category": {
+      "type": "string",
+      "enum": [
+        "bug",
+        "feature",
+        "enhancement",
+        "question",
+        "opinion",
+        "duplicate",
+        "needs-clarification"
+      ],
+      "description": "Triage category for the issue"
+    },
+    "validity": {
+      "type": "string",
+      "enum": [
+        "valid",
+        "invalid",
+        "needs-clarification"
+      ],
+      "description": "Whether the issue is valid"
+    },
+    "objectivity": {
+      "type": "string",
+      "enum": [
+        "objective",
+        "subjective"
+      ],
+      "description": "Whether the issue is objective or subjective"
+    },
+    "duplicate_of": {
+      "type": [
+        "integer",
+        "null"
+      ],
+      "description": "Issue number of the duplicate"
+    },
+    "assessments": {
+      "items": {
+        "properties": {
+          "agent": {
+            "type": "string",
+            "description": "Agent identifier, e.g. divisor-adversary"
+          },
+          "verdict": {
+            "type": "string",
+            "enum": [
+              "valid",
+              "invalid",
+              "needs-clarification"
+            ],
+            "description": "Agent verdict on issue validity"
+          },
+          "category": {
+            "type": "string",
+            "enum": [
+              "bug",
+              "feature",
+              "enhancement",
+              "question",
+              "opinion",
+              "duplicate",
+              "needs-clarification"
+            ],
+            "description": "Agent category assessment"
+          },
+          "objectivity": {
+            "type": "string",
+            "enum": [
+              "objective",
+              "subjective"
+            ],
+            "description": "Agent objectivity assessment"
+          },
+          "reasoning": {
+            "type": "string",
+            "description": "Evidence-based explanation for the assessment"
+          },
+          "split_recommendation": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "properties": {
+                "title": {
+                  "type": "string",
+                  "description": "Recommended split issue title"
+                },
+                "description": {
+                  "type": "string",
+                  "description": "Recommended split issue description"
+                }
+              },
+              "additionalProperties": false,
+              "type": "object",
+              "required": [
+                "title",
+                "description"
+              ]
+            },
+            "description": "Recommended issues to split into"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "agent",
+          "verdict",
+          "category",
+          "objectivity",
+          "reasoning"
+        ]
+      },
+      "type": "array",
+      "description": "Individual agent assessments"
+    },
+    "split_issues": {
+      "items": {
+        "properties": {
+          "number": {
+            "type": "integer",
+            "description": "Created issue number"
+          },
+          "title": {
+            "type": "string",
+            "description": "Created issue title"
+          },
+          "url": {
+            "type": "string",
+            "description": "Created issue URL"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "number",
+          "title",
+          "url"
+        ]
+      },
+      "type": "array",
+      "default": [],
+      "description": "Issues created from splitting this issue"
+    },
+    "actions_taken": {
+      "properties": {
+        "labels_applied": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Labels applied to the issue"
+        },
+        "comment_posted": {
+          "type": "boolean",
+          "description": "Whether a triage comment was posted"
+        },
+        "child_issues_created": {
+          "items": {
+            "properties": {
+              "number": {
+                "type": "integer",
+                "description": "Created issue number"
+              },
+              "title": {
+                "type": "string",
+                "description": "Created issue title"
+              },
+              "url": {
+                "type": "string",
+                "description": "Created issue URL"
+              }
+            },
+            "additionalProperties": false,
+            "type": "object",
+            "required": [
+              "number",
+              "title",
+              "url"
+            ]
+          },
+          "type": "array",
+          "description": "Child issues created during triage"
+        },
+        "label_creation_failed": {
+          "type": "boolean",
+          "default": false,
+          "description": "Whether label creation failed due to permissions"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "labels_applied",
+        "comment_posted",
+        "child_issues_created",
+        "label_creation_failed"
+      ]
+    },
+    "summary": {
+      "properties": {
+        "agents_consulted": {
+          "type": "integer",
+          "description": "Number of agents consulted"
+        },
+        "agents_available": {
+          "type": "integer",
+          "description": "Number of agents available"
+        },
+        "consensus": {
+          "type": "string",
+          "description": "Consensus summary, e.g. 4/5 valid"
+        },
+        "dissenting_agents": {
+          "items": {
+            "properties": {
+              "agent": {
+                "type": "string",
+                "description": "Dissenting agent identifier"
+              },
+              "reasoning": {
+                "type": "string",
+                "description": "Reasoning for dissent"
+              }
+            },
+            "additionalProperties": false,
+            "type": "object",
+            "required": [
+              "agent",
+              "reasoning"
+            ]
+          },
+          "type": "array",
+          "description": "Agents that dissented from the consensus"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "agents_consulted",
+        "agents_available",
+        "consensus",
+        "dissenting_agents"
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "type": "object",
+  "required": [
+    "issue_number",
+    "issue_url",
+    "repo",
+    "title",
+    "author",
+    "category",
+    "validity",
+    "objectivity",
+    "assessments",
+    "actions_taken",
+    "summary"
+  ]
+}


### PR DESCRIPTION
## Summary

Adds a new `/triage-issue <N>` slash command that brings the Divisor review panel
(5 agents: adversary, architect, guard, sre, testing) to evaluate GitHub issues.

### What it does

- **Classifies** issues into 7 categories (bug, feature, enhancement, question,
  opinion, duplicate, needs-clarification)
- **Determines validity** via 3-rule majority consensus with tie-breaking
- **Assesses objectivity** (objective defect vs. subjective preference)
- **Detects duplicates** with two-layer keyword search + agent agreement
- **Recommends splitting** compound issues into focused child issues
- **Posts tone-appropriate comments** (warm for rejections, factual for valid)
- **Applies labels** automatically (except `duplicate`, which requires confirmation)
- **Produces a JSON artifact** with per-agent assessment provenance

### Files

- `.opencode/commands/triage-issue.md` — Slash command (four-phase pipeline)
- `schemas/issue-triage/v1.0.0.schema.json` — JSON Schema + README + 4 samples
- `internal/schemas/ci_test.go` — Register in `handAuthoredSchemas`
- `internal/scaffold/` — Scaffold asset + drift test update
- `AGENTS.md` — Project structure + Issue Triage Commands table
- `CHANGELOG.md` — Release notes entry
- `openspec/changes/triage-issue/` — Full spec artifacts (proposal, design,
  specs with 39 FRs, tasks)

Spec: `openspec/changes/triage-issue/`
