### PR TITLE
feat: add ci.md convention pack for CI workflow authoring

### DIFF
--- a/.gaze/baseline.json
+++ b/.gaze/baseline.json
@@ -3,7 +3,7 @@
     {
       "package": "main",
       "function": "newSyncerFromParams",
-      "file": "cmd/mutimind/main.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/cmd/mutimind/main.go",
       "line": 26,
       "complexity": 2,
       "line_coverage": 100,
@@ -12,7 +12,7 @@
     {
       "package": "main",
       "function": "newRootCmd",
-      "file": "cmd/mutimind/main.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/cmd/mutimind/main.go",
       "line": 34,
       "complexity": 1,
       "line_coverage": 100,
@@ -21,7 +21,7 @@
     {
       "package": "main",
       "function": "newRootCmdWithParams",
-      "file": "cmd/mutimind/main.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/cmd/mutimind/main.go",
       "line": 42,
       "complexity": 1,
       "line_coverage": 100,
@@ -30,7 +30,7 @@
     {
       "package": "main",
       "function": "newInitCmd",
-      "file": "cmd/mutimind/main.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/cmd/mutimind/main.go",
       "line": 68,
       "complexity": 4,
       "line_coverage": 80,
@@ -39,7 +39,7 @@
     {
       "package": "main",
       "function": "newAddCmd",
-      "file": "cmd/mutimind/main.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/cmd/mutimind/main.go",
       "line": 90,
       "complexity": 6,
       "line_coverage": 86.95652173913044,
@@ -48,7 +48,7 @@
     {
       "package": "main",
       "function": "newListCmd",
-      "file": "cmd/mutimind/main.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/cmd/mutimind/main.go",
       "line": 138,
       "complexity": 10,
       "line_coverage": 89.28571428571429,
@@ -57,16 +57,16 @@
     {
       "package": "main",
       "function": "newUpdateCmd",
-      "file": "cmd/mutimind/main.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/cmd/mutimind/main.go",
       "line": 185,
       "complexity": 6,
       "line_coverage": 80,
-      "crap": 6.287999999999999
+      "crap": 6.288
     },
     {
       "package": "main",
       "function": "newShowCmd",
-      "file": "cmd/mutimind/main.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/cmd/mutimind/main.go",
       "line": 222,
       "complexity": 6,
       "line_coverage": 84.61538461538461,
@@ -75,7 +75,7 @@
     {
       "package": "main",
       "function": "newSyncPushCmd",
-      "file": "cmd/mutimind/main.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/cmd/mutimind/main.go",
       "line": 264,
       "complexity": 2,
       "line_coverage": 100,
@@ -84,7 +84,7 @@
     {
       "package": "main",
       "function": "newSyncPullCmd",
-      "file": "cmd/mutimind/main.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/cmd/mutimind/main.go",
       "line": 281,
       "complexity": 1,
       "line_coverage": 100,
@@ -93,7 +93,7 @@
     {
       "package": "main",
       "function": "newSyncStatusCmd",
-      "file": "cmd/mutimind/main.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/cmd/mutimind/main.go",
       "line": 293,
       "complexity": 1,
       "line_coverage": 100,
@@ -102,7 +102,7 @@
     {
       "package": "main",
       "function": "newSyncCmd",
-      "file": "cmd/mutimind/main.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/cmd/mutimind/main.go",
       "line": 305,
       "complexity": 1,
       "line_coverage": 100,
@@ -111,7 +111,7 @@
     {
       "package": "main",
       "function": "newSyncProjectCmd",
-      "file": "cmd/mutimind/main.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/cmd/mutimind/main.go",
       "line": 317,
       "complexity": 1,
       "line_coverage": 100,
@@ -120,7 +120,7 @@
     {
       "package": "main",
       "function": "newGenerateArtifactCmd",
-      "file": "cmd/mutimind/main.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/cmd/mutimind/main.go",
       "line": 329,
       "complexity": 3,
       "line_coverage": 80,
@@ -129,7 +129,7 @@
     {
       "package": "main",
       "function": "newDecideCmd",
-      "file": "cmd/mutimind/main.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/cmd/mutimind/main.go",
       "line": 350,
       "complexity": 5,
       "line_coverage": 91.66666666666667,
@@ -138,7 +138,7 @@
     {
       "package": "main",
       "function": "main",
-      "file": "cmd/mutimind/main.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/cmd/mutimind/main.go",
       "line": 398,
       "complexity": 2,
       "line_coverage": 0,
@@ -147,7 +147,7 @@
     {
       "package": "main",
       "function": "newRootCmd",
-      "file": "cmd/mxf/main.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/cmd/mxf/main.go",
       "line": 37,
       "complexity": 1,
       "line_coverage": 100,
@@ -156,7 +156,7 @@
     {
       "package": "main",
       "function": "newRootCmdWithParams",
-      "file": "cmd/mxf/main.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/cmd/mxf/main.go",
       "line": 41,
       "complexity": 1,
       "line_coverage": 100,
@@ -165,7 +165,7 @@
     {
       "package": "main",
       "function": "(*MxFParams).defaults",
-      "file": "cmd/mxf/main.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/cmd/mxf/main.go",
       "line": 69,
       "complexity": 6,
       "line_coverage": 100,
@@ -174,7 +174,7 @@
     {
       "package": "main",
       "function": "newCollectCmd",
-      "file": "cmd/mxf/main.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/cmd/mxf/main.go",
       "line": 87,
       "complexity": 1,
       "line_coverage": 50,
@@ -183,7 +183,7 @@
     {
       "package": "main",
       "function": "newMetricsCmd",
-      "file": "cmd/mxf/main.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/cmd/mxf/main.go",
       "line": 105,
       "complexity": 2,
       "line_coverage": 66.66666666666667,
@@ -192,7 +192,7 @@
     {
       "package": "main",
       "function": "newImpedimentCmd",
-      "file": "cmd/mxf/main.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/cmd/mxf/main.go",
       "line": 135,
       "complexity": 1,
       "line_coverage": 51.724137931034484,
@@ -201,7 +201,7 @@
     {
       "package": "main",
       "function": "newDashboardCmd",
-      "file": "cmd/mxf/main.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/cmd/mxf/main.go",
       "line": 196,
       "complexity": 2,
       "line_coverage": 55.55555555555556,
@@ -210,7 +210,7 @@
     {
       "package": "main",
       "function": "newSprintCmd",
-      "file": "cmd/mxf/main.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/cmd/mxf/main.go",
       "line": 233,
       "complexity": 1,
       "line_coverage": 54.54545454545455,
@@ -219,7 +219,7 @@
     {
       "package": "main",
       "function": "newStandupCmd",
-      "file": "cmd/mxf/main.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/cmd/mxf/main.go",
       "line": 261,
       "complexity": 1,
       "line_coverage": 33.333333333333336,
@@ -228,7 +228,7 @@
     {
       "package": "main",
       "function": "newRetroCmd",
-      "file": "cmd/mxf/main.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/cmd/mxf/main.go",
       "line": 272,
       "complexity": 1,
       "line_coverage": 54.54545454545455,
@@ -237,7 +237,7 @@
     {
       "package": "main",
       "function": "runCollect",
-      "file": "cmd/mxf/main.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/cmd/mxf/main.go",
       "line": 301,
       "complexity": 2,
       "line_coverage": 85.71428571428571,
@@ -246,7 +246,7 @@
     {
       "package": "main",
       "function": "runMetrics",
-      "file": "cmd/mxf/main.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/cmd/mxf/main.go",
       "line": 318,
       "complexity": 22,
       "line_coverage": 78,
@@ -256,7 +256,7 @@
     {
       "package": "main",
       "function": "runImpedimentAdd",
-      "file": "cmd/mxf/main.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/cmd/mxf/main.go",
       "line": 395,
       "complexity": 2,
       "line_coverage": 83.33333333333333,
@@ -265,7 +265,7 @@
     {
       "package": "main",
       "function": "runImpedimentList",
-      "file": "cmd/mxf/main.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/cmd/mxf/main.go",
       "line": 406,
       "complexity": 6,
       "line_coverage": 93.75,
@@ -274,7 +274,7 @@
     {
       "package": "main",
       "function": "runImpedimentResolve",
-      "file": "cmd/mxf/main.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/cmd/mxf/main.go",
       "line": 431,
       "complexity": 2,
       "line_coverage": 0,
@@ -283,16 +283,16 @@
     {
       "package": "main",
       "function": "runImpedimentDetect",
-      "file": "cmd/mxf/main.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/cmd/mxf/main.go",
       "line": 440,
       "complexity": 4,
       "line_coverage": 41.666666666666664,
-      "crap": 7.1759259259259265
+      "crap": 7.175925925925927
     },
     {
       "package": "main",
       "function": "runDashboard",
-      "file": "cmd/mxf/main.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/cmd/mxf/main.go",
       "line": 458,
       "complexity": 14,
       "line_coverage": 94.11764705882354,
@@ -301,7 +301,7 @@
     {
       "package": "main",
       "function": "runSprint",
-      "file": "cmd/mxf/main.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/cmd/mxf/main.go",
       "line": 513,
       "complexity": 10,
       "line_coverage": 73.33333333333333,
@@ -310,7 +310,7 @@
     {
       "package": "main",
       "function": "runStandup",
-      "file": "cmd/mxf/main.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/cmd/mxf/main.go",
       "line": 557,
       "complexity": 1,
       "line_coverage": 100,
@@ -319,7 +319,7 @@
     {
       "package": "main",
       "function": "runRetro",
-      "file": "cmd/mxf/main.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/cmd/mxf/main.go",
       "line": 564,
       "complexity": 17,
       "line_coverage": 80.85106382978724,
@@ -329,7 +329,7 @@
     {
       "package": "main",
       "function": "outputJSON",
-      "file": "cmd/mxf/main.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/cmd/mxf/main.go",
       "line": 637,
       "complexity": 1,
       "line_coverage": 100,
@@ -338,7 +338,7 @@
     {
       "package": "main",
       "function": "outputMetricsSummary",
-      "file": "cmd/mxf/main.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/cmd/mxf/main.go",
       "line": 643,
       "complexity": 1,
       "line_coverage": 100,
@@ -347,7 +347,7 @@
     {
       "package": "main",
       "function": "main",
-      "file": "cmd/mxf/main.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/cmd/mxf/main.go",
       "line": 659,
       "complexity": 2,
       "line_coverage": 0,
@@ -356,7 +356,7 @@
     {
       "package": "main",
       "function": "runConfigInit",
-      "file": "cmd/unbound-force/config.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/cmd/unbound-force/config.go",
       "line": 21,
       "complexity": 6,
       "line_coverage": 88.23529411764706,
@@ -365,7 +365,7 @@
     {
       "package": "main",
       "function": "runConfigShow",
-      "file": "cmd/unbound-force/config.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/cmd/unbound-force/config.go",
       "line": 59,
       "complexity": 5,
       "line_coverage": 76.92307692307692,
@@ -374,7 +374,7 @@
     {
       "package": "main",
       "function": "runConfigValidate",
-      "file": "cmd/unbound-force/config.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/cmd/unbound-force/config.go",
       "line": 92,
       "complexity": 7,
       "line_coverage": 75.86206896551724,
@@ -383,7 +383,7 @@
     {
       "package": "main",
       "function": "newConfigCmd",
-      "file": "cmd/unbound-force/config.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/cmd/unbound-force/config.go",
       "line": 144,
       "complexity": 1,
       "line_coverage": 100,
@@ -392,7 +392,7 @@
     {
       "package": "main",
       "function": "newGatewayCmd",
-      "file": "cmd/unbound-force/gateway.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/cmd/unbound-force/gateway.go",
       "line": 15,
       "complexity": 2,
       "line_coverage": 0,
@@ -401,7 +401,7 @@
     {
       "package": "main",
       "function": "runGateway",
-      "file": "cmd/unbound-force/gateway.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/cmd/unbound-force/gateway.go",
       "line": 81,
       "complexity": 7,
       "line_coverage": 0,
@@ -411,7 +411,7 @@
     {
       "package": "main",
       "function": "runGatewayStop",
-      "file": "cmd/unbound-force/gateway.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/cmd/unbound-force/gateway.go",
       "line": 114,
       "complexity": 1,
       "line_coverage": 0,
@@ -420,7 +420,7 @@
     {
       "package": "main",
       "function": "newGatewayStopCmd",
-      "file": "cmd/unbound-force/gateway.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/cmd/unbound-force/gateway.go",
       "line": 123,
       "complexity": 2,
       "line_coverage": 0,
@@ -429,7 +429,7 @@
     {
       "package": "main",
       "function": "runGatewayStatus",
-      "file": "cmd/unbound-force/gateway.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/cmd/unbound-force/gateway.go",
       "line": 153,
       "complexity": 1,
       "line_coverage": 0,
@@ -438,7 +438,7 @@
     {
       "package": "main",
       "function": "newGatewayStatusCmd",
-      "file": "cmd/unbound-force/gateway.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/cmd/unbound-force/gateway.go",
       "line": 162,
       "complexity": 2,
       "line_coverage": 0,
@@ -447,7 +447,7 @@
     {
       "package": "main",
       "function": "main",
-      "file": "cmd/unbound-force/main.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/cmd/unbound-force/main.go",
       "line": 21,
       "complexity": 2,
       "line_coverage": 0,
@@ -456,7 +456,7 @@
     {
       "package": "main",
       "function": "runInit",
-      "file": "cmd/unbound-force/main.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/cmd/unbound-force/main.go",
       "line": 51,
       "complexity": 5,
       "line_coverage": 85.71428571428571,
@@ -465,7 +465,7 @@
     {
       "package": "main",
       "function": "newVersionCmd",
-      "file": "cmd/unbound-force/main.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/cmd/unbound-force/main.go",
       "line": 71,
       "complexity": 1,
       "line_coverage": 100,
@@ -474,7 +474,7 @@
     {
       "package": "main",
       "function": "newInitCmd",
-      "file": "cmd/unbound-force/main.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/cmd/unbound-force/main.go",
       "line": 83,
       "complexity": 2,
       "line_coverage": 91.66666666666667,
@@ -483,27 +483,25 @@
     {
       "package": "main",
       "function": "runDoctor",
-      "file": "cmd/unbound-force/main.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/cmd/unbound-force/main.go",
       "line": 138,
       "complexity": 6,
-      "line_coverage": 0,
-      "crap": 42,
-      "fix_strategy": "add_tests"
+      "line_coverage": 85.71428571428571,
+      "crap": 6.104956268221574
     },
     {
       "package": "main",
       "function": "newDoctorCmd",
-      "file": "cmd/unbound-force/main.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/cmd/unbound-force/main.go",
       "line": 170,
       "complexity": 6,
-      "line_coverage": 28.571428571428573,
-      "crap": 19.119533527696788,
-      "fix_strategy": "add_tests"
+      "line_coverage": 71.42857142857143,
+      "crap": 6.839650145772595
     },
     {
       "package": "main",
       "function": "runSetup",
-      "file": "cmd/unbound-force/main.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/cmd/unbound-force/main.go",
       "line": 220,
       "complexity": 2,
       "line_coverage": 0,
@@ -512,7 +510,7 @@
     {
       "package": "main",
       "function": "newSetupCmd",
-      "file": "cmd/unbound-force/main.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/cmd/unbound-force/main.go",
       "line": 240,
       "complexity": 4,
       "line_coverage": 35.714285714285715,
@@ -521,26 +519,26 @@
     {
       "package": "main",
       "function": "newSandboxCmd",
-      "file": "cmd/unbound-force/sandbox.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/cmd/unbound-force/sandbox.go",
       "line": 19,
       "complexity": 1,
-      "line_coverage": 0,
-      "crap": 2
+      "line_coverage": 100,
+      "crap": 1
     },
     {
       "package": "main",
       "function": "applySandboxConfig",
-      "file": "cmd/unbound-force/sandbox.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/cmd/unbound-force/sandbox.go",
       "line": 58,
       "complexity": 19,
-      "line_coverage": 85,
-      "crap": 20.218375,
+      "line_coverage": 95,
+      "crap": 19.045125,
       "fix_strategy": "decompose"
     },
     {
       "package": "main",
       "function": "runSandboxInit",
-      "file": "cmd/unbound-force/sandbox.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/cmd/unbound-force/sandbox.go",
       "line": 104,
       "complexity": 2,
       "line_coverage": 0,
@@ -549,16 +547,16 @@
     {
       "package": "main",
       "function": "newSandboxInitCmd",
-      "file": "cmd/unbound-force/sandbox.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/cmd/unbound-force/sandbox.go",
       "line": 120,
       "complexity": 2,
-      "line_coverage": 0,
-      "crap": 6
+      "line_coverage": 41.666666666666664,
+      "crap": 2.793981481481482
     },
     {
       "package": "main",
       "function": "runSandboxCreate",
-      "file": "cmd/unbound-force/sandbox.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/cmd/unbound-force/sandbox.go",
       "line": 181,
       "complexity": 1,
       "line_coverage": 0,
@@ -567,16 +565,16 @@
     {
       "package": "main",
       "function": "newSandboxCreateCmd",
-      "file": "cmd/unbound-force/sandbox.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/cmd/unbound-force/sandbox.go",
       "line": 200,
       "complexity": 2,
-      "line_coverage": 0,
-      "crap": 6
+      "line_coverage": 45.833333333333336,
+      "crap": 2.635706018518518
     },
     {
       "package": "main",
       "function": "runSandboxDestroy",
-      "file": "cmd/unbound-force/sandbox.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/cmd/unbound-force/sandbox.go",
       "line": 275,
       "complexity": 5,
       "line_coverage": 92.3076923076923,
@@ -585,16 +583,16 @@
     {
       "package": "main",
       "function": "newSandboxDestroyCmd",
-      "file": "cmd/unbound-force/sandbox.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/cmd/unbound-force/sandbox.go",
       "line": 304,
       "complexity": 2,
-      "line_coverage": 0,
-      "crap": 6
+      "line_coverage": 40,
+      "crap": 2.864
     },
     {
       "package": "main",
       "function": "runSandboxStart",
-      "file": "cmd/unbound-force/sandbox.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/cmd/unbound-force/sandbox.go",
       "line": 357,
       "complexity": 1,
       "line_coverage": 0,
@@ -603,16 +601,16 @@
     {
       "package": "main",
       "function": "newSandboxStartCmd",
-      "file": "cmd/unbound-force/sandbox.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/cmd/unbound-force/sandbox.go",
       "line": 376,
       "complexity": 2,
-      "line_coverage": 0,
-      "crap": 6
+      "line_coverage": 45.833333333333336,
+      "crap": 2.635706018518518
     },
     {
       "package": "main",
       "function": "runSandboxStop",
-      "file": "cmd/unbound-force/sandbox.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/cmd/unbound-force/sandbox.go",
       "line": 450,
       "complexity": 1,
       "line_coverage": 0,
@@ -621,16 +619,16 @@
     {
       "package": "main",
       "function": "newSandboxStopCmd",
-      "file": "cmd/unbound-force/sandbox.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/cmd/unbound-force/sandbox.go",
       "line": 457,
       "complexity": 2,
-      "line_coverage": 0,
-      "crap": 6
+      "line_coverage": 20,
+      "crap": 4.048
     },
     {
       "package": "main",
       "function": "runSandboxAttach",
-      "file": "cmd/unbound-force/sandbox.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/cmd/unbound-force/sandbox.go",
       "line": 484,
       "complexity": 1,
       "line_coverage": 0,
@@ -639,16 +637,16 @@
     {
       "package": "main",
       "function": "newSandboxAttachCmd",
-      "file": "cmd/unbound-force/sandbox.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/cmd/unbound-force/sandbox.go",
       "line": 490,
       "complexity": 1,
-      "line_coverage": 0,
-      "crap": 2
+      "line_coverage": 50,
+      "crap": 1.125
     },
     {
       "package": "main",
       "function": "runSandboxExtract",
-      "file": "cmd/unbound-force/sandbox.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/cmd/unbound-force/sandbox.go",
       "line": 514,
       "complexity": 1,
       "line_coverage": 0,
@@ -657,16 +655,16 @@
     {
       "package": "main",
       "function": "newSandboxExtractCmd",
-      "file": "cmd/unbound-force/sandbox.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/cmd/unbound-force/sandbox.go",
       "line": 523,
       "complexity": 1,
-      "line_coverage": 0,
-      "crap": 2
+      "line_coverage": 60,
+      "crap": 1.064
     },
     {
       "package": "main",
       "function": "runSandboxStatus",
-      "file": "cmd/unbound-force/sandbox.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/cmd/unbound-force/sandbox.go",
       "line": 556,
       "complexity": 4,
       "line_coverage": 0,
@@ -676,40 +674,50 @@
     {
       "package": "main",
       "function": "newSandboxStatusCmd",
-      "file": "cmd/unbound-force/sandbox.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/cmd/unbound-force/sandbox.go",
       "line": 581,
       "complexity": 2,
-      "line_coverage": 0,
-      "crap": 6
+      "line_coverage": 20,
+      "crap": 4.048
     },
     {
       "package": "artifacts",
       "function": "WriteArtifact",
-      "file": "internal/artifacts/artifacts.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/artifacts/artifacts.go",
       "line": 51,
       "complexity": 1,
       "line_coverage": 100,
       "crap": 1,
-      "contract_coverage": 100,
-      "gaze_crap": 1,
-      "quadrant": "Q1_Safe"
+      "contract_coverage": 0,
+      "gaze_crap": 2,
+      "quadrant": "Q1_Safe",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        68,
+        68
+      ]
     },
     {
       "package": "artifacts",
       "function": "WriteArtifactWithContext",
-      "file": "internal/artifacts/artifacts.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/artifacts/artifacts.go",
       "line": 57,
       "complexity": 7,
       "line_coverage": 78.94736842105263,
       "crap": 7.457209505758857,
-      "contract_coverage": 100,
-      "gaze_crap": 7,
-      "quadrant": "Q1_Safe"
+      "contract_coverage": 0,
+      "gaze_crap": 56,
+      "quadrant": "Q3_SimpleButUnderspecified",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        63,
+        73
+      ]
     },
     {
       "package": "artifacts",
       "function": "ReadEnvelope",
-      "file": "internal/artifacts/artifacts.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/artifacts/artifacts.go",
       "line": 98,
       "complexity": 3,
       "line_coverage": 85.71428571428571,
@@ -721,91 +729,126 @@
     {
       "package": "artifacts",
       "function": "FindArtifacts",
-      "file": "internal/artifacts/artifacts.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/artifacts/artifacts.go",
       "line": 112,
       "complexity": 7,
       "line_coverage": 81.25,
       "crap": 7.322998046875,
-      "contract_coverage": 100,
-      "gaze_crap": 7,
-      "quadrant": "Q1_Safe"
+      "contract_coverage": 0,
+      "gaze_crap": 56,
+      "quadrant": "Q3_SimpleButUnderspecified",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        78,
+        78
+      ]
     },
     {
       "package": "artifacts",
       "function": "FindArtifactsByHero",
-      "file": "internal/artifacts/artifacts.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/artifacts/artifacts.go",
       "line": 140,
       "complexity": 5,
       "line_coverage": 81.81818181818181,
       "crap": 5.150262960180315,
-      "contract_coverage": 100,
-      "gaze_crap": 5,
-      "quadrant": "Q1_Safe"
+      "contract_coverage": 0,
+      "gaze_crap": 30,
+      "quadrant": "Q3_SimpleButUnderspecified",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        73,
+        73
+      ]
     },
     {
       "package": "artifacts",
       "function": "FindArtifactsSince",
-      "file": "internal/artifacts/artifacts.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/artifacts/artifacts.go",
       "line": 161,
       "complexity": 7,
       "line_coverage": 78.57142857142857,
-      "crap": 7.482142857142857,
-      "contract_coverage": 100,
-      "gaze_crap": 7,
-      "quadrant": "Q1_Safe"
+      "crap": 7.482142857142858,
+      "contract_coverage": 0,
+      "gaze_crap": 56,
+      "quadrant": "Q3_SimpleButUnderspecified",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        73,
+        73
+      ]
     },
     {
       "package": "artifacts",
       "function": "CheckSchemaVersion",
-      "file": "internal/artifacts/artifacts.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/artifacts/artifacts.go",
       "line": 187,
       "complexity": 5,
       "line_coverage": 88.88888888888889,
       "crap": 5.034293552812072,
-      "contract_coverage": 50,
-      "gaze_crap": 8.125,
-      "quadrant": "Q1_Safe"
+      "contract_coverage": 0,
+      "gaze_crap": 30,
+      "quadrant": "Q3_SimpleButUnderspecified",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        73,
+        73
+      ]
     },
     {
       "package": "artifacts",
       "function": "GenerateBacklogItemArtifact",
-      "file": "internal/artifacts/artifacts.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/artifacts/artifacts.go",
       "line": 207,
       "complexity": 1,
       "line_coverage": 100,
       "crap": 1,
-      "contract_coverage": 100,
-      "gaze_crap": 1,
-      "quadrant": "Q1_Safe"
+      "contract_coverage": 0,
+      "gaze_crap": 2,
+      "quadrant": "Q1_Safe",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        63,
+        63
+      ]
     },
     {
       "package": "artifacts",
       "function": "GenerateAcceptanceDecision",
-      "file": "internal/artifacts/artifacts.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/artifacts/artifacts.go",
       "line": 212,
       "complexity": 1,
       "line_coverage": 100,
       "crap": 1,
-      "contract_coverage": 100,
-      "gaze_crap": 1,
-      "quadrant": "Q1_Safe"
+      "contract_coverage": 0,
+      "gaze_crap": 2,
+      "quadrant": "Q1_Safe",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        63,
+        63
+      ]
     },
     {
       "package": "backlog",
       "function": "NewRepository",
-      "file": "internal/backlog/backlog.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/backlog/backlog.go",
       "line": 28,
       "complexity": 1,
       "line_coverage": 100,
       "crap": 1,
       "contract_coverage": 0,
       "gaze_crap": 2,
-      "quadrant": "Q1_Safe"
+      "quadrant": "Q1_Safe",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        69,
+        69
+      ]
     },
     {
       "package": "backlog",
       "function": "(*Repository).ensureDir",
-      "file": "internal/backlog/backlog.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/backlog/backlog.go",
       "line": 33,
       "complexity": 1,
       "line_coverage": 100,
@@ -814,7 +857,7 @@
     {
       "package": "backlog",
       "function": "(*Repository).getFilePath",
-      "file": "internal/backlog/backlog.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/backlog/backlog.go",
       "line": 38,
       "complexity": 1,
       "line_coverage": 100,
@@ -823,31 +866,36 @@
     {
       "package": "backlog",
       "function": "(*Repository).NextID",
-      "file": "internal/backlog/backlog.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/backlog/backlog.go",
       "line": 43,
       "complexity": 5,
       "line_coverage": 92.3076923076923,
       "crap": 5.011379153390988,
-      "contract_coverage": 100,
-      "gaze_crap": 5,
-      "quadrant": "Q1_Safe"
+      "contract_coverage": 0,
+      "gaze_crap": 30,
+      "quadrant": "Q3_SimpleButUnderspecified",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        74,
+        74
+      ]
     },
     {
       "package": "backlog",
       "function": "(*Repository).Save",
-      "file": "internal/backlog/backlog.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/backlog/backlog.go",
       "line": 66,
       "complexity": 5,
       "line_coverage": 88.23529411764706,
       "crap": 5.0407083248524325,
-      "contract_coverage": 33.333333333333336,
-      "gaze_crap": 12.407407407407405,
+      "contract_coverage": 50,
+      "gaze_crap": 8.125,
       "quadrant": "Q1_Safe"
     },
     {
       "package": "backlog",
       "function": "(*Repository).Get",
-      "file": "internal/backlog/backlog.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/backlog/backlog.go",
       "line": 95,
       "complexity": 5,
       "line_coverage": 85.71428571428571,
@@ -859,7 +907,7 @@
     {
       "package": "backlog",
       "function": "(*Repository).List",
-      "file": "internal/backlog/backlog.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/backlog/backlog.go",
       "line": 120,
       "complexity": 8,
       "line_coverage": 78.94736842105263,
@@ -871,7 +919,7 @@
     {
       "package": "coaching",
       "function": "(*ActionItem).IsStale",
-      "file": "internal/coaching/models.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/coaching/models.go",
       "line": 37,
       "complexity": 3,
       "line_coverage": 66.66666666666667,
@@ -883,40 +931,58 @@
     {
       "package": "coaching",
       "function": "NewRetroStore",
-      "file": "internal/coaching/retro.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/coaching/retro.go",
       "line": 21,
       "complexity": 1,
       "line_coverage": 100,
       "crap": 1,
       "contract_coverage": 0,
       "gaze_crap": 2,
-      "quadrant": "Q1_Safe"
+      "quadrant": "Q1_Safe",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        69,
+        69
+      ]
     },
     {
       "package": "coaching",
       "function": "(*RetroStore).StartRetro",
-      "file": "internal/coaching/retro.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/coaching/retro.go",
       "line": 26,
       "complexity": 2,
-      "line_coverage": 0,
-      "crap": 6
+      "line_coverage": 75,
+      "crap": 2.0625,
+      "contract_coverage": 0,
+      "gaze_crap": 6,
+      "quadrant": "Q1_Safe",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        75,
+        75
+      ]
     },
     {
       "package": "coaching",
       "function": "(*RetroStore).SaveRetro",
-      "file": "internal/coaching/retro.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/coaching/retro.go",
       "line": 40,
       "complexity": 3,
       "line_coverage": 75,
       "crap": 3.140625,
-      "contract_coverage": 100,
-      "gaze_crap": 3,
-      "quadrant": "Q1_Safe"
+      "contract_coverage": 0,
+      "gaze_crap": 12,
+      "quadrant": "Q1_Safe",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        69,
+        79
+      ]
     },
     {
       "package": "coaching",
       "function": "(*RetroStore).LoadRetro",
-      "file": "internal/coaching/retro.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/coaching/retro.go",
       "line": 56,
       "complexity": 4,
       "line_coverage": 76.92307692307692,
@@ -928,7 +994,7 @@
     {
       "package": "coaching",
       "function": "(*RetroStore).ListRetros",
-      "file": "internal/coaching/retro.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/coaching/retro.go",
       "line": 78,
       "complexity": 7,
       "line_coverage": 70.58823529411765,
@@ -940,31 +1006,41 @@
     {
       "package": "coaching",
       "function": "NextActionID",
-      "file": "internal/coaching/retro.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/coaching/retro.go",
       "line": 107,
       "complexity": 6,
       "line_coverage": 100,
       "crap": 6,
-      "contract_coverage": 100,
-      "gaze_crap": 6,
-      "quadrant": "Q1_Safe"
+      "contract_coverage": 0,
+      "gaze_crap": 42,
+      "quadrant": "Q3_SimpleButUnderspecified",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        73,
+        73
+      ]
     },
     {
       "package": "coaching",
       "function": "ReviewPreviousActions",
-      "file": "internal/coaching/retro.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/coaching/retro.go",
       "line": 125,
       "complexity": 5,
       "line_coverage": 100,
       "crap": 5,
-      "contract_coverage": 100,
-      "gaze_crap": 5,
-      "quadrant": "Q1_Safe"
+      "contract_coverage": 0,
+      "gaze_crap": 30,
+      "quadrant": "Q3_SimpleButUnderspecified",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        69,
+        69
+      ]
     },
     {
       "package": "config",
       "function": "(*LoadOptions).defaults",
-      "file": "internal/config/config.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/config/config.go",
       "line": 112,
       "complexity": 4,
       "line_coverage": 66.66666666666667,
@@ -973,7 +1049,7 @@
     {
       "package": "config",
       "function": "Load",
-      "file": "internal/config/config.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/config/config.go",
       "line": 130,
       "complexity": 6,
       "line_coverage": 88.88888888888889,
@@ -985,7 +1061,7 @@
     {
       "package": "config",
       "function": "merge",
-      "file": "internal/config/config.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/config/config.go",
       "line": 179,
       "complexity": 30,
       "line_coverage": 66.66666666666667,
@@ -995,7 +1071,7 @@
     {
       "package": "config",
       "function": "applyEnvOverrides",
-      "file": "internal/config/config.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/config/config.go",
       "line": 286,
       "complexity": 15,
       "line_coverage": 96,
@@ -1005,19 +1081,24 @@
     {
       "package": "config",
       "function": "Defaults",
-      "file": "internal/config/config.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/config/config.go",
       "line": 330,
       "complexity": 1,
       "line_coverage": 100,
       "crap": 1,
-      "contract_coverage": 100,
-      "gaze_crap": 1,
-      "quadrant": "Q1_Safe"
+      "contract_coverage": 0,
+      "gaze_crap": 2,
+      "quadrant": "Q1_Safe",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        79,
+        79
+      ]
     },
     {
       "package": "config",
       "function": "(SandboxConfig).IsEmpty",
-      "file": "internal/config/config.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/config/config.go",
       "line": 376,
       "complexity": 8,
       "line_coverage": 100,
@@ -1026,44 +1107,59 @@
     {
       "package": "config",
       "function": "RepoConfigPath",
-      "file": "internal/config/config.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/config/config.go",
       "line": 389,
       "complexity": 1,
       "line_coverage": 100,
       "crap": 1,
-      "contract_coverage": 100,
-      "gaze_crap": 1,
-      "quadrant": "Q1_Safe"
+      "contract_coverage": 0,
+      "gaze_crap": 2,
+      "quadrant": "Q1_Safe",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        78,
+        78
+      ]
     },
     {
       "package": "config",
       "function": "UserConfigPath",
-      "file": "internal/config/config.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/config/config.go",
       "line": 395,
       "complexity": 3,
       "line_coverage": 83.33333333333333,
       "crap": 3.0416666666666665,
-      "contract_coverage": 100,
-      "gaze_crap": 3,
-      "quadrant": "Q1_Safe"
+      "contract_coverage": 0,
+      "gaze_crap": 12,
+      "quadrant": "Q1_Safe",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        58,
+        73
+      ]
     },
     {
       "package": "config",
       "function": "InitFile",
-      "file": "internal/config/init.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/config/init.go",
       "line": 44,
       "complexity": 10,
       "line_coverage": 88.88888888888889,
       "crap": 10.137174211248286,
-      "contract_coverage": 50,
-      "gaze_crap": 22.5,
-      "quadrant": "Q3_SimpleButUnderspecified"
+      "contract_coverage": 0,
+      "gaze_crap": 110,
+      "quadrant": "Q3_SimpleButUnderspecified",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        69,
+        69
+      ]
     },
     {
       "package": "config",
       "function": "updateExisting",
-      "file": "internal/config/init.go",
-      "line": 100,
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/config/init.go",
+      "line": 105,
       "complexity": 15,
       "line_coverage": 81.08108108108108,
       "crap": 16.52360176100132,
@@ -1072,8 +1168,8 @@
     {
       "package": "config",
       "function": "detectSections",
-      "file": "internal/config/init.go",
-      "line": 179,
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/config/init.go",
+      "line": 184,
       "complexity": 10,
       "line_coverage": 100,
       "crap": 10
@@ -1081,8 +1177,8 @@
     {
       "package": "config",
       "function": "lineSectionName",
-      "file": "internal/config/init.go",
-      "line": 216,
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/config/init.go",
+      "line": 221,
       "complexity": 8,
       "line_coverage": 100,
       "crap": 8
@@ -1090,8 +1186,8 @@
     {
       "package": "config",
       "function": "extractTemplateSection",
-      "file": "internal/config/init.go",
-      "line": 246,
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/config/init.go",
+      "line": 251,
       "complexity": 7,
       "line_coverage": 100,
       "crap": 7
@@ -1099,8 +1195,8 @@
     {
       "package": "config",
       "function": "writeFileAtomic",
-      "file": "internal/config/init.go",
-      "line": 269,
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/config/init.go",
+      "line": 274,
       "complexity": 6,
       "line_coverage": 47.36842105263158,
       "crap": 11.248578509986878
@@ -1108,8 +1204,8 @@
     {
       "package": "config",
       "function": "contains",
-      "file": "internal/config/init.go",
-      "line": 297,
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/config/init.go",
+      "line": 302,
       "complexity": 3,
       "line_coverage": 100,
       "crap": 3
@@ -1117,31 +1213,41 @@
     {
       "package": "config",
       "function": "Template",
-      "file": "internal/config/template.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/config/template.go",
       "line": 8,
       "complexity": 1,
       "line_coverage": 100,
       "crap": 1,
       "contract_coverage": 0,
       "gaze_crap": 2,
-      "quadrant": "Q1_Safe"
+      "quadrant": "Q1_Safe",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        73,
+        73
+      ]
     },
     {
       "package": "config",
       "function": "Validate",
-      "file": "internal/config/validate.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/config/validate.go",
       "line": 10,
       "complexity": 1,
       "line_coverage": 100,
       "crap": 1,
-      "contract_coverage": 100,
-      "gaze_crap": 1,
-      "quadrant": "Q1_Safe"
+      "contract_coverage": 0,
+      "gaze_crap": 2,
+      "quadrant": "Q1_Safe",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        78,
+        78
+      ]
     },
     {
       "package": "config",
       "function": "validateSetup",
-      "file": "internal/config/validate.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/config/validate.go",
       "line": 20,
       "complexity": 4,
       "line_coverage": 100,
@@ -1150,7 +1256,7 @@
     {
       "package": "config",
       "function": "validateSandbox",
-      "file": "internal/config/validate.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/config/validate.go",
       "line": 47,
       "complexity": 4,
       "line_coverage": 100,
@@ -1159,7 +1265,7 @@
     {
       "package": "config",
       "function": "validateGateway",
-      "file": "internal/config/validate.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/config/validate.go",
       "line": 78,
       "complexity": 4,
       "line_coverage": 100,
@@ -1168,7 +1274,7 @@
     {
       "package": "config",
       "function": "validateEmbedding",
-      "file": "internal/config/validate.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/config/validate.go",
       "line": 97,
       "complexity": 3,
       "line_coverage": 100,
@@ -1177,7 +1283,7 @@
     {
       "package": "config",
       "function": "validateDoctor",
-      "file": "internal/config/validate.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/config/validate.go",
       "line": 115,
       "complexity": 3,
       "line_coverage": 100,
@@ -1186,7 +1292,7 @@
     {
       "package": "dashboard",
       "function": "capitalize",
-      "file": "internal/dashboard/html.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/dashboard/html.go",
       "line": 69,
       "complexity": 2,
       "line_coverage": 66.66666666666667,
@@ -1195,55 +1301,75 @@
     {
       "package": "dashboard",
       "function": "RenderHTML",
-      "file": "internal/dashboard/html.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/dashboard/html.go",
       "line": 77,
       "complexity": 6,
       "line_coverage": 83.33333333333333,
       "crap": 6.166666666666667,
-      "contract_coverage": 100,
-      "gaze_crap": 6,
-      "quadrant": "Q1_Safe"
+      "contract_coverage": 0,
+      "gaze_crap": 42,
+      "quadrant": "Q3_SimpleButUnderspecified",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        63,
+        63
+      ]
     },
     {
       "package": "dashboard",
       "function": "RenderBarChart",
-      "file": "internal/dashboard/text.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/dashboard/text.go",
       "line": 21,
       "complexity": 9,
       "line_coverage": 95.23809523809524,
       "crap": 9.008746355685131,
-      "contract_coverage": 100,
-      "gaze_crap": 9,
-      "quadrant": "Q1_Safe"
+      "contract_coverage": 0,
+      "gaze_crap": 90,
+      "quadrant": "Q3_SimpleButUnderspecified",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        63,
+        63
+      ]
     },
     {
       "package": "dashboard",
       "function": "RenderSparkline",
-      "file": "internal/dashboard/text.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/dashboard/text.go",
       "line": 57,
       "complexity": 8,
       "line_coverage": 88,
       "crap": 8.110592,
-      "contract_coverage": 100,
-      "gaze_crap": 8,
-      "quadrant": "Q1_Safe"
+      "contract_coverage": 0,
+      "gaze_crap": 72,
+      "quadrant": "Q3_SimpleButUnderspecified",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        63,
+        63
+      ]
     },
     {
       "package": "dashboard",
       "function": "RenderHealthIndicators",
-      "file": "internal/dashboard/text.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/dashboard/text.go",
       "line": 98,
       "complexity": 4,
       "line_coverage": 100,
       "crap": 4,
-      "contract_coverage": 100,
-      "gaze_crap": 4,
-      "quadrant": "Q1_Safe"
+      "contract_coverage": 0,
+      "gaze_crap": 20,
+      "quadrant": "Q3_SimpleButUnderspecified",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        63,
+        63
+      ]
     },
     {
       "package": "dashboard",
       "function": "formatValue",
-      "file": "internal/dashboard/text.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/dashboard/text.go",
       "line": 123,
       "complexity": 6,
       "line_coverage": 57.142857142857146,
@@ -1252,7 +1378,7 @@
     {
       "package": "doctor",
       "function": "embeddingModel",
-      "file": "internal/doctor/checks.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/doctor/checks.go",
       "line": 27,
       "complexity": 2,
       "line_coverage": 66.66666666666667,
@@ -1261,7 +1387,7 @@
     {
       "package": "doctor",
       "function": "checkDetectedEnvironment",
-      "file": "internal/doctor/checks.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/doctor/checks.go",
       "line": 37,
       "complexity": 3,
       "line_coverage": 100,
@@ -1270,7 +1396,7 @@
     {
       "package": "doctor",
       "function": "managerDescription",
-      "file": "internal/doctor/checks.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/doctor/checks.go",
       "line": 66,
       "complexity": 8,
       "line_coverage": 100,
@@ -1279,7 +1405,7 @@
     {
       "package": "doctor",
       "function": "checkCoreTools",
-      "file": "internal/doctor/checks.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/doctor/checks.go",
       "line": 143,
       "complexity": 9,
       "line_coverage": 92.3076923076923,
@@ -1288,7 +1414,7 @@
     {
       "package": "doctor",
       "function": "checkOllamaModel",
-      "file": "internal/doctor/checks.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/doctor/checks.go",
       "line": 182,
       "complexity": 3,
       "line_coverage": 81.81818181818181,
@@ -1297,7 +1423,7 @@
     {
       "package": "doctor",
       "function": "checkPodmanRuntime",
-      "file": "internal/doctor/checks.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/doctor/checks.go",
       "line": 207,
       "complexity": 2,
       "line_coverage": 66.66666666666667,
@@ -1306,25 +1432,26 @@
     {
       "package": "doctor",
       "function": "checkPodmanRuntimeDarwin",
-      "file": "internal/doctor/checks.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/doctor/checks.go",
       "line": 216,
       "complexity": 4,
       "line_coverage": 0,
-      "crap": 20
+      "crap": 20,
+      "fix_strategy": "add_tests"
     },
     {
       "package": "doctor",
       "function": "checkPodmanRuntimeLinux",
-      "file": "internal/doctor/checks.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/doctor/checks.go",
       "line": 248,
       "complexity": 2,
-      "line_coverage": 0,
-      "crap": 6
+      "line_coverage": 75,
+      "crap": 2.0625
     },
     {
       "package": "doctor",
       "function": "checkDockerPodmanShim",
-      "file": "internal/doctor/checks.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/doctor/checks.go",
       "line": 272,
       "complexity": 4,
       "line_coverage": 33.333333333333336,
@@ -1333,7 +1460,7 @@
     {
       "package": "doctor",
       "function": "checkOneTool",
-      "file": "internal/doctor/checks.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/doctor/checks.go",
       "line": 302,
       "complexity": 17,
       "line_coverage": 91.17647058823529,
@@ -1343,7 +1470,7 @@
     {
       "package": "doctor",
       "function": "parseGoVersion",
-      "file": "internal/doctor/checks.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/doctor/checks.go",
       "line": 404,
       "complexity": 7,
       "line_coverage": 100,
@@ -1352,7 +1479,7 @@
     {
       "package": "doctor",
       "function": "checkGoVersion",
-      "file": "internal/doctor/checks.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/doctor/checks.go",
       "line": 419,
       "complexity": 2,
       "line_coverage": 100,
@@ -1361,7 +1488,7 @@
     {
       "package": "doctor",
       "function": "parseVersionParts",
-      "file": "internal/doctor/checks.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/doctor/checks.go",
       "line": 432,
       "complexity": 3,
       "line_coverage": 100,
@@ -1370,7 +1497,7 @@
     {
       "package": "doctor",
       "function": "extractLeadingDigits",
-      "file": "internal/doctor/checks.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/doctor/checks.go",
       "line": 447,
       "complexity": 4,
       "line_coverage": 100,
@@ -1379,7 +1506,7 @@
     {
       "package": "doctor",
       "function": "parseNodeVersion",
-      "file": "internal/doctor/checks.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/doctor/checks.go",
       "line": 458,
       "complexity": 2,
       "line_coverage": 100,
@@ -1388,7 +1515,7 @@
     {
       "package": "doctor",
       "function": "checkNodeVersion",
-      "file": "internal/doctor/checks.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/doctor/checks.go",
       "line": 467,
       "complexity": 1,
       "line_coverage": 100,
@@ -1397,7 +1524,7 @@
     {
       "package": "doctor",
       "function": "parsePodmanVersion",
-      "file": "internal/doctor/checks.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/doctor/checks.go",
       "line": 477,
       "complexity": 5,
       "line_coverage": 71.42857142857143,
@@ -1406,7 +1533,7 @@
     {
       "package": "doctor",
       "function": "checkPodmanVersion",
-      "file": "internal/doctor/checks.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/doctor/checks.go",
       "line": 492,
       "complexity": 2,
       "line_coverage": 80,
@@ -1415,7 +1542,7 @@
     {
       "package": "doctor",
       "function": "checkReplicator",
-      "file": "internal/doctor/checks.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/doctor/checks.go",
       "line": 503,
       "complexity": 13,
       "line_coverage": 94.28571428571429,
@@ -1424,7 +1551,7 @@
     {
       "package": "doctor",
       "function": "checkConfiguration",
-      "file": "internal/doctor/checks.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/doctor/checks.go",
       "line": 622,
       "complexity": 3,
       "line_coverage": 100,
@@ -1433,7 +1560,7 @@
     {
       "package": "doctor",
       "function": "checkScaffoldedFiles",
-      "file": "internal/doctor/checks.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/doctor/checks.go",
       "line": 660,
       "complexity": 5,
       "line_coverage": 100,
@@ -1442,7 +1569,7 @@
     {
       "package": "doctor",
       "function": "checkDirWithCount",
-      "file": "internal/doctor/checks.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/doctor/checks.go",
       "line": 711,
       "complexity": 6,
       "line_coverage": 90,
@@ -1451,7 +1578,7 @@
     {
       "package": "doctor",
       "function": "checkHeroAvailability",
-      "file": "internal/doctor/checks.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/doctor/checks.go",
       "line": 747,
       "complexity": 8,
       "line_coverage": 86.36363636363636,
@@ -1460,7 +1587,7 @@
     {
       "package": "doctor",
       "function": "countDivisorPersonas",
-      "file": "internal/doctor/checks.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/doctor/checks.go",
       "line": 810,
       "complexity": 6,
       "line_coverage": 87.5,
@@ -1469,7 +1596,7 @@
     {
       "package": "doctor",
       "function": "checkMCPConfig",
-      "file": "internal/doctor/checks.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/doctor/checks.go",
       "line": 826,
       "complexity": 9,
       "line_coverage": 88.88888888888889,
@@ -1478,7 +1605,7 @@
     {
       "package": "doctor",
       "function": "extractMCPBinary",
-      "file": "internal/doctor/checks.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/doctor/checks.go",
       "line": 909,
       "complexity": 5,
       "line_coverage": 85.71428571428571,
@@ -1487,7 +1614,7 @@
     {
       "package": "doctor",
       "function": "checkAgentSkillIntegrity",
-      "file": "internal/doctor/checks.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/doctor/checks.go",
       "line": 931,
       "complexity": 4,
       "line_coverage": 100,
@@ -1496,7 +1623,7 @@
     {
       "package": "doctor",
       "function": "validateAgents",
-      "file": "internal/doctor/checks.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/doctor/checks.go",
       "line": 956,
       "complexity": 10,
       "line_coverage": 86.20689655172414,
@@ -1505,7 +1632,7 @@
     {
       "package": "doctor",
       "function": "validateSkills",
-      "file": "internal/doctor/checks.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/doctor/checks.go",
       "line": 1028,
       "complexity": 11,
       "line_coverage": 93.54838709677419,
@@ -1514,16 +1641,16 @@
     {
       "package": "doctor",
       "function": "defaultEmbedCheck",
-      "file": "internal/doctor/checks.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/doctor/checks.go",
       "line": 1106,
       "complexity": 8,
-      "line_coverage": 95.65217391304348,
-      "crap": 8.005260129859456
+      "line_coverage": 100,
+      "crap": 8
     },
     {
       "package": "doctor",
       "function": "checkEmbeddingCapability",
-      "file": "internal/doctor/checks.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/doctor/checks.go",
       "line": 1153,
       "complexity": 4,
       "line_coverage": 100,
@@ -1532,7 +1659,7 @@
     {
       "package": "doctor",
       "function": "checkDewey",
-      "file": "internal/doctor/checks.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/doctor/checks.go",
       "line": 1199,
       "complexity": 6,
       "line_coverage": 100,
@@ -1541,7 +1668,7 @@
     {
       "package": "doctor",
       "function": "isDevPodDetected",
-      "file": "internal/doctor/checks.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/doctor/checks.go",
       "line": 1295,
       "complexity": 4,
       "line_coverage": 85.71428571428571,
@@ -1550,7 +1677,7 @@
     {
       "package": "doctor",
       "function": "parseDevPodVersion",
-      "file": "internal/doctor/checks.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/doctor/checks.go",
       "line": 1317,
       "complexity": 6,
       "line_coverage": 66.66666666666667,
@@ -1559,7 +1686,7 @@
     {
       "package": "doctor",
       "function": "checkDevPodVersionMin",
-      "file": "internal/doctor/checks.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/doctor/checks.go",
       "line": 1338,
       "complexity": 2,
       "line_coverage": 80,
@@ -1568,7 +1695,7 @@
     {
       "package": "doctor",
       "function": "hasDevPodProvider",
-      "file": "internal/doctor/checks.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/doctor/checks.go",
       "line": 1351,
       "complexity": 5,
       "line_coverage": 77.77777777777777,
@@ -1577,7 +1704,7 @@
     {
       "package": "doctor",
       "function": "checkDevPod",
-      "file": "internal/doctor/checks.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/doctor/checks.go",
       "line": 1371,
       "complexity": 9,
       "line_coverage": 74.07407407407408,
@@ -1586,7 +1713,7 @@
     {
       "package": "doctor",
       "function": "parseFrontmatter",
-      "file": "internal/doctor/checks.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/doctor/checks.go",
       "line": 1478,
       "complexity": 9,
       "line_coverage": 87.5,
@@ -1595,7 +1722,7 @@
     {
       "package": "doctor",
       "function": "detectAGENTSmdSections",
-      "file": "internal/doctor/checks.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/doctor/checks.go",
       "line": 1583,
       "complexity": 6,
       "line_coverage": 100,
@@ -1604,7 +1731,7 @@
     {
       "package": "doctor",
       "function": "hasBuildCodeBlocks",
-      "file": "internal/doctor/checks.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/doctor/checks.go",
       "line": 1606,
       "complexity": 7,
       "line_coverage": 100,
@@ -1613,7 +1740,7 @@
     {
       "package": "doctor",
       "function": "hasSpecNumberedDirs",
-      "file": "internal/doctor/checks.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/doctor/checks.go",
       "line": 1635,
       "complexity": 5,
       "line_coverage": 87.5,
@@ -1622,7 +1749,7 @@
     {
       "package": "doctor",
       "function": "checkBridgeFile",
-      "file": "internal/doctor/checks.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/doctor/checks.go",
       "line": 1653,
       "complexity": 3,
       "line_coverage": 100,
@@ -1631,7 +1758,7 @@
     {
       "package": "doctor",
       "function": "checkAgentContext",
-      "file": "internal/doctor/checks.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/doctor/checks.go",
       "line": 1685,
       "complexity": 13,
       "line_coverage": 100,
@@ -1639,8 +1766,35 @@
     },
     {
       "package": "doctor",
+      "function": "isPythonProject",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/doctor/checks.go",
+      "line": 1848,
+      "complexity": 3,
+      "line_coverage": 100,
+      "crap": 3
+    },
+    {
+      "package": "doctor",
+      "function": "checkPythonTools",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/doctor/checks.go",
+      "line": 1929,
+      "complexity": 2,
+      "line_coverage": 100,
+      "crap": 2
+    },
+    {
+      "package": "doctor",
+      "function": "checkAnyTool",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/doctor/checks.go",
+      "line": 1949,
+      "complexity": 10,
+      "line_coverage": 89.47368421052632,
+      "crap": 10.116635077999709
+    },
+    {
+      "package": "doctor",
       "function": "(*Options).goos",
-      "file": "internal/doctor/doctor.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/doctor/doctor.go",
       "line": 84,
       "complexity": 2,
       "line_coverage": 66.66666666666667,
@@ -1649,7 +1803,7 @@
     {
       "package": "doctor",
       "function": "(*Options).defaults",
-      "file": "internal/doctor/doctor.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/doctor/doctor.go",
       "line": 92,
       "complexity": 11,
       "line_coverage": 100,
@@ -1658,7 +1812,7 @@
     {
       "package": "doctor",
       "function": "defaultExecCmd",
-      "file": "internal/doctor/doctor.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/doctor/doctor.go",
       "line": 126,
       "complexity": 1,
       "line_coverage": 0,
@@ -1667,7 +1821,7 @@
     {
       "package": "doctor",
       "function": "defaultExecCmdTimeout",
-      "file": "internal/doctor/doctor.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/doctor/doctor.go",
       "line": 132,
       "complexity": 1,
       "line_coverage": 0,
@@ -1676,20 +1830,29 @@
     {
       "package": "doctor",
       "function": "Run",
-      "file": "internal/doctor/doctor.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/doctor/doctor.go",
       "line": 141,
-      "complexity": 4,
-      "line_coverage": 84.61538461538461,
-      "crap": 4.058261265361857,
+      "complexity": 3,
+      "line_coverage": 91.66666666666667,
+      "crap": 3.0052083333333335,
       "contract_coverage": 100,
-      "gaze_crap": 4,
+      "gaze_crap": 3,
       "quadrant": "Q1_Safe"
     },
     {
       "package": "doctor",
+      "function": "appendConditionalGroups",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/doctor/doctor.go",
+      "line": 191,
+      "complexity": 3,
+      "line_coverage": 80,
+      "crap": 3.072
+    },
+    {
+      "package": "doctor",
       "function": "filterSkippedChecks",
-      "file": "internal/doctor/doctor.go",
-      "line": 192,
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/doctor/doctor.go",
+      "line": 207,
       "complexity": 8,
       "line_coverage": 100,
       "crap": 8
@@ -1697,8 +1860,8 @@
     {
       "package": "doctor",
       "function": "computeSummary",
-      "file": "internal/doctor/doctor.go",
-      "line": 225,
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/doctor/doctor.go",
+      "line": 240,
       "complexity": 6,
       "line_coverage": 100,
       "crap": 6
@@ -1706,32 +1869,42 @@
     {
       "package": "doctor",
       "function": "DetectEnvironment",
-      "file": "internal/doctor/environ.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/doctor/environ.go",
       "line": 12,
       "complexity": 13,
       "line_coverage": 88.46153846153847,
       "crap": 13.259615384615383,
-      "contract_coverage": 100,
-      "gaze_crap": 13,
-      "quadrant": "Q1_Safe"
+      "contract_coverage": 0,
+      "gaze_crap": 182,
+      "quadrant": "Q3_SimpleButUnderspecified",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        69,
+        69
+      ]
     },
     {
       "package": "doctor",
       "function": "DetectProvenance",
-      "file": "internal/doctor/environ.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/doctor/environ.go",
       "line": 123,
       "complexity": 18,
       "line_coverage": 100,
       "crap": 18,
-      "contract_coverage": 100,
-      "gaze_crap": 18,
+      "contract_coverage": 0,
+      "gaze_crap": 342,
       "quadrant": "Q4_Dangerous",
-      "fix_strategy": "decompose"
+      "fix_strategy": "decompose",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        64,
+        64
+      ]
     },
     {
       "package": "doctor",
       "function": "installHint",
-      "file": "internal/doctor/environ.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/doctor/environ.go",
       "line": 191,
       "complexity": 6,
       "line_coverage": 75,
@@ -1740,7 +1913,7 @@
     {
       "package": "doctor",
       "function": "toolCategory",
-      "file": "internal/doctor/environ.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/doctor/environ.go",
       "line": 213,
       "complexity": 4,
       "line_coverage": 100,
@@ -1749,213 +1922,53 @@
     {
       "package": "doctor",
       "function": "managerInstallCmd",
-      "file": "internal/doctor/environ.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/doctor/environ.go",
       "line": 228,
       "complexity": 12,
       "line_coverage": 92.3076923076923,
-      "crap": 12.071005917159763
+      "crap": 12.06554392353209
     },
     {
       "package": "doctor",
       "function": "homebrewInstallCmd",
-      "file": "internal/doctor/environ.go",
-      "line": 259,
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/doctor/environ.go",
+      "line": 261,
       "complexity": 12,
       "line_coverage": 85.71428571428571,
       "crap": 12.419825072886297
     },
     {
       "package": "doctor",
+      "function": "dnfOrGenericCmd",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/doctor/environ.go",
+      "line": 296,
+      "complexity": 2,
+      "line_coverage": 100,
+      "crap": 2
+    },
+    {
+      "package": "doctor",
+      "function": "dnfInstallCmd",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/doctor/environ.go",
+      "line": 307,
+      "complexity": 8,
+      "line_coverage": 100,
+      "crap": 8
+    },
+    {
+      "package": "doctor",
       "function": "genericInstallCmd",
-      "file": "internal/doctor/environ.go",
-      "line": 292,
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/doctor/environ.go",
+      "line": 332,
       "complexity": 10,
-      "line_coverage": 90.9090909090909,
-      "crap": 10.075131480090159
+      "line_coverage": 100,
+      "crap": 10
     },
     {
       "package": "doctor",
       "function": "HasManager",
-      "file": "internal/doctor/environ.go",
-      "line": 319,
-      "complexity": 3,
-      "line_coverage": 100,
-      "crap": 3,
-      "contract_coverage": 0,
-      "gaze_crap": 12,
-      "quadrant": "Q1_Safe"
-    },
-    {
-      "package": "doctor",
-      "function": "installURL",
-      "file": "internal/doctor/environ.go",
-      "line": 329,
-      "complexity": 11,
-      "line_coverage": 83.33333333333333,
-      "crap": 11.560185185185185
-    },
-    {
-      "package": "doctor",
-      "function": "FormatJSON",
-      "file": "internal/doctor/format.go",
-      "line": 16,
-      "complexity": 2,
-      "line_coverage": 80,
-      "crap": 2.032,
-      "contract_coverage": 100,
-      "gaze_crap": 2,
-      "quadrant": "Q1_Safe"
-    },
-    {
-      "package": "doctor",
-      "function": "FormatText",
-      "file": "internal/doctor/format.go",
-      "line": 28,
-      "complexity": 11,
-      "line_coverage": 94.87179487179488,
-      "crap": 11.016318548862927,
-      "contract_coverage": 100,
-      "gaze_crap": 11,
-      "quadrant": "Q1_Safe"
-    },
-    {
-      "package": "doctor",
-      "function": "formatIndicator",
-      "file": "internal/doctor/format.go",
-      "line": 104,
-      "complexity": 11,
-      "line_coverage": 100,
-      "crap": 11
-    },
-    {
-      "package": "doctor",
-      "function": "(Severity).String",
-      "file": "internal/doctor/models.go",
-      "line": 44,
-      "complexity": 2,
-      "line_coverage": 100,
-      "crap": 2
-    },
-    {
-      "package": "doctor",
-      "function": "(Severity).MarshalJSON",
-      "file": "internal/doctor/models.go",
-      "line": 52,
-      "complexity": 2,
-      "line_coverage": 100,
-      "crap": 2
-    },
-    {
-      "package": "doctor",
-      "function": "(*Severity).UnmarshalJSON",
-      "file": "internal/doctor/models.go",
-      "line": 61,
-      "complexity": 3,
-      "line_coverage": 87.5,
-      "crap": 3.017578125
-    },
-    {
-      "package": "gateway",
-      "function": "(*Options).defaults",
-      "file": "internal/gateway/gateway.go",
-      "line": 109,
-      "complexity": 12,
-      "line_coverage": 100,
-      "crap": 12
-    },
-    {
-      "package": "gateway",
-      "function": "defaultExecCmd",
-      "file": "internal/gateway/gateway.go",
-      "line": 146,
-      "complexity": 1,
-      "line_coverage": 0,
-      "crap": 2
-    },
-    {
-      "package": "gateway",
-      "function": "defaultExecStart",
-      "file": "internal/gateway/gateway.go",
-      "line": 151,
-      "complexity": 1,
-      "line_coverage": 0,
-      "crap": 2
-    },
-    {
-      "package": "gateway",
-      "function": "defaultHTTPGet",
-      "file": "internal/gateway/gateway.go",
-      "line": 156,
-      "complexity": 2,
-      "line_coverage": 0,
-      "crap": 6
-    },
-    {
-      "package": "gateway",
-      "function": "pidPath",
-      "file": "internal/gateway/gateway.go",
-      "line": 167,
-      "complexity": 1,
-      "line_coverage": 100,
-      "crap": 1
-    },
-    {
-      "package": "gateway",
-      "function": "newMux",
-      "file": "internal/gateway/gateway.go",
-      "line": 175,
-      "complexity": 7,
-      "line_coverage": 93.47826086956522,
-      "crap": 7.013592093367305
-    },
-    {
-      "package": "gateway",
-      "function": "writeJSONError",
-      "file": "internal/gateway/gateway.go",
-      "line": 399,
-      "complexity": 1,
-      "line_coverage": 100,
-      "crap": 1
-    },
-    {
-      "package": "gateway",
-      "function": "Start",
-      "file": "internal/gateway/gateway.go",
-      "line": 414,
-      "complexity": 15,
-      "line_coverage": 92,
-      "crap": 15.1152,
-      "contract_coverage": 100,
-      "gaze_crap": 15,
-      "quadrant": "Q4_Dangerous",
-      "fix_strategy": "decompose"
-    },
-    {
-      "package": "gateway",
-      "function": "detach",
-      "file": "internal/gateway/gateway.go",
-      "line": 539,
-      "complexity": 12,
-      "line_coverage": 92.5,
-      "crap": 12.06075
-    },
-    {
-      "package": "gateway",
-      "function": "Stop",
-      "file": "internal/gateway/gateway.go",
-      "line": 620,
-      "complexity": 5,
-      "line_coverage": 95.23809523809524,
-      "crap": 5.0026994924954105,
-      "contract_coverage": 100,
-      "gaze_crap": 5,
-      "quadrant": "Q1_Safe"
-    },
-    {
-      "package": "gateway",
-      "function": "Status",
-      "file": "internal/gateway/gateway.go",
-      "line": 662,
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/doctor/environ.go",
+      "line": 359,
       "complexity": 3,
       "line_coverage": 100,
       "crap": 3,
@@ -1964,14 +1977,213 @@
       "quadrant": "Q1_Safe",
       "contract_coverage_reason": "all_effects_ambiguous",
       "effect_confidence_range": [
-        53,
-        53
+        63,
+        63
+      ]
+    },
+    {
+      "package": "doctor",
+      "function": "installURL",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/doctor/environ.go",
+      "line": 369,
+      "complexity": 11,
+      "line_coverage": 83.33333333333333,
+      "crap": 11.560185185185187
+    },
+    {
+      "package": "doctor",
+      "function": "FormatJSON",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/doctor/format.go",
+      "line": 16,
+      "complexity": 2,
+      "line_coverage": 80,
+      "crap": 2.032,
+      "contract_coverage": 0,
+      "gaze_crap": 6,
+      "quadrant": "Q1_Safe",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        63,
+        63
+      ]
+    },
+    {
+      "package": "doctor",
+      "function": "FormatText",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/doctor/format.go",
+      "line": 28,
+      "complexity": 11,
+      "line_coverage": 94.87179487179488,
+      "crap": 11.016318548862927,
+      "contract_coverage": 0,
+      "gaze_crap": 132,
+      "quadrant": "Q3_SimpleButUnderspecified",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        63,
+        63
+      ]
+    },
+    {
+      "package": "doctor",
+      "function": "formatIndicator",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/doctor/format.go",
+      "line": 104,
+      "complexity": 11,
+      "line_coverage": 100,
+      "crap": 11
+    },
+    {
+      "package": "doctor",
+      "function": "(Severity).String",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/doctor/models.go",
+      "line": 44,
+      "complexity": 2,
+      "line_coverage": 100,
+      "crap": 2
+    },
+    {
+      "package": "doctor",
+      "function": "(Severity).MarshalJSON",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/doctor/models.go",
+      "line": 52,
+      "complexity": 2,
+      "line_coverage": 100,
+      "crap": 2
+    },
+    {
+      "package": "doctor",
+      "function": "(*Severity).UnmarshalJSON",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/doctor/models.go",
+      "line": 61,
+      "complexity": 3,
+      "line_coverage": 87.5,
+      "crap": 3.017578125
+    },
+    {
+      "package": "gateway",
+      "function": "(*Options).defaults",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/gateway/gateway.go",
+      "line": 109,
+      "complexity": 12,
+      "line_coverage": 100,
+      "crap": 12
+    },
+    {
+      "package": "gateway",
+      "function": "defaultExecCmd",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/gateway/gateway.go",
+      "line": 146,
+      "complexity": 1,
+      "line_coverage": 0,
+      "crap": 2
+    },
+    {
+      "package": "gateway",
+      "function": "defaultExecStart",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/gateway/gateway.go",
+      "line": 151,
+      "complexity": 1,
+      "line_coverage": 0,
+      "crap": 2
+    },
+    {
+      "package": "gateway",
+      "function": "defaultHTTPGet",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/gateway/gateway.go",
+      "line": 156,
+      "complexity": 2,
+      "line_coverage": 0,
+      "crap": 6
+    },
+    {
+      "package": "gateway",
+      "function": "pidPath",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/gateway/gateway.go",
+      "line": 167,
+      "complexity": 1,
+      "line_coverage": 100,
+      "crap": 1
+    },
+    {
+      "package": "gateway",
+      "function": "newMux",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/gateway/gateway.go",
+      "line": 175,
+      "complexity": 7,
+      "line_coverage": 93.47826086956522,
+      "crap": 7.013592093367305
+    },
+    {
+      "package": "gateway",
+      "function": "writeJSONError",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/gateway/gateway.go",
+      "line": 399,
+      "complexity": 1,
+      "line_coverage": 100,
+      "crap": 1
+    },
+    {
+      "package": "gateway",
+      "function": "Start",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/gateway/gateway.go",
+      "line": 414,
+      "complexity": 15,
+      "line_coverage": 92,
+      "crap": 15.1152,
+      "contract_coverage": 0,
+      "gaze_crap": 240,
+      "quadrant": "Q4_Dangerous",
+      "fix_strategy": "decompose",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        69,
+        69
       ]
     },
     {
       "package": "gateway",
+      "function": "detach",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/gateway/gateway.go",
+      "line": 539,
+      "complexity": 12,
+      "line_coverage": 92.5,
+      "crap": 12.06075
+    },
+    {
+      "package": "gateway",
+      "function": "Stop",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/gateway/gateway.go",
+      "line": 620,
+      "complexity": 5,
+      "line_coverage": 95.23809523809524,
+      "crap": 5.0026994924954105,
+      "contract_coverage": 0,
+      "gaze_crap": 30,
+      "quadrant": "Q3_SimpleButUnderspecified",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        69,
+        69
+      ]
+    },
+    {
+      "package": "gateway",
+      "function": "Status",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/gateway/gateway.go",
+      "line": 662,
+      "complexity": 3,
+      "line_coverage": 100,
+      "crap": 3,
+      "contract_coverage": 0,
+      "gaze_crap": 12,
+      "quadrant": "Q1_Safe",
+      "contract_coverage_reason": "no_effects_detected"
+    },
+    {
+      "package": "gateway",
       "function": "printGatewayStatus",
-      "file": "internal/gateway/gateway.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/gateway/gateway.go",
       "line": 692,
       "complexity": 2,
       "line_coverage": 100,
@@ -1980,7 +2192,7 @@
     {
       "package": "gateway",
       "function": "formatUptime",
-      "file": "internal/gateway/gateway.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/gateway/gateway.go",
       "line": 707,
       "complexity": 3,
       "line_coverage": 100,
@@ -1989,7 +2201,7 @@
     {
       "package": "gateway",
       "function": "isAddrInUse",
-      "file": "internal/gateway/gateway.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/gateway/gateway.go",
       "line": 721,
       "complexity": 4,
       "line_coverage": 100,
@@ -1998,19 +2210,24 @@
     {
       "package": "gateway",
       "function": "WritePID",
-      "file": "internal/gateway/pid.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/gateway/pid.go",
       "line": 45,
       "complexity": 4,
       "line_coverage": 72.72727272727273,
       "crap": 4.324567993989482,
-      "contract_coverage": 100,
-      "gaze_crap": 4,
-      "quadrant": "Q1_Safe"
+      "contract_coverage": 0,
+      "gaze_crap": 20,
+      "quadrant": "Q3_SimpleButUnderspecified",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        58,
+        68
+      ]
     },
     {
       "package": "gateway",
       "function": "ReadPID",
-      "file": "internal/gateway/pid.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/gateway/pid.go",
       "line": 69,
       "complexity": 10,
       "line_coverage": 94.73684210526316,
@@ -2022,19 +2239,24 @@
     {
       "package": "gateway",
       "function": "IsAlive",
-      "file": "internal/gateway/pid.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/gateway/pid.go",
       "line": 111,
       "complexity": 2,
       "line_coverage": 100,
       "crap": 2,
-      "contract_coverage": 100,
-      "gaze_crap": 2,
-      "quadrant": "Q1_Safe"
+      "contract_coverage": 0,
+      "gaze_crap": 6,
+      "quadrant": "Q1_Safe",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        58,
+        58
+      ]
     },
     {
       "package": "gateway",
       "function": "RemovePID",
-      "file": "internal/gateway/pid.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/gateway/pid.go",
       "line": 125,
       "complexity": 3,
       "line_coverage": 75,
@@ -2046,43 +2268,58 @@
     {
       "package": "gateway",
       "function": "CleanupStale",
-      "file": "internal/gateway/pid.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/gateway/pid.go",
       "line": 136,
       "complexity": 4,
       "line_coverage": 87.5,
       "crap": 4.03125,
-      "contract_coverage": 100,
-      "gaze_crap": 4,
-      "quadrant": "Q1_Safe"
+      "contract_coverage": 0,
+      "gaze_crap": 20,
+      "quadrant": "Q3_SimpleButUnderspecified",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        73,
+        73
+      ]
     },
     {
       "package": "gateway",
       "function": "DetectProvider",
-      "file": "internal/gateway/provider.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/gateway/provider.go",
       "line": 78,
       "complexity": 5,
       "line_coverage": 100,
       "crap": 5,
-      "contract_coverage": 100,
-      "gaze_crap": 5,
-      "quadrant": "Q1_Safe"
+      "contract_coverage": 0,
+      "gaze_crap": 30,
+      "quadrant": "Q3_SimpleButUnderspecified",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        64,
+        64
+      ]
     },
     {
       "package": "gateway",
       "function": "NewProviderByName",
-      "file": "internal/gateway/provider.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/gateway/provider.go",
       "line": 109,
       "complexity": 4,
       "line_coverage": 100,
       "crap": 4,
-      "contract_coverage": 100,
-      "gaze_crap": 4,
-      "quadrant": "Q1_Safe"
+      "contract_coverage": 0,
+      "gaze_crap": 20,
+      "quadrant": "Q3_SimpleButUnderspecified",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        79,
+        79
+      ]
     },
     {
       "package": "gateway",
       "function": "newAnthropicProvider",
-      "file": "internal/gateway/provider.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/gateway/provider.go",
       "line": 137,
       "complexity": 1,
       "line_coverage": 100,
@@ -2091,7 +2328,7 @@
     {
       "package": "gateway",
       "function": "(*AnthropicProvider).Name",
-      "file": "internal/gateway/provider.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/gateway/provider.go",
       "line": 142,
       "complexity": 1,
       "line_coverage": 100,
@@ -2100,31 +2337,41 @@
     {
       "package": "gateway",
       "function": "(*AnthropicProvider).Start",
-      "file": "internal/gateway/provider.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/gateway/provider.go",
       "line": 146,
       "complexity": 2,
       "line_coverage": 100,
       "crap": 2,
-      "contract_coverage": 50,
-      "gaze_crap": 2.5,
-      "quadrant": "Q1_Safe"
+      "contract_coverage": 0,
+      "gaze_crap": 6,
+      "quadrant": "Q1_Safe",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        64,
+        64
+      ]
     },
     {
       "package": "gateway",
       "function": "(*AnthropicProvider).PrepareRequest",
-      "file": "internal/gateway/provider.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/gateway/provider.go",
       "line": 156,
       "complexity": 1,
       "line_coverage": 100,
       "crap": 1,
-      "contract_coverage": 50,
-      "gaze_crap": 1.125,
-      "quadrant": "Q1_Safe"
+      "contract_coverage": 0,
+      "gaze_crap": 2,
+      "quadrant": "Q1_Safe",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        64,
+        79
+      ]
     },
     {
       "package": "gateway",
       "function": "(*AnthropicProvider).Stop",
-      "file": "internal/gateway/provider.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/gateway/provider.go",
       "line": 167,
       "complexity": 1,
       "line_coverage": 0,
@@ -2137,7 +2384,7 @@
     {
       "package": "gateway",
       "function": "newVertexProvider",
-      "file": "internal/gateway/provider.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/gateway/provider.go",
       "line": 185,
       "complexity": 5,
       "line_coverage": 100,
@@ -2146,7 +2393,7 @@
     {
       "package": "gateway",
       "function": "(*VertexProvider).Name",
-      "file": "internal/gateway/provider.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/gateway/provider.go",
       "line": 225,
       "complexity": 1,
       "line_coverage": 100,
@@ -2155,31 +2402,41 @@
     {
       "package": "gateway",
       "function": "(*VertexProvider).Start",
-      "file": "internal/gateway/provider.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/gateway/provider.go",
       "line": 229,
       "complexity": 3,
       "line_coverage": 76,
       "crap": 3.124416,
-      "contract_coverage": 100,
-      "gaze_crap": 3,
-      "quadrant": "Q1_Safe"
+      "contract_coverage": 0,
+      "gaze_crap": 12,
+      "quadrant": "Q1_Safe",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        64,
+        64
+      ]
     },
     {
       "package": "gateway",
       "function": "(*VertexProvider).PrepareRequest",
-      "file": "internal/gateway/provider.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/gateway/provider.go",
       "line": 279,
       "complexity": 4,
       "line_coverage": 100,
       "crap": 4,
-      "contract_coverage": 50,
-      "gaze_crap": 6,
-      "quadrant": "Q1_Safe"
+      "contract_coverage": 0,
+      "gaze_crap": 20,
+      "quadrant": "Q3_SimpleButUnderspecified",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        64,
+        79
+      ]
     },
     {
       "package": "gateway",
       "function": "(*VertexProvider).validToken",
-      "file": "internal/gateway/provider.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/gateway/provider.go",
       "line": 326,
       "complexity": 6,
       "line_coverage": 100,
@@ -2188,7 +2445,7 @@
     {
       "package": "gateway",
       "function": "(*VertexProvider).Stop",
-      "file": "internal/gateway/provider.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/gateway/provider.go",
       "line": 357,
       "complexity": 2,
       "line_coverage": 100,
@@ -2201,7 +2458,7 @@
     {
       "package": "gateway",
       "function": "(*VertexProvider).tryProactiveRefresh",
-      "file": "internal/gateway/provider.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/gateway/provider.go",
       "line": 377,
       "complexity": 5,
       "line_coverage": 88.88888888888889,
@@ -2210,7 +2467,7 @@
     {
       "package": "gateway",
       "function": "newBedrockProvider",
-      "file": "internal/gateway/provider.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/gateway/provider.go",
       "line": 427,
       "complexity": 3,
       "line_coverage": 100,
@@ -2219,7 +2476,7 @@
     {
       "package": "gateway",
       "function": "(*BedrockProvider).Name",
-      "file": "internal/gateway/provider.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/gateway/provider.go",
       "line": 446,
       "complexity": 1,
       "line_coverage": 100,
@@ -2228,31 +2485,41 @@
     {
       "package": "gateway",
       "function": "(*BedrockProvider).Start",
-      "file": "internal/gateway/provider.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/gateway/provider.go",
       "line": 450,
       "complexity": 3,
       "line_coverage": 74.19354838709677,
       "crap": 3.1546775871907626,
-      "contract_coverage": 100,
-      "gaze_crap": 3,
-      "quadrant": "Q1_Safe"
+      "contract_coverage": 0,
+      "gaze_crap": 12,
+      "quadrant": "Q1_Safe",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        64,
+        64
+      ]
     },
     {
       "package": "gateway",
       "function": "(*BedrockProvider).PrepareRequest",
-      "file": "internal/gateway/provider.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/gateway/provider.go",
       "line": 497,
       "complexity": 3,
       "line_coverage": 90.9090909090909,
       "crap": 3.006761833208114,
-      "contract_coverage": 50,
-      "gaze_crap": 4.125,
-      "quadrant": "Q1_Safe"
+      "contract_coverage": 0,
+      "gaze_crap": 12,
+      "quadrant": "Q1_Safe",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        64,
+        79
+      ]
     },
     {
       "package": "gateway",
       "function": "(*BedrockProvider).validCredentials",
-      "file": "internal/gateway/provider.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/gateway/provider.go",
       "line": 527,
       "complexity": 7,
       "line_coverage": 100,
@@ -2261,7 +2528,7 @@
     {
       "package": "gateway",
       "function": "(*BedrockProvider).Stop",
-      "file": "internal/gateway/provider.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/gateway/provider.go",
       "line": 560,
       "complexity": 2,
       "line_coverage": 100,
@@ -2274,7 +2541,7 @@
     {
       "package": "gateway",
       "function": "(*BedrockProvider).tryProactiveRefreshBedrock",
-      "file": "internal/gateway/provider.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/gateway/provider.go",
       "line": 576,
       "complexity": 5,
       "line_coverage": 85,
@@ -2283,7 +2550,7 @@
     {
       "package": "gateway",
       "function": "transformVertexBody",
-      "file": "internal/gateway/provider.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/gateway/provider.go",
       "line": 621,
       "complexity": 10,
       "line_coverage": 82.14285714285714,
@@ -2292,7 +2559,7 @@
     {
       "package": "gateway",
       "function": "extractModelFromBody",
-      "file": "internal/gateway/provider.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/gateway/provider.go",
       "line": 680,
       "complexity": 6,
       "line_coverage": 85.71428571428571,
@@ -2301,7 +2568,7 @@
     {
       "package": "gateway",
       "function": "refreshLoop",
-      "file": "internal/gateway/refresh.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/gateway/refresh.go",
       "line": 32,
       "complexity": 5,
       "line_coverage": 85.71428571428571,
@@ -2310,7 +2577,7 @@
     {
       "package": "gateway",
       "function": "refreshVertexToken",
-      "file": "internal/gateway/refresh.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/gateway/refresh.go",
       "line": 51,
       "complexity": 3,
       "line_coverage": 100,
@@ -2319,7 +2586,7 @@
     {
       "package": "gateway",
       "function": "refreshBedrockCredentials",
-      "file": "internal/gateway/refresh.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/gateway/refresh.go",
       "line": 75,
       "complexity": 5,
       "line_coverage": 91.66666666666667,
@@ -2328,7 +2595,7 @@
     {
       "package": "gateway",
       "function": "parseEnvExport",
-      "file": "internal/gateway/refresh.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/gateway/refresh.go",
       "line": 111,
       "complexity": 3,
       "line_coverage": 100,
@@ -2337,7 +2604,7 @@
     {
       "package": "gateway",
       "function": "parseAWSCredentialsJSON",
-      "file": "internal/gateway/refresh.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/gateway/refresh.go",
       "line": 128,
       "complexity": 4,
       "line_coverage": 100,
@@ -2346,7 +2613,7 @@
     {
       "package": "gateway",
       "function": "signV4",
-      "file": "internal/gateway/refresh.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/gateway/refresh.go",
       "line": 153,
       "complexity": 5,
       "line_coverage": 92,
@@ -2355,7 +2622,7 @@
     {
       "package": "gateway",
       "function": "buildCanonicalHeaders",
-      "file": "internal/gateway/refresh.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/gateway/refresh.go",
       "line": 225,
       "complexity": 8,
       "line_coverage": 96.15384615384616,
@@ -2364,7 +2631,7 @@
     {
       "package": "gateway",
       "function": "hashPayload",
-      "file": "internal/gateway/refresh.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/gateway/refresh.go",
       "line": 284,
       "complexity": 3,
       "line_coverage": 71.42857142857143,
@@ -2373,7 +2640,7 @@
     {
       "package": "gateway",
       "function": "deriveSigningKey",
-      "file": "internal/gateway/refresh.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/gateway/refresh.go",
       "line": 298,
       "complexity": 1,
       "line_coverage": 100,
@@ -2382,7 +2649,7 @@
     {
       "package": "gateway",
       "function": "sha256Hex",
-      "file": "internal/gateway/refresh.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/gateway/refresh.go",
       "line": 307,
       "complexity": 1,
       "line_coverage": 100,
@@ -2391,7 +2658,7 @@
     {
       "package": "gateway",
       "function": "hmacSHA256",
-      "file": "internal/gateway/refresh.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/gateway/refresh.go",
       "line": 313,
       "complexity": 1,
       "line_coverage": 100,
@@ -2400,7 +2667,7 @@
     {
       "package": "gateway",
       "function": "hmacSHA256Hex",
-      "file": "internal/gateway/refresh.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/gateway/refresh.go",
       "line": 321,
       "complexity": 1,
       "line_coverage": 100,
@@ -2409,7 +2676,7 @@
     {
       "package": "gateway",
       "function": "newSSEFilterReader",
-      "file": "internal/gateway/sse.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/gateway/sse.go",
       "line": 31,
       "complexity": 1,
       "line_coverage": 100,
@@ -2418,7 +2685,7 @@
     {
       "package": "gateway",
       "function": "(*sseFilterReader).Read",
-      "file": "internal/gateway/sse.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/gateway/sse.go",
       "line": 46,
       "complexity": 11,
       "line_coverage": 85.18518518518519,
@@ -2427,19 +2694,24 @@
     {
       "package": "gateway",
       "function": "(*sseFilterReader).Close",
-      "file": "internal/gateway/sse.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/gateway/sse.go",
       "line": 102,
       "complexity": 1,
       "line_coverage": 100,
       "crap": 1,
-      "contract_coverage": 100,
-      "gaze_crap": 1,
-      "quadrant": "Q1_Safe"
+      "contract_coverage": 0,
+      "gaze_crap": 2,
+      "quadrant": "Q1_Safe",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        58,
+        58
+      ]
     },
     {
       "package": "gateway",
       "function": "vertexSSEFilter",
-      "file": "internal/gateway/sse.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/gateway/sse.go",
       "line": 113,
       "complexity": 2,
       "line_coverage": 100,
@@ -2448,2419 +2720,25 @@
     {
       "package": "impediment",
       "function": "Detect",
-      "file": "internal/impediment/detect.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/impediment/detect.go",
       "line": 11,
       "complexity": 18,
       "line_coverage": 90.47619047619048,
       "crap": 18.279883381924197,
-      "contract_coverage": 100,
-      "gaze_crap": 18,
+      "contract_coverage": 0,
+      "gaze_crap": 342,
       "quadrant": "Q4_Dangerous",
-      "fix_strategy": "decompose"
+      "fix_strategy": "decompose",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        69,
+        69
+      ]
     },
     {
       "package": "impediment",
       "function": "NewRepository",
-      "file": "internal/impediment/impediment.go",
-      "line": 22,
-      "complexity": 1,
-      "line_coverage": 100,
-      "crap": 1,
-      "contract_coverage": 0,
-      "gaze_crap": 2,
-      "quadrant": "Q1_Safe"
-    },
-    {
-      "package": "impediment",
-      "function": "(*Repository).ensureDir",
-      "file": "internal/impediment/impediment.go",
-      "line": 26,
-      "complexity": 1,
-      "line_coverage": 100,
-      "crap": 1
-    },
-    {
-      "package": "impediment",
-      "function": "(*Repository).Add",
-      "file": "internal/impediment/impediment.go",
-      "line": 31,
-      "complexity": 5,
-      "line_coverage": 72.72727272727273,
-      "crap": 5.507137490608565,
-      "contract_coverage": 100,
-      "gaze_crap": 5,
-      "quadrant": "Q1_Safe"
-    },
-    {
-      "package": "impediment",
-      "function": "(*Repository).List",
-      "file": "internal/impediment/impediment.go",
-      "line": 63,
-      "complexity": 10,
-      "line_coverage": 72.72727272727273,
-      "crap": 12.02854996243426,
-      "contract_coverage": 100,
-      "gaze_crap": 10,
-      "quadrant": "Q1_Safe"
-    },
-    {
-      "package": "impediment",
-      "function": "(*Repository).Resolve",
-      "file": "internal/impediment/impediment.go",
-      "line": 102,
-      "complexity": 2,
-      "line_coverage": 85.71428571428571,
-      "crap": 2.011661807580175,
-      "contract_coverage": 100,
-      "gaze_crap": 2,
-      "quadrant": "Q1_Safe"
-    },
-    {
-      "package": "impediment",
-      "function": "(*Repository).Get",
-      "file": "internal/impediment/impediment.go",
-      "line": 116,
-      "complexity": 1,
-      "line_coverage": 100,
-      "crap": 1,
-      "contract_coverage": 100,
-      "gaze_crap": 1,
-      "quadrant": "Q1_Safe"
-    },
-    {
-      "package": "impediment",
-      "function": "(*Repository).save",
-      "file": "internal/impediment/impediment.go",
-      "line": 121,
-      "complexity": 2,
-      "line_coverage": 83.33333333333333,
-      "crap": 2.0185185185185186
-    },
-    {
-      "package": "impediment",
-      "function": "(*Repository).load",
-      "file": "internal/impediment/impediment.go",
-      "line": 132,
-      "complexity": 4,
-      "line_coverage": 75,
-      "crap": 4.25
-    },
-    {
-      "package": "impediment",
-      "function": "(*Repository).nextID",
-      "file": "internal/impediment/impediment.go",
-      "line": 155,
-      "complexity": 7,
-      "line_coverage": 78.57142857142857,
-      "crap": 7.482142857142857
-    },
-    {
-      "package": "impediment",
-      "function": "(*Impediment).AgeDays",
-      "file": "internal/impediment/models.go",
-      "line": 20,
-      "complexity": 2,
-      "line_coverage": 75,
-      "crap": 2.0625,
-      "contract_coverage": 0,
-      "gaze_crap": 6,
-      "quadrant": "Q1_Safe"
-    },
-    {
-      "package": "impediment",
-      "function": "(*Impediment).IsStale",
-      "file": "internal/impediment/models.go",
-      "line": 29,
-      "complexity": 2,
-      "line_coverage": 100,
-      "crap": 2,
-      "contract_coverage": 0,
-      "gaze_crap": 6,
-      "quadrant": "Q1_Safe"
-    },
-    {
-      "package": "metrics",
-      "function": "CollectDivisor",
-      "file": "internal/metrics/collect_divisor.go",
-      "line": 11,
-      "complexity": 6,
-      "line_coverage": 84.21052631578948,
-      "crap": 6.141711619769645,
-      "contract_coverage": 50,
-      "gaze_crap": 10.5,
-      "quadrant": "Q1_Safe"
-    },
-    {
-      "package": "metrics",
-      "function": "CollectGaze",
-      "file": "internal/metrics/collect_gaze.go",
-      "line": 11,
-      "complexity": 6,
-      "line_coverage": 84.21052631578948,
-      "crap": 6.141711619769645,
-      "contract_coverage": 50,
-      "gaze_crap": 10.5,
-      "quadrant": "Q1_Safe"
-    },
-    {
-      "package": "metrics",
-      "function": "CollectGitHub",
-      "file": "internal/metrics/collect_github.go",
-      "line": 15,
-      "complexity": 26,
-      "line_coverage": 96.72131147540983,
-      "crap": 26.023825782774768,
-      "contract_coverage": 100,
-      "gaze_crap": 26,
-      "quadrant": "Q4_Dangerous",
-      "fix_strategy": "decompose"
-    },
-    {
-      "package": "metrics",
-      "function": "CollectMutiMind",
-      "file": "internal/metrics/collect_mutimind.go",
-      "line": 11,
-      "complexity": 15,
-      "line_coverage": 87.17948717948718,
-      "crap": 15.474131391291154,
-      "contract_coverage": 100,
-      "gaze_crap": 15,
-      "quadrant": "Q4_Dangerous",
-      "fix_strategy": "decompose"
-    },
-    {
-      "package": "metrics",
-      "function": "ParsePeriod",
-      "file": "internal/metrics/collector.go",
-      "line": 24,
-      "complexity": 7,
-      "line_coverage": 100,
-      "crap": 7,
-      "contract_coverage": 100,
-      "gaze_crap": 7,
-      "quadrant": "Q1_Safe"
-    },
-    {
-      "package": "metrics",
-      "function": "(*Collector).Collect",
-      "file": "internal/metrics/collector.go",
-      "line": 53,
-      "complexity": 14,
-      "line_coverage": 92.10526315789474,
-      "crap": 14.09644263012101,
-      "contract_coverage": 100,
-      "gaze_crap": 14,
-      "quadrant": "Q1_Safe"
-    },
-    {
-      "package": "metrics",
-      "function": "formatPeriod",
-      "file": "internal/metrics/collector.go",
-      "line": 118,
-      "complexity": 2,
-      "line_coverage": 75,
-      "crap": 2.0625
-    },
-    {
-      "package": "metrics",
-      "function": "ComputeVelocity",
-      "file": "internal/metrics/compute.go",
-      "line": 10,
-      "complexity": 2,
-      "line_coverage": 100,
-      "crap": 2,
-      "contract_coverage": 100,
-      "gaze_crap": 2,
-      "quadrant": "Q1_Safe"
-    },
-    {
-      "package": "metrics",
-      "function": "ComputeCycleTimeFromValues",
-      "file": "internal/metrics/compute.go",
-      "line": 22,
-      "complexity": 3,
-      "line_coverage": 100,
-      "crap": 3,
-      "contract_coverage": 100,
-      "gaze_crap": 3,
-      "quadrant": "Q1_Safe"
-    },
-    {
-      "package": "metrics",
-      "function": "percentile",
-      "file": "internal/metrics/compute.go",
-      "line": 44,
-      "complexity": 5,
-      "line_coverage": 100,
-      "crap": 5
-    },
-    {
-      "package": "metrics",
-      "function": "ComputeFlowEfficiency",
-      "file": "internal/metrics/compute.go",
-      "line": 62,
-      "complexity": 2,
-      "line_coverage": 100,
-      "crap": 2,
-      "contract_coverage": 100,
-      "gaze_crap": 2,
-      "quadrant": "Q1_Safe"
-    },
-    {
-      "package": "metrics",
-      "function": "DetermineTrend",
-      "file": "internal/metrics/compute.go",
-      "line": 70,
-      "complexity": 6,
-      "line_coverage": 100,
-      "crap": 6,
-      "contract_coverage": 100,
-      "gaze_crap": 6,
-      "quadrant": "Q1_Safe"
-    },
-    {
-      "package": "metrics",
-      "function": "defaultThresholds",
-      "file": "internal/metrics/health.go",
-      "line": 4,
-      "complexity": 1,
-      "line_coverage": 100,
-      "crap": 1
-    },
-    {
-      "package": "metrics",
-      "function": "ComputeHealth",
-      "file": "internal/metrics/health.go",
-      "line": 15,
-      "complexity": 2,
-      "line_coverage": 100,
-      "crap": 2,
-      "contract_coverage": 100,
-      "gaze_crap": 2,
-      "quadrant": "Q1_Safe"
-    },
-    {
-      "package": "metrics",
-      "function": "computeIndicator",
-      "file": "internal/metrics/health.go",
-      "line": 60,
-      "complexity": 4,
-      "line_coverage": 100,
-      "crap": 4
-    },
-    {
-      "package": "metrics",
-      "function": "computeStatus",
-      "file": "internal/metrics/health.go",
-      "line": 86,
-      "complexity": 6,
-      "line_coverage": 100,
-      "crap": 6
-    },
-    {
-      "package": "metrics",
-      "function": "extractValues",
-      "file": "internal/metrics/health.go",
-      "line": 107,
-      "complexity": 2,
-      "line_coverage": 100,
-      "crap": 2
-    },
-    {
-      "package": "metrics",
-      "function": "NewQuery",
-      "file": "internal/metrics/query.go",
-      "line": 18,
-      "complexity": 1,
-      "line_coverage": 100,
-      "crap": 1,
-      "contract_coverage": 0,
-      "gaze_crap": 2,
-      "quadrant": "Q1_Safe"
-    },
-    {
-      "package": "metrics",
-      "function": "(*Query).now",
-      "file": "internal/metrics/query.go",
-      "line": 22,
-      "complexity": 2,
-      "line_coverage": 66.66666666666667,
-      "crap": 2.148148148148148
-    },
-    {
-      "package": "metrics",
-      "function": "(*Query).Summary",
-      "file": "internal/metrics/query.go",
-      "line": 30,
-      "complexity": 3,
-      "line_coverage": 88.88888888888889,
-      "crap": 3.0123456790123457,
-      "contract_coverage": 100,
-      "gaze_crap": 3,
-      "quadrant": "Q1_Safe"
-    },
-    {
-      "package": "metrics",
-      "function": "(*Query).Velocity",
-      "file": "internal/metrics/query.go",
-      "line": 55,
-      "complexity": 5,
-      "line_coverage": 77.77777777777777,
-      "crap": 5.274348422496571,
-      "contract_coverage": 0,
-      "gaze_crap": 30,
-      "quadrant": "Q3_SimpleButUnderspecified",
-      "contract_coverage_reason": "all_effects_ambiguous",
-      "effect_confidence_range": [
-        65,
-        65
-      ]
-    },
-    {
-      "package": "metrics",
-      "function": "(*Query).CycleTime",
-      "file": "internal/metrics/query.go",
-      "line": 73,
-      "complexity": 5,
-      "line_coverage": 83.33333333333333,
-      "crap": 5.1157407407407405,
-      "contract_coverage": 100,
-      "gaze_crap": 5,
-      "quadrant": "Q1_Safe"
-    },
-    {
-      "package": "metrics",
-      "function": "(*Query).Bottlenecks",
-      "file": "internal/metrics/query.go",
-      "line": 96,
-      "complexity": 3,
-      "line_coverage": 80,
-      "crap": 3.072,
-      "contract_coverage": 100,
-      "gaze_crap": 3,
-      "quadrant": "Q1_Safe"
-    },
-    {
-      "package": "metrics",
-      "function": "(*Query).Health",
-      "file": "internal/metrics/query.go",
-      "line": 125,
-      "complexity": 3,
-      "line_coverage": 71.42857142857143,
-      "crap": 3.2099125364431487,
-      "contract_coverage": 100,
-      "gaze_crap": 3,
-      "quadrant": "Q1_Safe"
-    },
-    {
-      "package": "metrics",
-      "function": "NewStore",
-      "file": "internal/metrics/store.go",
-      "line": 19,
-      "complexity": 1,
-      "line_coverage": 100,
-      "crap": 1,
-      "contract_coverage": 0,
-      "gaze_crap": 2,
-      "quadrant": "Q1_Safe"
-    },
-    {
-      "package": "metrics",
-      "function": "(*Store).WriteCollection",
-      "file": "internal/metrics/store.go",
-      "line": 24,
-      "complexity": 3,
-      "line_coverage": 81.81818181818181,
-      "crap": 3.0540946656649135,
-      "contract_coverage": 100,
-      "gaze_crap": 3,
-      "quadrant": "Q1_Safe"
-    },
-    {
-      "package": "metrics",
-      "function": "(*Store).ReadCollections",
-      "file": "internal/metrics/store.go",
-      "line": 45,
-      "complexity": 10,
-      "line_coverage": 77.27272727272727,
-      "crap": 11.173929376408715,
-      "contract_coverage": 100,
-      "gaze_crap": 10,
-      "quadrant": "Q1_Safe"
-    },
-    {
-      "package": "metrics",
-      "function": "(*Store).WriteSnapshot",
-      "file": "internal/metrics/store.go",
-      "line": 82,
-      "complexity": 3,
-      "line_coverage": 81.81818181818181,
-      "crap": 3.0540946656649135,
-      "contract_coverage": 100,
-      "gaze_crap": 3,
-      "quadrant": "Q1_Safe"
-    },
-    {
-      "package": "metrics",
-      "function": "(*Store).ReadSnapshots",
-      "file": "internal/metrics/store.go",
-      "line": 101,
-      "complexity": 10,
-      "line_coverage": 77.27272727272727,
-      "crap": 11.173929376408715,
-      "contract_coverage": 100,
-      "gaze_crap": 10,
-      "quadrant": "Q1_Safe"
-    },
-    {
-      "package": "orchestration",
-      "function": "LoadWorkflowConfig",
-      "file": "internal/orchestration/config.go",
-      "line": 33,
-      "complexity": 4,
-      "line_coverage": 90,
-      "crap": 4.016,
-      "contract_coverage": 100,
-      "gaze_crap": 4,
-      "quadrant": "Q1_Safe"
-    },
-    {
-      "package": "orchestration",
-      "function": "(*Orchestrator).store",
-      "file": "internal/orchestration/engine.go",
-      "line": 45,
-      "complexity": 1,
-      "line_coverage": 100,
-      "crap": 1
-    },
-    {
-      "package": "orchestration",
-      "function": "(*Orchestrator).now",
-      "file": "internal/orchestration/engine.go",
-      "line": 50,
-      "complexity": 2,
-      "line_coverage": 66.66666666666667,
-      "crap": 2.148148148148148
-    },
-    {
-      "package": "orchestration",
-      "function": "(*Orchestrator).lookPath",
-      "file": "internal/orchestration/engine.go",
-      "line": 58,
-      "complexity": 2,
-      "line_coverage": 66.66666666666667,
-      "crap": 2.148148148148148
-    },
-    {
-      "package": "orchestration",
-      "function": "(*Orchestrator).NewWorkflow",
-      "file": "internal/orchestration/engine.go",
-      "line": 72,
-      "complexity": 11,
-      "line_coverage": 100,
-      "crap": 11,
-      "contract_coverage": 33.333333333333336,
-      "gaze_crap": 46.85185185185185,
-      "quadrant": "Q3_SimpleButUnderspecified"
-    },
-    {
-      "package": "orchestration",
-      "function": "(*Orchestrator).Start",
-      "file": "internal/orchestration/engine.go",
-      "line": 151,
-      "complexity": 14,
-      "line_coverage": 96.875,
-      "crap": 14.0059814453125,
-      "contract_coverage": 66.66666666666667,
-      "gaze_crap": 21.259259259259256,
-      "quadrant": "Q3_SimpleButUnderspecified"
-    },
-    {
-      "package": "orchestration",
-      "function": "(*Orchestrator).Advance",
-      "file": "internal/orchestration/engine.go",
-      "line": 218,
-      "complexity": 32,
-      "line_coverage": 86.44067796610169,
-      "crap": 34.552782903802246,
-      "contract_coverage": 100,
-      "gaze_crap": 32,
-      "quadrant": "Q4_Dangerous",
-      "fix_strategy": "decompose"
-    },
-    {
-      "package": "orchestration",
-      "function": "(*Orchestrator).Skip",
-      "file": "internal/orchestration/engine.go",
-      "line": 361,
-      "complexity": 4,
-      "line_coverage": 75,
-      "crap": 4.25,
-      "contract_coverage": 100,
-      "gaze_crap": 4,
-      "quadrant": "Q1_Safe"
-    },
-    {
-      "package": "orchestration",
-      "function": "(*Orchestrator).Escalate",
-      "file": "internal/orchestration/engine.go",
-      "line": 378,
-      "complexity": 4,
-      "line_coverage": 90.9090909090909,
-      "crap": 4.012021036814425,
-      "contract_coverage": 100,
-      "gaze_crap": 4,
-      "quadrant": "Q1_Safe"
-    },
-    {
-      "package": "orchestration",
-      "function": "(*Orchestrator).Complete",
-      "file": "internal/orchestration/engine.go",
-      "line": 400,
-      "complexity": 4,
-      "line_coverage": 76.92307692307692,
-      "crap": 4.196631770596268,
-      "contract_coverage": 100,
-      "gaze_crap": 4,
-      "quadrant": "Q1_Safe"
-    },
-    {
-      "package": "orchestration",
-      "function": "(*Orchestrator).Status",
-      "file": "internal/orchestration/engine.go",
-      "line": 433,
-      "complexity": 1,
-      "line_coverage": 100,
-      "crap": 1,
-      "contract_coverage": 100,
-      "gaze_crap": 1,
-      "quadrant": "Q1_Safe"
-    },
-    {
-      "package": "orchestration",
-      "function": "(*Orchestrator).List",
-      "file": "internal/orchestration/engine.go",
-      "line": 438,
-      "complexity": 1,
-      "line_coverage": 0,
-      "crap": 2
-    },
-    {
-      "package": "orchestration",
-      "function": "(*Orchestrator).doEscalate",
-      "file": "internal/orchestration/engine.go",
-      "line": 445,
-      "complexity": 4,
-      "line_coverage": 90,
-      "crap": 4.016
-    },
-    {
-      "package": "orchestration",
-      "function": "(*Orchestrator).HandleHeroUnavailable",
-      "file": "internal/orchestration/engine.go",
-      "line": 470,
-      "complexity": 1,
-      "line_coverage": 0,
-      "crap": 2
-    },
-    {
-      "package": "orchestration",
-      "function": "(*Orchestrator).HandleMaxIterations",
-      "file": "internal/orchestration/engine.go",
-      "line": 477,
-      "complexity": 1,
-      "line_coverage": 0,
-      "crap": 2
-    },
-    {
-      "package": "orchestration",
-      "function": "(*Orchestrator).HandleAcceptanceRejection",
-      "file": "internal/orchestration/engine.go",
-      "line": 485,
-      "complexity": 4,
-      "line_coverage": 92.85714285714286,
-      "crap": 4.005830903790088,
-      "contract_coverage": 100,
-      "gaze_crap": 4,
-      "quadrant": "Q1_Safe"
-    },
-    {
-      "package": "orchestration",
-      "function": "(*Orchestrator).HandleContradiction",
-      "file": "internal/orchestration/engine.go",
-      "line": 512,
-      "complexity": 4,
-      "line_coverage": 90.9090909090909,
-      "crap": 4.012021036814425,
-      "contract_coverage": 100,
-      "gaze_crap": 4,
-      "quadrant": "Q1_Safe"
-    },
-    {
-      "package": "orchestration",
-      "function": "effectiveMode",
-      "file": "internal/orchestration/engine.go",
-      "line": 535,
-      "complexity": 2,
-      "line_coverage": 100,
-      "crap": 2
-    },
-    {
-      "package": "orchestration",
-      "function": "sanitizeBranch",
-      "file": "internal/orchestration/engine.go",
-      "line": 545,
-      "complexity": 9,
-      "line_coverage": 100,
-      "crap": 9
-    },
-    {
-      "package": "orchestration",
-      "function": "DetectHeroes",
-      "file": "internal/orchestration/heroes.go",
-      "line": 32,
-      "complexity": 10,
-      "line_coverage": 100,
-      "crap": 10,
-      "contract_coverage": 66.66666666666667,
-      "gaze_crap": 13.703703703703702,
-      "quadrant": "Q1_Safe"
-    },
-    {
-      "package": "orchestration",
-      "function": "StageHeroMap",
-      "file": "internal/orchestration/heroes.go",
-      "line": 82,
-      "complexity": 1,
-      "line_coverage": 100,
-      "crap": 1,
-      "contract_coverage": 100,
-      "gaze_crap": 1,
-      "quadrant": "Q1_Safe"
-    },
-    {
-      "package": "orchestration",
-      "function": "StageExecutionModeMap",
-      "file": "internal/orchestration/heroes.go",
-      "line": 97,
-      "complexity": 1,
-      "line_coverage": 100,
-      "crap": 1,
-      "contract_coverage": 100,
-      "gaze_crap": 1,
-      "quadrant": "Q1_Safe"
-    },
-    {
-      "package": "orchestration",
-      "function": "hasDivisorAgent",
-      "file": "internal/orchestration/heroes.go",
-      "line": 109,
-      "complexity": 6,
-      "line_coverage": 85.71428571428571,
-      "crap": 6.104956268221574
-    },
-    {
-      "package": "orchestration",
-      "function": "fileExists",
-      "file": "internal/orchestration/heroes.go",
-      "line": 123,
-      "complexity": 2,
-      "line_coverage": 100,
-      "crap": 2
-    },
-    {
-      "package": "orchestration",
-      "function": "AnalyzeWorkflows",
-      "file": "internal/orchestration/learning.go",
-      "line": 25,
-      "complexity": 2,
-      "line_coverage": 100,
-      "crap": 2,
-      "contract_coverage": 100,
-      "gaze_crap": 2,
-      "quadrant": "Q1_Safe"
-    },
-    {
-      "package": "orchestration",
-      "function": "analyzeReviewPatterns",
-      "file": "internal/orchestration/learning.go",
-      "line": 47,
-      "complexity": 7,
-      "line_coverage": 100,
-      "crap": 7
-    },
-    {
-      "package": "orchestration",
-      "function": "analyzeVelocityPatterns",
-      "file": "internal/orchestration/learning.go",
-      "line": 84,
-      "complexity": 6,
-      "line_coverage": 73.33333333333333,
-      "crap": 6.682666666666667
-    },
-    {
-      "package": "orchestration",
-      "function": "countReviewIterations",
-      "file": "internal/orchestration/learning.go",
-      "line": 126,
-      "complexity": 3,
-      "line_coverage": 100,
-      "crap": 3
-    },
-    {
-      "package": "orchestration",
-      "function": "normalizeError",
-      "file": "internal/orchestration/learning.go",
-      "line": 137,
-      "complexity": 4,
-      "line_coverage": 66.66666666666667,
-      "crap": 4.592592592592593
-    },
-    {
-      "package": "orchestration",
-      "function": "NextFeedbackID",
-      "file": "internal/orchestration/learning.go",
-      "line": 151,
-      "complexity": 4,
-      "line_coverage": 100,
-      "crap": 4,
-      "contract_coverage": 100,
-      "gaze_crap": 4,
-      "quadrant": "Q1_Safe"
-    },
-    {
-      "package": "orchestration",
-      "function": "SaveFeedback",
-      "file": "internal/orchestration/learning.go",
-      "line": 166,
-      "complexity": 5,
-      "line_coverage": 72.72727272727273,
-      "crap": 5.507137490608565,
-      "contract_coverage": 100,
-      "gaze_crap": 5,
-      "quadrant": "Q1_Safe"
-    },
-    {
-      "package": "orchestration",
-      "function": "LoadFeedback",
-      "file": "internal/orchestration/learning.go",
-      "line": 188,
-      "complexity": 8,
-      "line_coverage": 80.95238095238095,
-      "crap": 8.442284850448116,
-      "contract_coverage": 100,
-      "gaze_crap": 8,
-      "quadrant": "Q1_Safe"
-    },
-    {
-      "package": "orchestration",
-      "function": "dedup",
-      "file": "internal/orchestration/learning.go",
-      "line": 226,
-      "complexity": 3,
-      "line_coverage": 100,
-      "crap": 3
-    },
-    {
-      "package": "orchestration",
-      "function": "StageOrder",
-      "file": "internal/orchestration/models.go",
-      "line": 22,
-      "complexity": 1,
-      "line_coverage": 100,
-      "crap": 1,
-      "contract_coverage": 100,
-      "gaze_crap": 1,
-      "quadrant": "Q1_Safe"
-    },
-    {
-      "package": "orchestration",
-      "function": "GenerateWorkflowRecord",
-      "file": "internal/orchestration/record.go",
-      "line": 13,
-      "complexity": 2,
-      "line_coverage": 100,
-      "crap": 2,
-      "contract_coverage": 100,
-      "gaze_crap": 2,
-      "quadrant": "Q1_Safe"
-    },
-    {
-      "package": "orchestration",
-      "function": "determineOutcome",
-      "file": "internal/orchestration/record.go",
-      "line": 40,
-      "complexity": 6,
-      "line_coverage": 100,
-      "crap": 6
-    },
-    {
-      "package": "orchestration",
-      "function": "(*WorkflowStore).Save",
-      "file": "internal/orchestration/store.go",
-      "line": 20,
-      "complexity": 4,
-      "line_coverage": 66.66666666666667,
-      "crap": 4.592592592592593,
-      "contract_coverage": 100,
-      "gaze_crap": 4,
-      "quadrant": "Q1_Safe"
-    },
-    {
-      "package": "orchestration",
-      "function": "(*WorkflowStore).Load",
-      "file": "internal/orchestration/store.go",
-      "line": 38,
-      "complexity": 3,
-      "line_coverage": 87.5,
-      "crap": 3.017578125,
-      "contract_coverage": 100,
-      "gaze_crap": 3,
-      "quadrant": "Q1_Safe"
-    },
-    {
-      "package": "orchestration",
-      "function": "(*WorkflowStore).List",
-      "file": "internal/orchestration/store.go",
-      "line": 55,
-      "complexity": 10,
-      "line_coverage": 80.95238095238095,
-      "crap": 10.691070078825181,
-      "contract_coverage": 100,
-      "gaze_crap": 10,
-      "quadrant": "Q1_Safe"
-    },
-    {
-      "package": "orchestration",
-      "function": "(*WorkflowStore).Latest",
-      "file": "internal/orchestration/store.go",
-      "line": 99,
-      "complexity": 6,
-      "line_coverage": 87.5,
-      "crap": 6.0703125,
-      "contract_coverage": 100,
-      "gaze_crap": 6,
-      "quadrant": "Q1_Safe"
-    },
-    {
-      "package": "sandbox",
-      "function": "ResolveBackend",
-      "file": "internal/sandbox/backend.go",
-      "line": 80,
-      "complexity": 11,
-      "line_coverage": 85,
-      "crap": 11.408375,
-      "contract_coverage": 100,
-      "gaze_crap": 11,
-      "quadrant": "Q1_Safe"
-    },
-    {
-      "package": "sandbox",
-      "function": "autoDetectBackend",
-      "file": "internal/sandbox/backend.go",
-      "line": 130,
-      "complexity": 3,
-      "line_coverage": 100,
-      "crap": 3
-    },
-    {
-      "package": "sandbox",
-      "function": "gatewayEnvVars",
-      "file": "internal/sandbox/config.go",
-      "line": 80,
-      "complexity": 1,
-      "line_coverage": 100,
-      "crap": 1
-    },
-    {
-      "package": "sandbox",
-      "function": "DefaultConfig",
-      "file": "internal/sandbox/config.go",
-      "line": 90,
-      "complexity": 8,
-      "line_coverage": 93.33333333333333,
-      "crap": 8.018962962962963,
-      "contract_coverage": 100,
-      "gaze_crap": 8,
-      "quadrant": "Q1_Safe"
-    },
-    {
-      "package": "sandbox",
-      "function": "forwardedEnvVars",
-      "file": "internal/sandbox/config.go",
-      "line": 129,
-      "complexity": 5,
-      "line_coverage": 100,
-      "crap": 5
-    },
-    {
-      "package": "sandbox",
-      "function": "useParentMount",
-      "file": "internal/sandbox/config.go",
-      "line": 150,
-      "complexity": 3,
-      "line_coverage": 100,
-      "crap": 3
-    },
-    {
-      "package": "sandbox",
-      "function": "buildVolumeMounts",
-      "file": "internal/sandbox/config.go",
-      "line": 166,
-      "complexity": 4,
-      "line_coverage": 100,
-      "crap": 4
-    },
-    {
-      "package": "sandbox",
-      "function": "uidMappingArgs",
-      "file": "internal/sandbox/config.go",
-      "line": 189,
-      "complexity": 2,
-      "line_coverage": 100,
-      "crap": 2
-    },
-    {
-      "package": "sandbox",
-      "function": "buildRunArgs",
-      "file": "internal/sandbox/config.go",
-      "line": 211,
-      "complexity": 3,
-      "line_coverage": 100,
-      "crap": 3
-    },
-    {
-      "package": "sandbox",
-      "function": "DetectPlatform",
-      "file": "internal/sandbox/detect.go",
-      "line": 36,
-      "complexity": 7,
-      "line_coverage": 40,
-      "crap": 17.583999999999996,
-      "contract_coverage": 100,
-      "gaze_crap": 7,
-      "quadrant": "Q2_ComplexButTested",
-      "fix_strategy": "add_tests"
-    },
-    {
-      "package": "sandbox",
-      "function": "probeUIDMapping",
-      "file": "internal/sandbox/detect.go",
-      "line": 84,
-      "complexity": 3,
-      "line_coverage": 100,
-      "crap": 3
-    },
-    {
-      "package": "sandbox",
-      "function": "parsePodmanVersion",
-      "file": "internal/sandbox/detect.go",
-      "line": 112,
-      "complexity": 6,
-      "line_coverage": 70.58823529411765,
-      "crap": 6.915937309179727
-    },
-    {
-      "package": "sandbox",
-      "function": "isRootlessPodman",
-      "file": "internal/sandbox/detect.go",
-      "line": 146,
-      "complexity": 2,
-      "line_coverage": 75,
-      "crap": 2.0625
-    },
-    {
-      "package": "sandbox",
-      "function": "validateIDE",
-      "file": "internal/sandbox/devpod.go",
-      "line": 23,
-      "complexity": 3,
-      "line_coverage": 100,
-      "crap": 3
-    },
-    {
-      "package": "sandbox",
-      "function": "(*DevPodBackend).Name",
-      "file": "internal/sandbox/devpod.go",
-      "line": 41,
-      "complexity": 1,
-      "line_coverage": 100,
-      "crap": 1
-    },
-    {
-      "package": "sandbox",
-      "function": "devpodWorkspaceName",
-      "file": "internal/sandbox/devpod.go",
-      "line": 46,
-      "complexity": 1,
-      "line_coverage": 100,
-      "crap": 1
-    },
-    {
-      "package": "sandbox",
-      "function": "(*DevPodBackend).Create",
-      "file": "internal/sandbox/devpod.go",
-      "line": 60,
-      "complexity": 11,
-      "line_coverage": 83.33333333333333,
-      "crap": 11.560185185185185,
-      "contract_coverage": 100,
-      "gaze_crap": 11,
-      "quadrant": "Q1_Safe"
-    },
-    {
-      "package": "sandbox",
-      "function": "(*DevPodBackend).Start",
-      "file": "internal/sandbox/devpod.go",
-      "line": 160,
-      "complexity": 7,
-      "line_coverage": 95,
-      "crap": 7.006125,
-      "contract_coverage": 100,
-      "gaze_crap": 7,
-      "quadrant": "Q1_Safe"
-    },
-    {
-      "package": "sandbox",
-      "function": "(*DevPodBackend).Stop",
-      "file": "internal/sandbox/devpod.go",
-      "line": 216,
-      "complexity": 2,
-      "line_coverage": 85.71428571428571,
-      "crap": 2.011661807580175,
-      "contract_coverage": 100,
-      "gaze_crap": 2,
-      "quadrant": "Q1_Safe"
-    },
-    {
-      "package": "sandbox",
-      "function": "(*DevPodBackend).Destroy",
-      "file": "internal/sandbox/devpod.go",
-      "line": 232,
-      "complexity": 2,
-      "line_coverage": 85.71428571428571,
-      "crap": 2.011661807580175,
-      "contract_coverage": 100,
-      "gaze_crap": 2,
-      "quadrant": "Q1_Safe"
-    },
-    {
-      "package": "sandbox",
-      "function": "(*DevPodBackend).isWorkspaceRunning",
-      "file": "internal/sandbox/devpod.go",
-      "line": 252,
-      "complexity": 3,
-      "line_coverage": 100,
-      "crap": 3
-    },
-    {
-      "package": "sandbox",
-      "function": "(*DevPodBackend).startServerViaSSH",
-      "file": "internal/sandbox/devpod.go",
-      "line": 278,
-      "complexity": 1,
-      "line_coverage": 100,
-      "crap": 1
-    },
-    {
-      "package": "sandbox",
-      "function": "(*DevPodBackend).attachOrDetach",
-      "file": "internal/sandbox/devpod.go",
-      "line": 293,
-      "complexity": 2,
-      "line_coverage": 66.66666666666667,
-      "crap": 2.148148148148148
-    },
-    {
-      "package": "sandbox",
-      "function": "(*DevPodBackend).Status",
-      "file": "internal/sandbox/devpod.go",
-      "line": 315,
-      "complexity": 3,
-      "line_coverage": 80,
-      "crap": 3.072,
-      "contract_coverage": 100,
-      "gaze_crap": 3,
-      "quadrant": "Q1_Safe"
-    },
-    {
-      "package": "sandbox",
-      "function": "(*DevPodBackend).Attach",
-      "file": "internal/sandbox/devpod.go",
-      "line": 350,
-      "complexity": 2,
-      "line_coverage": 80,
-      "crap": 2.032,
-      "contract_coverage": 100,
-      "gaze_crap": 2,
-      "quadrant": "Q1_Safe"
-    },
-    {
-      "package": "sandbox",
-      "function": "parseDevPodVersion",
-      "file": "internal/sandbox/devpod.go",
-      "line": 365,
-      "complexity": 7,
-      "line_coverage": 76.19047619047619,
-      "crap": 7.661375661375661
-    },
-    {
-      "package": "sandbox",
-      "function": "checkDevPodVersion",
-      "file": "internal/sandbox/devpod.go",
-      "line": 408,
-      "complexity": 4,
-      "line_coverage": 83.33333333333333,
-      "crap": 4.074074074074074
-    },
-    {
-      "package": "sandbox",
-      "function": "isDevPodWorkspace",
-      "file": "internal/sandbox/devpod.go",
-      "line": 430,
-      "complexity": 2,
-      "line_coverage": 100,
-      "crap": 2
-    },
-    {
-      "package": "sandbox",
-      "function": "(*PodmanBackend).Name",
-      "file": "internal/sandbox/podman.go",
-      "line": 15,
-      "complexity": 1,
-      "line_coverage": 100,
-      "crap": 1
-    },
-    {
-      "package": "sandbox",
-      "function": "(*PodmanBackend).Create",
-      "file": "internal/sandbox/podman.go",
-      "line": 30,
-      "complexity": 9,
-      "line_coverage": 92.6829268292683,
-      "crap": 9.031731982995023,
-      "contract_coverage": 100,
-      "gaze_crap": 9,
-      "quadrant": "Q1_Safe"
-    },
-    {
-      "package": "sandbox",
-      "function": "(*PodmanBackend).Start",
-      "file": "internal/sandbox/podman.go",
-      "line": 113,
-      "complexity": 5,
-      "line_coverage": 75,
-      "crap": 5.390625,
-      "contract_coverage": 100,
-      "gaze_crap": 5,
-      "quadrant": "Q1_Safe"
-    },
-    {
-      "package": "sandbox",
-      "function": "(*PodmanBackend).Stop",
-      "file": "internal/sandbox/podman.go",
-      "line": 154,
-      "complexity": 2,
-      "line_coverage": 75,
-      "crap": 2.0625,
-      "contract_coverage": 100,
-      "gaze_crap": 2,
-      "quadrant": "Q1_Safe"
-    },
-    {
-      "package": "sandbox",
-      "function": "(*PodmanBackend).Destroy",
-      "file": "internal/sandbox/podman.go",
-      "line": 174,
-      "complexity": 1,
-      "line_coverage": 100,
-      "crap": 1,
-      "contract_coverage": 100,
-      "gaze_crap": 1,
-      "quadrant": "Q1_Safe"
-    },
-    {
-      "package": "sandbox",
-      "function": "(*PodmanBackend).Status",
-      "file": "internal/sandbox/podman.go",
-      "line": 194,
-      "complexity": 8,
-      "line_coverage": 96.15384615384616,
-      "crap": 8.003641329085116,
-      "contract_coverage": 100,
-      "gaze_crap": 8,
-      "quadrant": "Q1_Safe"
-    },
-    {
-      "package": "sandbox",
-      "function": "(*PodmanBackend).Attach",
-      "file": "internal/sandbox/podman.go",
-      "line": 253,
-      "complexity": 2,
-      "line_coverage": 80,
-      "crap": 2.032,
-      "contract_coverage": 100,
-      "gaze_crap": 2,
-      "quadrant": "Q1_Safe"
-    },
-    {
-      "package": "sandbox",
-      "function": "buildPersistentRunArgs",
-      "file": "internal/sandbox/podman.go",
-      "line": 267,
-      "complexity": 3,
-      "line_coverage": 100,
-      "crap": 3
-    },
-    {
-      "package": "sandbox",
-      "function": "mergeDemoPorts",
-      "file": "internal/sandbox/podman.go",
-      "line": 311,
-      "complexity": 5,
-      "line_coverage": 100,
-      "crap": 5
-    },
-    {
-      "package": "sandbox",
-      "function": "(*Options).defaults",
-      "file": "internal/sandbox/sandbox.go",
-      "line": 200,
-      "complexity": 14,
-      "line_coverage": 100,
-      "crap": 14
-    },
-    {
-      "package": "sandbox",
-      "function": "defaultExecCmd",
-      "file": "internal/sandbox/sandbox.go",
-      "line": 243,
-      "complexity": 1,
-      "line_coverage": 0,
-      "crap": 2
-    },
-    {
-      "package": "sandbox",
-      "function": "defaultExecInteractive",
-      "file": "internal/sandbox/sandbox.go",
-      "line": 249,
-      "complexity": 1,
-      "line_coverage": 0,
-      "crap": 2
-    },
-    {
-      "package": "sandbox",
-      "function": "defaultHTTPGet",
-      "file": "internal/sandbox/sandbox.go",
-      "line": 258,
-      "complexity": 2,
-      "line_coverage": 0,
-      "crap": 6
-    },
-    {
-      "package": "sandbox",
-      "function": "gatewayHealthCheck",
-      "file": "internal/sandbox/sandbox.go",
-      "line": 275,
-      "complexity": 2,
-      "line_coverage": 100,
-      "crap": 2
-    },
-    {
-      "package": "sandbox",
-      "function": "autoStartGateway",
-      "file": "internal/sandbox/sandbox.go",
-      "line": 294,
-      "complexity": 11,
-      "line_coverage": 69.56521739130434,
-      "crap": 14.411112024328101
-    },
-    {
-      "package": "sandbox",
-      "function": "isContainerRunning",
-      "file": "internal/sandbox/sandbox.go",
-      "line": 345,
-      "complexity": 2,
-      "line_coverage": 100,
-      "crap": 2
-    },
-    {
-      "package": "sandbox",
-      "function": "isContainerExists",
-      "file": "internal/sandbox/sandbox.go",
-      "line": 357,
-      "complexity": 1,
-      "line_coverage": 100,
-      "crap": 1
-    },
-    {
-      "package": "sandbox",
-      "function": "waitForHealth",
-      "file": "internal/sandbox/sandbox.go",
-      "line": 366,
-      "complexity": 6,
-      "line_coverage": 92.85714285714286,
-      "crap": 6.013119533527696
-    },
-    {
-      "package": "sandbox",
-      "function": "Create",
-      "file": "internal/sandbox/sandbox.go",
-      "line": 395,
-      "complexity": 10,
-      "line_coverage": 69.23076923076923,
-      "crap": 12.913063268092854,
-      "contract_coverage": 100,
-      "gaze_crap": 10,
-      "quadrant": "Q1_Safe"
-    },
-    {
-      "package": "sandbox",
-      "function": "Destroy",
-      "file": "internal/sandbox/sandbox.go",
-      "line": 451,
-      "complexity": 4,
-      "line_coverage": 69.23076923076923,
-      "crap": 4.466090122894856,
-      "contract_coverage": 100,
-      "gaze_crap": 4,
-      "quadrant": "Q1_Safe"
-    },
-    {
-      "package": "sandbox",
-      "function": "isPersistentWorkspace",
-      "file": "internal/sandbox/sandbox.go",
-      "line": 481,
-      "complexity": 2,
-      "line_coverage": 100,
-      "crap": 2
-    },
-    {
-      "package": "sandbox",
-      "function": "Start",
-      "file": "internal/sandbox/sandbox.go",
-      "line": 501,
-      "complexity": 31,
-      "line_coverage": 81.81818181818181,
-      "crap": 36.77610818933134,
-      "contract_coverage": 100,
-      "gaze_crap": 31,
-      "quadrant": "Q4_Dangerous",
-      "fix_strategy": "decompose"
-    },
-    {
-      "package": "sandbox",
-      "function": "Stop",
-      "file": "internal/sandbox/sandbox.go",
-      "line": 678,
-      "complexity": 5,
-      "line_coverage": 64.28571428571429,
-      "crap": 6.138848396501457,
-      "contract_coverage": 100,
-      "gaze_crap": 5,
-      "quadrant": "Q1_Safe"
-    },
-    {
-      "package": "sandbox",
-      "function": "Attach",
-      "file": "internal/sandbox/sandbox.go",
-      "line": 717,
-      "complexity": 6,
-      "line_coverage": 73.33333333333333,
-      "crap": 6.682666666666667,
-      "contract_coverage": 100,
-      "gaze_crap": 6,
-      "quadrant": "Q1_Safe"
-    },
-    {
-      "package": "sandbox",
-      "function": "Extract",
-      "file": "internal/sandbox/sandbox.go",
-      "line": 757,
-      "complexity": 15,
-      "line_coverage": 86.95652173913044,
-      "crap": 15.49930138900304,
-      "contract_coverage": 100,
-      "gaze_crap": 15,
-      "quadrant": "Q4_Dangerous",
-      "fix_strategy": "decompose"
-    },
-    {
-      "package": "sandbox",
-      "function": "WorkspaceStatusCheck",
-      "file": "internal/sandbox/sandbox.go",
-      "line": 847,
-      "complexity": 3,
-      "line_coverage": 85.71428571428571,
-      "crap": 3.0262390670553936,
-      "contract_coverage": 50,
-      "gaze_crap": 4.125,
-      "quadrant": "Q1_Safe"
-    },
-    {
-      "package": "sandbox",
-      "function": "Status",
-      "file": "internal/sandbox/sandbox.go",
-      "line": 865,
-      "complexity": 9,
-      "line_coverage": 92,
-      "crap": 9.041472,
-      "contract_coverage": 100,
-      "gaze_crap": 9,
-      "quadrant": "Q1_Safe"
-    },
-    {
-      "package": "sandbox",
-      "function": "FormatStatus",
-      "file": "internal/sandbox/sandbox.go",
-      "line": 923,
-      "complexity": 3,
-      "line_coverage": 100,
-      "crap": 3,
-      "contract_coverage": 0,
-      "gaze_crap": 12,
-      "quadrant": "Q1_Safe",
-      "contract_coverage_reason": "no_effects_detected"
-    },
-    {
-      "package": "sandbox",
-      "function": "InitDevcontainer",
-      "file": "internal/sandbox/sandbox.go",
-      "line": 988,
-      "complexity": 15,
-      "line_coverage": 75.60975609756098,
-      "crap": 18.264607304014742,
-      "contract_coverage": 100,
-      "gaze_crap": 15,
-      "quadrant": "Q4_Dangerous",
-      "fix_strategy": "decompose"
-    },
-    {
-      "package": "sandbox",
-      "function": "devcontainerRunArgs",
-      "file": "internal/sandbox/sandbox.go",
-      "line": 1072,
-      "complexity": 2,
-      "line_coverage": 100,
-      "crap": 2
-    },
-    {
-      "package": "sandbox",
-      "function": "isYes",
-      "file": "internal/sandbox/sandbox.go",
-      "line": 1082,
-      "complexity": 2,
-      "line_coverage": 100,
-      "crap": 2
-    },
-    {
-      "package": "sandbox",
-      "function": "ProjectNameFromDir",
-      "file": "internal/sandbox/workspace.go",
-      "line": 120,
-      "complexity": 1,
-      "line_coverage": 0,
-      "crap": 2
-    },
-    {
-      "package": "sandbox",
-      "function": "projectName",
-      "file": "internal/sandbox/workspace.go",
-      "line": 129,
-      "complexity": 2,
-      "line_coverage": 100,
-      "crap": 2
-    },
-    {
-      "package": "sandbox",
-      "function": "containerNameForProject",
-      "file": "internal/sandbox/workspace.go",
-      "line": 143,
-      "complexity": 1,
-      "line_coverage": 100,
-      "crap": 1
-    },
-    {
-      "package": "sandbox",
-      "function": "volumeNameForProject",
-      "file": "internal/sandbox/workspace.go",
-      "line": 150,
-      "complexity": 1,
-      "line_coverage": 100,
-      "crap": 1
-    },
-    {
-      "package": "sandbox",
-      "function": "LoadConfig",
-      "file": "internal/sandbox/workspace.go",
-      "line": 159,
-      "complexity": 6,
-      "line_coverage": 92.3076923076923,
-      "crap": 6.0163859808830225,
-      "contract_coverage": 100,
-      "gaze_crap": 6,
-      "quadrant": "Q1_Safe"
-    },
-    {
-      "package": "sandbox",
-      "function": "FormatWorkspaceStatus",
-      "file": "internal/sandbox/workspace.go",
-      "line": 187,
-      "complexity": 10,
-      "line_coverage": 100,
-      "crap": 10,
-      "contract_coverage": 0,
-      "gaze_crap": 110,
-      "quadrant": "Q3_SimpleButUnderspecified",
-      "contract_coverage_reason": "no_effects_detected"
-    },
-    {
-      "package": "sandbox",
-      "function": "setupGitSync",
-      "file": "internal/sandbox/workspace.go",
-      "line": 231,
-      "complexity": 5,
-      "line_coverage": 78.57142857142857,
-      "crap": 5.2459912536443145
-    },
-    {
-      "package": "sandbox",
-      "function": "checkGitSync",
-      "file": "internal/sandbox/workspace.go",
-      "line": 271,
-      "complexity": 4,
-      "line_coverage": 77.77777777777777,
-      "crap": 4.175582990397806
-    },
-    {
-      "package": "scaffold",
-      "function": "defaultExecCmd",
-      "file": "internal/scaffold/scaffold.go",
-      "line": 55,
-      "complexity": 1,
-      "line_coverage": 100,
-      "crap": 1
-    },
-    {
-      "package": "scaffold",
-      "function": "Run",
-      "file": "internal/scaffold/scaffold.go",
-      "line": 61,
-      "complexity": 33,
-      "line_coverage": 82.22222222222223,
-      "crap": 39.118716049382705,
-      "contract_coverage": 100,
-      "gaze_crap": 33,
-      "quadrant": "Q4_Dangerous",
-      "fix_strategy": "decompose"
-    },
-    {
-      "package": "scaffold",
-      "function": "warnLegacyReviewerFiles",
-      "file": "internal/scaffold/scaffold.go",
-      "line": 252,
-      "complexity": 4,
-      "line_coverage": 100,
-      "crap": 4
-    },
-    {
-      "package": "scaffold",
-      "function": "mapAssetPath",
-      "file": "internal/scaffold/scaffold.go",
-      "line": 279,
-      "complexity": 4,
-      "line_coverage": 80,
-      "crap": 4.128
-    },
-    {
-      "package": "scaffold",
-      "function": "isToolOwned",
-      "file": "internal/scaffold/scaffold.go",
-      "line": 306,
-      "complexity": 5,
-      "line_coverage": 100,
-      "crap": 5
-    },
-    {
-      "package": "scaffold",
-      "function": "isDivisorAsset",
-      "file": "internal/scaffold/scaffold.go",
-      "line": 332,
-      "complexity": 5,
-      "line_coverage": 100,
-      "crap": 5
-    },
-    {
-      "package": "scaffold",
-      "function": "isConventionPack",
-      "file": "internal/scaffold/scaffold.go",
-      "line": 347,
-      "complexity": 1,
-      "line_coverage": 100,
-      "crap": 1
-    },
-    {
-      "package": "scaffold",
-      "function": "shouldDeployPack",
-      "file": "internal/scaffold/scaffold.go",
-      "line": 356,
-      "complexity": 9,
-      "line_coverage": 100,
-      "crap": 9
-    },
-    {
-      "package": "scaffold",
-      "function": "detectLang",
-      "file": "internal/scaffold/scaffold.go",
-      "line": 378,
-      "complexity": 3,
-      "line_coverage": 100,
-      "crap": 3
-    },
-    {
-      "package": "scaffold",
-      "function": "versionMarker",
-      "file": "internal/scaffold/scaffold.go",
-      "line": 400,
-      "complexity": 2,
-      "line_coverage": 100,
-      "crap": 2
-    },
-    {
-      "package": "scaffold",
-      "function": "stripExistingMarkers",
-      "file": "internal/scaffold/scaffold.go",
-      "line": 414,
-      "complexity": 4,
-      "line_coverage": 100,
-      "crap": 4
-    },
-    {
-      "package": "scaffold",
-      "function": "insertMarkerAfterFrontmatter",
-      "file": "internal/scaffold/scaffold.go",
-      "line": 435,
-      "complexity": 6,
-      "line_coverage": 86.66666666666667,
-      "crap": 6.085333333333334
-    },
-    {
-      "package": "scaffold",
-      "function": "configureOpencodeJSON",
-      "file": "internal/scaffold/scaffold.go",
-      "line": 488,
-      "complexity": 48,
-      "line_coverage": 97.16981132075472,
-      "crap": 48.052231036358876,
-      "fix_strategy": "decompose"
-    },
-    {
-      "package": "scaffold",
-      "function": "ensureGitignore",
-      "file": "internal/scaffold/scaffold.go",
-      "line": 773,
-      "complexity": 10,
-      "line_coverage": 82.3529411764706,
-      "crap": 10.549562385507835
-    },
-    {
-      "package": "scaffold",
-      "function": "migrateCommandDir",
-      "file": "internal/scaffold/scaffold.go",
-      "line": 829,
-      "complexity": 14,
-      "line_coverage": 80.85106382978724,
-      "crap": 15.376226847615653,
-      "fix_strategy": "add_tests"
-    },
-    {
-      "package": "scaffold",
-      "function": "moveFile",
-      "file": "internal/scaffold/scaffold.go",
-      "line": 940,
-      "complexity": 4,
-      "line_coverage": 25,
-      "crap": 10.75
-    },
-    {
-      "package": "scaffold",
-      "function": "countMDFiles",
-      "file": "internal/scaffold/scaffold.go",
-      "line": 956,
-      "complexity": 5,
-      "line_coverage": 87.5,
-      "crap": 5.048828125
-    },
-    {
-      "package": "scaffold",
-      "function": "ensureAGENTSmdPackSection",
-      "file": "internal/scaffold/scaffold.go",
-      "line": 979,
-      "complexity": 7,
-      "line_coverage": 86.95652173913044,
-      "crap": 7.10873674693844
-    },
-    {
-      "package": "scaffold",
-      "function": "replaceManagedBlock",
-      "file": "internal/scaffold/scaffold.go",
-      "line": 1038,
-      "complexity": 3,
-      "line_coverage": 100,
-      "crap": 3
-    },
-    {
-      "package": "scaffold",
-      "function": "buildCLAUDEmdBlock",
-      "file": "internal/scaffold/scaffold.go",
-      "line": 1055,
-      "complexity": 2,
-      "line_coverage": 100,
-      "crap": 2
-    },
-    {
-      "package": "scaffold",
-      "function": "ensureCLAUDEmd",
-      "file": "internal/scaffold/scaffold.go",
-      "line": 1081,
-      "complexity": 13,
-      "line_coverage": 84.61538461538461,
-      "crap": 13.615384615384615
-    },
-    {
-      "package": "scaffold",
-      "function": "buildCursorrulesBlock",
-      "file": "internal/scaffold/scaffold.go",
-      "line": 1155,
-      "complexity": 2,
-      "line_coverage": 100,
-      "crap": 2
-    },
-    {
-      "package": "scaffold",
-      "function": "ensureCursorrules",
-      "file": "internal/scaffold/scaffold.go",
-      "line": 1185,
-      "complexity": 13,
-      "line_coverage": 84.61538461538461,
-      "crap": 13.615384615384615
-    },
-    {
-      "package": "scaffold",
-      "function": "collectDeployedPacks",
-      "file": "internal/scaffold/scaffold.go",
-      "line": 1259,
-      "complexity": 3,
-      "line_coverage": 100,
-      "crap": 3
-    },
-    {
-      "package": "scaffold",
-      "function": "initSubTools",
-      "file": "internal/scaffold/scaffold.go",
-      "line": 1278,
-      "complexity": 25,
-      "line_coverage": 95.08196721311475,
-      "crap": 25.074345429793684,
-      "fix_strategy": "decompose"
-    },
-    {
-      "package": "scaffold",
-      "function": "subToolSymbol",
-      "file": "internal/scaffold/scaffold.go",
-      "line": 1432,
-      "complexity": 3,
-      "line_coverage": 75,
-      "crap": 3.140625
-    },
-    {
-      "package": "scaffold",
-      "function": "printSummary",
-      "file": "internal/scaffold/scaffold.go",
-      "line": 1456,
-      "complexity": 25,
-      "line_coverage": 100,
-      "crap": 25,
-      "fix_strategy": "decompose"
-    },
-    {
-      "package": "scaffold",
-      "function": "assetPaths",
-      "file": "internal/scaffold/scaffold.go",
-      "line": 1551,
-      "complexity": 3,
-      "line_coverage": 88.88888888888889,
-      "crap": 3.0123456790123457
-    },
-    {
-      "package": "scaffold",
-      "function": "assetContent",
-      "file": "internal/scaffold/scaffold.go",
-      "line": 1568,
-      "complexity": 1,
-      "line_coverage": 100,
-      "crap": 1
-    },
-    {
-      "package": "scaffold",
-      "function": "generateDeweySources",
-      "file": "internal/scaffold/scaffold.go",
-      "line": 1582,
-      "complexity": 11,
-      "line_coverage": 88.46153846153847,
-      "crap": 11.185878470641784
-    },
-    {
-      "package": "scaffold",
-      "function": "isDefaultSourcesConfig",
-      "file": "internal/scaffold/scaffold.go",
-      "line": 1652,
-      "complexity": 1,
-      "line_coverage": 100,
-      "crap": 1
-    },
-    {
-      "package": "scaffold",
-      "function": "extractGitHubOrg",
-      "file": "internal/scaffold/scaffold.go",
-      "line": 1661,
-      "complexity": 8,
-      "line_coverage": 90,
-      "crap": 8.064
-    },
-    {
-      "package": "scaffold",
-      "function": "DevcontainerContent",
-      "file": "internal/scaffold/scaffold.go",
-      "line": 1700,
-      "complexity": 1,
-      "line_coverage": 0,
-      "crap": 2
-    },
-    {
-      "package": "scaffold",
-      "function": "writeSourcesConfig",
-      "file": "internal/scaffold/scaffold.go",
-      "line": 1709,
-      "complexity": 4,
-      "line_coverage": 100,
-      "crap": 4
-    },
-    {
-      "package": "schemas",
-      "function": "GenerateSchema",
-      "file": "internal/schemas/generate.go",
-      "line": 20,
-      "complexity": 2,
-      "line_coverage": 80,
-      "crap": 2.032
-    },
-    {
-      "package": "schemas",
-      "function": "WriteSchema",
-      "file": "internal/schemas/generate.go",
-      "line": 34,
-      "complexity": 4,
-      "line_coverage": 66.66666666666667,
-      "crap": 4.592592592592593
-    },
-    {
-      "package": "schemas",
-      "function": "ValidateConventionPack",
-      "file": "internal/schemas/packvalidator.go",
-      "line": 31,
-      "complexity": 8,
-      "line_coverage": 94.44444444444444,
-      "crap": 8.010973936899862
-    },
-    {
-      "package": "schemas",
-      "function": "extractFrontmatter",
-      "file": "internal/schemas/packvalidator.go",
-      "line": 73,
-      "complexity": 7,
-      "line_coverage": 87.5,
-      "crap": 7.095703125
-    },
-    {
-      "package": "schemas",
-      "function": "extractH2Sections",
-      "file": "internal/schemas/packvalidator.go",
-      "line": 105,
-      "complexity": 3,
-      "line_coverage": 100,
-      "crap": 3
-    },
-    {
-      "package": "schemas",
-      "function": "registeredTypes",
-      "file": "internal/schemas/registry.go",
-      "line": 21,
-      "complexity": 1,
-      "line_coverage": 100,
-      "crap": 1
-    },
-    {
-      "package": "schemas",
-      "function": "RegisteredTypeNames",
-      "file": "internal/schemas/registry.go",
-      "line": 36,
-      "complexity": 2,
-      "line_coverage": 100,
-      "crap": 2
-    },
-    {
-      "package": "schemas",
-      "function": "GenerateAll",
-      "file": "internal/schemas/registry.go",
-      "line": 49,
-      "complexity": 4,
-      "line_coverage": 75,
-      "crap": 4.25
-    },
-    {
-      "package": "schemas",
-      "function": "ValidateArtifact",
-      "file": "internal/schemas/validate.go",
-      "line": 16,
-      "complexity": 3,
-      "line_coverage": 85.71428571428571,
-      "crap": 3.0262390670553936,
-      "contract_coverage": 100,
-      "gaze_crap": 3,
-      "quadrant": "Q1_Safe"
-    },
-    {
-      "package": "schemas",
-      "function": "ValidateBytes",
-      "file": "internal/schemas/validate.go",
-      "line": 33,
-      "complexity": 6,
-      "line_coverage": 86.66666666666667,
-      "crap": 6.085333333333334,
-      "contract_coverage": 100,
-      "gaze_crap": 6,
-      "quadrant": "Q1_Safe"
-    },
-    {
-      "package": "schemas",
-      "function": "semverParts",
-      "file": "internal/schemas/version.go",
-      "line": 11,
-      "complexity": 5,
-      "line_coverage": 78.57142857142857,
-      "crap": 5.2459912536443145
-    },
-    {
-      "package": "schemas",
-      "function": "CheckCompatibility",
-      "file": "internal/schemas/version.go",
-      "line": 49,
-      "complexity": 4,
-      "line_coverage": 100,
-      "crap": 4
-    },
-    {
-      "package": "setup",
-      "function": "(*Options).defaults",
-      "file": "internal/setup/setup.go",
-      "line": 91,
-      "complexity": 12,
-      "line_coverage": 100,
-      "crap": 12
-    },
-    {
-      "package": "setup",
-      "function": "defaultExecCmd",
-      "file": "internal/setup/setup.go",
-      "line": 128,
-      "complexity": 1,
-      "line_coverage": 0,
-      "crap": 2
-    },
-    {
-      "package": "setup",
-      "function": "(*Options).embeddingModel",
-      "file": "internal/setup/setup.go",
-      "line": 148,
-      "complexity": 2,
-      "line_coverage": 100,
-      "crap": 2
-    },
-    {
-      "package": "setup",
-      "function": "(*Options).embeddingDim",
-      "file": "internal/setup/setup.go",
-      "line": 156,
-      "complexity": 2,
-      "line_coverage": 100,
-      "crap": 2
-    },
-    {
-      "package": "setup",
-      "function": "(*Options).shouldSkipTool",
-      "file": "internal/setup/setup.go",
-      "line": 165,
-      "complexity": 11,
-      "line_coverage": 91.66666666666667,
-      "crap": 11.070023148148149
-    },
-    {
-      "package": "setup",
-      "function": "(*Options).toolMethod",
-      "file": "internal/setup/setup.go",
-      "line": 190,
-      "complexity": 4,
-      "line_coverage": 100,
-      "crap": 4
-    },
-    {
-      "package": "setup",
-      "function": "Run",
-      "file": "internal/setup/setup.go",
-      "line": 229,
-      "complexity": 2,
-      "line_coverage": 92.3076923076923,
-      "crap": 2.0018206645425582,
-      "contract_coverage": 100,
-      "gaze_crap": 2,
-      "quadrant": "Q1_Safe"
-    },
-    {
-      "package": "setup",
-      "function": "buildSteps",
-      "file": "internal/setup/setup.go",
-      "line": 274,
-      "complexity": 5,
-      "line_coverage": 100,
-      "crap": 5
-    },
-    {
-      "package": "setup",
-      "function": "executeSteps",
-      "file": "internal/setup/setup.go",
-      "line": 334,
-      "complexity": 9,
-      "line_coverage": 95.23809523809524,
-      "crap": 9.008746355685131
-    },
-    {
-      "package": "setup",
-      "function": "printHeader",
-      "file": "internal/setup/setup.go",
-      "line": 373,
-      "complexity": 4,
-      "line_coverage": 100,
-      "crap": 4
-    },
-    {
-      "package": "setup",
-      "function": "printSummary",
-      "file": "internal/setup/setup.go",
-      "line": 400,
-      "complexity": 5,
-      "line_coverage": 100,
-      "crap": 5
-    },
-    {
-      "package": "setup",
-      "function": "installOpenCode",
-      "file": "internal/setup/setup.go",
-      "line": 432,
-      "complexity": 9,
-      "line_coverage": 93.33333333333333,
-      "crap": 9.024000000000001
-    },
-    {
-      "package": "setup",
-      "function": "installGH",
-      "file": "internal/setup/setup.go",
-      "line": 470,
-      "complexity": 6,
-      "line_coverage": 90.9090909090909,
-      "crap": 6.027047332832457
-    },
-    {
-      "package": "setup",
-      "function": "installOpenSpec",
-      "file": "internal/setup/setup.go",
-      "line": 498,
-      "complexity": 4,
-      "line_coverage": 100,
-      "crap": 4
-    },
-    {
-      "package": "setup",
-      "function": "installGaze",
-      "file": "internal/setup/setup.go",
-      "line": 519,
-      "complexity": 10,
-      "line_coverage": 89.47368421052632,
-      "crap": 10.116635077999709
-    },
-    {
-      "package": "setup",
-      "function": "ensureNodeJS",
-      "file": "internal/setup/setup.go",
-      "line": 563,
-      "complexity": 5,
-      "line_coverage": 88.88888888888889,
-      "crap": 5.034293552812072
-    },
-    {
-      "package": "setup",
-      "function": "parseNodeMajor",
-      "file": "internal/setup/setup.go",
-      "line": 586,
-      "complexity": 2,
-      "line_coverage": 75,
-      "crap": 2.0625
-    },
-    {
-      "package": "setup",
-      "function": "installNodeJS",
-      "file": "internal/setup/setup.go",
-      "line": 596,
-      "complexity": 11,
-      "line_coverage": 92,
-      "crap": 11.061952
-    },
-    {
-      "package": "setup",
-      "function": "installUV",
-      "file": "internal/setup/setup.go",
-      "line": 650,
-      "complexity": 9,
-      "line_coverage": 86.66666666666667,
-      "crap": 9.192
-    },
-    {
-      "package": "setup",
-      "function": "installSpecify",
-      "file": "internal/setup/setup.go",
-      "line": 689,
-      "complexity": 5,
-      "line_coverage": 100,
-      "crap": 5
-    },
-    {
-      "package": "setup",
-      "function": "installReplicator",
-      "file": "internal/setup/setup.go",
-      "line": 721,
-      "complexity": 6,
-      "line_coverage": 100,
-      "crap": 6
-    },
-    {
-      "package": "setup",
-      "function": "runReplicatorSetup",
-      "file": "internal/setup/setup.go",
-      "line": 749,
-      "complexity": 5,
-      "line_coverage": 100,
-      "crap": 5
-    },
-    {
-      "package": "setup",
-      "function": "installGolangciLint",
-      "file": "internal/setup/setup.go",
-      "line": 770,
-      "complexity": 6,
-      "line_coverage": 54.54545454545455,
-      "crap": 9.3809166040571
-    },
-    {
-      "package": "setup",
-      "function": "installGovulncheck",
-      "file": "internal/setup/setup.go",
-      "line": 802,
-      "complexity": 4,
-      "line_coverage": 85.71428571428571,
-      "crap": 4.0466472303206995
-    },
-    {
-      "package": "setup",
-      "function": "rpmURL",
-      "file": "internal/setup/setup.go",
-      "line": 819,
-      "complexity": 1,
-      "line_coverage": 100,
-      "crap": 1
-    },
-    {
-      "package": "setup",
-      "function": "repoName",
-      "file": "internal/setup/setup.go",
-      "line": 831,
-      "complexity": 2,
-      "line_coverage": 100,
-      "crap": 2
-    },
-    {
-      "package": "setup",
-      "function": "rpmArch",
-      "file": "internal/setup/setup.go",
-      "line": 841,
-      "complexity": 2,
-      "line_coverage": 66.66666666666667,
-      "crap": 2.148148148148148
-    },
-    {
-      "package": "setup",
-      "function": "installViaRpm",
-      "file": "internal/setup/setup.go",
-      "line": 852,
-      "complexity": 4,
-      "line_coverage": 100,
-      "crap": 4
-    },
-    {
-      "package": "setup",
-      "function": "ollamaBrew",
-      "file": "internal/setup/setup.go",
-      "line": 886,
-      "complexity": 2,
-      "line_coverage": 100,
-      "crap": 2
-    },
-    {
-      "package": "setup",
-      "function": "installOllama",
-      "file": "internal/setup/setup.go",
-      "line": 1010,
-      "complexity": 6,
-      "line_coverage": 100,
-      "crap": 6
-    },
-    {
-      "package": "setup",
-      "function": "installPodman",
-      "file": "internal/setup/setup.go",
-      "line": 940,
-      "complexity": 8,
-      "line_coverage": 94.11764705882354,
-      "crap": 8.013026663952779
-    },
-    {
-      "package": "setup",
-      "function": "podmanMachineInit",
-      "file": "internal/setup/setup.go",
-      "line": 985,
-      "complexity": 5,
-      "line_coverage": 100,
-      "crap": 5
-    },
-    {
-      "package": "setup",
-      "function": "initMachineWithTimeout",
-      "file": "internal/setup/setup.go",
-      "line": 1012,
-      "complexity": 3,
-      "line_coverage": 60,
-      "crap": 3.576
-    },
-    {
-      "package": "setup",
-      "function": "installDevPod",
-      "file": "internal/setup/setup.go",
-      "line": 1210,
-      "complexity": 6,
-      "line_coverage": 90.9090909090909,
-      "crap": 6.027047332832457
-    },
-    {
-      "package": "setup",
-      "function": "configureDevPodProvider",
-      "file": "internal/setup/setup.go",
-      "line": 1061,
-      "complexity": 7,
-      "line_coverage": 100,
-      "crap": 7
-    },
-    {
-      "package": "setup",
-      "function": "hasProvider",
-      "file": "internal/setup/setup.go",
-      "line": 1111,
-      "complexity": 4,
-      "line_coverage": 100,
-      "crap": 4
-    },
-    {
-      "package": "setup",
-      "function": "installDewey",
-      "file": "internal/setup/setup.go",
-      "line": 1128,
-      "complexity": 7,
-      "line_coverage": 85.71428571428571,
-      "crap": 7.142857142857143
-    },
-    {
-      "package": "setup",
-      "function": "pullEmbeddingModel",
-      "file": "internal/setup/setup.go",
-      "line": 1165,
-      "complexity": 6,
-      "line_coverage": 80,
-      "crap": 6.287999999999999
-    },
-    {
-      "package": "setup",
-      "function": "printStepResult",
-      "file": "internal/setup/setup.go",
-      "line": 1193,
-      "complexity": 6,
-      "line_coverage": 100,
-      "crap": 6
-    },
-    {
-      "package": "setup",
-      "function": "FormatSetupText",
-      "file": "internal/setup/setup.go",
-      "line": 1218,
-      "complexity": 2,
-      "line_coverage": 100,
-      "crap": 2,
-      "contract_coverage": 0,
-      "gaze_crap": 6,
-      "quadrant": "Q1_Safe",
-      "contract_coverage_reason": "no_effects_detected"
-    },
-    {
-      "package": "setup",
-      "function": "atomicWriteFile",
-      "file": "internal/setup/setup.go",
-      "line": 1226,
-      "complexity": 7,
-      "line_coverage": 61.111111111111114,
-      "crap": 9.881858710562414
-    },
-    {
-      "package": "sprint",
-      "function": "(*SprintState).ComputeVelocity",
-      "file": "internal/sprint/models.go",
-      "line": 18,
-      "complexity": 1,
-      "line_coverage": 100,
-      "crap": 1,
-      "contract_coverage": 0,
-      "gaze_crap": 2,
-      "quadrant": "Q1_Safe"
-    },
-    {
-      "package": "sprint",
-      "function": "(*SprintState).DurationDays",
-      "file": "internal/sprint/models.go",
-      "line": 23,
-      "complexity": 3,
-      "line_coverage": 0,
-      "crap": 12
-    },
-    {
-      "package": "sprint",
-      "function": "NewSprintStore",
-      "file": "internal/sprint/sprint.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/impediment/impediment.go",
       "line": 22,
       "complexity": 1,
       "line_coverage": 100,
@@ -4875,34 +2753,456 @@
       ]
     },
     {
-      "package": "sprint",
-      "function": "(*SprintStore).Plan",
-      "file": "internal/sprint/sprint.go",
-      "line": 27,
+      "package": "impediment",
+      "function": "(*Repository).ensureDir",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/impediment/impediment.go",
+      "line": 26,
+      "complexity": 1,
+      "line_coverage": 100,
+      "crap": 1
+    },
+    {
+      "package": "impediment",
+      "function": "(*Repository).Add",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/impediment/impediment.go",
+      "line": 31,
       "complexity": 5,
-      "line_coverage": 86.66666666666667,
-      "crap": 5.059259259259259,
+      "line_coverage": 72.72727272727273,
+      "crap": 5.507137490608565,
+      "contract_coverage": 0,
+      "gaze_crap": 30,
+      "quadrant": "Q3_SimpleButUnderspecified",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        75,
+        75
+      ]
+    },
+    {
+      "package": "impediment",
+      "function": "(*Repository).List",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/impediment/impediment.go",
+      "line": 63,
+      "complexity": 10,
+      "line_coverage": 72.72727272727273,
+      "crap": 12.028549962434258,
+      "contract_coverage": 100,
+      "gaze_crap": 10,
+      "quadrant": "Q1_Safe"
+    },
+    {
+      "package": "impediment",
+      "function": "(*Repository).Resolve",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/impediment/impediment.go",
+      "line": 102,
+      "complexity": 2,
+      "line_coverage": 85.71428571428571,
+      "crap": 2.011661807580175,
+      "contract_coverage": 0,
+      "gaze_crap": 6,
+      "quadrant": "Q1_Safe",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        69,
+        69
+      ]
+    },
+    {
+      "package": "impediment",
+      "function": "(*Repository).Get",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/impediment/impediment.go",
+      "line": 116,
+      "complexity": 1,
+      "line_coverage": 100,
+      "crap": 1,
+      "contract_coverage": 100,
+      "gaze_crap": 1,
+      "quadrant": "Q1_Safe"
+    },
+    {
+      "package": "impediment",
+      "function": "(*Repository).save",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/impediment/impediment.go",
+      "line": 121,
+      "complexity": 2,
+      "line_coverage": 83.33333333333333,
+      "crap": 2.0185185185185186
+    },
+    {
+      "package": "impediment",
+      "function": "(*Repository).load",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/impediment/impediment.go",
+      "line": 132,
+      "complexity": 4,
+      "line_coverage": 75,
+      "crap": 4.25
+    },
+    {
+      "package": "impediment",
+      "function": "(*Repository).nextID",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/impediment/impediment.go",
+      "line": 155,
+      "complexity": 7,
+      "line_coverage": 78.57142857142857,
+      "crap": 7.482142857142858
+    },
+    {
+      "package": "impediment",
+      "function": "(*Impediment).AgeDays",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/impediment/models.go",
+      "line": 20,
+      "complexity": 2,
+      "line_coverage": 75,
+      "crap": 2.0625,
+      "contract_coverage": 0,
+      "gaze_crap": 6,
+      "quadrant": "Q1_Safe"
+    },
+    {
+      "package": "impediment",
+      "function": "(*Impediment).IsStale",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/impediment/models.go",
+      "line": 29,
+      "complexity": 2,
+      "line_coverage": 100,
+      "crap": 2,
+      "contract_coverage": 0,
+      "gaze_crap": 6,
+      "quadrant": "Q1_Safe"
+    },
+    {
+      "package": "metrics",
+      "function": "CollectDivisor",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/metrics/collect_divisor.go",
+      "line": 11,
+      "complexity": 6,
+      "line_coverage": 84.21052631578948,
+      "crap": 6.141711619769645,
+      "contract_coverage": 0,
+      "gaze_crap": 42,
+      "quadrant": "Q3_SimpleButUnderspecified",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        64,
+        64
+      ]
+    },
+    {
+      "package": "metrics",
+      "function": "CollectGaze",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/metrics/collect_gaze.go",
+      "line": 11,
+      "complexity": 6,
+      "line_coverage": 84.21052631578948,
+      "crap": 6.141711619769645,
+      "contract_coverage": 0,
+      "gaze_crap": 42,
+      "quadrant": "Q3_SimpleButUnderspecified",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        64,
+        64
+      ]
+    },
+    {
+      "package": "metrics",
+      "function": "CollectGitHub",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/metrics/collect_github.go",
+      "line": 15,
+      "complexity": 26,
+      "line_coverage": 96.72131147540983,
+      "crap": 26.023825782774768,
+      "contract_coverage": 0,
+      "gaze_crap": 702,
+      "quadrant": "Q4_Dangerous",
+      "fix_strategy": "decompose",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        64,
+        64
+      ]
+    },
+    {
+      "package": "metrics",
+      "function": "CollectMutiMind",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/metrics/collect_mutimind.go",
+      "line": 11,
+      "complexity": 15,
+      "line_coverage": 87.17948717948718,
+      "crap": 15.474131391291154,
+      "contract_coverage": 0,
+      "gaze_crap": 240,
+      "quadrant": "Q4_Dangerous",
+      "fix_strategy": "decompose",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        64,
+        64
+      ]
+    },
+    {
+      "package": "metrics",
+      "function": "ParsePeriod",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/metrics/collector.go",
+      "line": 24,
+      "complexity": 7,
+      "line_coverage": 100,
+      "crap": 7,
+      "contract_coverage": 0,
+      "gaze_crap": 56,
+      "quadrant": "Q3_SimpleButUnderspecified",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        79,
+        79
+      ]
+    },
+    {
+      "package": "metrics",
+      "function": "(*Collector).Collect",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/metrics/collector.go",
+      "line": 53,
+      "complexity": 14,
+      "line_coverage": 92.10526315789474,
+      "crap": 14.09644263012101,
+      "contract_coverage": 0,
+      "gaze_crap": 210,
+      "quadrant": "Q3_SimpleButUnderspecified",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        69,
+        69
+      ]
+    },
+    {
+      "package": "metrics",
+      "function": "formatPeriod",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/metrics/collector.go",
+      "line": 118,
+      "complexity": 2,
+      "line_coverage": 75,
+      "crap": 2.0625
+    },
+    {
+      "package": "metrics",
+      "function": "ComputeVelocity",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/metrics/compute.go",
+      "line": 10,
+      "complexity": 2,
+      "line_coverage": 100,
+      "crap": 2,
+      "contract_coverage": 0,
+      "gaze_crap": 6,
+      "quadrant": "Q1_Safe",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        74,
+        74
+      ]
+    },
+    {
+      "package": "metrics",
+      "function": "ComputeCycleTimeFromValues",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/metrics/compute.go",
+      "line": 22,
+      "complexity": 3,
+      "line_coverage": 100,
+      "crap": 3,
+      "contract_coverage": 0,
+      "gaze_crap": 12,
+      "quadrant": "Q1_Safe",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        74,
+        74
+      ]
+    },
+    {
+      "package": "metrics",
+      "function": "percentile",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/metrics/compute.go",
+      "line": 44,
+      "complexity": 5,
+      "line_coverage": 100,
+      "crap": 5
+    },
+    {
+      "package": "metrics",
+      "function": "ComputeFlowEfficiency",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/metrics/compute.go",
+      "line": 62,
+      "complexity": 2,
+      "line_coverage": 100,
+      "crap": 2,
+      "contract_coverage": 0,
+      "gaze_crap": 6,
+      "quadrant": "Q1_Safe",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        68,
+        68
+      ]
+    },
+    {
+      "package": "metrics",
+      "function": "DetermineTrend",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/metrics/compute.go",
+      "line": 70,
+      "complexity": 6,
+      "line_coverage": 100,
+      "crap": 6,
+      "contract_coverage": 0,
+      "gaze_crap": 42,
+      "quadrant": "Q3_SimpleButUnderspecified",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        58,
+        58
+      ]
+    },
+    {
+      "package": "metrics",
+      "function": "defaultThresholds",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/metrics/health.go",
+      "line": 4,
+      "complexity": 1,
+      "line_coverage": 100,
+      "crap": 1
+    },
+    {
+      "package": "metrics",
+      "function": "ComputeHealth",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/metrics/health.go",
+      "line": 15,
+      "complexity": 2,
+      "line_coverage": 100,
+      "crap": 2,
+      "contract_coverage": 0,
+      "gaze_crap": 6,
+      "quadrant": "Q1_Safe",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        74,
+        74
+      ]
+    },
+    {
+      "package": "metrics",
+      "function": "computeIndicator",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/metrics/health.go",
+      "line": 60,
+      "complexity": 4,
+      "line_coverage": 100,
+      "crap": 4
+    },
+    {
+      "package": "metrics",
+      "function": "computeStatus",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/metrics/health.go",
+      "line": 86,
+      "complexity": 6,
+      "line_coverage": 100,
+      "crap": 6
+    },
+    {
+      "package": "metrics",
+      "function": "extractValues",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/metrics/health.go",
+      "line": 107,
+      "complexity": 2,
+      "line_coverage": 100,
+      "crap": 2
+    },
+    {
+      "package": "metrics",
+      "function": "NewQuery",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/metrics/query.go",
+      "line": 18,
+      "complexity": 1,
+      "line_coverage": 100,
+      "crap": 1,
+      "contract_coverage": 0,
+      "gaze_crap": 2,
+      "quadrant": "Q1_Safe",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        69,
+        69
+      ]
+    },
+    {
+      "package": "metrics",
+      "function": "(*Query).now",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/metrics/query.go",
+      "line": 22,
+      "complexity": 2,
+      "line_coverage": 66.66666666666667,
+      "crap": 2.148148148148148
+    },
+    {
+      "package": "metrics",
+      "function": "(*Query).Summary",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/metrics/query.go",
+      "line": 30,
+      "complexity": 3,
+      "line_coverage": 88.88888888888889,
+      "crap": 3.0123456790123457,
+      "contract_coverage": 0,
+      "gaze_crap": 12,
+      "quadrant": "Q1_Safe",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        75,
+        75
+      ]
+    },
+    {
+      "package": "metrics",
+      "function": "(*Query).Velocity",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/metrics/query.go",
+      "line": 55,
+      "complexity": 5,
+      "line_coverage": 77.77777777777777,
+      "crap": 5.274348422496571,
+      "contract_coverage": 0,
+      "gaze_crap": 30,
+      "quadrant": "Q3_SimpleButUnderspecified",
+      "contract_coverage_reason": "no_effects_detected"
+    },
+    {
+      "package": "metrics",
+      "function": "(*Query).CycleTime",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/metrics/query.go",
+      "line": 73,
+      "complexity": 5,
+      "line_coverage": 83.33333333333333,
+      "crap": 5.1157407407407405,
       "contract_coverage": 100,
       "gaze_crap": 5,
       "quadrant": "Q1_Safe"
     },
     {
-      "package": "sprint",
-      "function": "(*SprintStore).Review",
-      "file": "internal/sprint/sprint.go",
-      "line": 62,
-      "complexity": 2,
-      "line_coverage": 83.33333333333333,
-      "crap": 2.0185185185185186,
-      "contract_coverage": 100,
-      "gaze_crap": 2,
-      "quadrant": "Q1_Safe"
+      "package": "metrics",
+      "function": "(*Query).Bottlenecks",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/metrics/query.go",
+      "line": 96,
+      "complexity": 3,
+      "line_coverage": 80,
+      "crap": 3.072,
+      "contract_coverage": 0,
+      "gaze_crap": 12,
+      "quadrant": "Q1_Safe",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        75,
+        75
+      ]
     },
     {
-      "package": "sprint",
-      "function": "(*SprintStore).Save",
-      "file": "internal/sprint/sprint.go",
-      "line": 75,
+      "package": "metrics",
+      "function": "(*Query).Health",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/metrics/query.go",
+      "line": 125,
       "complexity": 3,
       "line_coverage": 71.42857142857143,
       "crap": 3.2099125364431487,
@@ -4911,9 +3211,2505 @@
       "quadrant": "Q1_Safe"
     },
     {
+      "package": "metrics",
+      "function": "NewStore",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/metrics/store.go",
+      "line": 19,
+      "complexity": 1,
+      "line_coverage": 100,
+      "crap": 1,
+      "contract_coverage": 0,
+      "gaze_crap": 2,
+      "quadrant": "Q1_Safe",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        69,
+        69
+      ]
+    },
+    {
+      "package": "metrics",
+      "function": "(*Store).WriteCollection",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/metrics/store.go",
+      "line": 24,
+      "complexity": 3,
+      "line_coverage": 81.81818181818181,
+      "crap": 3.0540946656649135,
+      "contract_coverage": 0,
+      "gaze_crap": 12,
+      "quadrant": "Q1_Safe",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        64,
+        74
+      ]
+    },
+    {
+      "package": "metrics",
+      "function": "(*Store).ReadCollections",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/metrics/store.go",
+      "line": 45,
+      "complexity": 10,
+      "line_coverage": 77.27272727272727,
+      "crap": 11.173929376408715,
+      "contract_coverage": 100,
+      "gaze_crap": 10,
+      "quadrant": "Q1_Safe"
+    },
+    {
+      "package": "metrics",
+      "function": "(*Store).WriteSnapshot",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/metrics/store.go",
+      "line": 82,
+      "complexity": 3,
+      "line_coverage": 81.81818181818181,
+      "crap": 3.0540946656649135,
+      "contract_coverage": 0,
+      "gaze_crap": 12,
+      "quadrant": "Q1_Safe",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        64,
+        74
+      ]
+    },
+    {
+      "package": "metrics",
+      "function": "(*Store).ReadSnapshots",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/metrics/store.go",
+      "line": 101,
+      "complexity": 10,
+      "line_coverage": 77.27272727272727,
+      "crap": 11.173929376408715,
+      "contract_coverage": 100,
+      "gaze_crap": 10,
+      "quadrant": "Q1_Safe"
+    },
+    {
+      "package": "orchestration",
+      "function": "LoadWorkflowConfig",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/orchestration/config.go",
+      "line": 33,
+      "complexity": 4,
+      "line_coverage": 90,
+      "crap": 4.016,
+      "contract_coverage": 100,
+      "gaze_crap": 4,
+      "quadrant": "Q1_Safe"
+    },
+    {
+      "package": "orchestration",
+      "function": "(*Orchestrator).store",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/orchestration/engine.go",
+      "line": 45,
+      "complexity": 1,
+      "line_coverage": 100,
+      "crap": 1
+    },
+    {
+      "package": "orchestration",
+      "function": "(*Orchestrator).now",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/orchestration/engine.go",
+      "line": 50,
+      "complexity": 2,
+      "line_coverage": 66.66666666666667,
+      "crap": 2.148148148148148
+    },
+    {
+      "package": "orchestration",
+      "function": "(*Orchestrator).lookPath",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/orchestration/engine.go",
+      "line": 58,
+      "complexity": 2,
+      "line_coverage": 66.66666666666667,
+      "crap": 2.148148148148148
+    },
+    {
+      "package": "orchestration",
+      "function": "(*Orchestrator).NewWorkflow",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/orchestration/engine.go",
+      "line": 72,
+      "complexity": 11,
+      "line_coverage": 100,
+      "crap": 11,
+      "contract_coverage": 100,
+      "gaze_crap": 11,
+      "quadrant": "Q1_Safe"
+    },
+    {
+      "package": "orchestration",
+      "function": "(*Orchestrator).Start",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/orchestration/engine.go",
+      "line": 151,
+      "complexity": 14,
+      "line_coverage": 96.875,
+      "crap": 14.0059814453125,
+      "contract_coverage": 100,
+      "gaze_crap": 14,
+      "quadrant": "Q1_Safe"
+    },
+    {
+      "package": "orchestration",
+      "function": "(*Orchestrator).Advance",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/orchestration/engine.go",
+      "line": 218,
+      "complexity": 32,
+      "line_coverage": 86.44067796610169,
+      "crap": 34.552782903802246,
+      "contract_coverage": 0,
+      "gaze_crap": 1056,
+      "quadrant": "Q4_Dangerous",
+      "fix_strategy": "decompose",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        70,
+        70
+      ]
+    },
+    {
+      "package": "orchestration",
+      "function": "(*Orchestrator).Skip",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/orchestration/engine.go",
+      "line": 361,
+      "complexity": 4,
+      "line_coverage": 75,
+      "crap": 4.25,
+      "contract_coverage": 0,
+      "gaze_crap": 20,
+      "quadrant": "Q3_SimpleButUnderspecified",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        64,
+        64
+      ]
+    },
+    {
+      "package": "orchestration",
+      "function": "(*Orchestrator).Escalate",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/orchestration/engine.go",
+      "line": 378,
+      "complexity": 4,
+      "line_coverage": 90.9090909090909,
+      "crap": 4.012021036814425,
+      "contract_coverage": 0,
+      "gaze_crap": 20,
+      "quadrant": "Q3_SimpleButUnderspecified",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        64,
+        64
+      ]
+    },
+    {
+      "package": "orchestration",
+      "function": "(*Orchestrator).Complete",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/orchestration/engine.go",
+      "line": 400,
+      "complexity": 4,
+      "line_coverage": 76.92307692307692,
+      "crap": 4.196631770596268,
+      "contract_coverage": 100,
+      "gaze_crap": 4,
+      "quadrant": "Q1_Safe"
+    },
+    {
+      "package": "orchestration",
+      "function": "(*Orchestrator).Status",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/orchestration/engine.go",
+      "line": 433,
+      "complexity": 1,
+      "line_coverage": 100,
+      "crap": 1,
+      "contract_coverage": 100,
+      "gaze_crap": 1,
+      "quadrant": "Q1_Safe"
+    },
+    {
+      "package": "orchestration",
+      "function": "(*Orchestrator).List",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/orchestration/engine.go",
+      "line": 438,
+      "complexity": 1,
+      "line_coverage": 0,
+      "crap": 2
+    },
+    {
+      "package": "orchestration",
+      "function": "(*Orchestrator).doEscalate",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/orchestration/engine.go",
+      "line": 445,
+      "complexity": 4,
+      "line_coverage": 90,
+      "crap": 4.016
+    },
+    {
+      "package": "orchestration",
+      "function": "(*Orchestrator).HandleHeroUnavailable",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/orchestration/engine.go",
+      "line": 470,
+      "complexity": 1,
+      "line_coverage": 0,
+      "crap": 2
+    },
+    {
+      "package": "orchestration",
+      "function": "(*Orchestrator).HandleMaxIterations",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/orchestration/engine.go",
+      "line": 477,
+      "complexity": 1,
+      "line_coverage": 0,
+      "crap": 2
+    },
+    {
+      "package": "orchestration",
+      "function": "(*Orchestrator).HandleAcceptanceRejection",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/orchestration/engine.go",
+      "line": 485,
+      "complexity": 4,
+      "line_coverage": 92.85714285714286,
+      "crap": 4.005830903790088,
+      "contract_coverage": 0,
+      "gaze_crap": 20,
+      "quadrant": "Q3_SimpleButUnderspecified",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        74,
+        74
+      ]
+    },
+    {
+      "package": "orchestration",
+      "function": "(*Orchestrator).HandleContradiction",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/orchestration/engine.go",
+      "line": 512,
+      "complexity": 4,
+      "line_coverage": 90.9090909090909,
+      "crap": 4.012021036814425,
+      "contract_coverage": 0,
+      "gaze_crap": 20,
+      "quadrant": "Q3_SimpleButUnderspecified",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        74,
+        74
+      ]
+    },
+    {
+      "package": "orchestration",
+      "function": "effectiveMode",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/orchestration/engine.go",
+      "line": 535,
+      "complexity": 2,
+      "line_coverage": 100,
+      "crap": 2
+    },
+    {
+      "package": "orchestration",
+      "function": "sanitizeBranch",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/orchestration/engine.go",
+      "line": 545,
+      "complexity": 9,
+      "line_coverage": 100,
+      "crap": 9
+    },
+    {
+      "package": "orchestration",
+      "function": "DetectHeroes",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/orchestration/heroes.go",
+      "line": 32,
+      "complexity": 10,
+      "line_coverage": 100,
+      "crap": 10,
+      "contract_coverage": 100,
+      "gaze_crap": 10,
+      "quadrant": "Q1_Safe"
+    },
+    {
+      "package": "orchestration",
+      "function": "StageHeroMap",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/orchestration/heroes.go",
+      "line": 82,
+      "complexity": 1,
+      "line_coverage": 100,
+      "crap": 1,
+      "contract_coverage": 0,
+      "gaze_crap": 2,
+      "quadrant": "Q1_Safe",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        73,
+        73
+      ]
+    },
+    {
+      "package": "orchestration",
+      "function": "StageExecutionModeMap",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/orchestration/heroes.go",
+      "line": 97,
+      "complexity": 1,
+      "line_coverage": 100,
+      "crap": 1,
+      "contract_coverage": 0,
+      "gaze_crap": 2,
+      "quadrant": "Q1_Safe",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        73,
+        73
+      ]
+    },
+    {
+      "package": "orchestration",
+      "function": "hasDivisorAgent",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/orchestration/heroes.go",
+      "line": 109,
+      "complexity": 6,
+      "line_coverage": 85.71428571428571,
+      "crap": 6.104956268221574
+    },
+    {
+      "package": "orchestration",
+      "function": "fileExists",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/orchestration/heroes.go",
+      "line": 123,
+      "complexity": 2,
+      "line_coverage": 100,
+      "crap": 2
+    },
+    {
+      "package": "orchestration",
+      "function": "AnalyzeWorkflows",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/orchestration/learning.go",
+      "line": 25,
+      "complexity": 2,
+      "line_coverage": 100,
+      "crap": 2,
+      "contract_coverage": 0,
+      "gaze_crap": 6,
+      "quadrant": "Q1_Safe",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        74,
+        74
+      ]
+    },
+    {
+      "package": "orchestration",
+      "function": "analyzeReviewPatterns",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/orchestration/learning.go",
+      "line": 47,
+      "complexity": 7,
+      "line_coverage": 100,
+      "crap": 7
+    },
+    {
+      "package": "orchestration",
+      "function": "analyzeVelocityPatterns",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/orchestration/learning.go",
+      "line": 84,
+      "complexity": 6,
+      "line_coverage": 73.33333333333333,
+      "crap": 6.682666666666667
+    },
+    {
+      "package": "orchestration",
+      "function": "countReviewIterations",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/orchestration/learning.go",
+      "line": 126,
+      "complexity": 3,
+      "line_coverage": 100,
+      "crap": 3
+    },
+    {
+      "package": "orchestration",
+      "function": "normalizeError",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/orchestration/learning.go",
+      "line": 137,
+      "complexity": 4,
+      "line_coverage": 66.66666666666667,
+      "crap": 4.592592592592593
+    },
+    {
+      "package": "orchestration",
+      "function": "NextFeedbackID",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/orchestration/learning.go",
+      "line": 151,
+      "complexity": 4,
+      "line_coverage": 100,
+      "crap": 4,
+      "contract_coverage": 0,
+      "gaze_crap": 20,
+      "quadrant": "Q3_SimpleButUnderspecified",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        58,
+        58
+      ]
+    },
+    {
+      "package": "orchestration",
+      "function": "SaveFeedback",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/orchestration/learning.go",
+      "line": 166,
+      "complexity": 5,
+      "line_coverage": 72.72727272727273,
+      "crap": 5.507137490608565,
+      "contract_coverage": 0,
+      "gaze_crap": 30,
+      "quadrant": "Q3_SimpleButUnderspecified",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        58,
+        68
+      ]
+    },
+    {
+      "package": "orchestration",
+      "function": "LoadFeedback",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/orchestration/learning.go",
+      "line": 188,
+      "complexity": 8,
+      "line_coverage": 80.95238095238095,
+      "crap": 8.442284850448116,
+      "contract_coverage": 0,
+      "gaze_crap": 72,
+      "quadrant": "Q3_SimpleButUnderspecified",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        74,
+        74
+      ]
+    },
+    {
+      "package": "orchestration",
+      "function": "dedup",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/orchestration/learning.go",
+      "line": 226,
+      "complexity": 3,
+      "line_coverage": 100,
+      "crap": 3
+    },
+    {
+      "package": "orchestration",
+      "function": "StageOrder",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/orchestration/models.go",
+      "line": 22,
+      "complexity": 1,
+      "line_coverage": 100,
+      "crap": 1,
+      "contract_coverage": 0,
+      "gaze_crap": 2,
+      "quadrant": "Q1_Safe",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        73,
+        73
+      ]
+    },
+    {
+      "package": "orchestration",
+      "function": "GenerateWorkflowRecord",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/orchestration/record.go",
+      "line": 13,
+      "complexity": 2,
+      "line_coverage": 100,
+      "crap": 2,
+      "contract_coverage": 0,
+      "gaze_crap": 6,
+      "quadrant": "Q1_Safe",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        64,
+        64
+      ]
+    },
+    {
+      "package": "orchestration",
+      "function": "determineOutcome",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/orchestration/record.go",
+      "line": 40,
+      "complexity": 6,
+      "line_coverage": 100,
+      "crap": 6
+    },
+    {
+      "package": "orchestration",
+      "function": "(*WorkflowStore).Save",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/orchestration/store.go",
+      "line": 20,
+      "complexity": 4,
+      "line_coverage": 66.66666666666667,
+      "crap": 4.592592592592593,
+      "contract_coverage": 0,
+      "gaze_crap": 20,
+      "quadrant": "Q3_SimpleButUnderspecified",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        64,
+        74
+      ]
+    },
+    {
+      "package": "orchestration",
+      "function": "(*WorkflowStore).Load",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/orchestration/store.go",
+      "line": 38,
+      "complexity": 3,
+      "line_coverage": 87.5,
+      "crap": 3.017578125,
+      "contract_coverage": 100,
+      "gaze_crap": 3,
+      "quadrant": "Q1_Safe"
+    },
+    {
+      "package": "orchestration",
+      "function": "(*WorkflowStore).List",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/orchestration/store.go",
+      "line": 55,
+      "complexity": 10,
+      "line_coverage": 80.95238095238095,
+      "crap": 10.691070078825181,
+      "contract_coverage": 0,
+      "gaze_crap": 110,
+      "quadrant": "Q3_SimpleButUnderspecified",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        70,
+        70
+      ]
+    },
+    {
+      "package": "orchestration",
+      "function": "(*WorkflowStore).Latest",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/orchestration/store.go",
+      "line": 99,
+      "complexity": 6,
+      "line_coverage": 87.5,
+      "crap": 6.0703125,
+      "contract_coverage": 100,
+      "gaze_crap": 6,
+      "quadrant": "Q1_Safe"
+    },
+    {
+      "package": "sandbox",
+      "function": "ResolveBackend",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/sandbox/backend.go",
+      "line": 80,
+      "complexity": 11,
+      "line_coverage": 85,
+      "crap": 11.408375,
+      "contract_coverage": 0,
+      "gaze_crap": 132,
+      "quadrant": "Q3_SimpleButUnderspecified",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        64,
+        64
+      ]
+    },
+    {
+      "package": "sandbox",
+      "function": "autoDetectBackend",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/sandbox/backend.go",
+      "line": 130,
+      "complexity": 3,
+      "line_coverage": 100,
+      "crap": 3
+    },
+    {
+      "package": "sandbox",
+      "function": "gatewayEnvVars",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/sandbox/config.go",
+      "line": 80,
+      "complexity": 1,
+      "line_coverage": 100,
+      "crap": 1
+    },
+    {
+      "package": "sandbox",
+      "function": "DefaultConfig",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/sandbox/config.go",
+      "line": 90,
+      "complexity": 8,
+      "line_coverage": 93.33333333333333,
+      "crap": 8.018962962962963,
+      "contract_coverage": 0,
+      "gaze_crap": 72,
+      "quadrant": "Q3_SimpleButUnderspecified",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        64,
+        64
+      ]
+    },
+    {
+      "package": "sandbox",
+      "function": "forwardedEnvVars",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/sandbox/config.go",
+      "line": 129,
+      "complexity": 5,
+      "line_coverage": 100,
+      "crap": 5
+    },
+    {
+      "package": "sandbox",
+      "function": "useParentMount",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/sandbox/config.go",
+      "line": 150,
+      "complexity": 3,
+      "line_coverage": 100,
+      "crap": 3
+    },
+    {
+      "package": "sandbox",
+      "function": "buildVolumeMounts",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/sandbox/config.go",
+      "line": 166,
+      "complexity": 4,
+      "line_coverage": 100,
+      "crap": 4
+    },
+    {
+      "package": "sandbox",
+      "function": "uidMappingArgs",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/sandbox/config.go",
+      "line": 189,
+      "complexity": 2,
+      "line_coverage": 100,
+      "crap": 2
+    },
+    {
+      "package": "sandbox",
+      "function": "buildRunArgs",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/sandbox/config.go",
+      "line": 211,
+      "complexity": 3,
+      "line_coverage": 100,
+      "crap": 3
+    },
+    {
+      "package": "sandbox",
+      "function": "DetectPlatform",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/sandbox/detect.go",
+      "line": 36,
+      "complexity": 7,
+      "line_coverage": 90,
+      "crap": 7.049,
+      "contract_coverage": 0,
+      "gaze_crap": 56,
+      "quadrant": "Q3_SimpleButUnderspecified",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        64,
+        64
+      ]
+    },
+    {
+      "package": "sandbox",
+      "function": "probeUIDMapping",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/sandbox/detect.go",
+      "line": 84,
+      "complexity": 3,
+      "line_coverage": 100,
+      "crap": 3
+    },
+    {
+      "package": "sandbox",
+      "function": "parsePodmanVersion",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/sandbox/detect.go",
+      "line": 112,
+      "complexity": 6,
+      "line_coverage": 70.58823529411765,
+      "crap": 6.915937309179727
+    },
+    {
+      "package": "sandbox",
+      "function": "isRootlessPodman",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/sandbox/detect.go",
+      "line": 146,
+      "complexity": 2,
+      "line_coverage": 75,
+      "crap": 2.0625
+    },
+    {
+      "package": "sandbox",
+      "function": "validateIDE",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/sandbox/devpod.go",
+      "line": 23,
+      "complexity": 3,
+      "line_coverage": 100,
+      "crap": 3
+    },
+    {
+      "package": "sandbox",
+      "function": "(*DevPodBackend).Name",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/sandbox/devpod.go",
+      "line": 41,
+      "complexity": 1,
+      "line_coverage": 100,
+      "crap": 1
+    },
+    {
+      "package": "sandbox",
+      "function": "devpodWorkspaceName",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/sandbox/devpod.go",
+      "line": 46,
+      "complexity": 1,
+      "line_coverage": 100,
+      "crap": 1
+    },
+    {
+      "package": "sandbox",
+      "function": "(*DevPodBackend).Create",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/sandbox/devpod.go",
+      "line": 60,
+      "complexity": 11,
+      "line_coverage": 83.33333333333333,
+      "crap": 11.560185185185187,
+      "contract_coverage": 0,
+      "gaze_crap": 132,
+      "quadrant": "Q3_SimpleButUnderspecified",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        58,
+        58
+      ]
+    },
+    {
+      "package": "sandbox",
+      "function": "(*DevPodBackend).Start",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/sandbox/devpod.go",
+      "line": 160,
+      "complexity": 7,
+      "line_coverage": 95,
+      "crap": 7.006125,
+      "contract_coverage": 0,
+      "gaze_crap": 56,
+      "quadrant": "Q3_SimpleButUnderspecified",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        58,
+        58
+      ]
+    },
+    {
+      "package": "sandbox",
+      "function": "(*DevPodBackend).Stop",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/sandbox/devpod.go",
+      "line": 216,
+      "complexity": 2,
+      "line_coverage": 85.71428571428571,
+      "crap": 2.011661807580175,
+      "contract_coverage": 0,
+      "gaze_crap": 6,
+      "quadrant": "Q1_Safe",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        73,
+        73
+      ]
+    },
+    {
+      "package": "sandbox",
+      "function": "(*DevPodBackend).Destroy",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/sandbox/devpod.go",
+      "line": 232,
+      "complexity": 2,
+      "line_coverage": 85.71428571428571,
+      "crap": 2.011661807580175,
+      "contract_coverage": 0,
+      "gaze_crap": 6,
+      "quadrant": "Q1_Safe",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        58,
+        58
+      ]
+    },
+    {
+      "package": "sandbox",
+      "function": "(*DevPodBackend).isWorkspaceRunning",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/sandbox/devpod.go",
+      "line": 252,
+      "complexity": 3,
+      "line_coverage": 100,
+      "crap": 3
+    },
+    {
+      "package": "sandbox",
+      "function": "(*DevPodBackend).startServerViaSSH",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/sandbox/devpod.go",
+      "line": 278,
+      "complexity": 1,
+      "line_coverage": 100,
+      "crap": 1
+    },
+    {
+      "package": "sandbox",
+      "function": "(*DevPodBackend).attachOrDetach",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/sandbox/devpod.go",
+      "line": 293,
+      "complexity": 2,
+      "line_coverage": 66.66666666666667,
+      "crap": 2.148148148148148
+    },
+    {
+      "package": "sandbox",
+      "function": "(*DevPodBackend).Status",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/sandbox/devpod.go",
+      "line": 315,
+      "complexity": 3,
+      "line_coverage": 80,
+      "crap": 3.072,
+      "contract_coverage": 0,
+      "gaze_crap": 12,
+      "quadrant": "Q1_Safe",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        79,
+        79
+      ]
+    },
+    {
+      "package": "sandbox",
+      "function": "(*DevPodBackend).Attach",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/sandbox/devpod.go",
+      "line": 350,
+      "complexity": 2,
+      "line_coverage": 80,
+      "crap": 2.032,
+      "contract_coverage": 0,
+      "gaze_crap": 6,
+      "quadrant": "Q1_Safe",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        58,
+        58
+      ]
+    },
+    {
+      "package": "sandbox",
+      "function": "parseDevPodVersion",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/sandbox/devpod.go",
+      "line": 365,
+      "complexity": 7,
+      "line_coverage": 76.19047619047619,
+      "crap": 7.661375661375661
+    },
+    {
+      "package": "sandbox",
+      "function": "checkDevPodVersion",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/sandbox/devpod.go",
+      "line": 408,
+      "complexity": 4,
+      "line_coverage": 83.33333333333333,
+      "crap": 4.074074074074074
+    },
+    {
+      "package": "sandbox",
+      "function": "isDevPodWorkspace",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/sandbox/devpod.go",
+      "line": 430,
+      "complexity": 2,
+      "line_coverage": 100,
+      "crap": 2
+    },
+    {
+      "package": "sandbox",
+      "function": "(*PodmanBackend).Name",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/sandbox/podman.go",
+      "line": 15,
+      "complexity": 1,
+      "line_coverage": 100,
+      "crap": 1
+    },
+    {
+      "package": "sandbox",
+      "function": "(*PodmanBackend).Create",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/sandbox/podman.go",
+      "line": 30,
+      "complexity": 9,
+      "line_coverage": 92.6829268292683,
+      "crap": 9.031731982995023,
+      "contract_coverage": 0,
+      "gaze_crap": 90,
+      "quadrant": "Q3_SimpleButUnderspecified",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        58,
+        58
+      ]
+    },
+    {
+      "package": "sandbox",
+      "function": "(*PodmanBackend).Start",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/sandbox/podman.go",
+      "line": 123,
+      "complexity": 5,
+      "line_coverage": 75,
+      "crap": 5.390625,
+      "contract_coverage": 0,
+      "gaze_crap": 30,
+      "quadrant": "Q3_SimpleButUnderspecified",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        58,
+        58
+      ]
+    },
+    {
+      "package": "sandbox",
+      "function": "(*PodmanBackend).Stop",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/sandbox/podman.go",
+      "line": 164,
+      "complexity": 2,
+      "line_coverage": 75,
+      "crap": 2.0625,
+      "contract_coverage": 0,
+      "gaze_crap": 6,
+      "quadrant": "Q1_Safe",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        73,
+        73
+      ]
+    },
+    {
+      "package": "sandbox",
+      "function": "(*PodmanBackend).Destroy",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/sandbox/podman.go",
+      "line": 184,
+      "complexity": 1,
+      "line_coverage": 100,
+      "crap": 1,
+      "contract_coverage": 0,
+      "gaze_crap": 2,
+      "quadrant": "Q1_Safe",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        58,
+        58
+      ]
+    },
+    {
+      "package": "sandbox",
+      "function": "(*PodmanBackend).Status",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/sandbox/podman.go",
+      "line": 204,
+      "complexity": 8,
+      "line_coverage": 92.3076923076923,
+      "crap": 8.029130632680928,
+      "contract_coverage": 0,
+      "gaze_crap": 72,
+      "quadrant": "Q3_SimpleButUnderspecified",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        79,
+        79
+      ]
+    },
+    {
+      "package": "sandbox",
+      "function": "(*PodmanBackend).Attach",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/sandbox/podman.go",
+      "line": 263,
+      "complexity": 2,
+      "line_coverage": 80,
+      "crap": 2.032,
+      "contract_coverage": 0,
+      "gaze_crap": 6,
+      "quadrant": "Q1_Safe",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        58,
+        58
+      ]
+    },
+    {
+      "package": "sandbox",
+      "function": "buildPersistentRunArgs",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/sandbox/podman.go",
+      "line": 277,
+      "complexity": 3,
+      "line_coverage": 100,
+      "crap": 3
+    },
+    {
+      "package": "sandbox",
+      "function": "mergeDemoPorts",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/sandbox/podman.go",
+      "line": 321,
+      "complexity": 5,
+      "line_coverage": 100,
+      "crap": 5
+    },
+    {
+      "package": "sandbox",
+      "function": "(*Options).defaults",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/sandbox/sandbox.go",
+      "line": 200,
+      "complexity": 14,
+      "line_coverage": 100,
+      "crap": 14
+    },
+    {
+      "package": "sandbox",
+      "function": "defaultExecCmd",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/sandbox/sandbox.go",
+      "line": 243,
+      "complexity": 1,
+      "line_coverage": 0,
+      "crap": 2
+    },
+    {
+      "package": "sandbox",
+      "function": "defaultExecInteractive",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/sandbox/sandbox.go",
+      "line": 249,
+      "complexity": 1,
+      "line_coverage": 0,
+      "crap": 2
+    },
+    {
+      "package": "sandbox",
+      "function": "defaultHTTPGet",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/sandbox/sandbox.go",
+      "line": 258,
+      "complexity": 2,
+      "line_coverage": 0,
+      "crap": 6
+    },
+    {
+      "package": "sandbox",
+      "function": "gatewayHealthCheck",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/sandbox/sandbox.go",
+      "line": 275,
+      "complexity": 2,
+      "line_coverage": 100,
+      "crap": 2
+    },
+    {
+      "package": "sandbox",
+      "function": "autoStartGateway",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/sandbox/sandbox.go",
+      "line": 294,
+      "complexity": 11,
+      "line_coverage": 69.56521739130434,
+      "crap": 14.411112024328101
+    },
+    {
+      "package": "sandbox",
+      "function": "isContainerRunning",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/sandbox/sandbox.go",
+      "line": 345,
+      "complexity": 2,
+      "line_coverage": 100,
+      "crap": 2
+    },
+    {
+      "package": "sandbox",
+      "function": "isContainerExists",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/sandbox/sandbox.go",
+      "line": 357,
+      "complexity": 1,
+      "line_coverage": 100,
+      "crap": 1
+    },
+    {
+      "package": "sandbox",
+      "function": "waitForHealth",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/sandbox/sandbox.go",
+      "line": 366,
+      "complexity": 6,
+      "line_coverage": 92.85714285714286,
+      "crap": 6.013119533527696
+    },
+    {
+      "package": "sandbox",
+      "function": "Create",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/sandbox/sandbox.go",
+      "line": 396,
+      "complexity": 4,
+      "line_coverage": 84.61538461538461,
+      "crap": 4.058261265361857,
+      "contract_coverage": 0,
+      "gaze_crap": 20,
+      "quadrant": "Q3_SimpleButUnderspecified",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        63,
+        63
+      ]
+    },
+    {
+      "package": "sandbox",
+      "function": "Destroy",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/sandbox/sandbox.go",
+      "line": 429,
+      "complexity": 4,
+      "line_coverage": 69.23076923076923,
+      "crap": 4.466090122894856,
+      "contract_coverage": 0,
+      "gaze_crap": 20,
+      "quadrant": "Q3_SimpleButUnderspecified",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        63,
+        63
+      ]
+    },
+    {
+      "package": "sandbox",
+      "function": "isPersistentWorkspace",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/sandbox/sandbox.go",
+      "line": 459,
+      "complexity": 2,
+      "line_coverage": 100,
+      "crap": 2
+    },
+    {
+      "package": "sandbox",
+      "function": "Start",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/sandbox/sandbox.go",
+      "line": 479,
+      "complexity": 31,
+      "line_coverage": 81.81818181818181,
+      "crap": 36.77610818933134,
+      "contract_coverage": 0,
+      "gaze_crap": 992,
+      "quadrant": "Q4_Dangerous",
+      "fix_strategy": "decompose",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        63,
+        63
+      ]
+    },
+    {
+      "package": "sandbox",
+      "function": "Stop",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/sandbox/sandbox.go",
+      "line": 656,
+      "complexity": 5,
+      "line_coverage": 64.28571428571429,
+      "crap": 6.138848396501457,
+      "contract_coverage": 0,
+      "gaze_crap": 30,
+      "quadrant": "Q3_SimpleButUnderspecified",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        78,
+        78
+      ]
+    },
+    {
+      "package": "sandbox",
+      "function": "Attach",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/sandbox/sandbox.go",
+      "line": 695,
+      "complexity": 6,
+      "line_coverage": 73.33333333333333,
+      "crap": 6.682666666666667,
+      "contract_coverage": 0,
+      "gaze_crap": 42,
+      "quadrant": "Q3_SimpleButUnderspecified",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        63,
+        63
+      ]
+    },
+    {
+      "package": "sandbox",
+      "function": "Extract",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/sandbox/sandbox.go",
+      "line": 735,
+      "complexity": 15,
+      "line_coverage": 86.95652173913044,
+      "crap": 15.49930138900304,
+      "contract_coverage": 0,
+      "gaze_crap": 240,
+      "quadrant": "Q4_Dangerous",
+      "fix_strategy": "decompose",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        63,
+        63
+      ]
+    },
+    {
+      "package": "sandbox",
+      "function": "WorkspaceStatusCheck",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/sandbox/sandbox.go",
+      "line": 825,
+      "complexity": 3,
+      "line_coverage": 85.71428571428571,
+      "crap": 3.0262390670553936,
+      "contract_coverage": 50,
+      "gaze_crap": 4.125,
+      "quadrant": "Q1_Safe"
+    },
+    {
+      "package": "sandbox",
+      "function": "Status",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/sandbox/sandbox.go",
+      "line": 843,
+      "complexity": 9,
+      "line_coverage": 92,
+      "crap": 9.041472,
+      "contract_coverage": 100,
+      "gaze_crap": 9,
+      "quadrant": "Q1_Safe"
+    },
+    {
+      "package": "sandbox",
+      "function": "FormatStatus",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/sandbox/sandbox.go",
+      "line": 901,
+      "complexity": 3,
+      "line_coverage": 100,
+      "crap": 3,
+      "contract_coverage": 0,
+      "gaze_crap": 12,
+      "quadrant": "Q1_Safe",
+      "contract_coverage_reason": "no_effects_detected"
+    },
+    {
+      "package": "sandbox",
+      "function": "InitDevcontainer",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/sandbox/sandbox.go",
+      "line": 966,
+      "complexity": 15,
+      "line_coverage": 75.60975609756098,
+      "crap": 18.264607304014742,
+      "contract_coverage": 0,
+      "gaze_crap": 240,
+      "quadrant": "Q4_Dangerous",
+      "fix_strategy": "decompose",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        63,
+        63
+      ]
+    },
+    {
+      "package": "sandbox",
+      "function": "devcontainerRunArgs",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/sandbox/sandbox.go",
+      "line": 1050,
+      "complexity": 2,
+      "line_coverage": 100,
+      "crap": 2
+    },
+    {
+      "package": "sandbox",
+      "function": "isYes",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/sandbox/sandbox.go",
+      "line": 1060,
+      "complexity": 2,
+      "line_coverage": 100,
+      "crap": 2
+    },
+    {
+      "package": "sandbox",
+      "function": "ProjectNameFromDir",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/sandbox/workspace.go",
+      "line": 120,
+      "complexity": 1,
+      "line_coverage": 100,
+      "crap": 1,
+      "contract_coverage": 0,
+      "gaze_crap": 2,
+      "quadrant": "Q1_Safe",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        63,
+        63
+      ]
+    },
+    {
+      "package": "sandbox",
+      "function": "projectName",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/sandbox/workspace.go",
+      "line": 129,
+      "complexity": 2,
+      "line_coverage": 100,
+      "crap": 2
+    },
+    {
+      "package": "sandbox",
+      "function": "containerNameForProject",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/sandbox/workspace.go",
+      "line": 143,
+      "complexity": 1,
+      "line_coverage": 100,
+      "crap": 1
+    },
+    {
+      "package": "sandbox",
+      "function": "volumeNameForProject",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/sandbox/workspace.go",
+      "line": 150,
+      "complexity": 1,
+      "line_coverage": 100,
+      "crap": 1
+    },
+    {
+      "package": "sandbox",
+      "function": "LoadConfig",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/sandbox/workspace.go",
+      "line": 159,
+      "complexity": 6,
+      "line_coverage": 92.3076923076923,
+      "crap": 6.0163859808830225,
+      "contract_coverage": 100,
+      "gaze_crap": 6,
+      "quadrant": "Q1_Safe"
+    },
+    {
+      "package": "sandbox",
+      "function": "FormatWorkspaceStatus",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/sandbox/workspace.go",
+      "line": 187,
+      "complexity": 10,
+      "line_coverage": 100,
+      "crap": 10,
+      "contract_coverage": 0,
+      "gaze_crap": 110,
+      "quadrant": "Q3_SimpleButUnderspecified",
+      "contract_coverage_reason": "no_effects_detected"
+    },
+    {
+      "package": "sandbox",
+      "function": "setupGitSync",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/sandbox/workspace.go",
+      "line": 231,
+      "complexity": 5,
+      "line_coverage": 78.57142857142857,
+      "crap": 5.2459912536443145
+    },
+    {
+      "package": "sandbox",
+      "function": "checkGitSync",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/sandbox/workspace.go",
+      "line": 271,
+      "complexity": 4,
+      "line_coverage": 77.77777777777777,
+      "crap": 4.175582990397805
+    },
+    {
+      "package": "scaffold",
+      "function": "defaultExecCmd",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/scaffold/scaffold.go",
+      "line": 57,
+      "complexity": 1,
+      "line_coverage": 100,
+      "crap": 1
+    },
+    {
+      "package": "scaffold",
+      "function": "Run",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/scaffold/scaffold.go",
+      "line": 63,
+      "complexity": 33,
+      "line_coverage": 82.22222222222223,
+      "crap": 39.11871604938271,
+      "contract_coverage": 0,
+      "gaze_crap": 1122,
+      "quadrant": "Q4_Dangerous",
+      "fix_strategy": "decompose",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        69,
+        69
+      ]
+    },
+    {
+      "package": "scaffold",
+      "function": "warnLegacyReviewerFiles",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/scaffold/scaffold.go",
+      "line": 254,
+      "complexity": 4,
+      "line_coverage": 100,
+      "crap": 4
+    },
+    {
+      "package": "scaffold",
+      "function": "mapAssetPath",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/scaffold/scaffold.go",
+      "line": 281,
+      "complexity": 4,
+      "line_coverage": 80,
+      "crap": 4.128
+    },
+    {
+      "package": "scaffold",
+      "function": "isToolOwned",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/scaffold/scaffold.go",
+      "line": 308,
+      "complexity": 5,
+      "line_coverage": 100,
+      "crap": 5
+    },
+    {
+      "package": "scaffold",
+      "function": "isDivisorAsset",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/scaffold/scaffold.go",
+      "line": 334,
+      "complexity": 5,
+      "line_coverage": 100,
+      "crap": 5
+    },
+    {
+      "package": "scaffold",
+      "function": "isConventionPack",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/scaffold/scaffold.go",
+      "line": 352,
+      "complexity": 1,
+      "line_coverage": 100,
+      "crap": 1
+    },
+    {
+      "package": "scaffold",
+      "function": "shouldDeployPack",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/scaffold/scaffold.go",
+      "line": 373,
+      "complexity": 5,
+      "line_coverage": 100,
+      "crap": 5
+    },
+    {
+      "package": "scaffold",
+      "function": "detectLang",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/scaffold/scaffold.go",
+      "line": 394,
+      "complexity": 3,
+      "line_coverage": 100,
+      "crap": 3
+    },
+    {
+      "package": "scaffold",
+      "function": "versionMarker",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/scaffold/scaffold.go",
+      "line": 421,
+      "complexity": 2,
+      "line_coverage": 100,
+      "crap": 2
+    },
+    {
+      "package": "scaffold",
+      "function": "stripExistingMarkers",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/scaffold/scaffold.go",
+      "line": 435,
+      "complexity": 4,
+      "line_coverage": 100,
+      "crap": 4
+    },
+    {
+      "package": "scaffold",
+      "function": "insertMarkerAfterFrontmatter",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/scaffold/scaffold.go",
+      "line": 456,
+      "complexity": 6,
+      "line_coverage": 86.66666666666667,
+      "crap": 6.085333333333334
+    },
+    {
+      "package": "scaffold",
+      "function": "configureOpencodeJSON",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/scaffold/scaffold.go",
+      "line": 514,
+      "complexity": 48,
+      "line_coverage": 97.16981132075472,
+      "crap": 48.052231036358876,
+      "fix_strategy": "decompose"
+    },
+    {
+      "package": "scaffold",
+      "function": "ensureGitignore",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/scaffold/scaffold.go",
+      "line": 799,
+      "complexity": 10,
+      "line_coverage": 82.3529411764706,
+      "crap": 10.549562385507835
+    },
+    {
+      "package": "scaffold",
+      "function": "migrateCommandDir",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/scaffold/scaffold.go",
+      "line": 855,
+      "complexity": 14,
+      "line_coverage": 80.85106382978724,
+      "crap": 15.376226847615651,
+      "fix_strategy": "add_tests"
+    },
+    {
+      "package": "scaffold",
+      "function": "moveFile",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/scaffold/scaffold.go",
+      "line": 966,
+      "complexity": 4,
+      "line_coverage": 25,
+      "crap": 10.75
+    },
+    {
+      "package": "scaffold",
+      "function": "countMDFiles",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/scaffold/scaffold.go",
+      "line": 982,
+      "complexity": 5,
+      "line_coverage": 87.5,
+      "crap": 5.048828125
+    },
+    {
+      "package": "scaffold",
+      "function": "ensureAGENTSmdPackSection",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/scaffold/scaffold.go",
+      "line": 1005,
+      "complexity": 7,
+      "line_coverage": 86.95652173913044,
+      "crap": 7.10873674693844
+    },
+    {
+      "package": "scaffold",
+      "function": "replaceManagedBlock",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/scaffold/scaffold.go",
+      "line": 1064,
+      "complexity": 3,
+      "line_coverage": 100,
+      "crap": 3
+    },
+    {
+      "package": "scaffold",
+      "function": "buildCLAUDEmdBlock",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/scaffold/scaffold.go",
+      "line": 1084,
+      "complexity": 2,
+      "line_coverage": 100,
+      "crap": 2
+    },
+    {
+      "package": "scaffold",
+      "function": "ensureCLAUDEmd",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/scaffold/scaffold.go",
+      "line": 1110,
+      "complexity": 13,
+      "line_coverage": 84.61538461538461,
+      "crap": 13.615384615384615
+    },
+    {
+      "package": "scaffold",
+      "function": "buildCursorrulesBlock",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/scaffold/scaffold.go",
+      "line": 1186,
+      "complexity": 2,
+      "line_coverage": 100,
+      "crap": 2
+    },
+    {
+      "package": "scaffold",
+      "function": "ensureCursorrules",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/scaffold/scaffold.go",
+      "line": 1216,
+      "complexity": 13,
+      "line_coverage": 84.61538461538461,
+      "crap": 13.615384615384615
+    },
+    {
+      "package": "scaffold",
+      "function": "hasRuleContent",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/scaffold/scaffold.go",
+      "line": 1291,
+      "complexity": 3,
+      "line_coverage": 100,
+      "crap": 3
+    },
+    {
+      "package": "scaffold",
+      "function": "collectDeployedPacks",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/scaffold/scaffold.go",
+      "line": 1318,
+      "complexity": 3,
+      "line_coverage": 100,
+      "crap": 3
+    },
+    {
+      "package": "scaffold",
+      "function": "filterEmptyCustomPacks",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/scaffold/scaffold.go",
+      "line": 1338,
+      "complexity": 5,
+      "line_coverage": 100,
+      "crap": 5
+    },
+    {
+      "package": "scaffold",
+      "function": "initSubTools",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/scaffold/scaffold.go",
+      "line": 1360,
+      "complexity": 13,
+      "line_coverage": 100,
+      "crap": 13
+    },
+    {
+      "package": "scaffold",
+      "function": "initDewey",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/scaffold/scaffold.go",
+      "line": 1504,
+      "complexity": 8,
+      "line_coverage": 90.9090909090909,
+      "crap": 8.0480841472577
+    },
+    {
+      "package": "scaffold",
+      "function": "initSimpleTool",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/scaffold/scaffold.go",
+      "line": 1566,
+      "complexity": 3,
+      "line_coverage": 100,
+      "crap": 3
+    },
+    {
+      "package": "scaffold",
+      "function": "subToolSymbol",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/scaffold/scaffold.go",
+      "line": 1589,
+      "complexity": 3,
+      "line_coverage": 75,
+      "crap": 3.140625
+    },
+    {
+      "package": "scaffold",
+      "function": "printFileCategories",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/scaffold/scaffold.go",
+      "line": 1609,
+      "complexity": 9,
+      "line_coverage": 100,
+      "crap": 9
+    },
+    {
+      "package": "scaffold",
+      "function": "printSubToolResults",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/scaffold/scaffold.go",
+      "line": 1638,
+      "complexity": 10,
+      "line_coverage": 100,
+      "crap": 10
+    },
+    {
+      "package": "scaffold",
+      "function": "printNextSteps",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/scaffold/scaffold.go",
+      "line": 1667,
+      "complexity": 11,
+      "line_coverage": 100,
+      "crap": 11
+    },
+    {
+      "package": "scaffold",
+      "function": "printSummary",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/scaffold/scaffold.go",
+      "line": 1704,
+      "complexity": 2,
+      "line_coverage": 100,
+      "crap": 2
+    },
+    {
+      "package": "scaffold",
+      "function": "assetPaths",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/scaffold/scaffold.go",
+      "line": 1720,
+      "complexity": 3,
+      "line_coverage": 88.88888888888889,
+      "crap": 3.0123456790123457
+    },
+    {
+      "package": "scaffold",
+      "function": "assetContent",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/scaffold/scaffold.go",
+      "line": 1737,
+      "complexity": 1,
+      "line_coverage": 100,
+      "crap": 1
+    },
+    {
+      "package": "scaffold",
+      "function": "generateDeweySources",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/scaffold/scaffold.go",
+      "line": 1751,
+      "complexity": 11,
+      "line_coverage": 88.46153846153847,
+      "crap": 11.185878470641784
+    },
+    {
+      "package": "scaffold",
+      "function": "isDefaultSourcesConfig",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/scaffold/scaffold.go",
+      "line": 1821,
+      "complexity": 1,
+      "line_coverage": 100,
+      "crap": 1
+    },
+    {
+      "package": "scaffold",
+      "function": "extractGitHubOrg",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/scaffold/scaffold.go",
+      "line": 1830,
+      "complexity": 8,
+      "line_coverage": 90,
+      "crap": 8.064
+    },
+    {
+      "package": "scaffold",
+      "function": "DevcontainerContent",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/scaffold/scaffold.go",
+      "line": 1869,
+      "complexity": 1,
+      "line_coverage": 0,
+      "crap": 2
+    },
+    {
+      "package": "scaffold",
+      "function": "writeSourcesConfig",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/scaffold/scaffold.go",
+      "line": 1878,
+      "complexity": 4,
+      "line_coverage": 100,
+      "crap": 4
+    },
+    {
+      "package": "schemas",
+      "function": "GenerateSchema",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/schemas/generate.go",
+      "line": 20,
+      "complexity": 2,
+      "line_coverage": 80,
+      "crap": 2.032
+    },
+    {
+      "package": "schemas",
+      "function": "WriteSchema",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/schemas/generate.go",
+      "line": 34,
+      "complexity": 4,
+      "line_coverage": 66.66666666666667,
+      "crap": 4.592592592592593
+    },
+    {
+      "package": "schemas",
+      "function": "ValidateConventionPack",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/schemas/packvalidator.go",
+      "line": 31,
+      "complexity": 8,
+      "line_coverage": 94.44444444444444,
+      "crap": 8.010973936899862
+    },
+    {
+      "package": "schemas",
+      "function": "extractFrontmatter",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/schemas/packvalidator.go",
+      "line": 73,
+      "complexity": 7,
+      "line_coverage": 87.5,
+      "crap": 7.095703125
+    },
+    {
+      "package": "schemas",
+      "function": "extractH2Sections",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/schemas/packvalidator.go",
+      "line": 105,
+      "complexity": 3,
+      "line_coverage": 100,
+      "crap": 3
+    },
+    {
+      "package": "schemas",
+      "function": "registeredTypes",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/schemas/registry.go",
+      "line": 21,
+      "complexity": 1,
+      "line_coverage": 100,
+      "crap": 1
+    },
+    {
+      "package": "schemas",
+      "function": "RegisteredTypeNames",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/schemas/registry.go",
+      "line": 36,
+      "complexity": 2,
+      "line_coverage": 100,
+      "crap": 2
+    },
+    {
+      "package": "schemas",
+      "function": "GenerateAll",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/schemas/registry.go",
+      "line": 49,
+      "complexity": 4,
+      "line_coverage": 75,
+      "crap": 4.25
+    },
+    {
+      "package": "schemas",
+      "function": "ValidateArtifact",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/schemas/validate.go",
+      "line": 16,
+      "complexity": 3,
+      "line_coverage": 85.71428571428571,
+      "crap": 3.0262390670553936,
+      "contract_coverage": 0,
+      "gaze_crap": 12,
+      "quadrant": "Q1_Safe",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        73,
+        73
+      ]
+    },
+    {
+      "package": "schemas",
+      "function": "ValidateBytes",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/schemas/validate.go",
+      "line": 33,
+      "complexity": 6,
+      "line_coverage": 86.66666666666667,
+      "crap": 6.085333333333334,
+      "contract_coverage": 0,
+      "gaze_crap": 42,
+      "quadrant": "Q3_SimpleButUnderspecified",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        58,
+        58
+      ]
+    },
+    {
+      "package": "schemas",
+      "function": "semverParts",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/schemas/version.go",
+      "line": 11,
+      "complexity": 5,
+      "line_coverage": 78.57142857142857,
+      "crap": 5.2459912536443145
+    },
+    {
+      "package": "schemas",
+      "function": "CheckCompatibility",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/schemas/version.go",
+      "line": 49,
+      "complexity": 4,
+      "line_coverage": 100,
+      "crap": 4
+    },
+    {
+      "package": "setup",
+      "function": "(*Options).defaults",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/setup/setup.go",
+      "line": 92,
+      "complexity": 12,
+      "line_coverage": 100,
+      "crap": 12
+    },
+    {
+      "package": "setup",
+      "function": "defaultExecCmd",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/setup/setup.go",
+      "line": 129,
+      "complexity": 1,
+      "line_coverage": 0,
+      "crap": 2
+    },
+    {
+      "package": "setup",
+      "function": "(*Options).embeddingModel",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/setup/setup.go",
+      "line": 152,
+      "complexity": 2,
+      "line_coverage": 100,
+      "crap": 2
+    },
+    {
+      "package": "setup",
+      "function": "(*Options).embeddingDim",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/setup/setup.go",
+      "line": 160,
+      "complexity": 2,
+      "line_coverage": 100,
+      "crap": 2
+    },
+    {
+      "package": "setup",
+      "function": "(*Options).shouldSkipTool",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/setup/setup.go",
+      "line": 169,
+      "complexity": 11,
+      "line_coverage": 91.66666666666667,
+      "crap": 11.070023148148149
+    },
+    {
+      "package": "setup",
+      "function": "(*Options).toolMethod",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/setup/setup.go",
+      "line": 194,
+      "complexity": 4,
+      "line_coverage": 100,
+      "crap": 4
+    },
+    {
+      "package": "setup",
+      "function": "(*Options).resolveMethod",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/setup/setup.go",
+      "line": 211,
+      "complexity": 7,
+      "line_coverage": 100,
+      "crap": 7
+    },
+    {
+      "package": "setup",
+      "function": "installViaBrew",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/setup/setup.go",
+      "line": 251,
+      "complexity": 3,
+      "line_coverage": 100,
+      "crap": 3
+    },
+    {
+      "package": "setup",
+      "function": "installViaGo",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/setup/setup.go",
+      "line": 274,
+      "complexity": 4,
+      "line_coverage": 100,
+      "crap": 4
+    },
+    {
+      "package": "setup",
+      "function": "Run",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/setup/setup.go",
+      "line": 334,
+      "complexity": 2,
+      "line_coverage": 92.3076923076923,
+      "crap": 2.0018206645425582,
+      "contract_coverage": 0,
+      "gaze_crap": 6,
+      "quadrant": "Q1_Safe",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        63,
+        63
+      ]
+    },
+    {
+      "package": "setup",
+      "function": "buildSteps",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/setup/setup.go",
+      "line": 379,
+      "complexity": 5,
+      "line_coverage": 100,
+      "crap": 5
+    },
+    {
+      "package": "setup",
+      "function": "executeSteps",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/setup/setup.go",
+      "line": 439,
+      "complexity": 9,
+      "line_coverage": 95.23809523809524,
+      "crap": 9.008746355685131
+    },
+    {
+      "package": "setup",
+      "function": "printHeader",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/setup/setup.go",
+      "line": 478,
+      "complexity": 4,
+      "line_coverage": 100,
+      "crap": 4
+    },
+    {
+      "package": "setup",
+      "function": "printSummary",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/setup/setup.go",
+      "line": 505,
+      "complexity": 5,
+      "line_coverage": 100,
+      "crap": 5
+    },
+    {
+      "package": "setup",
+      "function": "installOpenCode",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/setup/setup.go",
+      "line": 537,
+      "complexity": 9,
+      "line_coverage": 93.33333333333333,
+      "crap": 9.024000000000001
+    },
+    {
+      "package": "setup",
+      "function": "installGH",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/setup/setup.go",
+      "line": 576,
+      "complexity": 4,
+      "line_coverage": 100,
+      "crap": 4
+    },
+    {
+      "package": "setup",
+      "function": "installGHViaDnf",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/setup/setup.go",
+      "line": 596,
+      "complexity": 3,
+      "line_coverage": 100,
+      "crap": 3
+    },
+    {
+      "package": "setup",
+      "function": "ghSkipResult",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/setup/setup.go",
+      "line": 613,
+      "complexity": 2,
+      "line_coverage": 100,
+      "crap": 2
+    },
+    {
+      "package": "setup",
+      "function": "installOpenSpec",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/setup/setup.go",
+      "line": 630,
+      "complexity": 4,
+      "line_coverage": 100,
+      "crap": 4
+    },
+    {
+      "package": "setup",
+      "function": "installGaze",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/setup/setup.go",
+      "line": 653,
+      "complexity": 6,
+      "line_coverage": 91.66666666666667,
+      "crap": 6.020833333333333
+    },
+    {
+      "package": "setup",
+      "function": "ensureNodeJS",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/setup/setup.go",
+      "line": 682,
+      "complexity": 5,
+      "line_coverage": 88.88888888888889,
+      "crap": 5.034293552812072
+    },
+    {
+      "package": "setup",
+      "function": "parseNodeMajor",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/setup/setup.go",
+      "line": 705,
+      "complexity": 2,
+      "line_coverage": 75,
+      "crap": 2.0625
+    },
+    {
+      "package": "setup",
+      "function": "installNodeJS",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/setup/setup.go",
+      "line": 715,
+      "complexity": 11,
+      "line_coverage": 92.3076923076923,
+      "crap": 11.055075102412381
+    },
+    {
+      "package": "setup",
+      "function": "installUV",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/setup/setup.go",
+      "line": 770,
+      "complexity": 9,
+      "line_coverage": 86.66666666666667,
+      "crap": 9.192
+    },
+    {
+      "package": "setup",
+      "function": "installSpecify",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/setup/setup.go",
+      "line": 809,
+      "complexity": 5,
+      "line_coverage": 100,
+      "crap": 5
+    },
+    {
+      "package": "setup",
+      "function": "installReplicator",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/setup/setup.go",
+      "line": 841,
+      "complexity": 6,
+      "line_coverage": 91.66666666666667,
+      "crap": 6.020833333333333
+    },
+    {
+      "package": "setup",
+      "function": "runReplicatorSetup",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/setup/setup.go",
+      "line": 871,
+      "complexity": 5,
+      "line_coverage": 100,
+      "crap": 5
+    },
+    {
+      "package": "setup",
+      "function": "installGolangciLint",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/setup/setup.go",
+      "line": 892,
+      "complexity": 7,
+      "line_coverage": 84.61538461538461,
+      "crap": 7.178425125170687
+    },
+    {
+      "package": "setup",
+      "function": "installGovulncheck",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/setup/setup.go",
+      "line": 924,
+      "complexity": 4,
+      "line_coverage": 85.71428571428571,
+      "crap": 4.0466472303206995
+    },
+    {
+      "package": "setup",
+      "function": "rpmURL",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/setup/setup.go",
+      "line": 941,
+      "complexity": 1,
+      "line_coverage": 100,
+      "crap": 1
+    },
+    {
+      "package": "setup",
+      "function": "repoName",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/setup/setup.go",
+      "line": 953,
+      "complexity": 2,
+      "line_coverage": 100,
+      "crap": 2
+    },
+    {
+      "package": "setup",
+      "function": "rpmArch",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/setup/setup.go",
+      "line": 963,
+      "complexity": 2,
+      "line_coverage": 66.66666666666667,
+      "crap": 2.148148148148148
+    },
+    {
+      "package": "setup",
+      "function": "installViaRpm",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/setup/setup.go",
+      "line": 974,
+      "complexity": 4,
+      "line_coverage": 100,
+      "crap": 4
+    },
+    {
+      "package": "setup",
+      "function": "ollamaBrew",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/setup/setup.go",
+      "line": 1009,
+      "complexity": 2,
+      "line_coverage": 100,
+      "crap": 2
+    },
+    {
+      "package": "setup",
+      "function": "installOllama",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/setup/setup.go",
+      "line": 1021,
+      "complexity": 6,
+      "line_coverage": 100,
+      "crap": 6
+    },
+    {
+      "package": "setup",
+      "function": "installOllamaViaCurl",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/setup/setup.go",
+      "line": 1054,
+      "complexity": 4,
+      "line_coverage": 100,
+      "crap": 4
+    },
+    {
+      "package": "setup",
+      "function": "installPodman",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/setup/setup.go",
+      "line": 1082,
+      "complexity": 4,
+      "line_coverage": 100,
+      "crap": 4
+    },
+    {
+      "package": "setup",
+      "function": "installPodmanViaBrew",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/setup/setup.go",
+      "line": 1101,
+      "complexity": 3,
+      "line_coverage": 80,
+      "crap": 3.072
+    },
+    {
+      "package": "setup",
+      "function": "installPodmanViaDnf",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/setup/setup.go",
+      "line": 1115,
+      "complexity": 3,
+      "line_coverage": 100,
+      "crap": 3
+    },
+    {
+      "package": "setup",
+      "function": "podmanSkipResult",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/setup/setup.go",
+      "line": 1135,
+      "complexity": 2,
+      "line_coverage": 100,
+      "crap": 2
+    },
+    {
+      "package": "setup",
+      "function": "podmanPostInstall",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/setup/setup.go",
+      "line": 1152,
+      "complexity": 3,
+      "line_coverage": 100,
+      "crap": 3
+    },
+    {
+      "package": "setup",
+      "function": "podmanMachineInit",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/setup/setup.go",
+      "line": 1173,
+      "complexity": 5,
+      "line_coverage": 100,
+      "crap": 5
+    },
+    {
+      "package": "setup",
+      "function": "initMachineWithTimeout",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/setup/setup.go",
+      "line": 1200,
+      "complexity": 3,
+      "line_coverage": 60,
+      "crap": 3.576
+    },
+    {
+      "package": "setup",
+      "function": "devpodBinaryURL",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/setup/setup.go",
+      "line": 1217,
+      "complexity": 1,
+      "line_coverage": 100,
+      "crap": 1
+    },
+    {
+      "package": "setup",
+      "function": "installDevPod",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/setup/setup.go",
+      "line": 1227,
+      "complexity": 6,
+      "line_coverage": 90.9090909090909,
+      "crap": 6.027047332832457
+    },
+    {
+      "package": "setup",
+      "function": "installDevPodViaBinary",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/setup/setup.go",
+      "line": 1265,
+      "complexity": 4,
+      "line_coverage": 100,
+      "crap": 4
+    },
+    {
+      "package": "setup",
+      "function": "configureDevPodProvider",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/setup/setup.go",
+      "line": 1297,
+      "complexity": 7,
+      "line_coverage": 100,
+      "crap": 7
+    },
+    {
+      "package": "setup",
+      "function": "hasProvider",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/setup/setup.go",
+      "line": 1348,
+      "complexity": 4,
+      "line_coverage": 100,
+      "crap": 4
+    },
+    {
+      "package": "setup",
+      "function": "installDewey",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/setup/setup.go",
+      "line": 1366,
+      "complexity": 7,
+      "line_coverage": 93.33333333333333,
+      "crap": 7.014518518518519
+    },
+    {
+      "package": "setup",
+      "function": "deweyPostInstall",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/setup/setup.go",
+      "line": 1410,
+      "complexity": 2,
+      "line_coverage": 75,
+      "crap": 2.0625
+    },
+    {
+      "package": "setup",
+      "function": "pullEmbeddingModel",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/setup/setup.go",
+      "line": 1425,
+      "complexity": 6,
+      "line_coverage": 80,
+      "crap": 6.288
+    },
+    {
+      "package": "setup",
+      "function": "printStepError",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/setup/setup.go",
+      "line": 1455,
+      "complexity": 6,
+      "line_coverage": 100,
+      "crap": 6
+    },
+    {
+      "package": "setup",
+      "function": "printStepResult",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/setup/setup.go",
+      "line": 1471,
+      "complexity": 5,
+      "line_coverage": 100,
+      "crap": 5
+    },
+    {
+      "package": "setup",
+      "function": "FormatSetupText",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/setup/setup.go",
+      "line": 1494,
+      "complexity": 2,
+      "line_coverage": 100,
+      "crap": 2,
+      "contract_coverage": 0,
+      "gaze_crap": 6,
+      "quadrant": "Q1_Safe",
+      "contract_coverage_reason": "no_effects_detected"
+    },
+    {
+      "package": "setup",
+      "function": "atomicWriteFile",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/setup/setup.go",
+      "line": 1502,
+      "complexity": 7,
+      "line_coverage": 61.111111111111114,
+      "crap": 9.881858710562412
+    },
+    {
+      "package": "sprint",
+      "function": "(*SprintState).ComputeVelocity",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/sprint/models.go",
+      "line": 18,
+      "complexity": 1,
+      "line_coverage": 100,
+      "crap": 1,
+      "contract_coverage": 0,
+      "gaze_crap": 2,
+      "quadrant": "Q1_Safe",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        79,
+        79
+      ]
+    },
+    {
+      "package": "sprint",
+      "function": "(*SprintState).DurationDays",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/sprint/models.go",
+      "line": 23,
+      "complexity": 3,
+      "line_coverage": 100,
+      "crap": 3,
+      "contract_coverage": 0,
+      "gaze_crap": 12,
+      "quadrant": "Q1_Safe",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        79,
+        79
+      ]
+    },
+    {
+      "package": "sprint",
+      "function": "NewSprintStore",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/sprint/sprint.go",
+      "line": 22,
+      "complexity": 1,
+      "line_coverage": 100,
+      "crap": 1,
+      "contract_coverage": 0,
+      "gaze_crap": 2,
+      "quadrant": "Q1_Safe",
+      "contract_coverage_reason": "no_effects_detected"
+    },
+    {
+      "package": "sprint",
+      "function": "(*SprintStore).Plan",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/sprint/sprint.go",
+      "line": 27,
+      "complexity": 5,
+      "line_coverage": 86.66666666666667,
+      "crap": 5.059259259259259,
+      "contract_coverage": 0,
+      "gaze_crap": 30,
+      "quadrant": "Q3_SimpleButUnderspecified",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        75,
+        75
+      ]
+    },
+    {
+      "package": "sprint",
+      "function": "(*SprintStore).Review",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/sprint/sprint.go",
+      "line": 62,
+      "complexity": 2,
+      "line_coverage": 83.33333333333333,
+      "crap": 2.0185185185185186,
+      "contract_coverage": 0,
+      "gaze_crap": 6,
+      "quadrant": "Q1_Safe",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        75,
+        75
+      ]
+    },
+    {
+      "package": "sprint",
+      "function": "(*SprintStore).Save",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/sprint/sprint.go",
+      "line": 75,
+      "complexity": 3,
+      "line_coverage": 71.42857142857143,
+      "crap": 3.2099125364431487,
+      "contract_coverage": 0,
+      "gaze_crap": 12,
+      "quadrant": "Q1_Safe",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        64,
+        74
+      ]
+    },
+    {
       "package": "sprint",
       "function": "(*SprintStore).Load",
-      "file": "internal/sprint/sprint.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/sprint/sprint.go",
       "line": 90,
       "complexity": 3,
       "line_coverage": 87.5,
@@ -4925,7 +5721,7 @@
     {
       "package": "sprint",
       "function": "(*SprintStore).Latest",
-      "file": "internal/sprint/sprint.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/sprint/sprint.go",
       "line": 105,
       "complexity": 8,
       "line_coverage": 78.57142857142857,
@@ -4937,19 +5733,24 @@
     {
       "package": "sprint",
       "function": "Standup",
-      "file": "internal/sprint/sprint.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/sprint/sprint.go",
       "line": 131,
       "complexity": 6,
       "line_coverage": 75,
       "crap": 6.5625,
-      "contract_coverage": 100,
-      "gaze_crap": 6,
-      "quadrant": "Q1_Safe"
+      "contract_coverage": 0,
+      "gaze_crap": 42,
+      "quadrant": "Q3_SimpleButUnderspecified",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        63,
+        63
+      ]
     },
     {
       "package": "sync",
       "function": "(*DefaultGHRunner).Run",
-      "file": "internal/sync/sync.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/sync/sync.go",
       "line": 23,
       "complexity": 2,
       "line_coverage": 0,
@@ -4958,52 +5759,75 @@
     {
       "package": "sync",
       "function": "NewSyncer",
-      "file": "internal/sync/sync.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/sync/sync.go",
       "line": 42,
       "complexity": 1,
       "line_coverage": 100,
       "crap": 1,
       "contract_coverage": 0,
       "gaze_crap": 2,
-      "quadrant": "Q1_Safe"
+      "quadrant": "Q1_Safe",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        69,
+        69
+      ]
     },
     {
       "package": "sync",
       "function": "(*Syncer).SetRunner",
-      "file": "internal/sync/sync.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/sync/sync.go",
       "line": 52,
       "complexity": 1,
-      "line_coverage": 0,
-      "crap": 2
+      "line_coverage": 100,
+      "crap": 1,
+      "contract_coverage": 0,
+      "gaze_crap": 2,
+      "quadrant": "Q1_Safe",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        79,
+        79
+      ]
     },
     {
       "package": "sync",
       "function": "(*Syncer).Push",
-      "file": "internal/sync/sync.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/sync/sync.go",
       "line": 57,
       "complexity": 11,
       "line_coverage": 84.84848484848484,
       "crap": 11.420875420875422,
-      "contract_coverage": 100,
-      "gaze_crap": 11,
-      "quadrant": "Q1_Safe"
+      "contract_coverage": 0,
+      "gaze_crap": 132,
+      "quadrant": "Q3_SimpleButUnderspecified",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        69,
+        69
+      ]
     },
     {
       "package": "sync",
       "function": "(*Syncer).Pull",
-      "file": "internal/sync/sync.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/sync/sync.go",
       "line": 114,
       "complexity": 12,
       "line_coverage": 82.3529411764706,
       "crap": 12.791369835131283,
-      "contract_coverage": 100,
-      "gaze_crap": 12,
-      "quadrant": "Q1_Safe"
+      "contract_coverage": 0,
+      "gaze_crap": 156,
+      "quadrant": "Q3_SimpleButUnderspecified",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        69,
+        69
+      ]
     },
     {
       "package": "sync",
       "function": "(*Syncer).Status",
-      "file": "internal/sync/sync.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/sync/sync.go",
       "line": 188,
       "complexity": 4,
       "line_coverage": 92.3076923076923,
@@ -5015,81 +5839,75 @@
     {
       "package": "sync",
       "function": "(*Syncer).Sync",
-      "file": "internal/sync/sync.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/sync/sync.go",
       "line": 211,
       "complexity": 3,
       "line_coverage": 71.42857142857143,
       "crap": 3.2099125364431487,
-      "contract_coverage": 100,
-      "gaze_crap": 3,
-      "quadrant": "Q1_Safe"
+      "contract_coverage": 0,
+      "gaze_crap": 12,
+      "quadrant": "Q1_Safe",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        69,
+        69
+      ]
     },
     {
       "package": "sync",
       "function": "(*Syncer).SyncProject",
-      "file": "internal/sync/sync.go",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/sync/sync.go",
       "line": 224,
       "complexity": 1,
       "line_coverage": 100,
       "crap": 1,
+      "contract_coverage": 0,
+      "gaze_crap": 2,
+      "quadrant": "Q1_Safe",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        69,
+        69
+      ]
+    },
+    {
+      "package": "textutil",
+      "function": "TruncateOutput",
+      "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/textutil/output.go",
+      "line": 13,
+      "complexity": 3,
+      "line_coverage": 100,
+      "crap": 3,
       "contract_coverage": 100,
-      "gaze_crap": 1,
+      "gaze_crap": 3,
       "quadrant": "Q1_Safe"
-    },
-    {
-      "package": "doctor",
-      "function": "dnfOrGenericCmd",
-      "file": "internal/doctor/environ.go",
-      "line": 296,
-      "complexity": 2,
-      "line_coverage": 100,
-      "crap": 2
-    },
-    {
-      "package": "setup",
-      "function": "installOllamaViaCurl",
-      "file": "internal/setup/setup.go",
-      "line": 1038,
-      "complexity": 4,
-      "line_coverage": 100,
-      "crap": 4
-    },
-    {
-      "package": "setup",
-      "function": "installDevPodViaBinary",
-      "file": "internal/setup/setup.go",
-      "line": 1241,
-      "complexity": 4,
-      "line_coverage": 100,
-      "crap": 4
     }
   ],
   "summary": {
-    "total_functions": 502,
-    "avg_complexity": 5.00996015936255,
-    "avg_line_coverage": 80.83044010927019,
-    "avg_crap": 5.786593546397692,
-    "crapload": 26,
+    "total_functions": 530,
+    "avg_complexity": 4.886792452830188,
+    "avg_line_coverage": 83.7510284411904,
+    "avg_crap": 5.451891735498352,
+    "crapload": 22,
     "crap_threshold": 15,
-    "gaze_crapload": 15,
+    "gaze_crapload": 65,
     "gaze_crap_threshold": 15,
-    "avg_gaze_crap": 7.320682944090587,
-    "avg_contract_coverage": 83.12101910828025,
+    "avg_gaze_crap": 57.217592592592595,
+    "avg_contract_coverage": 19.135802469135804,
     "quadrant_counts": {
-      "Q1_Safe": 141,
-      "Q2_ComplexButTested": 1,
-      "Q3_SimpleButUnderspecified": 5,
+      "Q1_Safe": 97,
+      "Q3_SimpleButUnderspecified": 55,
       "Q4_Dangerous": 10
     },
     "fix_strategy_counts": {
-      "add_tests": 6,
-      "decompose": 20
+      "add_tests": 4,
+      "decompose": 18
     },
     "worst_crap": [
       {
         "package": "config",
         "function": "merge",
-        "file": "internal/config/config.go",
+        "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/config/config.go",
         "line": 179,
         "complexity": 30,
         "line_coverage": 66.66666666666667,
@@ -5099,7 +5917,7 @@
       {
         "package": "main",
         "function": "runGateway",
-        "file": "cmd/unbound-force/gateway.go",
+        "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/cmd/unbound-force/gateway.go",
         "line": 81,
         "complexity": 7,
         "line_coverage": 0,
@@ -5109,299 +5927,140 @@
       {
         "package": "scaffold",
         "function": "configureOpencodeJSON",
-        "file": "internal/scaffold/scaffold.go",
-        "line": 488,
+        "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/scaffold/scaffold.go",
+        "line": 514,
         "complexity": 48,
         "line_coverage": 97.16981132075472,
         "crap": 48.052231036358876,
         "fix_strategy": "decompose"
       },
       {
-        "package": "main",
-        "function": "runDoctor",
-        "file": "cmd/unbound-force/main.go",
-        "line": 138,
-        "complexity": 6,
-        "line_coverage": 0,
-        "crap": 42,
-        "fix_strategy": "add_tests"
-      },
-      {
         "package": "scaffold",
         "function": "Run",
-        "file": "internal/scaffold/scaffold.go",
-        "line": 61,
+        "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/scaffold/scaffold.go",
+        "line": 63,
         "complexity": 33,
         "line_coverage": 82.22222222222223,
-        "crap": 39.118716049382705,
-        "contract_coverage": 100,
-        "gaze_crap": 33,
+        "crap": 39.11871604938271,
+        "contract_coverage": 0,
+        "gaze_crap": 1122,
         "quadrant": "Q4_Dangerous",
-        "fix_strategy": "decompose"
+        "fix_strategy": "decompose",
+        "contract_coverage_reason": "all_effects_ambiguous",
+        "effect_confidence_range": [
+          69,
+          69
+        ]
+      },
+      {
+        "package": "sandbox",
+        "function": "Start",
+        "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/sandbox/sandbox.go",
+        "line": 479,
+        "complexity": 31,
+        "line_coverage": 81.81818181818181,
+        "crap": 36.77610818933134,
+        "contract_coverage": 0,
+        "gaze_crap": 992,
+        "quadrant": "Q4_Dangerous",
+        "fix_strategy": "decompose",
+        "contract_coverage_reason": "all_effects_ambiguous",
+        "effect_confidence_range": [
+          63,
+          63
+        ]
       }
     ],
     "worst_gaze_crap": [
       {
-        "package": "sandbox",
-        "function": "FormatWorkspaceStatus",
-        "file": "internal/sandbox/workspace.go",
-        "line": 187,
-        "complexity": 10,
-        "line_coverage": 100,
-        "crap": 10,
-        "contract_coverage": 0,
-        "gaze_crap": 110,
-        "quadrant": "Q3_SimpleButUnderspecified",
-        "contract_coverage_reason": "no_effects_detected"
-      },
-      {
-        "package": "orchestration",
-        "function": "(*Orchestrator).NewWorkflow",
-        "file": "internal/orchestration/engine.go",
-        "line": 72,
-        "complexity": 11,
-        "line_coverage": 100,
-        "crap": 11,
-        "contract_coverage": 33.333333333333336,
-        "gaze_crap": 46.85185185185185,
-        "quadrant": "Q3_SimpleButUnderspecified"
-      },
-      {
         "package": "scaffold",
         "function": "Run",
-        "file": "internal/scaffold/scaffold.go",
-        "line": 61,
+        "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/scaffold/scaffold.go",
+        "line": 63,
         "complexity": 33,
         "line_coverage": 82.22222222222223,
-        "crap": 39.118716049382705,
-        "contract_coverage": 100,
-        "gaze_crap": 33,
+        "crap": 39.11871604938271,
+        "contract_coverage": 0,
+        "gaze_crap": 1122,
         "quadrant": "Q4_Dangerous",
-        "fix_strategy": "decompose"
+        "fix_strategy": "decompose",
+        "contract_coverage_reason": "all_effects_ambiguous",
+        "effect_confidence_range": [
+          69,
+          69
+        ]
       },
       {
         "package": "orchestration",
         "function": "(*Orchestrator).Advance",
-        "file": "internal/orchestration/engine.go",
+        "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/orchestration/engine.go",
         "line": 218,
         "complexity": 32,
         "line_coverage": 86.44067796610169,
         "crap": 34.552782903802246,
-        "contract_coverage": 100,
-        "gaze_crap": 32,
+        "contract_coverage": 0,
+        "gaze_crap": 1056,
         "quadrant": "Q4_Dangerous",
-        "fix_strategy": "decompose"
+        "fix_strategy": "decompose",
+        "contract_coverage_reason": "all_effects_ambiguous",
+        "effect_confidence_range": [
+          70,
+          70
+        ]
       },
       {
         "package": "sandbox",
         "function": "Start",
-        "file": "internal/sandbox/sandbox.go",
-        "line": 501,
+        "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/sandbox/sandbox.go",
+        "line": 479,
         "complexity": 31,
         "line_coverage": 81.81818181818181,
         "crap": 36.77610818933134,
-        "contract_coverage": 100,
-        "gaze_crap": 31,
+        "contract_coverage": 0,
+        "gaze_crap": 992,
         "quadrant": "Q4_Dangerous",
-        "fix_strategy": "decompose"
-      }
-    ],
-    "recommended_actions": [
-      {
-        "function": "runGateway",
-        "package": "main",
-        "file": "cmd/unbound-force/gateway.go",
-        "line": 81,
-        "fix_strategy": "add_tests",
-        "crap": 56,
-        "complexity": 7
-      },
-      {
-        "function": "runDoctor",
-        "package": "main",
-        "file": "cmd/unbound-force/main.go",
-        "line": 138,
-        "fix_strategy": "add_tests",
-        "crap": 42,
-        "complexity": 6
-      },
-      {
-        "function": "runSandboxStatus",
-        "package": "main",
-        "file": "cmd/unbound-force/sandbox.go",
-        "line": 556,
-        "fix_strategy": "add_tests",
-        "crap": 20,
-        "complexity": 4
-      },
-      {
-        "function": "newDoctorCmd",
-        "package": "main",
-        "file": "cmd/unbound-force/main.go",
-        "line": 170,
-        "fix_strategy": "add_tests",
-        "crap": 19.119533527696788,
-        "complexity": 6
-      },
-      {
-        "function": "DetectPlatform",
-        "package": "sandbox",
-        "file": "internal/sandbox/detect.go",
-        "line": 36,
-        "fix_strategy": "add_tests",
-        "crap": 17.583999999999996,
-        "gaze_crap": 7,
-        "complexity": 7,
-        "quadrant": "Q2_ComplexButTested"
-      },
-      {
-        "function": "migrateCommandDir",
-        "package": "scaffold",
-        "file": "internal/scaffold/scaffold.go",
-        "line": 829,
-        "fix_strategy": "add_tests",
-        "crap": 15.376226847615653,
-        "complexity": 14
-      },
-      {
-        "function": "merge",
-        "package": "config",
-        "file": "internal/config/config.go",
-        "line": 179,
         "fix_strategy": "decompose",
-        "crap": 63.333333333333314,
-        "complexity": 30
+        "contract_coverage_reason": "all_effects_ambiguous",
+        "effect_confidence_range": [
+          63,
+          63
+        ]
       },
       {
-        "function": "configureOpencodeJSON",
-        "package": "scaffold",
-        "file": "internal/scaffold/scaffold.go",
-        "line": 488,
-        "fix_strategy": "decompose",
-        "crap": 48.052231036358876,
-        "complexity": 48
-      },
-      {
-        "function": "Run",
-        "package": "scaffold",
-        "file": "internal/scaffold/scaffold.go",
-        "line": 61,
-        "fix_strategy": "decompose",
-        "crap": 39.118716049382705,
-        "gaze_crap": 33,
-        "complexity": 33,
-        "quadrant": "Q4_Dangerous"
-      },
-      {
-        "function": "Start",
-        "package": "sandbox",
-        "file": "internal/sandbox/sandbox.go",
-        "line": 501,
-        "fix_strategy": "decompose",
-        "crap": 36.77610818933134,
-        "gaze_crap": 31,
-        "complexity": 31,
-        "quadrant": "Q4_Dangerous"
-      },
-      {
-        "function": "(*Orchestrator).Advance",
-        "package": "orchestration",
-        "file": "internal/orchestration/engine.go",
-        "line": 218,
-        "fix_strategy": "decompose",
-        "crap": 34.552782903802246,
-        "gaze_crap": 32,
-        "complexity": 32,
-        "quadrant": "Q4_Dangerous"
-      },
-      {
-        "function": "runMetrics",
-        "package": "main",
-        "file": "cmd/mxf/main.go",
-        "line": 318,
-        "fix_strategy": "decompose",
-        "crap": 27.153631999999998,
-        "complexity": 22
-      },
-      {
-        "function": "CollectGitHub",
         "package": "metrics",
-        "file": "internal/metrics/collect_github.go",
+        "function": "CollectGitHub",
+        "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/metrics/collect_github.go",
         "line": 15,
-        "fix_strategy": "decompose",
-        "crap": 26.023825782774768,
-        "gaze_crap": 26,
         "complexity": 26,
-        "quadrant": "Q4_Dangerous"
-      },
-      {
-        "function": "initSubTools",
-        "package": "scaffold",
-        "file": "internal/scaffold/scaffold.go",
-        "line": 1278,
+        "line_coverage": 96.72131147540983,
+        "crap": 26.023825782774768,
+        "contract_coverage": 0,
+        "gaze_crap": 702,
+        "quadrant": "Q4_Dangerous",
         "fix_strategy": "decompose",
-        "crap": 25.074345429793684,
-        "complexity": 25
+        "contract_coverage_reason": "all_effects_ambiguous",
+        "effect_confidence_range": [
+          64,
+          64
+        ]
       },
       {
-        "function": "printSummary",
-        "package": "scaffold",
-        "file": "internal/scaffold/scaffold.go",
-        "line": 1456,
-        "fix_strategy": "decompose",
-        "crap": 25,
-        "complexity": 25
-      },
-      {
-        "function": "applySandboxConfig",
-        "package": "main",
-        "file": "cmd/unbound-force/sandbox.go",
-        "line": 58,
-        "fix_strategy": "decompose",
-        "crap": 20.218375,
-        "complexity": 19
-      },
-      {
-        "function": "runRetro",
-        "package": "main",
-        "file": "cmd/mxf/main.go",
-        "line": 564,
-        "fix_strategy": "decompose",
-        "crap": 19.029232443678183,
-        "complexity": 17
-      },
-      {
-        "function": "Detect",
         "package": "impediment",
-        "file": "internal/impediment/detect.go",
+        "function": "Detect",
+        "file": "/home/maburgha/GIT/ProdSec/uf-unbound-force/internal/impediment/detect.go",
         "line": 11,
-        "fix_strategy": "decompose",
+        "complexity": 18,
+        "line_coverage": 90.47619047619048,
         "crap": 18.279883381924197,
-        "gaze_crap": 18,
-        "complexity": 18,
-        "quadrant": "Q4_Dangerous"
-      },
-      {
-        "function": "InitDevcontainer",
-        "package": "sandbox",
-        "file": "internal/sandbox/sandbox.go",
-        "line": 988,
+        "contract_coverage": 0,
+        "gaze_crap": 342,
+        "quadrant": "Q4_Dangerous",
         "fix_strategy": "decompose",
-        "crap": 18.264607304014742,
-        "gaze_crap": 15,
-        "complexity": 15,
-        "quadrant": "Q4_Dangerous"
-      },
-      {
-        "function": "DetectProvenance",
-        "package": "doctor",
-        "file": "internal/doctor/environ.go",
-        "line": 123,
-        "fix_strategy": "decompose",
-        "crap": 18,
-        "gaze_crap": 18,
-        "complexity": 18,
-        "quadrant": "Q4_Dangerous"
+        "contract_coverage_reason": "all_effects_ambiguous",
+        "effect_confidence_range": [
+          69,
+          69
+        ]
       }
     ]
   }

--- a/.opencode/uf/packs/ci-custom.md
+++ b/.opencode/uf/packs/ci-custom.md
@@ -1,0 +1,19 @@
+---
+pack_id: ci-custom
+language: Any
+version: 1.0.0
+---
+
+# Custom Rules: CI
+
+Project-specific conventions that extend the canonical
+CI convention pack. Rules in this file are loaded alongside
+`ci.md` by Cobalt-Crush (during implementation) and
+all Divisor persona agents (during review).
+
+Use the `CR-NNN` prefix for all custom rules. Use `[MUST]`,
+`[SHOULD]`, or `[MAY]` severity indicators per RFC 2119.
+
+## Custom Rules
+
+<!-- Add project-specific rules below this line -->

--- a/.opencode/uf/packs/ci-custom.md
+++ b/.opencode/uf/packs/ci-custom.md
@@ -3,6 +3,7 @@ pack_id: ci-custom
 language: Any
 version: 1.0.0
 ---
+<!-- scaffolded by uf vdev -->
 
 # Custom Rules: CI
 

--- a/.opencode/uf/packs/ci.md
+++ b/.opencode/uf/packs/ci.md
@@ -3,6 +3,7 @@ pack_id: ci
 language: Any
 version: 1.0.0
 ---
+<!-- scaffolded by uf vdev -->
 
 # Convention Pack: CI (GitHub Actions Workflows)
 

--- a/.opencode/uf/packs/ci.md
+++ b/.opencode/uf/packs/ci.md
@@ -1,0 +1,115 @@
+---
+pack_id: ci
+language: Any
+version: 1.0.0
+---
+
+# Convention Pack: CI (GitHub Actions Workflows)
+
+This is the CI convention pack for the Unbound Force
+agent ecosystem. It contains rules for GitHub Actions
+workflow files: action pinning, supply chain integrity,
+workflow structure, permissions, and reusable workflow
+design. It complements the language-agnostic `default.md`
+pack with CI-specific standards.
+
+When this pack is active, agents load it alongside
+`default.md` and any language-specific pack. The CI pack
+is always deployed regardless of detected project
+language, because every project may have CI workflows.
+
+---
+
+## Action Pinning & Supply Chain
+
+- **CI-001** [MUST] Every `uses:` reference for actions
+  and reusable workflows in GitHub Actions workflow files
+  MUST be pinned to a full 40-character commit SHA.
+  Docker container references (`docker://image:tag`) are
+  excluded; they SHOULD be pinned to image digests
+  (`@sha256:...`) when available but are not subject to
+  this rule.
+
+- **CI-002** [MUST] SHAs MUST be verified against the
+  source repository at authoring time. The agent MUST
+  resolve the desired tag first, then derive the SHA
+  from the API response. When the API response object
+  type is `tag` (annotated tag), the agent MUST
+  dereference to get the commit SHA by following the
+  tag object's target. SHAs MUST NOT be sourced from
+  memory or training data. When verification cannot be
+  completed (network unavailable, API rate limit,
+  missing authentication, tag not found), the agent
+  MUST NOT write the unverified `uses:` reference and
+  MUST report the verification failure.
+
+- **CI-003** [SHOULD] A version comment (e.g.,
+  `# v6.0.2`) SHOULD follow the SHA for human
+  readability. Missing comments are a warning, not a
+  failure. When a version comment IS included, it MUST
+  accurately reflect the tag used to derive the SHA.
+
+---
+
+## Workflow Structure
+
+- **CI-010** [MUST] Reusable workflows MUST be prefixed
+  with `reusable_` and have a clear, descriptive name
+  reflecting their function (e.g.,
+  `reusable_vuln_scan.yml`). Consumer workflows MUST
+  be prefixed with `ci_` (e.g., `ci_security.yml`).
+
+- **CI-011** [MUST] Workflow files MUST include a header
+  comment block describing the workflow's purpose. The
+  comment SHOULD appear before or immediately after the
+  `name:` key.
+
+- **CI-012** [SHOULD] Workflows SHOULD use concurrency
+  groups to prevent redundant runs on the same branch
+  or pull request. Cancel-in-progress SHOULD be enabled
+  for non-default branches.
+
+---
+
+## Permissions & Secrets
+
+- **CI-020** [MUST] Workflows MUST follow the principle
+  of least privilege. Write permissions MUST be avoided;
+  when necessary, they MUST be defined in the minimal
+  possible scope. Prefer explicit `permissions` blocks
+  over relying on the default token permissions.
+
+- **CI-021** [SHOULD] Permissions SHOULD be defined at
+  the job level rather than the workflow level, so that
+  each job receives only the permissions it requires.
+
+- **CI-022** [MUST] Secrets MUST NOT be hardcoded in
+  workflow files. Use GitHub Secrets or environment-based
+  injection. Secrets MUST be scoped to the narrowest
+  context needed.
+
+---
+
+## Reusable Workflow Design
+
+- **CI-030** [MUST] Workflow inputs MUST have descriptive
+  `description` fields. Required inputs MUST be marked
+  with `required: true`.
+
+- **CI-031** [SHOULD] Optional inputs SHOULD provide
+  sensible `default` values aligned with the most common
+  use case (Convention Over Configuration).
+
+- **CI-032** [MUST] Reusable workflows MUST be generic
+  enough to be consumed by any repository. They MUST
+  NOT contain hardcoded org-specific or repo-specific
+  values that would prevent reuse.
+
+---
+
+## Custom Rules
+
+<!-- This section is intentionally empty in the canonical
+     pack. Project-specific custom rules belong in
+     ci-custom.md alongside this file. Custom rules
+     use the CR-NNN identifier prefix. -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,18 @@ Each entry follows the format: `- <change-name>: <summary>`.
   (Spec: openspec/changes/improve-finale-pr-description/)
 
 ### Added
+- `ci-convention-pack`: Added CI convention pack (`ci.md`,
+  `ci-custom.md`) with 12 rules across 5 sections (Action
+  Pinning & Supply Chain, Workflow Structure, Permissions &
+  Secrets, Reusable Workflow Design, Custom Rules). Fills
+  the Divisor SRE `[PACK]` CI/CD guidance gap. CI-002 rule
+  prevents SHA hallucination by requiring tag-first lookup
+  at authoring time. Always-deployed (language-agnostic),
+  following the `content.md`/`severity.md` pattern.
+  Centralizes CI rules from `coding-standards.md` into the
+  convention pack system. Related: complytime/org-infra#337
+  (CI guardrail).
+  (Spec: openspec/changes/ci-convention-pack/)
 - `/triage-issue` slash command for multi-agent GitHub issue
   triage using the Divisor review panel. Classifies issues
   (bug, feature, enhancement, question, opinion, duplicate,

--- a/cmd/unbound-force/main_test.go
+++ b/cmd/unbound-force/main_test.go
@@ -30,11 +30,12 @@ func TestRunInit_FreshDir(t *testing.T) {
 	}
 
 	// Verify the summary includes a non-trivial file count
-	// 41 = 39 prior + 1 pre-flight skill + 1 review-context skill.
+	// 43 = 39 prior + 1 pre-flight skill + 1 review-context
+	// skill + 2 CI convention pack files (ci.md + ci-custom.md).
 	// (devcontainer excluded — OS-specific, generated
 	// per-user by uf sandbox init).
-	if !strings.Contains(output, "41 files processed") {
-		t.Errorf("expected '41 files processed' in output, got:\n%s", output)
+	if !strings.Contains(output, "43 files processed") {
+		t.Errorf("expected '43 files processed' in output, got:\n%s", output)
 	}
 
 	// Verify a user-owned file was created

--- a/internal/scaffold/assets/opencode/uf/packs/ci-custom.md
+++ b/internal/scaffold/assets/opencode/uf/packs/ci-custom.md
@@ -1,0 +1,19 @@
+---
+pack_id: ci-custom
+language: Any
+version: 1.0.0
+---
+
+# Custom Rules: CI
+
+Project-specific conventions that extend the canonical
+CI convention pack. Rules in this file are loaded alongside
+`ci.md` by Cobalt-Crush (during implementation) and
+all Divisor persona agents (during review).
+
+Use the `CR-NNN` prefix for all custom rules. Use `[MUST]`,
+`[SHOULD]`, or `[MAY]` severity indicators per RFC 2119.
+
+## Custom Rules
+
+<!-- Add project-specific rules below this line -->

--- a/internal/scaffold/assets/opencode/uf/packs/ci-custom.md
+++ b/internal/scaffold/assets/opencode/uf/packs/ci-custom.md
@@ -3,6 +3,7 @@ pack_id: ci-custom
 language: Any
 version: 1.0.0
 ---
+<!-- scaffolded by uf vdev -->
 
 # Custom Rules: CI
 

--- a/internal/scaffold/assets/opencode/uf/packs/ci.md
+++ b/internal/scaffold/assets/opencode/uf/packs/ci.md
@@ -3,6 +3,7 @@ pack_id: ci
 language: Any
 version: 1.0.0
 ---
+<!-- scaffolded by uf vdev -->
 
 # Convention Pack: CI (GitHub Actions Workflows)
 

--- a/internal/scaffold/assets/opencode/uf/packs/ci.md
+++ b/internal/scaffold/assets/opencode/uf/packs/ci.md
@@ -1,0 +1,115 @@
+---
+pack_id: ci
+language: Any
+version: 1.0.0
+---
+
+# Convention Pack: CI (GitHub Actions Workflows)
+
+This is the CI convention pack for the Unbound Force
+agent ecosystem. It contains rules for GitHub Actions
+workflow files: action pinning, supply chain integrity,
+workflow structure, permissions, and reusable workflow
+design. It complements the language-agnostic `default.md`
+pack with CI-specific standards.
+
+When this pack is active, agents load it alongside
+`default.md` and any language-specific pack. The CI pack
+is always deployed regardless of detected project
+language, because every project may have CI workflows.
+
+---
+
+## Action Pinning & Supply Chain
+
+- **CI-001** [MUST] Every `uses:` reference for actions
+  and reusable workflows in GitHub Actions workflow files
+  MUST be pinned to a full 40-character commit SHA.
+  Docker container references (`docker://image:tag`) are
+  excluded; they SHOULD be pinned to image digests
+  (`@sha256:...`) when available but are not subject to
+  this rule.
+
+- **CI-002** [MUST] SHAs MUST be verified against the
+  source repository at authoring time. The agent MUST
+  resolve the desired tag first, then derive the SHA
+  from the API response. When the API response object
+  type is `tag` (annotated tag), the agent MUST
+  dereference to get the commit SHA by following the
+  tag object's target. SHAs MUST NOT be sourced from
+  memory or training data. When verification cannot be
+  completed (network unavailable, API rate limit,
+  missing authentication, tag not found), the agent
+  MUST NOT write the unverified `uses:` reference and
+  MUST report the verification failure.
+
+- **CI-003** [SHOULD] A version comment (e.g.,
+  `# v6.0.2`) SHOULD follow the SHA for human
+  readability. Missing comments are a warning, not a
+  failure. When a version comment IS included, it MUST
+  accurately reflect the tag used to derive the SHA.
+
+---
+
+## Workflow Structure
+
+- **CI-010** [MUST] Reusable workflows MUST be prefixed
+  with `reusable_` and have a clear, descriptive name
+  reflecting their function (e.g.,
+  `reusable_vuln_scan.yml`). Consumer workflows MUST
+  be prefixed with `ci_` (e.g., `ci_security.yml`).
+
+- **CI-011** [MUST] Workflow files MUST include a header
+  comment block describing the workflow's purpose. The
+  comment SHOULD appear before or immediately after the
+  `name:` key.
+
+- **CI-012** [SHOULD] Workflows SHOULD use concurrency
+  groups to prevent redundant runs on the same branch
+  or pull request. Cancel-in-progress SHOULD be enabled
+  for non-default branches.
+
+---
+
+## Permissions & Secrets
+
+- **CI-020** [MUST] Workflows MUST follow the principle
+  of least privilege. Write permissions MUST be avoided;
+  when necessary, they MUST be defined in the minimal
+  possible scope. Prefer explicit `permissions` blocks
+  over relying on the default token permissions.
+
+- **CI-021** [SHOULD] Permissions SHOULD be defined at
+  the job level rather than the workflow level, so that
+  each job receives only the permissions it requires.
+
+- **CI-022** [MUST] Secrets MUST NOT be hardcoded in
+  workflow files. Use GitHub Secrets or environment-based
+  injection. Secrets MUST be scoped to the narrowest
+  context needed.
+
+---
+
+## Reusable Workflow Design
+
+- **CI-030** [MUST] Workflow inputs MUST have descriptive
+  `description` fields. Required inputs MUST be marked
+  with `required: true`.
+
+- **CI-031** [SHOULD] Optional inputs SHOULD provide
+  sensible `default` values aligned with the most common
+  use case (Convention Over Configuration).
+
+- **CI-032** [MUST] Reusable workflows MUST be generic
+  enough to be consumed by any repository. They MUST
+  NOT contain hardcoded org-specific or repo-specific
+  values that would prevent reuse.
+
+---
+
+## Custom Rules
+
+<!-- This section is intentionally empty in the canonical
+     pack. Project-specific custom rules belong in
+     ci-custom.md alongside this file. Custom rules
+     use the CR-NNN identifier prefix. -->

--- a/internal/scaffold/scaffold.go
+++ b/internal/scaffold/scaffold.go
@@ -353,6 +353,18 @@ func isConventionPack(relPath string) bool {
 	return strings.HasPrefix(relPath, "opencode/uf/packs/")
 }
 
+// alwaysDeployedPacks lists convention packs that are deployed
+// regardless of the detected project language.
+var alwaysDeployedPacks = map[string]bool{
+	"default":        true,
+	"default-custom": true,
+	"severity":       true,
+	"content":        true,
+	"content-custom": true,
+	"ci":             true,
+	"ci-custom":      true,
+}
+
 // shouldDeployPack returns true if the convention pack file
 // should be deployed for the given resolved language. Always
 // deploys default packs. For language-specific packs, only
@@ -365,10 +377,8 @@ func shouldDeployPack(relPath, lang string) bool {
 	base := filepath.Base(relPath)
 	name := strings.TrimSuffix(base, filepath.Ext(base))
 
-	// Always deploy default, severity, content, and ci packs (language-agnostic)
-	if name == "default" || name == "default-custom" || name == "severity" ||
-		name == "content" || name == "content-custom" ||
-		name == "ci" || name == "ci-custom" {
+	// Always deploy language-agnostic packs
+	if alwaysDeployedPacks[name] {
 		return true
 	}
 	// Deploy language-specific pack and its custom extension

--- a/internal/scaffold/scaffold.go
+++ b/internal/scaffold/scaffold.go
@@ -365,9 +365,10 @@ func shouldDeployPack(relPath, lang string) bool {
 	base := filepath.Base(relPath)
 	name := strings.TrimSuffix(base, filepath.Ext(base))
 
-	// Always deploy default, severity, and content packs (language-agnostic)
+	// Always deploy default, severity, content, and ci packs (language-agnostic)
 	if name == "default" || name == "default-custom" || name == "severity" ||
-		name == "content" || name == "content-custom" {
+		name == "content" || name == "content-custom" ||
+		name == "ci" || name == "ci-custom" {
 		return true
 	}
 	// Deploy language-specific pack and its custom extension
@@ -1311,6 +1312,8 @@ func collectDeployedPacks(lang, root string) []string {
 		"severity.md",
 		"content.md",
 		"content-custom.md",
+		"ci.md",
+		"ci-custom.md",
 	}
 	if lang != "" && lang != "default" {
 		candidates = append(candidates, lang+".md", lang+"-custom.md")

--- a/internal/scaffold/scaffold_test.go
+++ b/internal/scaffold/scaffold_test.go
@@ -157,7 +157,9 @@ var expectedAssetPaths = []string{
 	"opencode/agents/divisor-scribe.md",
 	"opencode/agents/divisor-herald.md",
 	"opencode/agents/divisor-envoy.md",
-	// Convention packs — shared by all heroes (11)
+	// Convention packs — shared by all heroes (13)
+	"opencode/uf/packs/ci-custom.md",
+	"opencode/uf/packs/ci.md",
 	"opencode/uf/packs/content-custom.md",
 	"opencode/uf/packs/content.md",
 	"opencode/uf/packs/default-custom.md",
@@ -587,11 +589,14 @@ func TestIsToolOwned(t *testing.T) {
 		{"opencode/uf/packs/typescript.md", true},
 		// Tool-owned: convention packs (canonical) — Python
 		{"opencode/uf/packs/python.md", true},
+		// Tool-owned: convention packs (canonical) — CI
+		{"opencode/uf/packs/ci.md", true},
 		// User-owned: convention packs (custom)
 		{"opencode/uf/packs/go-custom.md", false},
 		{"opencode/uf/packs/default-custom.md", false},
 		{"opencode/uf/packs/typescript-custom.md", false},
 		{"opencode/uf/packs/python-custom.md", false},
+		{"opencode/uf/packs/ci-custom.md", false},
 		// User-owned: agents (including Divisor personas and Cobalt-Crush)
 		{"opencode/agents/divisor-guard.md", false},
 		{"opencode/agents/divisor-architect.md", false},
@@ -1236,6 +1241,13 @@ func TestShouldDeployPack(t *testing.T) {
 		{"opencode/uf/packs/severity.md", "go", true},
 		{"opencode/uf/packs/severity.md", "typescript", true},
 		{"opencode/uf/packs/severity.md", "default", true},
+		// CI packs always deploy (language-agnostic)
+		{"opencode/uf/packs/ci.md", "go", true},
+		{"opencode/uf/packs/ci-custom.md", "go", true},
+		{"opencode/uf/packs/ci.md", "typescript", true},
+		{"opencode/uf/packs/ci-custom.md", "typescript", true},
+		{"opencode/uf/packs/ci.md", "", true},
+		{"opencode/uf/packs/ci-custom.md", "", true},
 		// Matching language packs deploy
 		{"opencode/uf/packs/go.md", "go", true},
 		{"opencode/uf/packs/go-custom.md", "go", true},
@@ -1411,13 +1423,13 @@ func TestRun_DivisorSubset_DefaultFallback(t *testing.T) {
 		t.Fatalf("Run() error: %v", err)
 	}
 
-	// Verify only always-deploy packs deployed (default, severity, content)
+	// Verify only always-deploy packs deployed (default, severity, content, ci)
 	for _, f := range result.Created {
 		if strings.Contains(f, "uf/packs") {
 			base := filepath.Base(f)
 			if !strings.HasPrefix(base, "default") && base != "severity.md" &&
-				!strings.HasPrefix(base, "content") {
-				t.Errorf("expected only default/severity/content packs, got %s", f)
+				!strings.HasPrefix(base, "content") && !strings.HasPrefix(base, "ci") {
+				t.Errorf("expected only default/severity/content/ci packs, got %s", f)
 			}
 		}
 	}
@@ -5170,6 +5182,8 @@ func TestCollectDeployedPacks_Go(t *testing.T) {
 		"severity.md":       true,
 		"content.md":        true,
 		"content-custom.md": true,
+		"ci.md":             true,
+		"ci-custom.md":      true,
 		"go.md":             true,
 		"go-custom.md":      true,
 	}
@@ -5204,13 +5218,14 @@ func TestCollectDeployedPacks_Default(t *testing.T) {
 	for _, p := range packs {
 		if p == "default.md" || p == "default-custom.md" ||
 			p == "severity.md" || p == "content.md" ||
-			p == "content-custom.md" {
+			p == "content-custom.md" || p == "ci.md" ||
+			p == "ci-custom.md" {
 			continue
 		}
 		t.Errorf("unexpected pack %q for default lang", p)
 	}
-	if len(packs) != 5 {
-		t.Errorf("expected 5 packs for default lang, got %d", len(packs))
+	if len(packs) != 7 {
+		t.Errorf("expected 7 packs for default lang, got %d", len(packs))
 	}
 }
 
@@ -5311,7 +5326,7 @@ func TestCollectDeployedPacks_WithRoot_AllEmpty(t *testing.T) {
 	}
 
 	sentinel := "<!-- Add project-specific rules below this line -->"
-	stubs := []string{"default-custom.md", "content-custom.md", "go-custom.md"}
+	stubs := []string{"default-custom.md", "content-custom.md", "ci-custom.md", "go-custom.md"}
 	for _, name := range stubs {
 		if err := os.WriteFile(filepath.Join(packsDir, name), []byte(sentinel), 0o644); err != nil {
 			t.Fatalf("write %s: %v", name, err)
@@ -5326,7 +5341,7 @@ func TestCollectDeployedPacks_WithRoot_AllEmpty(t *testing.T) {
 		}
 	}
 	// Non-custom packs must still be present.
-	required := []string{"default.md", "severity.md", "content.md", "go.md"}
+	required := []string{"default.md", "severity.md", "content.md", "ci.md", "go.md"}
 	packSet := make(map[string]bool, len(packs))
 	for _, p := range packs {
 		packSet[p] = true
@@ -5346,8 +5361,8 @@ func TestCollectDeployedPacks_WithRoot_OnePopulated(t *testing.T) {
 	}
 
 	sentinel := "<!-- Add project-specific rules below this line -->"
-	// default-custom and content-custom are empty stubs.
-	for _, name := range []string{"default-custom.md", "content-custom.md"} {
+	// default-custom, content-custom, and ci-custom are empty stubs.
+	for _, name := range []string{"default-custom.md", "content-custom.md", "ci-custom.md"} {
 		if err := os.WriteFile(filepath.Join(packsDir, name), []byte(sentinel), 0o644); err != nil {
 			t.Fatalf("write %s: %v", name, err)
 		}
@@ -5373,6 +5388,9 @@ func TestCollectDeployedPacks_WithRoot_OnePopulated(t *testing.T) {
 	if packSet["content-custom.md"] {
 		t.Error("content-custom.md should be excluded (empty)")
 	}
+	if packSet["ci-custom.md"] {
+		t.Error("ci-custom.md should be excluded (empty)")
+	}
 }
 
 func TestCollectDeployedPacks_WithRoot_EmptyRootFallback(t *testing.T) {
@@ -5384,7 +5402,7 @@ func TestCollectDeployedPacks_WithRoot_EmptyRootFallback(t *testing.T) {
 	for _, p := range packs {
 		packSet[p] = true
 	}
-	for _, name := range []string{"default-custom.md", "content-custom.md", "go-custom.md"} {
+	for _, name := range []string{"default-custom.md", "content-custom.md", "ci-custom.md", "go-custom.md"} {
 		if !packSet[name] {
 			t.Errorf("expected %q in packs when root is empty, got: %v", name, packs)
 		}

--- a/internal/schemas/packvalidator_test.go
+++ b/internal/schemas/packvalidator_test.go
@@ -179,6 +179,12 @@ func TestValidateConventionPack_AllPacksValid(t *testing.T) {
 		if name == "content.md" {
 			continue
 		}
+		// Skip ci pack — it's a CI workflow convention pack with
+		// different required sections (CI-NNN rules) than coding
+		// packs (Coding Style, etc.)
+		if name == "ci.md" {
+			continue
+		}
 
 		t.Run(name, func(t *testing.T) {
 			packPath := filepath.Join(packsDir, name)

--- a/openspec/changes/ci-convention-pack/.openspec.yaml
+++ b/openspec/changes/ci-convention-pack/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: unbound-force
+created: 2026-06-12

--- a/openspec/changes/ci-convention-pack/design.md
+++ b/openspec/changes/ci-convention-pack/design.md
@@ -1,0 +1,153 @@
+## Context
+
+The Unbound Force scaffold system deploys convention packs to
+projects via `uf init`. Packs are Markdown files with YAML
+frontmatter, embedded in the binary from
+`internal/scaffold/assets/opencode/uf/packs/` and deployed to
+`.opencode/uf/packs/` in target projects.
+
+The Divisor SRE and Adversary agents reference `[PACK]` CI/CD
+guidance during review, but no pack provides CI rules today. CI
+workflow conventions exist only in the user-level
+`~/.config/opencode/coding-standards.md`, which is invisible to
+the `[PACK]` mechanism.
+
+This design adds a `ci.md` convention pack as the canonical,
+centralized home for all CI workflow authoring rules.
+
+## Goals / Non-Goals
+
+### Goals
+
+- Add a `ci.md` canonical convention pack with rules for action
+  pinning, SHA verification, workflow structure, permissions,
+  and reusable workflow design
+- Follow all established scaffold patterns (dual-copy drift
+  detection, `-custom` companion, always-deployed, validator
+  exemption)
+- Fill the SRE/Adversary `[PACK]` gap for CI/CD guidance
+- Centralize CI rules: `ci.md` pack is the single source of
+  truth; trim the duplicated section from `coding-standards.md`
+
+### Non-Goals
+
+- CI guardrail implementation (reusable workflow in org-infra) --
+  tracked separately as
+  [complytime/org-infra#337](https://github.com/complytime/org-infra/issues/337)
+- Changes to Divisor agent files -- the existing `[PACK]` tags
+  will automatically resolve to the new pack's rules
+- Container image conventions -- these remain in
+  `coding-standards.md` (different concern)
+- Python-specific or Rust-specific CI rules -- the pack is
+  language-agnostic
+
+## Decisions
+
+### D1: Always-deployed, concern-specific pack
+
+**Decision**: `ci.md` is always deployed regardless of detected
+language, following the `content.md` and `severity.md` pattern.
+
+**Rationale**: CI workflows are language-agnostic. Every project
+that uses GitHub Actions benefits from these rules, regardless
+of whether it's Go, TypeScript, or Python.
+
+**Alternatives rejected**: Language-specific deployment (would
+miss projects with CI but no detected language); `default.md`
+extension (would mix CI concerns into the general pack and
+inflate an already 214-line file).
+
+### D2: Validator exemption for non-coding H2 sections
+
+**Decision**: `ci.md` uses its own H2 section structure and is
+exempted from the pack validator's 6-section requirement, like
+`severity.md` and `content.md`.
+
+**Rationale**: The standard coding pack sections (Coding Style,
+Architectural Patterns, Security Checks, Testing Conventions,
+Documentation Requirements, Custom Rules) do not map to CI
+concerns. Forcing them would create empty sections or distort
+the content.
+
+**Sections chosen**:
+- `## Action Pinning & Supply Chain` (CI-001, CI-002, CI-003)
+- `## Workflow Structure` (CI-010, CI-011, CI-012)
+- `## Permissions & Secrets` (CI-020, CI-021, CI-022)
+- `## Reusable Workflow Design` (CI-030, CI-031, CI-032)
+- `## Custom Rules` (empty, for `ci-custom.md`)
+
+### D3: Rule numbering scheme
+
+**Decision**: `CI-NNN` prefix with section-based grouping.
+Supply chain: 001-009. Structure: 010-019. Permissions: 020-029.
+Reusable design: 030-039. Leaves room for growth within each
+section.
+
+**Rationale**: Consistent with existing pack schemes (CS-NNN,
+AP-NNN, SC-NNN, TC-NNN, DR-NNN in `default.md`; VB-NNN, TD-NNN,
+etc. in `content.md`).
+
+### D4: Centralization with `coding-standards.md` trim
+
+**Decision**: The `ci.md` pack is the canonical home for CI
+rules. The "YAML / GitHub Actions Workflows" section in
+`~/.config/opencode/coding-standards.md` is replaced with a
+reference to the pack.
+
+**Rationale**: Avoids duplication. Convention packs are the
+mechanism Divisor agents use for `[PACK]` lookups. All repos
+using Unbound Force use `uf init`, so the pack is always
+available. The `coding-standards.md` precedence hierarchy
+("repository-level rules take precedence") already supports
+this pattern.
+
+**What stays in `coding-standards.md`**: The Containers section
+(different concern -- container image building and supply chain,
+not workflow authoring).
+
+### D5: SHA verification rule semantics (CI-002)
+
+**Decision**: Strong verification: agents MUST look up the tag
+first, derive the SHA from it, and write both. SHAs MUST NOT be
+sourced from memory or training data.
+
+**Rationale**: The root cause of complytime/.github#114 was an
+agent writing a SHA from training data. The rule must prevent
+this at the behavioral level. Tag-first lookup eliminates the
+hallucination vector entirely.
+
+**Version comment (CI-003)**: SHOULD, not MUST. Missing comments
+produce a warning, not a failure. This matches the CI guardrail
+behavior defined in org-infra#337.
+
+## Risks / Trade-offs
+
+### R1: Pack proliferation
+
+Adding a fourth always-deployed pack (default, severity, content,
+ci) increases the CLAUDE.md and AGENTS.md import lists. This is
+acceptable: each pack serves a distinct concern and the scaffold
+system manages imports automatically.
+
+### R2: Existing test count updates
+
+Multiple test functions hardcode expected pack counts (e.g.,
+`TestCollectDeployedPacks_Default` expects 5, `_Go` expects 7).
+Adding ci.md and ci-custom.md increases each by 2. This is
+mechanical but touches several test cases.
+
+### R3: Stale `coding-standards.md` in other environments
+
+Other developers using the same `coding-standards.md` will still
+have the full CI section until they update. This is acceptable:
+the pack takes precedence per the stated hierarchy, and the trim
+is a user-config change, not a repo change.
+
+### R4: CI guardrail dependency
+
+The CI-002 rule (verify SHAs at authoring time) is a behavioral
+rule enforced by convention, not automation. The enforcement
+layer (org-infra#337) is tracked separately. Until implemented,
+the convention pack provides prevention but not enforcement.
+This is the same defense-in-depth pattern used for all other
+convention pack rules.

--- a/openspec/changes/ci-convention-pack/proposal.md
+++ b/openspec/changes/ci-convention-pack/proposal.md
@@ -1,0 +1,137 @@
+## Why
+
+AI agents and humans can write GitHub Actions `uses:` references
+with invalid or hallucinated commit SHAs. These pass all local
+validation (YAML lint, Go tests, formatting) but fail at runtime
+when GitHub cannot resolve the SHA. This happened in
+[complytime/.github#114](https://github.com/complytime/.github/pull/114)
+where `actions/setup-node` was pinned to a nonexistent SHA.
+
+No convention pack covers CI workflow authoring today. The Divisor
+SRE agent references `[PACK]` CI/CD guidance that no pack provides,
+causing it to fall back to "universal checks only" on every review.
+Existing CI rules in `~/.config/opencode/coding-standards.md` are
+invisible to the Divisor `[PACK]` mechanism -- they exist in the
+instruction chain but not in the convention pack system.
+
+This change centralizes all CI workflow conventions into a canonical
+`ci.md` convention pack and trims the duplicated section from the
+user-level `coding-standards.md` config.
+
+## What Changes
+
+1. **New `ci.md` canonical convention pack** -- always-deployed
+   (language-agnostic), covering action pinning & supply chain,
+   workflow structure, permissions & secrets, and reusable workflow
+   design.
+2. **New `ci-custom.md` companion** -- user-owned stub for
+   project-specific CI rules, following the established `-custom`
+   pattern.
+3. **Scaffold engine updates** -- `shouldDeployPack()` and
+   `collectDeployedPacks()` include the new pack in the
+   always-deployed set.
+4. **Pack validator exemption** -- `ci.md` uses a different H2
+   structure than coding packs, exempt from the 6-section
+   requirement (like `severity.md` and `content.md`).
+5. **User config trim** -- `~/.config/opencode/coding-standards.md`
+   "YAML / GitHub Actions Workflows" section replaced with a
+   reference to the `ci.md` pack.
+
+## Capabilities
+
+### New Capabilities
+
+- `ci.md convention pack`: Canonical CI workflow authoring rules
+  including SHA verification (CI-002), action pinning (CI-001),
+  version comments (CI-003), naming conventions, permissions,
+  secrets, and reusable workflow design.
+- `ci-custom.md`: Project-specific CI rule extension point.
+
+### Modified Capabilities
+
+- `shouldDeployPack()`: Recognizes `ci` and `ci-custom` as
+  always-deployed packs.
+- `collectDeployedPacks()`: Includes `ci.md` and `ci-custom.md`
+  in the candidates list for all projects.
+
+### Removed Capabilities
+
+- None. The `coding-standards.md` CI section is trimmed, not
+  removed -- replaced with a reference to the pack.
+
+## Impact
+
+- **Scaffold engine** (`internal/scaffold/scaffold.go`): Two
+  functions gain `ci`/`ci-custom` entries.
+- **Scaffold tests** (`internal/scaffold/scaffold_test.go`):
+  Asset manifest, `isToolOwned`, `shouldDeployPack`, and
+  `collectDeployedPacks` tests updated.
+- **Pack validator tests** (`internal/schemas/packvalidator_test.go`):
+  `ci.md` added to the skip list for structural validation.
+- **Embedded assets** (`internal/scaffold/assets/opencode/uf/packs/`):
+  Two new files.
+- **Canonical sources** (`.opencode/uf/packs/`): Two new
+  byte-identical copies for drift detection.
+- **User config** (`~/.config/opencode/coding-standards.md`):
+  CI section trimmed.
+- **All consumer repos**: `uf init` will deploy the new pack
+  on next run, auto-updating AGENTS.md and CLAUDE.md.
+- **Divisor SRE agent**: `[PACK]` CI/CD references will now
+  resolve to actual rules without code changes to the agent.
+
+## Constitution Alignment
+
+Assessed against the Unbound Force org constitution.
+
+### I. Autonomous Collaboration
+
+**Assessment**: PASS
+
+The convention pack is a self-describing artifact with
+frontmatter metadata (pack_id, language, version). It is
+consumed by Divisor agents through the established `[PACK]`
+mechanism without requiring synchronous interaction. No
+inter-hero communication changes.
+
+### II. Composability First
+
+**Assessment**: PASS
+
+The pack is always-deployed but imposes no mandatory
+dependencies. Projects without GitHub Actions workflows
+simply have unused rules (same as `content.md` in non-content
+projects). The pack follows the established `-custom`
+extension pattern for project-specific overrides.
+
+### III. Observable Quality
+
+**Assessment**: PASS
+
+The pack includes versioned YAML frontmatter (`pack_id`,
+`language`, `version`) conforming to the established schema.
+It supports machine-parseable consumption by the Divisor
+`[PACK]` mechanism and maintains provenance metadata through
+the scaffold version marker system.
+
+### IV. Testability
+
+**Assessment**: PASS
+
+All scaffold changes are covered by existing test patterns:
+drift detection (`TestEmbeddedAssets_MatchSource`,
+`TestCanonicalSources_AreEmbedded`), deployment filtering
+(`TestShouldDeployPack`), pack collection
+(`TestCollectDeployedPacks_*`), and tool ownership
+(`TestIsToolOwned`). The pack validator exemption follows the
+established pattern for non-coding packs.
+
+### V. Security by Default
+
+**Assessment**: PASS
+
+This change directly advances Principle V. The CI-002 rule
+(verify SHAs at authoring time) enforces supply chain
+integrity for CI pipelines. CI-001 (pin to commit SHAs)
+prevents mutable tag attacks. CI-020/CI-022 codify least
+privilege and secret hygiene. The pack makes these security
+properties structural rather than review-time afterthoughts.

--- a/openspec/changes/ci-convention-pack/specs/ci-pack/spec.md
+++ b/openspec/changes/ci-convention-pack/specs/ci-pack/spec.md
@@ -1,0 +1,238 @@
+## ADDED Requirements
+
+### Requirement: CI Convention Pack Deployment
+
+FR-001: The scaffold engine MUST deploy `ci.md` and
+`ci-custom.md` to `.opencode/uf/packs/` for all projects,
+regardless of detected language.
+
+FR-002: `ci.md` MUST be tool-owned (auto-updated on
+`uf init` re-runs). `ci-custom.md` MUST be user-owned
+(never overwritten unless `--force` is used).
+
+FR-003: `ci.md` and `ci-custom.md` MUST be included in
+the `collectDeployedPacks()` candidates list alongside
+default, severity, and content packs.
+
+FR-004: `shouldDeployPack()` MUST return true for `ci`
+and `ci-custom` pack names regardless of the resolved
+language.
+
+#### Scenario: Pack deployed for Go project
+
+- **GIVEN** a project with `go.mod` present
+- **WHEN** `uf init` is run
+- **THEN** `.opencode/uf/packs/ci.md` and
+  `.opencode/uf/packs/ci-custom.md` are created alongside
+  `default.md`, `severity.md`, `content.md`, and `go.md`
+
+#### Scenario: Pack deployed for project with no detected language
+
+- **GIVEN** a project with no language marker files
+- **WHEN** `uf init` is run
+- **THEN** `.opencode/uf/packs/ci.md` and
+  `.opencode/uf/packs/ci-custom.md` are created alongside
+  default, severity, and content packs
+
+#### Scenario: Custom pack preserved on re-run
+
+- **GIVEN** a project where `ci-custom.md` has been
+  populated with project-specific rules
+- **WHEN** `uf init` is run again
+- **THEN** `ci-custom.md` is NOT overwritten
+- **AND** `ci.md` IS updated to the latest canonical version
+
+### Requirement: CI Convention Pack Structure
+
+FR-010: The `ci.md` pack MUST have YAML frontmatter with
+`pack_id: ci`, `language: Any`, and `version: 1.0.0`.
+
+FR-011: The `ci.md` pack MUST contain the following H2
+sections: `Action Pinning & Supply Chain`,
+`Workflow Structure`, `Permissions & Secrets`,
+`Reusable Workflow Design`, `Custom Rules`.
+
+FR-012: The `ci.md` pack MUST be exempt from the pack
+validator's standard 6-section requirement (Coding Style,
+Architectural Patterns, etc.), following the established
+exemption pattern for `severity.md` and `content.md`.
+
+#### Scenario: Pack validator skips ci.md
+
+- **GIVEN** the `ci.md` pack exists in `.opencode/uf/packs/`
+- **WHEN** `TestValidateConventionPack_AllPacksValid` runs
+- **THEN** `ci.md` is skipped (not validated against the
+  6-section coding pack requirement)
+- **AND** no validation error is reported
+
+### Requirement: Drift Detection
+
+FR-020: The embedded copy at
+`internal/scaffold/assets/opencode/uf/packs/ci.md` MUST be
+byte-identical to `.opencode/uf/packs/ci.md`.
+
+FR-021: The embedded copy at
+`internal/scaffold/assets/opencode/uf/packs/ci-custom.md`
+MUST be byte-identical to `.opencode/uf/packs/ci-custom.md`.
+
+FR-022: Both files MUST be listed in the `expectedAssetPaths`
+manifest in `scaffold_test.go`.
+
+#### Scenario: Drift detected when embedded diverges
+
+- **GIVEN** `ci.md` is modified in `.opencode/uf/packs/`
+  but not in `internal/scaffold/assets/opencode/uf/packs/`
+- **WHEN** `TestEmbeddedAssets_MatchSource` runs
+- **THEN** the test fails with a drift error
+
+### Requirement: Action Pinning Rules
+
+FR-030: CI-001 MUST require that every `uses:` reference
+for actions and reusable workflows in GitHub Actions
+workflow files is pinned to a full 40-character commit SHA.
+Docker container references (`docker://image:tag`) are
+excluded from this requirement; they SHOULD be pinned to
+image digests (`@sha256:...`) when available but are not
+subject to CI-001.
+
+FR-031: CI-002 MUST require that SHAs are verified
+against the source repository at authoring time. The tag
+MUST be resolved first, and the SHA derived from it. SHAs
+MUST NOT be sourced from memory or training data. When the
+API response object type is `tag` (annotated tag), the
+agent MUST dereference to get the commit SHA by following
+the tag object's target.
+
+FR-032: CI-003 SHOULD recommend including a version
+comment (e.g., `# v6.0.2`) after the SHA for human
+readability. Missing comments are a warning, not a
+failure. When a version comment IS included, it MUST
+accurately reflect the tag used to derive the SHA.
+
+FR-033: CI-002 verification MUST fail safe. When SHA
+verification cannot be completed (network unavailable,
+API rate limit, missing authentication, tag not found),
+the agent MUST NOT write the unverified `uses:` reference
+and MUST report the verification failure.
+
+#### Scenario: Agent writes a new action reference
+
+- **GIVEN** an agent is adding `actions/checkout` to a
+  workflow file
+- **WHEN** the agent follows CI-002
+- **THEN** the agent resolves the desired tag via
+  `gh api repos/actions/checkout/git/ref/tags/v4`
+- **AND** if the response object type is `tag` (annotated
+  tag), the agent dereferences to get the commit SHA
+- **AND** derives the commit SHA from the API response
+- **AND** writes `uses: actions/checkout@<sha>  # v4.x.x`
+
+#### Scenario: Agent writes SHA from memory
+
+- **GIVEN** an agent writes a `uses:` reference with a
+  SHA sourced from training data
+- **WHEN** a Divisor agent reviews the change or the CI
+  guardrail runs
+- **THEN** the reviewer flags a CI-002 violation if the
+  SHA does not resolve or does not match the claimed tag
+
+#### Scenario: SHA verification fails
+
+- **GIVEN** an agent is adding an action reference
+- **WHEN** the `gh api` call fails (network, auth, rate
+  limit, missing tag)
+- **THEN** the agent MUST NOT write the `uses:` reference
+- **AND** the agent MUST report the verification failure
+
+### Requirement: Non-Pinning CI Rules
+
+FR-034: The Permissions & Secrets section (CI-020, CI-021,
+CI-022) MUST codify the CI workflow permission and secret
+management rules. The normative source for these rules is
+the "Security" subsection of the "YAML / GitHub Actions
+Workflows" section in the project's coding standards.
+CI-020 MUST require least-privilege permissions. CI-021
+SHOULD prefer job-level over workflow-level permissions.
+CI-022 MUST prohibit hardcoded secrets.
+
+FR-035: The Workflow Structure section (CI-010, CI-011,
+CI-012) MUST codify CI workflow naming and formatting
+rules. The normative source is the "Naming Conventions"
+and "Formatting" subsections of the coding standards.
+CI-010 MUST require `reusable_` prefix for reusable
+workflows and `ci_` prefix for consumers. CI-011 MUST
+require header comment blocks. CI-012 SHOULD recommend
+concurrency groups.
+
+FR-036: The Reusable Workflow Design section (CI-030,
+CI-031, CI-032) MUST codify reusable workflow interface
+rules. CI-030 MUST require descriptive input descriptions
+and `required: true` for required inputs. CI-031 SHOULD
+recommend sensible defaults. CI-032 MUST require reusable
+workflows to be generic enough for any consumer.
+
+### Requirement: Coding Standards Centralization
+
+FR-040: The `ci.md` pack MUST be the canonical source of
+truth for CI workflow conventions in repos that use the
+Unbound Force scaffold.
+
+FR-041: The "YAML / GitHub Actions Workflows" section in
+`~/.config/opencode/coding-standards.md` MUST be replaced
+with a condensed inline summary of essential CI rules
+(pin to SHA, least-privilege, naming) plus a reference to
+the `ci.md` pack for expanded enforceable rules. This
+preserves baseline guidance for non-UF repos.
+
+FR-042: The "Containers" section in `coding-standards.md`
+MUST remain unchanged (different concern).
+
+#### Scenario: Non-UF repo retains baseline CI guidance
+
+- **GIVEN** a developer opens a non-UF repo (no
+  `.opencode/uf/packs/ci.md` present)
+- **WHEN** the agent reads `coding-standards.md`
+- **THEN** essential CI baseline rules (pin to SHA,
+  least-privilege, naming) are available inline
+- **AND** a note indicates expanded rules are in the
+  `ci.md` pack for UF repos
+
+#### Scenario: UF repo uses pack as canonical source
+
+- **GIVEN** the `ci.md` pack is deployed in a UF repo
+- **WHEN** an agent reads both `coding-standards.md` and
+  the `ci.md` pack
+- **THEN** the pack contains the full CI rule set
+- **AND** `coding-standards.md` defers to the pack for
+  expanded rules
+
+## MODIFIED Requirements
+
+### Requirement: collectDeployedPacks candidates list
+
+Previously: candidates list contained 5 always-deployed
+entries (default, default-custom, severity, content,
+content-custom).
+
+Now: candidates list MUST contain 7 always-deployed entries
+(default, default-custom, severity, content, content-custom,
+ci, ci-custom).
+
+### Requirement: shouldDeployPack always-deploy set
+
+Previously: always-deploy set contained default,
+default-custom, severity, content, content-custom.
+
+Now: always-deploy set MUST also contain ci and ci-custom.
+
+### Requirement: expectedAssetPaths manifest
+
+Previously: convention packs section listed 11 entries.
+
+Now: convention packs section MUST list 13 entries,
+including `opencode/uf/packs/ci.md` and
+`opencode/uf/packs/ci-custom.md`.
+
+## REMOVED Requirements
+
+None.

--- a/openspec/changes/ci-convention-pack/tasks.md
+++ b/openspec/changes/ci-convention-pack/tasks.md
@@ -1,0 +1,54 @@
+<!--
+  [P] marks tasks eligible for parallel execution.
+  Add [P] when a task: (a) touches different files from
+  other [P] tasks in the group, (b) has no dependency
+  on prior tasks in the group, (c) can safely execute
+  without ordering constraints.
+  Do NOT add [P] when tasks modify the same file --
+  parallel workers will cause merge conflicts.
+  Tasks without [P] run sequentially first, then [P]
+  tasks run in parallel.
+-->
+
+## 1. Create Pack Content
+
+- [x] 1.1 [P] Create `.opencode/uf/packs/ci.md` (canonical source) with frontmatter (`pack_id: ci`, `language: Any`, `version: 1.0.0`) and all CI rules: Action Pinning & Supply Chain (CI-001, CI-002, CI-003), Workflow Structure (CI-010, CI-011, CI-012), Permissions & Secrets (CI-020, CI-021, CI-022), Reusable Workflow Design (CI-030, CI-031, CI-032), Custom Rules (empty).
+- [x] 1.2 [P] Create `.opencode/uf/packs/ci-custom.md` (canonical source) with frontmatter (`pack_id: ci-custom`, `language: Any`, `version: 1.0.0`), `## Custom Rules` section header, and sentinel comment `<!-- Add project-specific rules below this line -->`.
+- [x] 1.3 Copy `.opencode/uf/packs/ci.md` to `internal/scaffold/assets/opencode/uf/packs/ci.md` (byte-identical embedded copy for drift detection).
+- [x] 1.4 Copy `.opencode/uf/packs/ci-custom.md` to `internal/scaffold/assets/opencode/uf/packs/ci-custom.md` (byte-identical embedded copy for drift detection).
+
+## 2. Scaffold Engine Updates
+
+- [x] 2.1 Update `shouldDeployPack()` in `internal/scaffold/scaffold.go`: add `"ci"` and `"ci-custom"` to the always-deploy condition (line ~365).
+- [x] 2.2 Update `collectDeployedPacks()` in `internal/scaffold/scaffold.go`: add `"ci.md"` and `"ci-custom.md"` to the candidates slice (line ~1299).
+
+## 3. Test Updates
+
+- [x] 3.1 Update `expectedAssetPaths` in `internal/scaffold/scaffold_test.go`: add `"opencode/uf/packs/ci-custom.md"` and `"opencode/uf/packs/ci.md"` in alphabetical order. Update the comment count from 11 to 13.
+- [x] 3.2 [P] Add `ci.md` to the skip list in `TestValidateConventionPack_AllPacksValid` in `internal/schemas/packvalidator_test.go`, following the `severity.md` and `content.md` pattern.
+- [x] 3.3 Update `TestCollectDeployedPacks_Go` in `internal/scaffold/scaffold_test.go`: add `"ci.md": true` and `"ci-custom.md": true` to the expected map; update expected count.
+- [x] 3.4 Update `TestCollectDeployedPacks_Default` in `internal/scaffold/scaffold_test.go`: add `ci.md` and `ci-custom.md` to the allowed list; update expected count from 5 to 7.
+- [x] 3.5 Update `TestCollectDeployedPacks_WithRoot_AllEmpty` in `internal/scaffold/scaffold_test.go`: add `"ci-custom.md"` to the stubs list and add `"ci.md"` to the `required` non-custom pack assertions.
+- [x] 3.6 Update `TestCollectDeployedPacks_WithRoot_OnePopulated`: add `ci-custom.md` as an empty stub alongside `default-custom.md` and `content-custom.md`; verify it is excluded from the result. Update `TestCollectDeployedPacks_WithRoot_EmptyRootFallback`: add `ci-custom.md` to the expected pack list in the `for _, name := range` assertion.
+- [x] 3.7 Add test cases to `TestIsToolOwned` in `internal/scaffold/scaffold_test.go`: `"opencode/uf/packs/ci.md"` (true) and `"opencode/uf/packs/ci-custom.md"` (false).
+- [x] 3.8 Add test cases to `TestShouldDeployPack` in `internal/scaffold/scaffold_test.go`: `ci.md` and `ci-custom.md` return true regardless of language.
+- [x] 3.9 Update `TestRun_DivisorSubset` in `internal/scaffold/scaffold_test.go`: add `"ci"` to the allowed pack prefixes in the DivisorOnly pack filter (alongside default, severity, content).
+
+## 4. User Config Trim
+
+- [x] 4.1 Replace the "YAML / GitHub Actions Workflows" section in `~/.config/opencode/coding-standards.md` (lines ~143-168) with a condensed inline summary of essential CI rules (pin to SHA, least-privilege, naming conventions) plus a reference to the `ci.md` pack for expanded enforceable rules. Keep the "Containers" section unchanged.
+
+## 5. Documentation Gate
+
+- [x] 5.1 Run `uf init` to update AGENTS.md and CLAUDE.md convention pack lists (deferred to `chore/uf-init-sync` branch per behavioral rules).
+- [x] 5.2 Add CHANGELOG.md entry under the appropriate version header: `feat: add ci.md convention pack for CI workflow authoring`.
+- [x] 5.3 File a documentation issue (unbound-force/unbound-force#271) against this repo for the new ci.md convention pack.
+
+## 6. Verification
+
+- [x] 6.1 Run `make test` to verify all tests pass (drift detection, pack deployment, validator exemption, tool ownership, expected asset manifest, DivisorSubset).
+- [x] 6.2 Run `make lint` to verify no lint issues.
+- [x] 6.3 Run `make build` to verify the binary builds with the new embedded assets.
+- [x] 6.4 Verify constitution alignment: Principle II (ci.md works standalone, no mandatory dependencies), Principle IV (all changes covered by existing test patterns), Principle V (CI-002 advances supply chain integrity).
+<!-- spec-review: passed -->
+<!-- code-review: passed -->


### PR DESCRIPTION
## Summary

Add a new always-deployed `ci.md` convention pack with 12 rules
for CI workflow authoring, covering action pinning, SHA
verification, workflow structure, permissions, and reusable
workflow design.

### Motivation

- AI agents can write `uses:` references with hallucinated commit
  SHAs that pass all local checks but fail at runtime
  ([complytime/.github#114](https://github.com/complytime/.github/pull/114))
- The Divisor SRE agent references `[PACK]` CI/CD guidance that
  no pack provides, falling back to "universal checks only"
- CI rules in `coding-standards.md` are invisible to the Divisor
  `[PACK]` mechanism

### Changes

- New `ci.md` canonical pack + `ci-custom.md` companion
- Scaffold engine: `shouldDeployPack()` + `collectDeployedPacks()`
  updated for always-deployed CI pack
- Pack validator exemption (like severity.md, content.md)
- Test updates across 4 files (scaffold, schemas, cmd)
- CHANGELOG.md entry
- `~/.config/opencode/coding-standards.md` (user-level config,
  not repo-tracked) trimmed to condensed CI baseline + pack ref

### Related

- CI guardrail: complytime/org-infra#337
- Documentation: #271

Spec: `openspec/changes/ci-convention-pack/`
