### PR TITLE
refactor(commands): convert confirmation prompts to AskUserQuestion tool

### DIFF
--- a/.opencode/commands/address-feedback.md
+++ b/.opencode/commands/address-feedback.md
@@ -238,14 +238,16 @@ If the item has a GitHub suggestion block, display it clearly as an applicable c
 
 ### 3.2 Author Decision
 
-For each item, the author chooses exactly one:
+For each item, use the **AskUserQuestion tool** with
+options `["Accept", "Modify", "Reject", "Ask"]`. The
+author chooses exactly one:
 
-| Decision | Author provides | Queued action |
+| Decision | Follow-up | Queued action |
 |---|---|---|
-| **ACCEPT** | (nothing) | Code change using suggested approach |
-| **MODIFY** | Alternative approach | Code change using author's approach |
-| **REJECT** | Evidence-based reasoning | Reply comment with reasoning |
-| **ASK** | Clarification question | Reply comment with question |
+| **Accept** | (none) | Code change using suggested approach |
+| **Modify** | Use **AskUserQuestion tool** (open-ended, no preset options) to collect the alternative approach | Code change using author's approach |
+| **Reject** | Use **AskUserQuestion tool** (open-ended, no preset options) to collect evidence-based reasoning | Reply comment with reasoning |
+| **Ask** | Use **AskUserQuestion tool** (open-ended, no preset options) to collect the clarification question | Reply comment with question |
 
 **No item may be skipped or deferred.** Every item MUST receive a decision before the triage phase completes.
 
@@ -267,7 +269,10 @@ Total:   N items
 ─────────────────────────────────────────
 ```
 
-List each item with its decision. The author MUST confirm before execution proceeds.
+List each item with its decision. Use the
+**AskUserQuestion tool** with options `["Confirm --
+proceed with execution", "Revise -- change decisions"]`
+before execution proceeds.
 
 ---
 
@@ -316,11 +321,10 @@ git fetch origin <branch>
 git status
 ```
 
-**If branch has diverged** (another contributor pushed commits): warn the author and present options:
-- Rebase onto remote and push
-- Abort (preserve local commits for manual resolution)
-
-The author MUST confirm before proceeding.
+**If branch has diverged** (another contributor pushed
+commits): warn the author and use the
+**AskUserQuestion tool** with options `["Rebase onto
+remote and push", "Abort -- preserve local commits"]`.
 
 Push all commits:
 
@@ -333,7 +337,10 @@ git push origin <branch>
 
 ### 4.5 Post Reply Comments
 
-After push succeeds (or if there are no code changes), post reply comments to the PR. All comment posting requires author confirmation before execution.
+After push succeeds (or if there are no code changes),
+post reply comments to the PR. Before posting, use the
+**AskUserQuestion tool** with options `["Yes -- post
+reply comments", "No -- skip posting"]`.
 
 For each item, compose the reply:
 
@@ -379,7 +386,9 @@ After posting reply comments for accepted items, offer to resolve those threads:
 gh api graphql -f query='mutation { resolveReviewThread(input: {threadId: "<thread_id>"}) { thread { isResolved } } }'
 ```
 
-The author confirms before resolving.
+Use the **AskUserQuestion tool** with options
+`["Yes -- resolve accepted threads", "No -- leave
+threads open"]` before resolving.
 
 ### 4.7 Produce Feedback-Triage Artifact
 

--- a/.opencode/commands/review-pr.md
+++ b/.opencode/commands/review-pr.md
@@ -107,7 +107,10 @@ Categorize each check as:
 - **PENDING**: Check still running
 - **SKIPPED**: Check was skipped
 
-If checks are still PENDING, inform the user and ask whether to wait or proceed with the available results.
+If checks are still PENDING, inform the user and use
+the **AskUserQuestion tool** with options
+`["Wait for checks to complete", "Proceed with
+available results"]`.
 
 **If all checks pass**: Record this and move to Step 4. No CI triage needed.
 
@@ -234,8 +237,13 @@ navigate it with targeted reads:
    - CRAP baselines: `.gaze/baseline.json`
 
 4. For very large PRs (2000+ lines or 50+ files),
-   warn the user and ask whether to review all files
-   or focus on specific ones.
+   warn the user and use the **AskUserQuestion tool**
+   with options `["Review all files", "Focus on
+   specific files"]`. If the user selects "Focus on
+   specific files", follow up with the
+   **AskUserQuestion tool** (open-ended, no preset
+   options) to ask which files or directories to
+   focus on.
 
 **Do NOT attempt**:
 - `gh pr diff <N> -- <path>` (unsupported, will fail)
@@ -709,12 +717,12 @@ I identified <N> pre-existing CI failure(s) that are NOT caused by this PR:
 - <check name>: <brief description of failure>
 
 These failures also occur on the base branch (<BASE_BRANCH>).
-
-Would you like me to create a fix branch with a proposed resolution?
-I will create the branch and commit locally — you can review the changes and file a PR when ready.
 ```
 
-**If the user agrees**:
+Use the **AskUserQuestion tool** with options
+`["Yes -- create fix branch", "No -- skip"]`.
+
+**If the user selects "Yes -- create fix branch"**:
 
 1. **Verify clean working tree**:
    ```bash
@@ -804,15 +812,13 @@ GitHub review on the PR:
 ```
 I found <N> findings (X CRITICAL, Y HIGH).
 Verdict: <APPROVE / REQUEST CHANGES / COMMENT>
-
-Would you like me to post this as a GitHub review so the
-author can see the findings in context?
-
-I will prepare the review and show it to you for approval
-before posting anything.
 ```
 
-**If the user agrees**:
+Use the **AskUserQuestion tool** with options
+`["Yes -- post as GitHub review", "No -- terminal
+summary is sufficient"]`.
+
+**If the user selects "Yes -- post as GitHub review"**:
 
 #### 11a. Pre-posting Checks
 
@@ -824,19 +830,18 @@ the current user (Step 7.5c) already exists in the
 review list (Step 7.5a):
 
 - If a prior review with the **same verdict** exists:
-  ```
-  You already have an <APPROVE/REQUEST_CHANGES> review
-  on this PR. Post a new one? (The latest review takes
-  precedence.)
-  (yes/no)
-  ```
+  Inform the user that a prior review exists and the
+  latest review takes precedence. Use the
+  **AskUserQuestion tool** with options
+  `["Yes -- post new review", "No -- skip posting"]`.
+
 - If a prior review with a **different verdict** exists:
-  ```
-  You have a prior <old_verdict> review. Post a new
-  <new_verdict>? This will override the previous
-  verdict.
-  (yes/no)
-  ```
+  Inform the user of the prior verdict and that the new
+  review will override it. Use the
+  **AskUserQuestion tool** with options
+  `["Yes -- override with <new_verdict>",
+  "No -- keep existing <old_verdict>"]`.
+
 - If no prior review exists: proceed silently.
 
 **Stale review + CODEOWNER checks** (APPROVE verdicts
@@ -928,27 +933,23 @@ If any API call fails: skip silently.
    - REQUEST CHANGES → `"event": "REQUEST_CHANGES"`
    - COMMENT → `"event": "COMMENT"`
 
-   Display the confirmation prompt with the verdict type:
+   Display the verdict context, then use the
+   **AskUserQuestion tool** for confirmation:
 
-   For APPROVE verdicts:
-   ```
-   Post review as APPROVE with N comments?
-   ⚠ This may unblock merge in repos with branch
-     protection. This review will be labeled as
-     AI-generated.
-   Type "approve" to confirm:
-   (approve/no/edit/change-verdict)
-   ```
+   For APPROVE verdicts: inform the user that this may
+   unblock merge in repos with branch protection and
+   that the review will be labeled as AI-generated.
+   Use the **AskUserQuestion tool** with options
+   `["Approve -- post review", "No -- skip posting",
+   "Edit comments first", "Change verdict"]`.
 
-   For REQUEST CHANGES or COMMENT verdicts:
-   ```
-   Post review as REQUEST CHANGES with N comments?
-   ⚠ This will block merge in repos with branch
-     protection.
-   (yes/no/edit/change-verdict)
-   ```
+   For REQUEST CHANGES or COMMENT verdicts: inform the
+   user that this will block merge in repos with branch
+   protection. Use the **AskUserQuestion tool** with
+   options `["Yes -- post review", "No -- skip posting",
+   "Edit comments first", "Change verdict"]`.
 
-   The `change-verdict` option lets the user override the
+   The "Change verdict" option lets the user override the
    computed verdict (e.g., downgrade REQUEST CHANGES to
    COMMENT).
 
@@ -984,13 +985,14 @@ If any API call fails: skip silently.
    token lacks write permissions for PR reviews and
    suggest re-authenticating with `gh auth login`.
 
-   - **no**: Skip posting, the terminal summary is sufficient
-   - **edit**: Let the user modify comments before posting, then re-confirm
+   - **"No -- skip posting"**: Skip posting, the terminal summary is sufficient
+   - **"Edit comments first"**: Let the user modify comments before posting, then re-confirm with the **AskUserQuestion tool**
 
 5. **CRITICAL RULE**: NEVER post reviews without explicit
-   human confirmation. Always show the exact content
-   (verdict type + all comments) that will be posted and
-   wait for approval. For APPROVE verdicts, require the
-   user to type "approve" explicitly — not just "yes" —
-   to prevent reflexive confirmation of merge-unblocking
-   reviews.
+   human confirmation via the **AskUserQuestion tool**.
+   Always show the exact content (verdict type + all
+   comments) that will be posted and wait for the user
+   to select a confirming option. For APPROVE verdicts,
+   the user MUST select the "Approve -- post review"
+   option — a clearly-labeled action that conveys the
+   merge-unblocking consequence.

--- a/.opencode/commands/triage-issue.md
+++ b/.opencode/commands/triage-issue.md
@@ -270,8 +270,10 @@ If label creation fails due to insufficient permissions, report the specific lab
 gh issue edit <ISSUE_NUMBER> --add-label "<label>"
 ```
 
-**For `duplicate` label only**: Present to the user for confirmation before applying:
-> "The `duplicate` label will be applied to issue #<ISSUE_NUMBER>. This signals the issue should be closed. Confirm? (yes/no)"
+**For `duplicate` label only**: Inform the user that the
+`duplicate` label signals the issue should be closed.
+Use the **AskUserQuestion tool** with options
+`["Yes -- apply duplicate label", "No -- skip"]`.
 
 ### 4.3 Comment Composition and Posting
 
@@ -290,18 +292,27 @@ _This triage was performed by the Divisor review panel._
 
 **If duplicate candidates were found** (but not classified as duplicate): mention similar issues in the comment for the reporter's awareness.
 
-**Re-run check**: If a previous triage comment was detected in Phase 1.2, warn the user:
-> "A previous triage comment was detected on this issue. Posting another comment may cause confusion. Proceed?"
+**Re-run check**: If a previous triage comment was
+detected in Phase 1.2, warn the user that posting
+another comment may cause confusion. Use the
+**AskUserQuestion tool** with options `["Yes -- post
+another comment", "No -- skip comment"]`. If the user
+selects "No -- skip comment", record
+`comment_posted: false` in the artifact and skip to
+Phase 4.4.
 
-**Present the composed comment to the user for confirmation**:
+**Present the composed comment to the user for
+confirmation**: Use the **AskUserQuestion tool** with
+options `["Approve -- post as-is", "Modify -- adjust
+comment text", "Abort -- do not post"]`.
 
-| Decision | Action |
+| Selection | Action |
 |---|---|
-| **APPROVE** | Post the comment as-is |
-| **MODIFY** | User provides adjusted comment text; post the adjusted version |
-| **ABORT** | Do not post any comment; record `comment_posted: false` in artifact |
+| **Approve -- post as-is** | Post the comment as-is |
+| **Modify -- adjust comment text** | Use **AskUserQuestion tool** (open-ended, no preset options) to collect the adjusted comment text; post the adjusted version |
+| **Abort -- do not post** | Do not post any comment; record `comment_posted: false` in artifact |
 
-**Post the comment** (on APPROVE or MODIFY):
+**Post the comment** (on Approve or Modify):
 
 Write the comment body to a temporary file and post via `gh api --input`. NEVER interpolate comment text into shell arguments.
 
@@ -329,7 +340,10 @@ This section applies only when Phase 3.5 produced split recommendations.
 
 For each proposed child issue:
 
-1. **Present to user**: Show the proposed title and body. The user confirms each child issue individually.
+1. **Present to user**: Show the proposed title and body.
+   Use the **AskUserQuestion tool** with options
+   `["Yes -- create this child issue", "No -- skip"]`
+   for each child issue individually.
 
 2. **Duplicate check**: Before creating, search for existing issues matching the proposed title:
 
@@ -337,9 +351,12 @@ For each proposed child issue:
 gh issue list --search "<sanitized-child-title>" --state open --json number,title --limit 5
 ```
 
-If a close match is found, warn the user and ask whether to proceed.
+   If a close match is found, warn the user about the
+   potential duplicate and use the **AskUserQuestion
+   tool** with options `["Yes -- create anyway",
+   "No -- skip this child issue"]`.
 
-3. **Create the child issue** (on confirmation):
+3. **Create the child issue** (if the user selected a confirming option):
 
 Each child issue body MUST include a cross-reference: `Split from #<ISSUE_NUMBER>`.
 

--- a/internal/scaffold/assets/opencode/commands/address-feedback.md
+++ b/internal/scaffold/assets/opencode/commands/address-feedback.md
@@ -238,14 +238,16 @@ If the item has a GitHub suggestion block, display it clearly as an applicable c
 
 ### 3.2 Author Decision
 
-For each item, the author chooses exactly one:
+For each item, use the **AskUserQuestion tool** with
+options `["Accept", "Modify", "Reject", "Ask"]`. The
+author chooses exactly one:
 
-| Decision | Author provides | Queued action |
+| Decision | Follow-up | Queued action |
 |---|---|---|
-| **ACCEPT** | (nothing) | Code change using suggested approach |
-| **MODIFY** | Alternative approach | Code change using author's approach |
-| **REJECT** | Evidence-based reasoning | Reply comment with reasoning |
-| **ASK** | Clarification question | Reply comment with question |
+| **Accept** | (none) | Code change using suggested approach |
+| **Modify** | Use **AskUserQuestion tool** (open-ended, no preset options) to collect the alternative approach | Code change using author's approach |
+| **Reject** | Use **AskUserQuestion tool** (open-ended, no preset options) to collect evidence-based reasoning | Reply comment with reasoning |
+| **Ask** | Use **AskUserQuestion tool** (open-ended, no preset options) to collect the clarification question | Reply comment with question |
 
 **No item may be skipped or deferred.** Every item MUST receive a decision before the triage phase completes.
 
@@ -267,7 +269,10 @@ Total:   N items
 ─────────────────────────────────────────
 ```
 
-List each item with its decision. The author MUST confirm before execution proceeds.
+List each item with its decision. Use the
+**AskUserQuestion tool** with options `["Confirm --
+proceed with execution", "Revise -- change decisions"]`
+before execution proceeds.
 
 ---
 
@@ -316,11 +321,10 @@ git fetch origin <branch>
 git status
 ```
 
-**If branch has diverged** (another contributor pushed commits): warn the author and present options:
-- Rebase onto remote and push
-- Abort (preserve local commits for manual resolution)
-
-The author MUST confirm before proceeding.
+**If branch has diverged** (another contributor pushed
+commits): warn the author and use the
+**AskUserQuestion tool** with options `["Rebase onto
+remote and push", "Abort -- preserve local commits"]`.
 
 Push all commits:
 
@@ -333,7 +337,10 @@ git push origin <branch>
 
 ### 4.5 Post Reply Comments
 
-After push succeeds (or if there are no code changes), post reply comments to the PR. All comment posting requires author confirmation before execution.
+After push succeeds (or if there are no code changes),
+post reply comments to the PR. Before posting, use the
+**AskUserQuestion tool** with options `["Yes -- post
+reply comments", "No -- skip posting"]`.
 
 For each item, compose the reply:
 
@@ -379,7 +386,9 @@ After posting reply comments for accepted items, offer to resolve those threads:
 gh api graphql -f query='mutation { resolveReviewThread(input: {threadId: "<thread_id>"}) { thread { isResolved } } }'
 ```
 
-The author confirms before resolving.
+Use the **AskUserQuestion tool** with options
+`["Yes -- resolve accepted threads", "No -- leave
+threads open"]` before resolving.
 
 ### 4.7 Produce Feedback-Triage Artifact
 

--- a/internal/scaffold/assets/opencode/commands/review-pr.md
+++ b/internal/scaffold/assets/opencode/commands/review-pr.md
@@ -107,7 +107,10 @@ Categorize each check as:
 - **PENDING**: Check still running
 - **SKIPPED**: Check was skipped
 
-If checks are still PENDING, inform the user and ask whether to wait or proceed with the available results.
+If checks are still PENDING, inform the user and use
+the **AskUserQuestion tool** with options
+`["Wait for checks to complete", "Proceed with
+available results"]`.
 
 **If all checks pass**: Record this and move to Step 4. No CI triage needed.
 
@@ -234,8 +237,13 @@ navigate it with targeted reads:
    - CRAP baselines: `.gaze/baseline.json`
 
 4. For very large PRs (2000+ lines or 50+ files),
-   warn the user and ask whether to review all files
-   or focus on specific ones.
+   warn the user and use the **AskUserQuestion tool**
+   with options `["Review all files", "Focus on
+   specific files"]`. If the user selects "Focus on
+   specific files", follow up with the
+   **AskUserQuestion tool** (open-ended, no preset
+   options) to ask which files or directories to
+   focus on.
 
 **Do NOT attempt**:
 - `gh pr diff <N> -- <path>` (unsupported, will fail)
@@ -709,12 +717,12 @@ I identified <N> pre-existing CI failure(s) that are NOT caused by this PR:
 - <check name>: <brief description of failure>
 
 These failures also occur on the base branch (<BASE_BRANCH>).
-
-Would you like me to create a fix branch with a proposed resolution?
-I will create the branch and commit locally — you can review the changes and file a PR when ready.
 ```
 
-**If the user agrees**:
+Use the **AskUserQuestion tool** with options
+`["Yes -- create fix branch", "No -- skip"]`.
+
+**If the user selects "Yes -- create fix branch"**:
 
 1. **Verify clean working tree**:
    ```bash
@@ -804,15 +812,13 @@ GitHub review on the PR:
 ```
 I found <N> findings (X CRITICAL, Y HIGH).
 Verdict: <APPROVE / REQUEST CHANGES / COMMENT>
-
-Would you like me to post this as a GitHub review so the
-author can see the findings in context?
-
-I will prepare the review and show it to you for approval
-before posting anything.
 ```
 
-**If the user agrees**:
+Use the **AskUserQuestion tool** with options
+`["Yes -- post as GitHub review", "No -- terminal
+summary is sufficient"]`.
+
+**If the user selects "Yes -- post as GitHub review"**:
 
 #### 11a. Pre-posting Checks
 
@@ -824,19 +830,18 @@ the current user (Step 7.5c) already exists in the
 review list (Step 7.5a):
 
 - If a prior review with the **same verdict** exists:
-  ```
-  You already have an <APPROVE/REQUEST_CHANGES> review
-  on this PR. Post a new one? (The latest review takes
-  precedence.)
-  (yes/no)
-  ```
+  Inform the user that a prior review exists and the
+  latest review takes precedence. Use the
+  **AskUserQuestion tool** with options
+  `["Yes -- post new review", "No -- skip posting"]`.
+
 - If a prior review with a **different verdict** exists:
-  ```
-  You have a prior <old_verdict> review. Post a new
-  <new_verdict>? This will override the previous
-  verdict.
-  (yes/no)
-  ```
+  Inform the user of the prior verdict and that the new
+  review will override it. Use the
+  **AskUserQuestion tool** with options
+  `["Yes -- override with <new_verdict>",
+  "No -- keep existing <old_verdict>"]`.
+
 - If no prior review exists: proceed silently.
 
 **Stale review + CODEOWNER checks** (APPROVE verdicts
@@ -928,27 +933,23 @@ If any API call fails: skip silently.
    - REQUEST CHANGES → `"event": "REQUEST_CHANGES"`
    - COMMENT → `"event": "COMMENT"`
 
-   Display the confirmation prompt with the verdict type:
+   Display the verdict context, then use the
+   **AskUserQuestion tool** for confirmation:
 
-   For APPROVE verdicts:
-   ```
-   Post review as APPROVE with N comments?
-   ⚠ This may unblock merge in repos with branch
-     protection. This review will be labeled as
-     AI-generated.
-   Type "approve" to confirm:
-   (approve/no/edit/change-verdict)
-   ```
+   For APPROVE verdicts: inform the user that this may
+   unblock merge in repos with branch protection and
+   that the review will be labeled as AI-generated.
+   Use the **AskUserQuestion tool** with options
+   `["Approve -- post review", "No -- skip posting",
+   "Edit comments first", "Change verdict"]`.
 
-   For REQUEST CHANGES or COMMENT verdicts:
-   ```
-   Post review as REQUEST CHANGES with N comments?
-   ⚠ This will block merge in repos with branch
-     protection.
-   (yes/no/edit/change-verdict)
-   ```
+   For REQUEST CHANGES or COMMENT verdicts: inform the
+   user that this will block merge in repos with branch
+   protection. Use the **AskUserQuestion tool** with
+   options `["Yes -- post review", "No -- skip posting",
+   "Edit comments first", "Change verdict"]`.
 
-   The `change-verdict` option lets the user override the
+   The "Change verdict" option lets the user override the
    computed verdict (e.g., downgrade REQUEST CHANGES to
    COMMENT).
 
@@ -984,13 +985,14 @@ If any API call fails: skip silently.
    token lacks write permissions for PR reviews and
    suggest re-authenticating with `gh auth login`.
 
-   - **no**: Skip posting, the terminal summary is sufficient
-   - **edit**: Let the user modify comments before posting, then re-confirm
+   - **"No -- skip posting"**: Skip posting, the terminal summary is sufficient
+   - **"Edit comments first"**: Let the user modify comments before posting, then re-confirm with the **AskUserQuestion tool**
 
 5. **CRITICAL RULE**: NEVER post reviews without explicit
-   human confirmation. Always show the exact content
-   (verdict type + all comments) that will be posted and
-   wait for approval. For APPROVE verdicts, require the
-   user to type "approve" explicitly — not just "yes" —
-   to prevent reflexive confirmation of merge-unblocking
-   reviews.
+   human confirmation via the **AskUserQuestion tool**.
+   Always show the exact content (verdict type + all
+   comments) that will be posted and wait for the user
+   to select a confirming option. For APPROVE verdicts,
+   the user MUST select the "Approve -- post review"
+   option — a clearly-labeled action that conveys the
+   merge-unblocking consequence.

--- a/internal/scaffold/assets/opencode/commands/triage-issue.md
+++ b/internal/scaffold/assets/opencode/commands/triage-issue.md
@@ -270,8 +270,10 @@ If label creation fails due to insufficient permissions, report the specific lab
 gh issue edit <ISSUE_NUMBER> --add-label "<label>"
 ```
 
-**For `duplicate` label only**: Present to the user for confirmation before applying:
-> "The `duplicate` label will be applied to issue #<ISSUE_NUMBER>. This signals the issue should be closed. Confirm? (yes/no)"
+**For `duplicate` label only**: Inform the user that the
+`duplicate` label signals the issue should be closed.
+Use the **AskUserQuestion tool** with options
+`["Yes -- apply duplicate label", "No -- skip"]`.
 
 ### 4.3 Comment Composition and Posting
 
@@ -290,18 +292,27 @@ _This triage was performed by the Divisor review panel._
 
 **If duplicate candidates were found** (but not classified as duplicate): mention similar issues in the comment for the reporter's awareness.
 
-**Re-run check**: If a previous triage comment was detected in Phase 1.2, warn the user:
-> "A previous triage comment was detected on this issue. Posting another comment may cause confusion. Proceed?"
+**Re-run check**: If a previous triage comment was
+detected in Phase 1.2, warn the user that posting
+another comment may cause confusion. Use the
+**AskUserQuestion tool** with options `["Yes -- post
+another comment", "No -- skip comment"]`. If the user
+selects "No -- skip comment", record
+`comment_posted: false` in the artifact and skip to
+Phase 4.4.
 
-**Present the composed comment to the user for confirmation**:
+**Present the composed comment to the user for
+confirmation**: Use the **AskUserQuestion tool** with
+options `["Approve -- post as-is", "Modify -- adjust
+comment text", "Abort -- do not post"]`.
 
-| Decision | Action |
+| Selection | Action |
 |---|---|
-| **APPROVE** | Post the comment as-is |
-| **MODIFY** | User provides adjusted comment text; post the adjusted version |
-| **ABORT** | Do not post any comment; record `comment_posted: false` in artifact |
+| **Approve -- post as-is** | Post the comment as-is |
+| **Modify -- adjust comment text** | Use **AskUserQuestion tool** (open-ended, no preset options) to collect the adjusted comment text; post the adjusted version |
+| **Abort -- do not post** | Do not post any comment; record `comment_posted: false` in artifact |
 
-**Post the comment** (on APPROVE or MODIFY):
+**Post the comment** (on Approve or Modify):
 
 Write the comment body to a temporary file and post via `gh api --input`. NEVER interpolate comment text into shell arguments.
 
@@ -329,7 +340,10 @@ This section applies only when Phase 3.5 produced split recommendations.
 
 For each proposed child issue:
 
-1. **Present to user**: Show the proposed title and body. The user confirms each child issue individually.
+1. **Present to user**: Show the proposed title and body.
+   Use the **AskUserQuestion tool** with options
+   `["Yes -- create this child issue", "No -- skip"]`
+   for each child issue individually.
 
 2. **Duplicate check**: Before creating, search for existing issues matching the proposed title:
 
@@ -337,9 +351,12 @@ For each proposed child issue:
 gh issue list --search "<sanitized-child-title>" --state open --json number,title --limit 5
 ```
 
-If a close match is found, warn the user and ask whether to proceed.
+   If a close match is found, warn the user about the
+   potential duplicate and use the **AskUserQuestion
+   tool** with options `["Yes -- create anyway",
+   "No -- skip this child issue"]`.
 
-3. **Create the child issue** (on confirmation):
+3. **Create the child issue** (if the user selected a confirming option):
 
 Each child issue body MUST include a cross-reference: `Split from #<ISSUE_NUMBER>`.
 

--- a/openspec/changes/askuser-tool-confirmations/.openspec.yaml
+++ b/openspec/changes/askuser-tool-confirmations/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: unbound-force
+created: 2026-06-22

--- a/openspec/changes/askuser-tool-confirmations/design.md
+++ b/openspec/changes/askuser-tool-confirmations/design.md
@@ -1,0 +1,119 @@
+## Context
+
+Three slash commands (`/review-pr`, `/address-feedback`,
+`/triage-issue`) use free-text typed confirmations for
+human interaction points. The `opsx-*` commands already
+use the **AskUserQuestion tool** with structured options.
+This change aligns the three commands to the established
+convention.
+
+## Goals / Non-Goals
+
+### Goals
+- Convert all 15 free-text confirmation points across
+  three commands to use the AskUserQuestion tool
+- Preserve all existing safety semantics (no posting
+  without confirmation, deliberate APPROVE selection)
+- Maintain consistency with the AskUserQuestion patterns
+  established in `opsx-propose`, `opsx-apply`, and
+  `opsx-archive`
+- Keep scaffold assets byte-identical to command files
+
+### Non-Goals
+- Adding new interaction points or changing workflow
+  logic
+- Modifying the AskUserQuestion tool itself
+- Changing artifact schemas, JSON payloads, or API
+  calls
+- Modifying any Go source code beyond scaffold assets
+
+## Decisions
+
+### D1: Structured selection for all confirmations
+
+All 15 interaction points use the AskUserQuestion tool
+with predefined option lists, including the APPROVE
+verdict confirmation in `/review-pr`. The structured
+selection mechanism provides sufficient deliberateness
+-- selecting "Approve -- post review" from a list
+requires more intentional action than typing a word.
+
+**Rationale**: Consistency across all commands. The
+previous design required typing `"approve"` explicitly
+(not `"yes"`) to prevent reflexive confirmation. A
+structured selection achieves the same goal: the user
+must deliberately choose the correct option from a
+visible list.
+
+### D2: Option labels include action context
+
+Each option label describes what will happen, not just
+a bare `yes/no`. For example:
+- "Yes -- post as GitHub review" (not just "Yes")
+- "Approve -- post review" (not just "Approve")
+- "No -- skip posting" (not just "No")
+
+**Rationale**: Action-descriptive labels reduce
+ambiguity and help users understand the consequence
+of their selection without re-reading the prompt.
+
+### D3: Multi-step interactions use sequential prompts
+
+For interaction points where a choice requires
+follow-up input (e.g., `/address-feedback` MODIFY
+requires an alternative approach), the first prompt
+uses structured options and the follow-up uses an
+open-ended AskUserQuestion for free-form input.
+
+**Rationale**: Matches the pattern in `opsx-propose`
+where open-ended follow-ups are used after initial
+structured selection.
+
+### D4: Scaffold assets updated in lockstep
+
+Each command file under `.opencode/commands/` has a
+byte-identical copy under
+`internal/scaffold/assets/opencode/commands/`. Both
+must be updated together. The existing drift detection
+test (`TestEmbeddedAssets_MatchSource`) enforces this.
+
+**Rationale**: Required by the scaffold pattern.
+Existing test infrastructure validates this
+automatically.
+
+### D5: Bold formatting convention preserved
+
+The AskUserQuestion tool is referenced as
+`**AskUserQuestion tool**` (bold, PascalCase) in all
+command text, matching the existing convention in
+`opsx-propose.md`, `opsx-apply.md`, and
+`opsx-archive.md`.
+
+## Risks / Trade-offs
+
+### R1: Option list length
+
+Some interaction points (e.g., `/review-pr` APPROVE
+confirmation) have 4 options. Long option lists may
+feel heavier than a simple `yes/no` prompt. Accepted
+trade-off: the additional options (edit, change-verdict)
+were already present in the free-text version and
+provide genuine value.
+
+### R2: Per-item triage in `/address-feedback`
+
+The per-item triage (Phase 3.2) presents 4 options
+for each feedback item (ACCEPT/MODIFY/REJECT/ASK).
+For PRs with many feedback items, repeated structured
+prompts may feel slower than typing keywords. Accepted
+trade-off: clarity and discoverability outweigh the
+minor friction increase.
+
+### R3: No behavioral regression
+
+The change is purely instructional (markdown edits).
+No Go code logic changes, no API changes, no schema
+changes. Risk of behavioral regression is minimal.
+The scaffold drift test provides automated
+verification.
+<!-- scaffolded by uf vdev -->

--- a/openspec/changes/askuser-tool-confirmations/proposal.md
+++ b/openspec/changes/askuser-tool-confirmations/proposal.md
@@ -1,0 +1,103 @@
+## Why
+
+Three slash commands (`/review-pr`, `/address-feedback`,
+`/triage-issue`) use free-text typed confirmations
+(`yes/no`, `approve`, `ACCEPT/MODIFY/REJECT/ASK`) for
+human interaction points. This is inconsistent with the
+established convention used by `opsx-propose`,
+`opsx-apply`, and `opsx-archive`, which use the
+**AskUserQuestion tool** with structured options.
+
+Free-text confirmations create friction:
+- Users must remember exact keywords (`approve` vs `yes`)
+- Typos cause unnecessary retries
+- The agent must parse ambiguous natural language to
+  determine intent
+- No discoverability of available choices
+
+The AskUserQuestion tool provides structured selection
+that is more discoverable, less error-prone, and
+consistent across all slash commands.
+
+## What Changes
+
+Convert all 15 human interaction points across three
+slash commands from free-text typed confirmations to
+structured AskUserQuestion tool prompts with predefined
+options.
+
+## Capabilities
+
+### New Capabilities
+- None (no new functionality)
+
+### Modified Capabilities
+- `/review-pr`: 6 interaction points converted from
+  free-text to structured AskUserQuestion prompts
+- `/address-feedback`: 5 interaction points converted
+  from free-text to structured AskUserQuestion prompts
+- `/triage-issue`: 4 interaction points converted from
+  free-text to structured AskUserQuestion prompts
+
+### Removed Capabilities
+- None
+
+## Impact
+
+**Files modified** (3 command files + 3 scaffold assets):
+- `.opencode/commands/review-pr.md`
+- `.opencode/commands/address-feedback.md`
+- `.opencode/commands/triage-issue.md`
+- `internal/scaffold/assets/opencode/commands/review-pr.md`
+- `internal/scaffold/assets/opencode/commands/address-feedback.md`
+- `internal/scaffold/assets/opencode/commands/triage-issue.md`
+
+**Behavioral change**: All human confirmation gates
+retain their safety semantics (never post without
+confirmation, never merge without approval). Only the
+input mechanism changes from typed text to structured
+selection.
+
+**Scaffold drift**: Each command file has a
+corresponding scaffold asset that must be kept
+byte-identical. Both copies must be updated together.
+
+## Constitution Alignment
+
+Assessed against the Unbound Force org constitution.
+
+### I. Autonomous Collaboration
+
+**Assessment**: N/A
+
+This change modifies agent prompt instructions (slash
+command markdown files), not inter-hero artifact
+exchange. No artifact formats, envelopes, or hero
+interfaces are affected.
+
+### II. Composability First
+
+**Assessment**: N/A
+
+No hero dependencies are introduced or modified. The
+commands remain independently usable. The AskUserQuestion
+tool is a built-in OpenCode capability, not a hero
+dependency.
+
+### III. Observable Quality
+
+**Assessment**: N/A
+
+No machine-parseable outputs or provenance metadata are
+affected. The triage artifact schemas and review posting
+payloads remain unchanged.
+
+### IV. Testability
+
+**Assessment**: PASS
+
+The scaffold drift detection tests
+(`TestEmbeddedAssets_MatchSource`) will verify that
+command files and their scaffold assets remain
+synchronized. No new test infrastructure is needed.
+<!-- scaffolded by uf vdev -->

--- a/openspec/changes/askuser-tool-confirmations/specs/confirmation-prompts.md
+++ b/openspec/changes/askuser-tool-confirmations/specs/confirmation-prompts.md
@@ -1,0 +1,176 @@
+## ADDED Requirements
+
+(None -- no new interaction points are introduced.)
+
+## MODIFIED Requirements
+
+### Requirement: FR-001 Structured confirmation tool
+
+All human confirmation gates in `/review-pr`,
+`/address-feedback`, and `/triage-issue` MUST use the
+**AskUserQuestion tool** with predefined option lists
+instead of free-text typed responses.
+
+Previously: Commands used free-text prompts with
+`(yes/no)`, `(approve/no/edit/change-verdict)`, or
+conversational asks requiring the user to type specific
+keywords.
+
+#### Scenario: User confirms posting a GitHub review
+- **GIVEN** `/review-pr` has completed analysis and
+  prepared review comments
+- **WHEN** the command presents the posting
+  confirmation prompt
+- **THEN** the command MUST use the AskUserQuestion
+  tool with structured options instead of asking the
+  user to type a keyword
+
+#### Scenario: User triages a feedback item
+- **GIVEN** `/address-feedback` presents a feedback
+  item for triage in Phase 3.2
+- **WHEN** the author needs to choose a disposition
+- **THEN** the command MUST use the AskUserQuestion
+  tool with options `["Accept", "Modify", "Reject",
+  "Ask"]` instead of expecting typed keywords
+
+#### Scenario: User confirms duplicate label
+- **GIVEN** `/triage-issue` has classified an issue as
+  a duplicate
+- **WHEN** the command asks whether to apply the
+  `duplicate` label
+- **THEN** the command MUST use the AskUserQuestion
+  tool with options instead of `(yes/no)` text
+
+### Requirement: FR-002 Action-descriptive option labels
+
+All AskUserQuestion option labels MUST describe the
+action consequence, not bare keywords.
+
+Previously: Options were presented as `(yes/no)` or
+`(approve/no/edit/change-verdict)`.
+
+#### Scenario: Option labels include context
+- **GIVEN** any interaction point uses the
+  AskUserQuestion tool
+- **WHEN** the options are presented to the user
+- **THEN** each option label MUST describe what will
+  happen (e.g., "Yes -- post as GitHub review" instead
+  of "Yes")
+
+### Requirement: FR-003 APPROVE verdict deliberate
+  selection
+
+The `/review-pr` APPROVE confirmation MUST use a
+clearly-labeled structured option that conveys the
+merge-unblocking consequence.
+
+Previously: Required the user to type `"approve"`
+explicitly (not `"yes"`) to prevent reflexive
+confirmation.
+
+#### Scenario: APPROVE verdict confirmation
+- **GIVEN** `/review-pr` verdict is APPROVE
+- **WHEN** the posting confirmation is presented
+- **THEN** the command MUST use the AskUserQuestion
+  tool with an option labeled to convey the
+  merge-unblocking consequence (e.g.,
+  "Approve -- post review")
+- **AND** the option list MUST include escape hatches
+  for editing and changing the verdict
+
+### Requirement: FR-004 Multi-step interaction pattern
+
+When a structured option choice requires follow-up
+free-form input, the follow-up MUST use the
+AskUserQuestion tool in open-ended mode.
+
+Previously: Not specified; follow-up input was
+implicit.
+
+#### Scenario: MODIFY decision requires alternative
+  approach
+- **GIVEN** the author selects "Modify" for a feedback
+  item in `/address-feedback`
+- **WHEN** the command needs the alternative approach
+- **THEN** the command MUST use the AskUserQuestion
+  tool (open-ended, no preset options) to collect the
+  alternative approach text
+
+#### Scenario: REJECT decision requires reasoning
+- **GIVEN** the author selects "Reject" for a feedback
+  item in `/address-feedback`
+- **WHEN** the command needs the rejection reasoning
+- **THEN** the command MUST use the AskUserQuestion
+  tool (open-ended, no preset options) to collect the
+  evidence-based reasoning
+
+### Requirement: FR-005 Bold formatting convention
+
+All references to the AskUserQuestion tool in command
+files MUST use bold PascalCase: `**AskUserQuestion
+tool**`.
+
+Previously: Not specified for these three commands.
+
+#### Scenario: Consistent tool naming
+- **GIVEN** a command file references the
+  AskUserQuestion tool
+- **WHEN** the reference appears in instruction text
+- **THEN** it MUST be formatted as
+  `**AskUserQuestion tool**`
+
+### Requirement: FR-006 Scaffold asset synchronization
+
+After modifying any command file under
+`.opencode/commands/`, the corresponding scaffold asset
+under `internal/scaffold/assets/opencode/commands/`
+MUST be updated to remain byte-identical.
+
+Previously: Already required by scaffold pattern; made
+explicit here for this change.
+
+#### Scenario: Scaffold drift detection
+- **GIVEN** a command file has been modified
+- **WHEN** `go test ./internal/scaffold/...` runs
+- **THEN** `TestEmbeddedAssets_MatchSource` MUST pass,
+  confirming the scaffold asset matches the source
+
+### Requirement: FR-007 Safety semantics preserved
+
+The conversion to AskUserQuestion MUST NOT weaken any
+existing safety gate. Every interaction point that
+required confirmation before MUST still require
+confirmation after.
+
+Previously: Implicit in the original command designs.
+
+#### Scenario: No review posted without confirmation
+- **GIVEN** `/review-pr` has prepared a review
+- **WHEN** the AskUserQuestion prompt is presented
+- **THEN** the review MUST NOT be posted until the user
+  selects a confirming option
+- **AND** the critical rule about never posting without
+  explicit human confirmation MUST be updated to
+  reference the AskUserQuestion tool
+
+#### Scenario: No comments posted without confirmation
+- **GIVEN** `/address-feedback` or `/triage-issue` has
+  composed a comment
+- **WHEN** the posting confirmation is presented
+- **THEN** the comment MUST NOT be posted until the
+  user selects a confirming option
+
+## REMOVED Requirements
+
+### Requirement: Typed keyword confirmations
+
+Free-text typed keywords (`yes`, `no`, `approve`,
+`ACCEPT`, `MODIFY`, `REJECT`, `ASK`) are removed as
+the input mechanism for all 15 interaction points.
+The AskUserQuestion tool with structured options
+replaces them.
+
+**Reason**: Superseded by FR-001 (structured
+AskUserQuestion prompts). The safety intent is
+preserved through FR-003 and FR-007.
+<!-- scaffolded by uf vdev -->

--- a/openspec/changes/askuser-tool-confirmations/tasks.md
+++ b/openspec/changes/askuser-tool-confirmations/tasks.md
@@ -1,0 +1,186 @@
+<!--
+  [P] marks tasks eligible for parallel execution.
+  Add [P] when a task: (a) touches different files from
+  other [P] tasks in the group, (b) has no dependency
+  on prior tasks in the group, (c) can safely execute
+  without ordering constraints.
+  Do NOT add [P] when tasks modify the same file —
+  parallel workers will cause merge conflicts.
+  Tasks without [P] run sequentially first, then [P]
+  tasks run in parallel.
+-->
+
+## 1. Convert /review-pr confirmations
+
+All edits target `.opencode/commands/review-pr.md`.
+No [P] markers -- single file, sequential edits.
+
+- [x] 1.1 Convert pending CI checks prompt (line ~110).
+  Replace "inform the user and ask whether to wait or
+  proceed" with: Use the **AskUserQuestion tool** with
+  options `["Wait for checks to complete", "Proceed
+  with available results"]`.
+
+- [x] 1.2 Convert large PR warning (lines ~236-238).
+  Replace "warn the user and ask whether to review all
+  files or focus on specific ones" with: Use the
+  **AskUserQuestion tool** with options `["Review all
+  files", "Focus on specific files"]` (custom input
+  enabled for specifying which files).
+
+- [x] 1.3 Convert GitHub review posting offer
+  (lines ~697-704). Replace the conversational "Would
+  you like me to post this as a GitHub review..." with:
+  Use the **AskUserQuestion tool** with options
+  `["Yes -- post as GitHub review", "No -- terminal
+  summary is sufficient"]`.
+
+- [x] 1.4 Convert duplicate review detection
+  (lines ~717-731). Replace `(yes/no)` prompts with:
+  - Same verdict: Use the **AskUserQuestion tool** with
+    options `["Yes -- post new review", "No -- skip
+    posting"]`.
+  - Different verdict: Use the **AskUserQuestion tool**
+    with options `["Yes -- override with <new_verdict>",
+    "No -- keep existing <old_verdict>"]`.
+
+- [x] 1.5 Convert verdict-aligned confirmation
+  (lines ~824-840). Replace typed confirmations with:
+  - APPROVE: Use the **AskUserQuestion tool** with
+    options `["Approve -- post review", "No -- skip
+    posting", "Edit comments first", "Change verdict"]`.
+  - REQUEST CHANGES / COMMENT: Use the
+    **AskUserQuestion tool** with options `["Yes --
+    post review", "No -- skip posting", "Edit comments
+    first", "Change verdict"]`.
+
+- [x] 1.6 Convert fix-branch offer (lines ~598-606).
+  Replace conversational "Would you like me to create
+  a fix branch..." with: Use the **AskUserQuestion
+  tool** with options `["Yes -- create fix branch",
+  "No -- skip"]`.
+
+- [x] 1.7 Update the critical rule (lines ~881-887).
+  Replace "require the user to type 'approve'
+  explicitly" with: "require the user to select the
+  'Approve -- post review' option from the
+  AskUserQuestion tool". Preserve the safety intent.
+
+**Checkpoint**: Read the modified file end-to-end.
+Verify all 6 interaction points plus the critical rule
+reference the **AskUserQuestion tool**. Verify no
+`(yes/no)` or `(approve/no/edit/change-verdict)`
+patterns remain.
+
+## 2. Convert /address-feedback confirmations
+
+All edits target `.opencode/commands/address-feedback.md`.
+No [P] markers -- single file, sequential edits.
+
+- [x] 2.1 Convert per-item triage decision
+  (lines ~239-250). Replace the implicit typed keyword
+  mechanism with: Use the **AskUserQuestion tool** with
+  options `["Accept", "Modify", "Reject", "Ask"]`. For
+  MODIFY, follow up with the **AskUserQuestion tool**
+  (open-ended, no preset options) to collect the
+  alternative approach. For REJECT, follow up with
+  the **AskUserQuestion tool** (open-ended) to collect
+  evidence-based reasoning. For ASK, follow up with
+  the **AskUserQuestion tool** (open-ended) to collect
+  the clarification question.
+
+- [x] 2.2 Convert triage summary confirmation
+  (line ~270). Replace "The author MUST confirm before
+  execution proceeds" with: Use the **AskUserQuestion
+  tool** with options `["Confirm -- proceed with
+  execution", "Revise -- change decisions"]`.
+
+- [x] 2.3 Convert diverged branch handling
+  (lines ~319-323). Replace the free-text options with:
+  Use the **AskUserQuestion tool** with options
+  `["Rebase onto remote and push", "Abort -- preserve
+  local commits"]`.
+
+- [x] 2.4 Convert comment posting confirmation
+  (line ~336). Replace "All comment posting requires
+  author confirmation" with: Use the **AskUserQuestion
+  tool** with options `["Yes -- post reply comments",
+  "No -- skip posting"]`.
+
+- [x] 2.5 Convert thread resolution confirmation
+  (line ~382). Replace "The author confirms before
+  resolving" with: Use the **AskUserQuestion tool**
+  with options `["Yes -- resolve accepted threads",
+  "No -- leave threads open"]`.
+
+**Checkpoint**: Read the modified file end-to-end.
+Verify all 5 interaction points reference the
+**AskUserQuestion tool**. Verify no bare `confirm`
+or implicit typed-input patterns remain.
+
+## 3. Convert /triage-issue confirmations
+
+All edits target `.opencode/commands/triage-issue.md`.
+No [P] markers -- single file, sequential edits.
+
+- [x] 3.1 Convert duplicate label confirmation
+  (lines ~273-274). Replace `Confirm? (yes/no)` with:
+  Use the **AskUserQuestion tool** with options
+  `["Yes -- apply duplicate label", "No -- skip"]`.
+
+- [x] 3.2 Convert re-run triage comment warning
+  (lines ~293-294). Replace "Proceed?" with: Use the
+  **AskUserQuestion tool** with options `["Yes -- post
+  another comment", "No -- skip comment"]`.
+
+- [x] 3.3 Convert comment posting decision
+  (lines ~296-303). Replace the APPROVE/MODIFY/ABORT
+  choices with: Use the **AskUserQuestion tool** with
+  options `["Approve -- post as-is", "Modify -- adjust
+  comment text", "Abort -- do not post"]`. For MODIFY,
+  follow up with the **AskUserQuestion tool**
+  (open-ended) to collect adjusted comment text.
+
+- [x] 3.4 Convert child issue creation confirmations
+  (lines ~330-340). Replace per-child confirmation with:
+  Use the **AskUserQuestion tool** with options
+  `["Yes -- create this child issue", "No -- skip"]`.
+  For duplicate child warning, use: `["Yes -- create
+  anyway", "No -- skip this child issue"]`.
+
+**Checkpoint**: Read the modified file end-to-end.
+Verify all 4 interaction points reference the
+**AskUserQuestion tool**. Verify no `(yes/no)` or
+implicit typed-input patterns remain.
+
+## 4. Sync scaffold assets
+
+Each command file has a byte-identical copy under
+`internal/scaffold/assets/opencode/commands/`. These
+MUST be synced after all command edits are complete.
+
+- [x] 4.1 [P] Copy `.opencode/commands/review-pr.md` to
+  `internal/scaffold/assets/opencode/commands/review-pr.md`
+  (byte-identical).
+
+- [x] 4.2 [P] Copy `.opencode/commands/address-feedback.md`
+  to `internal/scaffold/assets/opencode/commands/address-feedback.md`
+  (byte-identical).
+
+- [x] 4.3 [P] Copy `.opencode/commands/triage-issue.md` to
+  `internal/scaffold/assets/opencode/commands/triage-issue.md`
+  (byte-identical).
+
+**Checkpoint**: Run `go test ./internal/scaffold/... -count=1`.
+`TestEmbeddedAssets_MatchSource` MUST pass.
+
+## 5. Verification
+
+- [x] 5.1 Run `go test -race -count=1 ./...` to verify
+  no test regressions.
+
+- [x] 5.2 Verify constitution alignment: confirm no
+  artifact formats, hero interfaces, or machine-parseable
+  outputs were modified. Only instruction text in
+  markdown files was changed.
+<!-- scaffolded by uf vdev -->


### PR DESCRIPTION
## Summary

Convert all 15 free-text typed confirmation prompts across
three slash commands to use the structured **AskUserQuestion
tool**, aligning with the established convention used by
`opsx-propose`, `opsx-apply`, and `opsx-archive`.

### Commands Updated

- **`/review-pr`** (6 interaction points + critical rule):
  pending CI checks, large PR warning, review posting offer,
  duplicate review detection, verdict confirmation, fix-branch
  offer
- **`/address-feedback`** (5 interaction points): per-item
  triage decision, triage summary, diverged branch, comment
  posting, thread resolution
- **`/triage-issue`** (4 interaction points): duplicate label,
  re-run comment warning, comment posting, child issue creation

### Key Decisions

- APPROVE verdict uses structured selection ("Approve -- post
  review") instead of requiring typed `"approve"` keyword --
  deliberate list selection provides equivalent safety
- Option labels are action-descriptive (e.g., "Yes -- post as
  GitHub review" not just "Yes")
- Multi-step interactions use sequential prompts (structured
  selection followed by open-ended input when needed)

All safety semantics preserved: no review/comment is posted
without explicit human confirmation.

Scaffold assets synced. `TestEmbeddedAssets_MatchSource` passes.

OpenSpec change: `openspec/changes/askuser-tool-confirmations/`