### PR TITLE
fix(ci): add missing pull-requests read permission

### DIFF
--- a/.github/workflows/ci_checks.yml
+++ b/.github/workflows/ci_checks.yml
@@ -32,3 +32,4 @@ jobs:
     permissions:
       contents: read
       issues: read
+      pull-requests: read


### PR DESCRIPTION
## Summary

Add `pull-requests: read` to the `call_reusable_ci` job permissions in `ci_checks.yml`.

## Problem

The CI Checks workflow fails with `startup_failure` because the nested `megalinter` job in the reusable workflow (`complytime/org-infra/reusable_ci.yml`) requires `pull-requests: read`, but the calling job only grants `contents: read` and `issues: read`. GitHub Actions denies permission escalation beyond what the caller grants, so `pull-requests` defaults to `none` and the workflow fails immediately.

## Fix

One-line addition: `pull-requests: read` in the `call_reusable_ci` job permissions block. This is a read-only permission (no write access) consistent with least-privilege (Constitution Principle V).

## Evidence

- Failed run: https://github.com/unbound-force/unbound-force/actions/runs/27955531002
- Same fix applied successfully in complytime/complypack#57
- GitHub docs: [Reusable workflow permissions](https://docs.github.com/en/actions/sharing-automations/reusing-workflows#supported-keywords-for-jobs-that-call-a-reusable-workflow)

Fixes #284