### PR TITLE
fix: align installGolangciLint dry-run with actual install path

### DIFF
--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -888,34 +888,34 @@ func runReplicatorSetup(opts *Options) stepResult {
 }
 
 // installGolangciLint installs golangci-lint if missing per Spec 019
-// FR-012. Uses go install as primary method with Homebrew fallback.
+// FR-012. Fallback chain: go install → Homebrew → skip.
 func installGolangciLint(opts *Options, env doctor.DetectedEnvironment) stepResult {
 	if _, err := opts.LookPath("golangci-lint"); err == nil {
 		return stepResult{name: "golangci-lint", action: "already installed"}
 	}
 
-	if opts.DryRun {
-		return stepResult{name: "golangci-lint", action: "dry-run", detail: "Would install: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest"}
-	}
-
-	// Try go install first (Go is already a prerequisite).
-	if _, err := opts.ExecCmd("go", "install", "github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest"); err == nil {
-		return stepResult{name: "golangci-lint", action: "installed", detail: "via go install"}
-	}
-
-	// Fallback to Homebrew.
-	if doctor.HasManager(env, doctor.ManagerHomebrew) {
-		if out, err := opts.ExecCmd("brew", "install", "golangci-lint"); err != nil {
-			return stepResult{name: "golangci-lint", action: "failed", detail: "brew install failed", err: err, output: out}
-		}
-		return stepResult{name: "golangci-lint", action: "installed", detail: "via Homebrew"}
-	}
-
-	return stepResult{
+	// Fallback chain: go install → Homebrew → skip.
+	skipResult := stepResult{
 		name:   "golangci-lint",
-		action: "failed",
-		detail: "Install: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest",
-		err:    fmt.Errorf("golangci-lint not available"),
+		action: "skipped",
+		detail: "Install: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest or brew install golangci-lint",
+	}
+	method := opts.resolveMethod("golangci-lint", env, "go", "homebrew")
+	switch method {
+	case "go":
+		result := installViaGo(opts, "golangci-lint", "github.com/golangci/golangci-lint/v2/cmd/golangci-lint")
+		if result.action != "skipped" && result.action != "failed" {
+			return result
+		}
+		// Go not available or failed — fall through to Homebrew.
+		if doctor.HasManager(env, doctor.ManagerHomebrew) {
+			return installViaBrew(opts, "golangci-lint", "golangci-lint")
+		}
+		return skipResult
+	case "homebrew":
+		return installViaBrew(opts, "golangci-lint", "golangci-lint")
+	default:
+		return skipResult
 	}
 }
 

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -5145,3 +5145,221 @@ func setupGenerateLines(n int) string {
 	}
 	return b.String()
 }
+
+// --- golangci-lint installation tests (issue #279) ---
+
+func TestInstallGolangciLint_AlreadyInstalled(t *testing.T) {
+	rec := &cmdRecorder{}
+
+	var buf bytes.Buffer
+	opts := Options{
+		Stdout: &buf,
+		Stderr: &buf,
+		LookPath: stubLookPath(map[string]string{
+			"golangci-lint": "/usr/local/bin/golangci-lint",
+		}),
+		ExecCmd:      rec.execCmd,
+		EvalSymlinks: stubEvalSymlinks(nil),
+		Getenv:       stubGetenv(map[string]string{}),
+	}
+	opts.defaults()
+
+	env := doctor.DetectEnvironment(&doctor.Options{
+		LookPath:     opts.LookPath,
+		EvalSymlinks: opts.EvalSymlinks,
+		Getenv:       opts.Getenv,
+	})
+
+	result := installGolangciLint(&opts, env)
+	if result.action != "already installed" {
+		t.Errorf("expected 'already installed', got %q", result.action)
+	}
+}
+
+func TestInstallGolangciLint_GoInstallSuccess(t *testing.T) {
+	rec := &cmdRecorder{}
+
+	var buf bytes.Buffer
+	opts := Options{
+		Stdout: &buf,
+		Stderr: &buf,
+		LookPath: stubLookPath(map[string]string{
+			"go": "/usr/local/bin/go",
+		}),
+		ExecCmd:      rec.execCmd,
+		EvalSymlinks: stubEvalSymlinks(nil),
+		Getenv:       stubGetenv(map[string]string{}),
+	}
+	opts.defaults()
+
+	env := doctor.DetectEnvironment(&doctor.Options{
+		LookPath:     opts.LookPath,
+		EvalSymlinks: opts.EvalSymlinks,
+		Getenv:       opts.Getenv,
+	})
+
+	result := installGolangciLint(&opts, env)
+	if result.action != "installed" {
+		t.Errorf("expected 'installed', got %q", result.action)
+	}
+	if !strings.Contains(result.detail, "via go install") {
+		t.Errorf("expected 'via go install' in detail, got %q", result.detail)
+	}
+}
+
+func TestInstallGolangciLint_GoFailsBrewFallback(t *testing.T) {
+	rec := &cmdRecorder{
+		errors: map[string]error{
+			"go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest": fmt.Errorf("go install failed"),
+		},
+	}
+
+	var buf bytes.Buffer
+	opts := Options{
+		Stdout: &buf,
+		Stderr: &buf,
+		LookPath: stubLookPath(map[string]string{
+			"go":   "/usr/local/bin/go",
+			"brew": "/opt/homebrew/bin/brew",
+		}),
+		ExecCmd:      rec.execCmd,
+		EvalSymlinks: stubEvalSymlinks(nil),
+		Getenv:       stubGetenv(map[string]string{}),
+	}
+	opts.defaults()
+
+	env := doctor.DetectEnvironment(&doctor.Options{
+		LookPath:     opts.LookPath,
+		EvalSymlinks: opts.EvalSymlinks,
+		Getenv:       opts.Getenv,
+	})
+
+	result := installGolangciLint(&opts, env)
+	if result.action != "installed" {
+		t.Errorf("expected 'installed', got %q", result.action)
+	}
+	if !strings.Contains(result.detail, "via Homebrew") {
+		t.Errorf("expected 'via Homebrew' in detail, got %q", result.detail)
+	}
+}
+
+func TestInstallGolangciLint_NoGoBrewFallback(t *testing.T) {
+	rec := &cmdRecorder{}
+
+	var buf bytes.Buffer
+	opts := Options{
+		Stdout: &buf,
+		Stderr: &buf,
+		LookPath: stubLookPath(map[string]string{
+			"brew": "/opt/homebrew/bin/brew",
+		}),
+		ExecCmd:      rec.execCmd,
+		EvalSymlinks: stubEvalSymlinks(nil),
+		Getenv:       stubGetenv(map[string]string{}),
+	}
+	opts.defaults()
+
+	env := doctor.DetectEnvironment(&doctor.Options{
+		LookPath:     opts.LookPath,
+		EvalSymlinks: opts.EvalSymlinks,
+		Getenv:       opts.Getenv,
+	})
+
+	result := installGolangciLint(&opts, env)
+	if result.action != "installed" {
+		t.Errorf("expected 'installed', got %q", result.action)
+	}
+	if !strings.Contains(result.detail, "via Homebrew") {
+		t.Errorf("expected 'via Homebrew' in detail, got %q", result.detail)
+	}
+}
+
+func TestInstallGolangciLint_NoManagers(t *testing.T) {
+	rec := &cmdRecorder{}
+
+	var buf bytes.Buffer
+	opts := Options{
+		Stdout:       &buf,
+		Stderr:       &buf,
+		LookPath:     stubLookPath(map[string]string{}),
+		ExecCmd:      rec.execCmd,
+		EvalSymlinks: stubEvalSymlinks(nil),
+		Getenv:       stubGetenv(map[string]string{}),
+	}
+	opts.defaults()
+
+	env := doctor.DetectEnvironment(&doctor.Options{
+		LookPath:     opts.LookPath,
+		EvalSymlinks: opts.EvalSymlinks,
+		Getenv:       opts.Getenv,
+	})
+
+	result := installGolangciLint(&opts, env)
+	if result.action != "skipped" {
+		t.Errorf("expected 'skipped', got %q", result.action)
+	}
+}
+
+func TestInstallGolangciLint_DryRunGoAvailable(t *testing.T) {
+	rec := &cmdRecorder{}
+
+	var buf bytes.Buffer
+	opts := Options{
+		DryRun: true,
+		Stdout: &buf,
+		Stderr: &buf,
+		LookPath: stubLookPath(map[string]string{
+			"go": "/usr/local/bin/go",
+		}),
+		ExecCmd:      rec.execCmd,
+		EvalSymlinks: stubEvalSymlinks(nil),
+		Getenv:       stubGetenv(map[string]string{}),
+	}
+	opts.defaults()
+
+	env := doctor.DetectEnvironment(&doctor.Options{
+		LookPath:     opts.LookPath,
+		EvalSymlinks: opts.EvalSymlinks,
+		Getenv:       opts.Getenv,
+	})
+
+	result := installGolangciLint(&opts, env)
+	if result.action != "dry-run" {
+		t.Errorf("expected 'dry-run', got %q", result.action)
+	}
+	if !strings.Contains(result.detail, "go install") {
+		t.Errorf("expected 'go install' in detail, got %q", result.detail)
+	}
+}
+
+func TestInstallGolangciLint_DryRunBrewFallback(t *testing.T) {
+	rec := &cmdRecorder{}
+
+	var buf bytes.Buffer
+	opts := Options{
+		DryRun: true,
+		Stdout: &buf,
+		Stderr: &buf,
+		LookPath: stubLookPath(map[string]string{
+			"brew": "/opt/homebrew/bin/brew",
+		}),
+		ExecCmd:      rec.execCmd,
+		EvalSymlinks: stubEvalSymlinks(nil),
+		Getenv:       stubGetenv(map[string]string{}),
+	}
+	opts.defaults()
+
+	env := doctor.DetectEnvironment(&doctor.Options{
+		LookPath:     opts.LookPath,
+		EvalSymlinks: opts.EvalSymlinks,
+		Getenv:       opts.Getenv,
+	})
+
+	result := installGolangciLint(&opts, env)
+	if result.action != "dry-run" {
+		t.Errorf("expected 'dry-run', got %q", result.action)
+	}
+	if !strings.Contains(result.detail, "brew install") {
+		t.Errorf("expected 'brew install' in detail, got %q", result.detail)
+	}
+}

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -5298,6 +5298,9 @@ func TestInstallGolangciLint_NoManagers(t *testing.T) {
 	if result.action != "skipped" {
 		t.Errorf("expected 'skipped', got %q", result.action)
 	}
+	if result.err != nil {
+		t.Errorf("expected nil error, got: %v", result.err)
+	}
 }
 
 func TestInstallGolangciLint_DryRunGoAvailable(t *testing.T) {


### PR DESCRIPTION
Fixes #279

### Problem

`installGolangciLint()` had a hardcoded dry-run message that always reported `go install` regardless of whether `go` was actually available on the system. The real execution path falls back to `brew install` when `go install` fails, but the dry-run output did not reflect this -- misleading users about what `uf setup` would actually do.

Without go in PATH, dry-run incorrectly reported:
~ golangci-lint  dry-run (Would install: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest)
Actual execution would use:
brew install golangci-lint

### Root Cause

The dry-run branch (line 897) returned early before any tool availability checks, unlike other install functions (`installGaze`, `installReplicator`, `installDewey`) which use the `resolveMethod()` + shared helper pattern.

### Fix

Refactored `installGolangciLint()` to use the `resolveMethod()` + helper pattern already established by peer functions:

- `resolveMethod("golangci-lint", env, "go", "homebrew")` determines the install method
- Delegates to `installViaGo` / `installViaBrew` which handle dry-run internally
- Each helper checks tool availability before producing its dry-run message

Also changes the terminal action from `"failed"` to `"skipped"` when no package manager is available, for consistency with `installGaze`, `installReplicator`, and `installDewey`.

### Dry-run output after fix

| Environment | Dry-run message |
|---|---|
| `go` available | `Would install: go install ...golangci-lint@latest` |
| `go` unavailable, `brew` available | `Would install: brew install golangci-lint` |
| Neither available | `skipped (Install: go install ... or brew install golangci-lint)` |

### Testing

Added 7 unit tests covering all code paths:

| Test | Scenario |
|---|---|
| `TestInstallGolangciLint_AlreadyInstalled` | Tool in PATH |
| `TestInstallGolangciLint_GoInstallSuccess` | `go install` succeeds |
| `TestInstallGolangciLint_GoFailsBrewFallback` | `go install` fails, Homebrew succeeds |
| `TestInstallGolangciLint_NoGoBrewFallback` | No `go`, Homebrew available |
| `TestInstallGolangciLint_NoManagers` | No `go`, no Homebrew |
| `TestInstallGolangciLint_DryRunGoAvailable` | Dry-run reports `go install` |
| `TestInstallGolangciLint_DryRunBrewFallback` | Dry-run reports `brew install` |

=== RUN   TestInstallGolangciLint_AlreadyInstalled
--- PASS: TestInstallGolangciLint_AlreadyInstalled (0.00s)
=== RUN   TestInstallGolangciLint_GoInstallSuccess
--- PASS: TestInstallGolangciLint_GoInstallSuccess (0.00s)
=== RUN   TestInstallGolangciLint_GoFailsBrewFallback
--- PASS: TestInstallGolangciLint_GoFailsBrewFallback (0.00s)
=== RUN   TestInstallGolangciLint_NoGoBrewFallback
--- PASS: TestInstallGolangciLint_NoGoBrewFallback (0.00s)
=== RUN   TestInstallGolangciLint_NoManagers
--- PASS: TestInstallGolangciLint_NoManagers (0.00s)
=== RUN   TestInstallGolangciLint_DryRunGoAvailable
--- PASS: TestInstallGolangciLint_DryRunGoAvailable (0.00s)
=== RUN   TestInstallGolangciLint_DryRunBrewFallback
--- PASS: TestInstallGolangciLint_DryRunBrewFallback (0.00s)
PASS

### Files changed

- `internal/setup/setup.go` -- refactored `installGolangciLint()` (net -2 lines)
- `internal/setup/setup_test.go` -- added 7 tests (+218 lines)

### Verification

- `go vet ./internal/setup/` -- pass
- `golangci-lint run ./internal/setup/` -- 0 issues
- `go test -race -count=1 ./internal/setup/` -- pass
- `go build ./...` -- pass