### PR TITLE
feat(uf-init): add missing customization steps and tighten idempotency

### DIFF
--- a/.opencode/commands/uf-init.md
+++ b/.opencode/commands/uf-init.md
@@ -101,19 +101,27 @@ completes to review all changes before committing.
 ### Step 2: Apply Branch Enforcement
 
 For each target file listed below, apply the branch enforcement
-customization. For each file:
+customization. Each enforcement category has **independent**
+idempotency checks -- presence of one variant MUST NOT cause
+other variants to be skipped. For each file:
 
 1. **Read** the file content
-2. **Check** if branch enforcement is already present. Look for
-   the concept semantically -- does the file already describe
-   creating, validating, or cleaning up an `opsx/<name>` branch?
-   Check for phrases like `git checkout -b opsx/`, `opsx/<name>`,
-   `opsx/<change-name>`, or equivalent branch management
-   instructions.
-3. **If already present**: Report `⊘ <filename>: already present (skipped)`
-4. **If not present**: Read the file structure, find the correct
-   insertion point, and insert the customization. Report
-   `✅ <filename>: inserted`
+2. **Check** each applicable variant independently:
+   - **Basic branch check**: Look for `opsx/<name>`,
+     `opsx/<change-name>`, or `git checkout -b opsx/`
+   - **Dirty tree check** (propose only): Look for
+     `git status --short` in a pre-branch-creation
+     context
+   - **Commit-before-archive** (archive-change only):
+     Look for `git add` and `git commit` appearing
+     before the archive move step
+   - **Branch-switch confirmation** (explore only): Look
+     for `uncommitted changes` or `switch branches` in
+     the guardrails section
+3. **For each variant**: If present, report
+   `⊘ <filename>: [variant] already present (skipped)`.
+   If not present, insert it and report
+   `✅ <filename>: [variant] inserted`
 
 #### Branch Enforcement: Propose (Skills + Commands)
 
@@ -121,8 +129,13 @@ customization. For each file:
 - `.opencode/skills/openspec-propose/SKILL.md`
 - `.opencode/commands/opsx-propose.md`
 
-**What to insert**: After the step that creates the change
-directory (`openspec new change "<name>"`), insert a new step:
+**Two independent checks**:
+
+**A. Basic branch check** -- idempotency marker:
+`opsx/<name>` or `git checkout -b opsx/`
+
+If not present, insert after the step that creates the
+change directory (`openspec new change "<name>"`):
 
 > **Create and checkout a branch**
 >
@@ -138,6 +151,32 @@ directory (`openspec new change "<name>"`), insert a new step:
 **Where**: After the change directory creation step, before the
 artifact creation steps. Insert as a new numbered step; do NOT
 renumber existing steps (to avoid accidental content loss).
+
+**B. Dirty tree check** -- idempotency marker:
+`git status --short` in a pre-branch-creation context
+
+If not present, insert before the branch creation guard
+(part A above), or immediately before the existing branch
+check if part A is already present:
+
+> **Check for uncommitted changes**
+>
+> Before creating or switching branches, run
+> `git status --short`. If there are uncommitted changes
+> (staged, unstaged, or untracked files that appear
+> related to work):
+> - **STOP** and ask the user for confirmation before
+>   switching branches. Show what uncommitted changes
+>   exist and warn that switching branches with a dirty
+>   working tree may cause changes to be applied to the
+>   wrong branch.
+> - If the user confirms, proceed. If not, abort.
+> - Exception: if the user explicitly requested a new
+>   change, this still requires confirmation -- never
+>   silently switch branches with uncommitted work.
+
+**Where**: Before the branch creation guard. Insert as a
+sub-step or preceding step.
 
 #### Branch Enforcement: Apply (Skills + Commands)
 
@@ -167,8 +206,12 @@ existing steps.
 - `.opencode/skills/openspec-archive-change/SKILL.md`
 - `.opencode/commands/opsx-archive.md`
 
-**What to insert**: After the archive move completes, insert a
-branch cleanup step:
+**Two independent checks**:
+
+**A. Return to main branch** -- idempotency marker:
+`git checkout main` after the archive move
+
+If not present, insert after the archive move completes:
 
 > **Return to main branch**
 >
@@ -185,10 +228,66 @@ branch cleanup step:
 the archive, before the display summary step. Insert as a new
 numbered step; do NOT renumber existing steps.
 
-**Note**: `openspec-explore` and `opsx-explore.md` are
-intentionally excluded from branch enforcement -- explore mode
-does not create or modify changes, so branch management does
-not apply.
+**B. Commit-before-archive** -- idempotency markers:
+`git add` and `git commit` appearing before the archive
+move step
+
+If not present, insert before the archive move step
+(the step that moves the change directory to the archive):
+
+> **Commit and push all changes**
+>
+> Before archiving, ensure all work is committed:
+>
+> 1. Run `git status --short` to check for uncommitted
+>    changes.
+> 2. If uncommitted changes exist:
+>    - Stage the change directory and implementation
+>      files explicitly:
+>      `git add openspec/changes/<name>/ .opencode/`
+>      and any other modified files shown by
+>      `git status --short`
+>    - Commit with a descriptive message:
+>      `git commit -m "feat(<name>): complete implementation"`
+>    - Push to remote: `git push`
+> 3. Verify the working tree is clean after push.
+>
+> **CRITICAL**: Do NOT move to the archive step with
+> uncommitted changes. All work must be committed and
+> pushed before the change directory is moved to the
+> archive.
+
+**Where**: Before the step that moves the change directory
+to the archive. Insert as a new numbered step; do NOT
+renumber existing steps.
+
+#### Branch Enforcement: Explore (Guardrail Only)
+
+**Target file**:
+- `.opencode/skills/openspec-explore/SKILL.md`
+
+**Note**: Explore mode does not create or modify changes, so
+full branch management does not apply. However, explore may
+lead to creating a proposal, which requires a branch switch.
+
+**Single check** -- idempotency marker: `uncommitted changes`
+or `switch branches` in the guardrails section
+
+If not present, append this bullet to the explore SKILL.md
+guardrails section:
+
+> - Don't switch branches without confirmation -- If
+>   exploration leads to creating a proposal (which
+>   requires a new `opsx/` branch), check for uncommitted
+>   changes first and ask the user before switching.
+>   Never silently leave uncommitted work behind.
+
+**Where**: Append to the existing guardrails bullet list
+at the end of the file.
+
+Report: `✅ openspec-explore/SKILL.md: branch-switch
+confirmation inserted` or `⊘ openspec-explore/SKILL.md:
+branch-switch confirmation already present (skipped)`
 
 ### Step 3: Apply Dewey Context
 
@@ -447,18 +546,66 @@ step: run `.specify/scripts/bash/check-prerequisites.sh
 ### Step 6: Speckit Command Guardrails
 
 Inject a `## Guardrails` section into ALL 9
-`.opencode/commands/speckit.*.md` files. For each file:
+`.opencode/commands/speckit.*.md` files. Use two
+variants depending on the command type.
+
+**Spec-phase commands** (get Guardrails WITH
+review-rationale sentence):
+- `speckit.specify.md`
+- `speckit.clarify.md`
+- `speckit.plan.md`
+- `speckit.tasks.md`
+- `speckit.analyze.md`
+- `speckit.checklist.md`
+
+**Execution/utility commands** (get Guardrails WITHOUT
+review-rationale sentence):
+- `speckit.implement.md`
+- `speckit.constitution.md`
+- `speckit.taskstoissues.md`
+
+For each file:
 
 1. **Read** the file content
 2. **Check** if a `## Guardrails` section already exists
    (search for the heading text `## Guardrails`)
-3. **If already present**: Report
-   `⊘ <filename>: guardrails already present (skipped)`
-4. **If not present**: Append the following block at the
-   very end of the file. Report
+3. **If NOT present**: Append the appropriate guardrails
+   variant at the very end of the file. Report
    `✅ <filename>: guardrails injected`
+4. **If already present**: Perform a secondary check
+   for spec-phase commands only -- search for the phrase
+   "review defeats the purpose". If the Guardrails
+   heading exists but the review-rationale sentence is
+   missing, append the sentence to the existing
+   Guardrails section. Report
+   `✅ <filename>: review-rationale added`.
+   If the sentence is already present, report
+   `⊘ <filename>: guardrails already present (skipped)`
 
-The guardrails block to append:
+**Spec-phase guardrails block** (with review-rationale):
+
+```markdown
+
+## Guardrails
+
+- **NEVER modify source code** — this command updates
+  spec artifacts ONLY. Implementation changes belong in
+  `/speckit.implement`, `/unleash`, or `/cobalt-crush`.
+- **NEVER modify test files, Go source, Markdown agents,
+  convention packs, or config files** outside the
+  `specs/NNN-*/` feature directory.
+- The ONLY files this command may write are:
+  - `FEATURE_SPEC` (the spec.md file)
+  - Files within `FEATURE_DIR` (spec artifacts:
+    plan.md, tasks.md, research.md, data-model.md,
+    quickstart.md, contracts/, checklists/)
+- The user needs to review the plan before
+  implementation begins. Implementing without review
+  defeats the purpose of the spec-first workflow.
+```
+
+**Execution/utility guardrails block** (no
+review-rationale):
 
 ```markdown
 
@@ -476,17 +623,6 @@ The guardrails block to append:
     plan.md, tasks.md, research.md, data-model.md,
     quickstart.md, contracts/, checklists/)
 ```
-
-The 9 target files are:
-- `speckit.specify.md`
-- `speckit.clarify.md`
-- `speckit.plan.md`
-- `speckit.tasks.md`
-- `speckit.analyze.md`
-- `speckit.checklist.md`
-- `speckit.implement.md`
-- `speckit.constitution.md`
-- `speckit.taskstoissues.md`
 
 **Note**: `speckit.implement.md` is an exception — it IS
 allowed to modify source code. However, the guardrails
@@ -595,6 +731,18 @@ After processing all customizations, display a summary:
   [status] [filename]: [action]
   ...
 
+### STOP HERE Blocks
+  [status] [filename]: [action]
+  ...
+
+### Scaffold Comment Deduplication
+  [status] [filename]: [action]
+  ...
+
+### Legacy Directory Cleanup
+  [status] [item]: [action]
+  ...
+
 ### Summary
 Applied: N | Already present: N | Errors: N
 ```
@@ -603,6 +751,119 @@ Use these status indicators:
 - `✅` -- customization was inserted
 - `⊘` -- customization already present (skipped)
 - `❌` -- file not found or error (with fix suggestion)
+
+### Step 10: STOP HERE Blocks
+
+Inject a STOP HERE block into each spec-phase speckit
+command file. The block prevents premature advancement
+to implementation by instructing the LLM to stop and
+prompt the user.
+
+**Target files** (spec-phase commands only):
+- `speckit.specify.md`
+- `speckit.plan.md`
+- `speckit.tasks.md`
+- `speckit.analyze.md`
+- `speckit.checklist.md`
+- `speckit.clarify.md`
+
+**Excluded** (execution/utility commands -- no STOP HERE):
+- `speckit.implement.md`
+- `speckit.constitution.md`
+- `speckit.taskstoissues.md`
+
+For each target file:
+
+1. **Read** the file content
+2. **Check** if "STOP HERE" (case-sensitive) is already
+   present in the file
+3. **If already present**: Report
+   `⊘ <filename>: STOP HERE already present (skipped)`
+4. **If not present**: Insert the STOP HERE block. Report
+   `✅ <filename>: STOP HERE inserted`
+
+**What to insert**:
+
+```markdown
+
+**STOP HERE. Do NOT proceed to implementation.**
+
+Your job is done. Report the results and prompt the
+user. The user will invoke a separate command
+(`/speckit.implement`, `/unleash`, or `/cobalt-crush`)
+when they are ready to implement.
+```
+
+**Where**: After the main workflow instructions, before
+the `## Guardrails` section. If no `## Guardrails`
+section exists, insert at the end of the file.
+
+### Step 11: Scaffold Comment Deduplication
+
+Deduplicate scaffold comments in all files processed by
+`/uf-init`. Repeated runs of `uf init` across versions
+can accumulate multiple `<!-- scaffolded by uf ... -->`
+comments in the same file.
+
+**Target scope**: All files processed by `/uf-init`:
+- The 4 OpenSpec skill files (Step 2-4 targets)
+- The 3 OpenSpec command files (Step 2-3 targets)
+- The 9 speckit command files (Step 5-6 targets)
+
+For each file:
+
+1. **Read** the file content
+2. **Count** lines matching the pattern
+   `<!-- scaffolded by uf` (any version string after "uf")
+3. **If 0 or 1 matches**: No action needed. Report
+   `⊘ <filename>: scaffold comments clean`
+4. **If 2+ matches**: Keep only the LAST occurrence,
+   remove all earlier occurrences. Report
+   `✅ <filename>: deduplicated scaffold comments
+   (N removed)`
+
+**Important**: This step runs AFTER all other insertion
+steps to catch any duplicates introduced by earlier steps.
+
+### Step 12: Legacy Directory Cleanup
+
+Clean up legacy directory artifacts from older versions
+of `uf init`.
+
+#### Sub-task A: `unbound/packs/` Removal
+
+1. Check if `.opencode/unbound/packs/` exists
+2. **If it does NOT exist**: Report
+   `⊘ unbound/packs/: not present`
+3. **If it exists**: Verify pre-conditions:
+   - `.opencode/uf/packs/default.md` MUST exist
+   - `.opencode/uf/packs/severity.md` MUST exist
+4. **If pre-conditions met**: Remove
+   `.opencode/unbound/packs/` recursively (NOT the
+   parent `unbound/` directory). Then check if
+   `.opencode/unbound/` is empty -- if so, remove it
+   too. If `.opencode/unbound/` still contains other
+   files or directories, leave it and report a warning:
+   `⚠️ unbound/: packs/ removed but directory contains
+   other content -- leaving in place`.
+   Report `✅ unbound/packs/: removed (migrated to
+   uf/packs/)`
+5. **If pre-conditions NOT met**: Report
+   `❌ unbound/packs/: uf/packs/ missing core files,
+   skipped`
+
+#### Sub-task B: `command/` Migration Hardening
+
+After Step 0 runs (command directory migration), verify
+the migration was effective:
+
+1. Check if any `speckit.*.md` files remain in
+   `.opencode/command/` (singular)
+2. **If found**: Report
+   `⚠️ command/: speckit commands still in singular
+   directory after migration -- check Step 0 output`
+3. **If not found**: Report
+   `⊘ command/: migration verified (or not needed)`
 
 ### Post-Write Verification
 

--- a/.opencode/commands/uf-init.md
+++ b/.opencode/commands/uf-init.md
@@ -830,26 +830,28 @@ steps to catch any duplicates introduced by earlier steps.
 Clean up legacy directory artifacts from older versions
 of `uf init`.
 
-#### Sub-task A: `unbound/packs/` Removal
+Set `LEGACY_PACKS = .opencode/` + `unbound/packs/`
+(the pre-Spec-025 convention pack location).
 
-1. Check if `.opencode/unbound/packs/` exists
+#### Sub-task A: Legacy Packs Removal
+
+1. Check if `LEGACY_PACKS` exists
 2. **If it does NOT exist**: Report
-   `⊘ unbound/packs/: not present`
+   `⊘ legacy packs: not present`
 3. **If it exists**: Verify pre-conditions:
    - `.opencode/uf/packs/default.md` MUST exist
    - `.opencode/uf/packs/severity.md` MUST exist
-4. **If pre-conditions met**: Remove
-   `.opencode/unbound/packs/` recursively (NOT the
-   parent `unbound/` directory). Then check if
-   `.opencode/unbound/` is empty -- if so, remove it
-   too. If `.opencode/unbound/` still contains other
-   files or directories, leave it and report a warning:
-   `⚠️ unbound/: packs/ removed but directory contains
-   other content -- leaving in place`.
-   Report `✅ unbound/packs/: removed (migrated to
+4. **If pre-conditions met**: Remove `LEGACY_PACKS`
+   recursively (NOT its parent directory). Then check
+   if the parent directory is empty -- if so, remove it
+   too. If the parent still contains other files or
+   directories, leave it and report a warning:
+   `⚠️ legacy parent dir: packs/ removed but directory
+   contains other content -- leaving in place`.
+   Report `✅ legacy packs: removed (migrated to
    uf/packs/)`
 5. **If pre-conditions NOT met**: Report
-   `❌ unbound/packs/: uf/packs/ missing core files,
+   `❌ legacy packs: uf/packs/ missing core files,
    skipped`
 
 #### Sub-task B: `command/` Migration Hardening

--- a/.uf/dewey/learnings/uf-init-20260622T203631-jay-flowers.md
+++ b/.uf/dewey/learnings/uf-init-20260622T203631-jay-flowers.md
@@ -1,0 +1,10 @@
+---
+tag: uf-init
+author: jay-flowers
+category: gotcha
+created_at: 2026-06-22T20:36:31Z
+identity: uf-init-20260622T203631-jay-flowers
+tier: draft
+---
+
+When modifying the /uf-init slash command (.opencode/commands/uf-init.md), the scaffold asset copy at internal/scaffold/assets/opencode/commands/uf-init.md must be kept byte-identical. This was caught during spec review by multiple Divisor agents referencing prior learnings. The drift detection test TestEmbeddedAssets_MatchSource in internal/scaffold/ will fail if the copies diverge. Always run `cp .opencode/commands/uf-init.md internal/scaffold/assets/opencode/commands/uf-init.md` followed by `go test -race -count=1 -run TestEmbeddedAssets_MatchSource ./internal/scaffold/` after any changes to uf-init.md.

--- a/.uf/dewey/learnings/uf-init-20260622T203637-jay-flowers.md
+++ b/.uf/dewey/learnings/uf-init-20260622T203637-jay-flowers.md
@@ -1,0 +1,10 @@
+---
+tag: uf-init
+author: jay-flowers
+category: pattern
+created_at: 2026-06-22T20:36:37Z
+identity: uf-init-20260622T203637-jay-flowers
+tier: draft
+---
+
+Cross-repo comparison between unbound-force and downstream hero repos (like gaze) is an effective technique for discovering gaps in slash command customization. The /uf-init command applies customizations to OpenSpec skill files and speckit command files, but its semantic idempotency checks were too coarse -- detecting a basic branch check and concluding the entire branch enforcement category was present. Splitting idempotency checks into independent variant checks (basic branch check, dirty tree check, commit-before-archive, branch-switch confirmation) with specific marker strings prevents partial application from being mistaken for complete application. Each variant uses a different structural marker: opsx/<name> for basic check, git status --short for dirty tree, git add/git commit for commit-before-archive, and uncommitted changes for branch-switch confirmation.

--- a/.uf/dewey/learnings/uf-init-20260622T203645-jay-flowers.md
+++ b/.uf/dewey/learnings/uf-init-20260622T203645-jay-flowers.md
@@ -1,0 +1,10 @@
+---
+tag: uf-init
+author: jay-flowers
+category: gotcha
+created_at: 2026-06-22T20:36:45Z
+identity: uf-init-20260622T203645-jay-flowers
+tier: draft
+---
+
+The AGENTS.md behavioral rule "Never use git add -A or git add . on feature branches -- stage files explicitly" applies to all branches including opsx/ branches. During spec review of the fix-uf-init-customizations change, the Architect reviewer caught that the commit-before-archive insertion content used git add -A, which directly contradicts this rule. The fix was to use explicit staging: git add openspec/changes/<name>/ .opencode/ plus any other modified files shown by git status. This was a HIGH severity finding because the behavioral rules are described as non-negotiable with CRITICAL severity for violations.

--- a/internal/scaffold/assets/opencode/commands/uf-init.md
+++ b/internal/scaffold/assets/opencode/commands/uf-init.md
@@ -101,19 +101,27 @@ completes to review all changes before committing.
 ### Step 2: Apply Branch Enforcement
 
 For each target file listed below, apply the branch enforcement
-customization. For each file:
+customization. Each enforcement category has **independent**
+idempotency checks -- presence of one variant MUST NOT cause
+other variants to be skipped. For each file:
 
 1. **Read** the file content
-2. **Check** if branch enforcement is already present. Look for
-   the concept semantically -- does the file already describe
-   creating, validating, or cleaning up an `opsx/<name>` branch?
-   Check for phrases like `git checkout -b opsx/`, `opsx/<name>`,
-   `opsx/<change-name>`, or equivalent branch management
-   instructions.
-3. **If already present**: Report `⊘ <filename>: already present (skipped)`
-4. **If not present**: Read the file structure, find the correct
-   insertion point, and insert the customization. Report
-   `✅ <filename>: inserted`
+2. **Check** each applicable variant independently:
+   - **Basic branch check**: Look for `opsx/<name>`,
+     `opsx/<change-name>`, or `git checkout -b opsx/`
+   - **Dirty tree check** (propose only): Look for
+     `git status --short` in a pre-branch-creation
+     context
+   - **Commit-before-archive** (archive-change only):
+     Look for `git add` and `git commit` appearing
+     before the archive move step
+   - **Branch-switch confirmation** (explore only): Look
+     for `uncommitted changes` or `switch branches` in
+     the guardrails section
+3. **For each variant**: If present, report
+   `⊘ <filename>: [variant] already present (skipped)`.
+   If not present, insert it and report
+   `✅ <filename>: [variant] inserted`
 
 #### Branch Enforcement: Propose (Skills + Commands)
 
@@ -121,8 +129,13 @@ customization. For each file:
 - `.opencode/skills/openspec-propose/SKILL.md`
 - `.opencode/commands/opsx-propose.md`
 
-**What to insert**: After the step that creates the change
-directory (`openspec new change "<name>"`), insert a new step:
+**Two independent checks**:
+
+**A. Basic branch check** -- idempotency marker:
+`opsx/<name>` or `git checkout -b opsx/`
+
+If not present, insert after the step that creates the
+change directory (`openspec new change "<name>"`):
 
 > **Create and checkout a branch**
 >
@@ -138,6 +151,32 @@ directory (`openspec new change "<name>"`), insert a new step:
 **Where**: After the change directory creation step, before the
 artifact creation steps. Insert as a new numbered step; do NOT
 renumber existing steps (to avoid accidental content loss).
+
+**B. Dirty tree check** -- idempotency marker:
+`git status --short` in a pre-branch-creation context
+
+If not present, insert before the branch creation guard
+(part A above), or immediately before the existing branch
+check if part A is already present:
+
+> **Check for uncommitted changes**
+>
+> Before creating or switching branches, run
+> `git status --short`. If there are uncommitted changes
+> (staged, unstaged, or untracked files that appear
+> related to work):
+> - **STOP** and ask the user for confirmation before
+>   switching branches. Show what uncommitted changes
+>   exist and warn that switching branches with a dirty
+>   working tree may cause changes to be applied to the
+>   wrong branch.
+> - If the user confirms, proceed. If not, abort.
+> - Exception: if the user explicitly requested a new
+>   change, this still requires confirmation -- never
+>   silently switch branches with uncommitted work.
+
+**Where**: Before the branch creation guard. Insert as a
+sub-step or preceding step.
 
 #### Branch Enforcement: Apply (Skills + Commands)
 
@@ -167,8 +206,12 @@ existing steps.
 - `.opencode/skills/openspec-archive-change/SKILL.md`
 - `.opencode/commands/opsx-archive.md`
 
-**What to insert**: After the archive move completes, insert a
-branch cleanup step:
+**Two independent checks**:
+
+**A. Return to main branch** -- idempotency marker:
+`git checkout main` after the archive move
+
+If not present, insert after the archive move completes:
 
 > **Return to main branch**
 >
@@ -185,10 +228,66 @@ branch cleanup step:
 the archive, before the display summary step. Insert as a new
 numbered step; do NOT renumber existing steps.
 
-**Note**: `openspec-explore` and `opsx-explore.md` are
-intentionally excluded from branch enforcement -- explore mode
-does not create or modify changes, so branch management does
-not apply.
+**B. Commit-before-archive** -- idempotency markers:
+`git add` and `git commit` appearing before the archive
+move step
+
+If not present, insert before the archive move step
+(the step that moves the change directory to the archive):
+
+> **Commit and push all changes**
+>
+> Before archiving, ensure all work is committed:
+>
+> 1. Run `git status --short` to check for uncommitted
+>    changes.
+> 2. If uncommitted changes exist:
+>    - Stage the change directory and implementation
+>      files explicitly:
+>      `git add openspec/changes/<name>/ .opencode/`
+>      and any other modified files shown by
+>      `git status --short`
+>    - Commit with a descriptive message:
+>      `git commit -m "feat(<name>): complete implementation"`
+>    - Push to remote: `git push`
+> 3. Verify the working tree is clean after push.
+>
+> **CRITICAL**: Do NOT move to the archive step with
+> uncommitted changes. All work must be committed and
+> pushed before the change directory is moved to the
+> archive.
+
+**Where**: Before the step that moves the change directory
+to the archive. Insert as a new numbered step; do NOT
+renumber existing steps.
+
+#### Branch Enforcement: Explore (Guardrail Only)
+
+**Target file**:
+- `.opencode/skills/openspec-explore/SKILL.md`
+
+**Note**: Explore mode does not create or modify changes, so
+full branch management does not apply. However, explore may
+lead to creating a proposal, which requires a branch switch.
+
+**Single check** -- idempotency marker: `uncommitted changes`
+or `switch branches` in the guardrails section
+
+If not present, append this bullet to the explore SKILL.md
+guardrails section:
+
+> - Don't switch branches without confirmation -- If
+>   exploration leads to creating a proposal (which
+>   requires a new `opsx/` branch), check for uncommitted
+>   changes first and ask the user before switching.
+>   Never silently leave uncommitted work behind.
+
+**Where**: Append to the existing guardrails bullet list
+at the end of the file.
+
+Report: `✅ openspec-explore/SKILL.md: branch-switch
+confirmation inserted` or `⊘ openspec-explore/SKILL.md:
+branch-switch confirmation already present (skipped)`
 
 ### Step 3: Apply Dewey Context
 
@@ -447,18 +546,66 @@ step: run `.specify/scripts/bash/check-prerequisites.sh
 ### Step 6: Speckit Command Guardrails
 
 Inject a `## Guardrails` section into ALL 9
-`.opencode/commands/speckit.*.md` files. For each file:
+`.opencode/commands/speckit.*.md` files. Use two
+variants depending on the command type.
+
+**Spec-phase commands** (get Guardrails WITH
+review-rationale sentence):
+- `speckit.specify.md`
+- `speckit.clarify.md`
+- `speckit.plan.md`
+- `speckit.tasks.md`
+- `speckit.analyze.md`
+- `speckit.checklist.md`
+
+**Execution/utility commands** (get Guardrails WITHOUT
+review-rationale sentence):
+- `speckit.implement.md`
+- `speckit.constitution.md`
+- `speckit.taskstoissues.md`
+
+For each file:
 
 1. **Read** the file content
 2. **Check** if a `## Guardrails` section already exists
    (search for the heading text `## Guardrails`)
-3. **If already present**: Report
-   `⊘ <filename>: guardrails already present (skipped)`
-4. **If not present**: Append the following block at the
-   very end of the file. Report
+3. **If NOT present**: Append the appropriate guardrails
+   variant at the very end of the file. Report
    `✅ <filename>: guardrails injected`
+4. **If already present**: Perform a secondary check
+   for spec-phase commands only -- search for the phrase
+   "review defeats the purpose". If the Guardrails
+   heading exists but the review-rationale sentence is
+   missing, append the sentence to the existing
+   Guardrails section. Report
+   `✅ <filename>: review-rationale added`.
+   If the sentence is already present, report
+   `⊘ <filename>: guardrails already present (skipped)`
 
-The guardrails block to append:
+**Spec-phase guardrails block** (with review-rationale):
+
+```markdown
+
+## Guardrails
+
+- **NEVER modify source code** — this command updates
+  spec artifacts ONLY. Implementation changes belong in
+  `/speckit.implement`, `/unleash`, or `/cobalt-crush`.
+- **NEVER modify test files, Go source, Markdown agents,
+  convention packs, or config files** outside the
+  `specs/NNN-*/` feature directory.
+- The ONLY files this command may write are:
+  - `FEATURE_SPEC` (the spec.md file)
+  - Files within `FEATURE_DIR` (spec artifacts:
+    plan.md, tasks.md, research.md, data-model.md,
+    quickstart.md, contracts/, checklists/)
+- The user needs to review the plan before
+  implementation begins. Implementing without review
+  defeats the purpose of the spec-first workflow.
+```
+
+**Execution/utility guardrails block** (no
+review-rationale):
 
 ```markdown
 
@@ -476,17 +623,6 @@ The guardrails block to append:
     plan.md, tasks.md, research.md, data-model.md,
     quickstart.md, contracts/, checklists/)
 ```
-
-The 9 target files are:
-- `speckit.specify.md`
-- `speckit.clarify.md`
-- `speckit.plan.md`
-- `speckit.tasks.md`
-- `speckit.analyze.md`
-- `speckit.checklist.md`
-- `speckit.implement.md`
-- `speckit.constitution.md`
-- `speckit.taskstoissues.md`
 
 **Note**: `speckit.implement.md` is an exception — it IS
 allowed to modify source code. However, the guardrails
@@ -595,6 +731,18 @@ After processing all customizations, display a summary:
   [status] [filename]: [action]
   ...
 
+### STOP HERE Blocks
+  [status] [filename]: [action]
+  ...
+
+### Scaffold Comment Deduplication
+  [status] [filename]: [action]
+  ...
+
+### Legacy Directory Cleanup
+  [status] [item]: [action]
+  ...
+
 ### Summary
 Applied: N | Already present: N | Errors: N
 ```
@@ -603,6 +751,119 @@ Use these status indicators:
 - `✅` -- customization was inserted
 - `⊘` -- customization already present (skipped)
 - `❌` -- file not found or error (with fix suggestion)
+
+### Step 10: STOP HERE Blocks
+
+Inject a STOP HERE block into each spec-phase speckit
+command file. The block prevents premature advancement
+to implementation by instructing the LLM to stop and
+prompt the user.
+
+**Target files** (spec-phase commands only):
+- `speckit.specify.md`
+- `speckit.plan.md`
+- `speckit.tasks.md`
+- `speckit.analyze.md`
+- `speckit.checklist.md`
+- `speckit.clarify.md`
+
+**Excluded** (execution/utility commands -- no STOP HERE):
+- `speckit.implement.md`
+- `speckit.constitution.md`
+- `speckit.taskstoissues.md`
+
+For each target file:
+
+1. **Read** the file content
+2. **Check** if "STOP HERE" (case-sensitive) is already
+   present in the file
+3. **If already present**: Report
+   `⊘ <filename>: STOP HERE already present (skipped)`
+4. **If not present**: Insert the STOP HERE block. Report
+   `✅ <filename>: STOP HERE inserted`
+
+**What to insert**:
+
+```markdown
+
+**STOP HERE. Do NOT proceed to implementation.**
+
+Your job is done. Report the results and prompt the
+user. The user will invoke a separate command
+(`/speckit.implement`, `/unleash`, or `/cobalt-crush`)
+when they are ready to implement.
+```
+
+**Where**: After the main workflow instructions, before
+the `## Guardrails` section. If no `## Guardrails`
+section exists, insert at the end of the file.
+
+### Step 11: Scaffold Comment Deduplication
+
+Deduplicate scaffold comments in all files processed by
+`/uf-init`. Repeated runs of `uf init` across versions
+can accumulate multiple `<!-- scaffolded by uf ... -->`
+comments in the same file.
+
+**Target scope**: All files processed by `/uf-init`:
+- The 4 OpenSpec skill files (Step 2-4 targets)
+- The 3 OpenSpec command files (Step 2-3 targets)
+- The 9 speckit command files (Step 5-6 targets)
+
+For each file:
+
+1. **Read** the file content
+2. **Count** lines matching the pattern
+   `<!-- scaffolded by uf` (any version string after "uf")
+3. **If 0 or 1 matches**: No action needed. Report
+   `⊘ <filename>: scaffold comments clean`
+4. **If 2+ matches**: Keep only the LAST occurrence,
+   remove all earlier occurrences. Report
+   `✅ <filename>: deduplicated scaffold comments
+   (N removed)`
+
+**Important**: This step runs AFTER all other insertion
+steps to catch any duplicates introduced by earlier steps.
+
+### Step 12: Legacy Directory Cleanup
+
+Clean up legacy directory artifacts from older versions
+of `uf init`.
+
+#### Sub-task A: `unbound/packs/` Removal
+
+1. Check if `.opencode/unbound/packs/` exists
+2. **If it does NOT exist**: Report
+   `⊘ unbound/packs/: not present`
+3. **If it exists**: Verify pre-conditions:
+   - `.opencode/uf/packs/default.md` MUST exist
+   - `.opencode/uf/packs/severity.md` MUST exist
+4. **If pre-conditions met**: Remove
+   `.opencode/unbound/packs/` recursively (NOT the
+   parent `unbound/` directory). Then check if
+   `.opencode/unbound/` is empty -- if so, remove it
+   too. If `.opencode/unbound/` still contains other
+   files or directories, leave it and report a warning:
+   `⚠️ unbound/: packs/ removed but directory contains
+   other content -- leaving in place`.
+   Report `✅ unbound/packs/: removed (migrated to
+   uf/packs/)`
+5. **If pre-conditions NOT met**: Report
+   `❌ unbound/packs/: uf/packs/ missing core files,
+   skipped`
+
+#### Sub-task B: `command/` Migration Hardening
+
+After Step 0 runs (command directory migration), verify
+the migration was effective:
+
+1. Check if any `speckit.*.md` files remain in
+   `.opencode/command/` (singular)
+2. **If found**: Report
+   `⚠️ command/: speckit commands still in singular
+   directory after migration -- check Step 0 output`
+3. **If not found**: Report
+   `⊘ command/: migration verified (or not needed)`
 
 ### Post-Write Verification
 

--- a/internal/scaffold/assets/opencode/commands/uf-init.md
+++ b/internal/scaffold/assets/opencode/commands/uf-init.md
@@ -830,26 +830,28 @@ steps to catch any duplicates introduced by earlier steps.
 Clean up legacy directory artifacts from older versions
 of `uf init`.
 
-#### Sub-task A: `unbound/packs/` Removal
+Set `LEGACY_PACKS = .opencode/` + `unbound/packs/`
+(the pre-Spec-025 convention pack location).
 
-1. Check if `.opencode/unbound/packs/` exists
+#### Sub-task A: Legacy Packs Removal
+
+1. Check if `LEGACY_PACKS` exists
 2. **If it does NOT exist**: Report
-   `⊘ unbound/packs/: not present`
+   `⊘ legacy packs: not present`
 3. **If it exists**: Verify pre-conditions:
    - `.opencode/uf/packs/default.md` MUST exist
    - `.opencode/uf/packs/severity.md` MUST exist
-4. **If pre-conditions met**: Remove
-   `.opencode/unbound/packs/` recursively (NOT the
-   parent `unbound/` directory). Then check if
-   `.opencode/unbound/` is empty -- if so, remove it
-   too. If `.opencode/unbound/` still contains other
-   files or directories, leave it and report a warning:
-   `⚠️ unbound/: packs/ removed but directory contains
-   other content -- leaving in place`.
-   Report `✅ unbound/packs/: removed (migrated to
+4. **If pre-conditions met**: Remove `LEGACY_PACKS`
+   recursively (NOT its parent directory). Then check
+   if the parent directory is empty -- if so, remove it
+   too. If the parent still contains other files or
+   directories, leave it and report a warning:
+   `⚠️ legacy parent dir: packs/ removed but directory
+   contains other content -- leaving in place`.
+   Report `✅ legacy packs: removed (migrated to
    uf/packs/)`
 5. **If pre-conditions NOT met**: Report
-   `❌ unbound/packs/: uf/packs/ missing core files,
+   `❌ legacy packs: uf/packs/ missing core files,
    skipped`
 
 #### Sub-task B: `command/` Migration Hardening

--- a/openspec/changes/fix-uf-init-customizations/.openspec.yaml
+++ b/openspec/changes/fix-uf-init-customizations/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: unbound-force
+created: 2026-06-22

--- a/openspec/changes/fix-uf-init-customizations/design.md
+++ b/openspec/changes/fix-uf-init-customizations/design.md
@@ -1,0 +1,154 @@
+## Context
+
+The `/uf-init` slash command (`.opencode/commands/uf-init.md`)
+applies project-specific customizations to OpenSpec skill files
+and speckit command files. Cross-repo comparison between
+`unbound-force` and `gaze` revealed that several customizations
+present in the meta repo are never applied to downstream repos
+because they are not defined in any `/uf-init` step.
+
+The command currently has 10 steps (0-9, where Step 9 is
+the report template). This change adds 3 new steps
+(10-12) and modifies 2 existing steps (2 and 6),
+bringing the total to 13 steps (0-12).
+
+## Goals / Non-Goals
+
+### Goals
+- Every customization present in `unbound-force/.opencode/`
+  files is traceable to a specific `/uf-init` step
+- Idempotency checks are specific enough to distinguish
+  between partial and complete application of each
+  customization category
+- Legacy directory artifacts are cleaned up
+- Scaffold comment accumulation is prevented
+
+### Non-Goals
+- Modifying the Go `uf init` binary (this change is
+  command-only)
+- Changing the content of the customizations themselves
+  (we are codifying what already exists in unbound-force)
+- Addressing issues #161/#162/#201/#213 (those relate to
+  the Go binary, not the slash command)
+- Verifying content parity between `uf/packs/` and
+  `unbound/packs/` before cleanup (the migration is
+  already complete in all active repos)
+
+## Decisions
+
+### D1: Add steps rather than restructure existing ones
+
+**Decision**: Add new steps (10, 11, 12) rather than
+restructuring the existing step numbering.
+
+**Rationale**: The existing step numbers (0-9) are
+referenced in AGENTS.md and potentially in user memory.
+Renumbering would create unnecessary confusion. Appending
+new steps at the end maintains backward compatibility with
+partial-run expectations.
+
+### D2: Split Guardrails into spec-phase and execution-phase
+
+**Decision**: Modify Step 6 to inject a variant Guardrails
+block depending on whether the command is a spec-phase
+command (specify, plan, tasks, analyze, checklist, clarify)
+or an execution/utility command (implement, constitution,
+taskstoissues).
+
+**Rationale**: The review-rationale sentence ("The user
+needs to review the plan before implementation begins...")
+is only meaningful for spec-phase commands. Adding it to
+implement or constitution commands would be contradictory.
+
+### D3: Tighten branch enforcement idempotency via specific markers
+
+**Decision**: Instead of checking semantically for "any
+branch management content," check for specific marker
+phrases that distinguish variants:
+- Basic branch check: `opsx/<name>` or `opsx/<change-name>`
+- Dirty tree check: `git status --short` in a
+  pre-branch-creation context
+- Commit-before-archive: `git add` + `git commit` before
+  the archive move step
+- Branch-switch confirmation: `uncommitted changes` in
+  explore guardrails
+
+**Rationale**: The current semantic check ("does the file
+already describe creating, validating, or cleaning up an
+opsx branch?") is too coarse. It detects the basic branch
+check and concludes the entire branch enforcement category
+is present, skipping the enhanced variants.
+
+### D4: STOP HERE blocks as a separate step
+
+**Decision**: Create a dedicated step for STOP HERE blocks
+rather than folding them into the existing Guardrails step.
+
+**Rationale**: STOP HERE blocks serve a different purpose
+than Guardrails. Guardrails constrain what the command may
+do; STOP HERE blocks control workflow flow (preventing
+premature advancement to implementation). They also have
+different insertion points (after the main workflow, before
+Guardrails vs. appended at the end).
+
+### D5: Scaffold comment deduplication approach
+
+**Decision**: Use a simple "keep the last one, remove
+earlier duplicates" strategy for scaffold comments. Match
+the pattern `<!-- scaffolded by uf ... -->`.
+
+**Rationale**: The most recent scaffold comment carries the
+version information that matters. Earlier ones are
+archaeological artifacts of previous `uf init` runs.
+
+## Risks / Trade-offs
+
+### R1: Step count growth
+
+The command grows from 9 to 12 substantive steps. This
+increases execution time and LLM context consumption.
+
+**Mitigation**: Each new step follows the established
+pattern (read, check, skip-or-insert, report) and adds
+minimal instruction text. The idempotency checks mean
+subsequent runs of already-customized files skip quickly.
+
+### R2: Marker-based idempotency is fragile
+
+Checking for specific strings (D3) could break if the
+customization text is reworded in a future update.
+
+**Mitigation**: The markers chosen are structural
+identifiers unlikely to change accidentally
+(`git status --short`, `git add`, `uncommitted changes`).
+If the customization text is intentionally reworded, the
+marker strings in `/uf-init` should be updated in the same
+change.
+
+### R3: Step count growth and maintenance burden
+
+The command grows from 10 to 13 steps. Steps 11 and 12
+are time-limited cleanup steps that should be retired
+once all downstream repos are clean:
+
+- **Step 11** (Scaffold Comment Dedup): Retire after all
+  active repos report `⊘` for all files. Estimated: 1-2
+  release cycles after this change ships.
+- **Step 12** (Legacy Directory Cleanup): Retire after
+  all active repos report `⊘ unbound/packs/: not
+  present`. Estimated: 1-2 release cycles.
+
+The root cause of scaffold comment accumulation was fixed
+in PR #127 (idempotent marker insertion in the Go
+binary). Step 11 remediates existing accumulation.
+
+### R4: Legacy cleanup could remove needed files
+
+Removing `unbound/packs/` in a downstream repo that
+somehow still depends on it would break that repo.
+
+**Mitigation**: The cleanup step verifies `uf/packs/`
+exists and contains at least the core files
+(`default.md`, `severity.md`) before removing
+`unbound/packs/`. If `uf/packs/` is missing or
+incomplete, the step reports an error and skips cleanup.

--- a/openspec/changes/fix-uf-init-customizations/proposal.md
+++ b/openspec/changes/fix-uf-init-customizations/proposal.md
@@ -1,0 +1,139 @@
+## Why
+
+The `/uf-init` slash command applies project-specific customizations
+to third-party tool files (OpenSpec skills and speckit commands)
+after `uf init` runs. Cross-project comparison between
+`unbound-force` and `gaze` reveals that `/uf-init` has gaps:
+customizations that exist in the meta repo are not reliably
+reproduced in downstream repos.
+
+**Problems identified:**
+
+1. **Missing customization steps**: The STOP HERE blocks (preventing
+   premature implementation) and review-rationale guardrail
+   sentences are present in unbound-force's speckit commands but
+   are not defined in any `/uf-init` step. They were likely added
+   manually, meaning downstream repos never receive them.
+
+2. **Incomplete branch enforcement**: The dirty working tree check
+   (propose), commit-before-archive flow (archive-change), and
+   branch-switch confirmation (explore) are missing from gaze,
+   suggesting the idempotency checks in Step 2 are too coarse --
+   detecting the basic branch check and skipping the enhanced
+   variants.
+
+3. **Scaffold comment accumulation**: Repeated `uf init` runs
+   across versions leave duplicate `<!-- scaffolded by uf ... -->`
+   comments (gaze has 5 per file vs 1 in unbound-force). No
+   deduplication step exists.
+
+4. **Legacy directory cleanup**: The old `unbound/packs/` and
+   `command/` (singular) directories persist in downstream repos.
+   Step 0 handles `command/` migration but may not trigger
+   reliably; `unbound/packs/` is not addressed at all.
+
+**Related issues**: #161 (new commands not scaffolded on upgrade),
+#162 (skip logic for user-owned files), #201 (tiered scaffolding),
+#213 (uf init does not scaffold usable constitution).
+
+## What Changes
+
+Modify `.opencode/commands/uf-init.md` to add missing
+customization steps, tighten idempotency checks, and add a
+cleanup step for legacy artifacts.
+
+## Capabilities
+
+### New Capabilities
+- `STOP HERE injection`: New step injecting STOP HERE blocks
+  into spec-phase speckit commands (specify, plan, tasks,
+  analyze, checklist, clarify) to prevent premature
+  implementation
+- `Review-rationale guardrail`: Extends Guardrails injection
+  to include the review-rationale sentence in spec-phase
+  commands
+- `Scaffold comment dedup`: Cleanup step that deduplicates
+  `<!-- scaffolded by uf ... -->` comments, keeping only the
+  most recent one
+- `Legacy directory cleanup`: New step removing `unbound/packs/`
+  after verifying `uf/packs/` exists, and improving `command/`
+  migration reliability
+
+### Modified Capabilities
+- `Branch enforcement (Step 2)`: Tightened idempotency checks
+  to distinguish between basic branch checks and enhanced
+  variants (dirty tree, commit-before-archive,
+  branch-switch confirmation)
+- `Guardrails injection (Step 6)`: Split into spec-phase and
+  execution-phase variants so the review-rationale sentence
+  is only added where appropriate
+
+### Removed Capabilities
+- None
+
+## Impact
+
+- **Files modified**: `.opencode/commands/uf-init.md` (sole
+  target)
+- **Downstream effect**: All repos running `/uf-init` will
+  receive the full set of customizations, producing parity
+  with the meta repo
+- **Risk**: Low. All insertions are idempotent and the command
+  instructs users to run `git diff` after completion. No Go
+  source or test files are modified.
+- **Related files**: The 7 OpenSpec skill/command files and
+  9 speckit command files that `/uf-init` targets are not
+  directly modified by this change -- only the command that
+  modifies them is updated
+
+## Constitution Alignment
+
+Assessed against the Unbound Force org constitution.
+
+### I. Autonomous Collaboration
+
+**Assessment**: PASS
+
+This change improves artifact consistency across repos by
+ensuring `/uf-init` produces identical customizations
+regardless of which repo it runs in. All customizations
+are file-based (Markdown insertions) with no runtime
+coupling between heroes.
+
+### II. Composability First
+
+**Assessment**: PASS
+
+`/uf-init` already handles missing files gracefully (skip
+and report). The new steps follow the same pattern: check
+for presence, skip if present, insert if absent. No new
+mandatory dependencies are introduced.
+
+### III. Observable Quality
+
+**Assessment**: PASS
+
+The command produces a structured summary report with status
+indicators for every file processed. The new steps follow
+the existing reporting pattern (checkmark/skip/error per
+file).
+
+### IV. Testability
+
+**Assessment**: PASS
+
+Verification is through scaffold asset drift detection
+tests (`TestEmbeddedAssets_MatchSource`) and cross-repo
+comparison after running the command. The spec scenarios
+define observable outcomes that serve as acceptance
+criteria.
+
+### V. Security by Default
+
+**Assessment**: N/A
+
+This change modifies a slash command (Markdown
+instructions), not Go source code. No supply chain,
+input validation, or privilege changes are introduced.
+The commit-before-archive step uses explicit file staging
+(not `git add -A`) to avoid staging unintended files.

--- a/openspec/changes/fix-uf-init-customizations/specs/uf-init-delta.md
+++ b/openspec/changes/fix-uf-init-customizations/specs/uf-init-delta.md
@@ -1,0 +1,292 @@
+## ADDED Requirements
+
+### Requirement: STOP HERE Block Injection
+
+The `/uf-init` command MUST inject a STOP HERE block into
+each spec-phase speckit command file. The block MUST
+appear after the main workflow instructions and before
+the Guardrails section.
+
+Spec-phase commands: `speckit.specify.md`,
+`speckit.plan.md`, `speckit.tasks.md`,
+`speckit.analyze.md`, `speckit.checklist.md`,
+`speckit.clarify.md`.
+
+The STOP HERE block MUST contain:
+1. A bold directive: "STOP HERE. Do NOT proceed to
+   implementation."
+2. Instructions to report results and prompt the user
+3. Direction to invoke a separate command for
+   implementation
+
+The idempotency check MUST search for the phrase
+"STOP HERE" (case-sensitive). If found, skip.
+
+#### Scenario: First run on a file without STOP HERE
+
+- **GIVEN** `speckit.specify.md` exists and does not
+  contain "STOP HERE"
+- **WHEN** `/uf-init` runs
+- **THEN** the STOP HERE block is inserted after the
+  main workflow, before Guardrails
+- **AND** the report shows
+  `✅ speckit.specify.md: STOP HERE inserted`
+
+#### Scenario: Subsequent run on a file with STOP HERE
+
+- **GIVEN** `speckit.specify.md` already contains
+  "STOP HERE"
+- **WHEN** `/uf-init` runs
+- **THEN** no modification is made
+- **AND** the report shows
+  `⊘ speckit.specify.md: STOP HERE already present (skipped)`
+
+#### Scenario: Execution command excluded
+
+- **GIVEN** `speckit.implement.md` exists
+- **WHEN** `/uf-init` runs
+- **THEN** no STOP HERE block is inserted into
+  `speckit.implement.md`
+
+#### Scenario: File without Guardrails section
+
+- **GIVEN** `speckit.specify.md` does not contain
+  "STOP HERE"
+- **AND** does not contain a `## Guardrails` section
+- **WHEN** `/uf-init` runs
+- **THEN** the STOP HERE block is inserted at the end
+  of the file
+
+---
+
+### Requirement: Review-Rationale Guardrail Sentence
+
+The Guardrails section injected by Step 6 MUST include a
+review-rationale sentence for spec-phase commands only.
+
+The sentence: "The user needs to review the plan before
+implementation begins. Implementing without review defeats
+the purpose of the spec-first workflow."
+
+This sentence MUST NOT be added to execution or utility
+commands (`speckit.implement.md`,
+`speckit.constitution.md`, `speckit.taskstoissues.md`).
+
+#### Scenario: Spec-phase command gets review-rationale
+
+- **GIVEN** `speckit.plan.md` does not have a Guardrails
+  section
+- **WHEN** `/uf-init` runs Step 6
+- **THEN** the Guardrails section includes the
+  review-rationale sentence
+
+#### Scenario: Execution command omits review-rationale
+
+- **GIVEN** `speckit.implement.md` does not have a
+  Guardrails section
+- **WHEN** `/uf-init` runs Step 6
+- **THEN** the Guardrails section does NOT include the
+  review-rationale sentence
+
+#### Scenario: Review-rationale already present
+
+- **GIVEN** `speckit.plan.md` has a `## Guardrails`
+  section
+- **AND** contains "review defeats the purpose"
+- **WHEN** `/uf-init` runs Step 6
+- **THEN** no modification is made
+- **AND** the report shows
+  `⊘ speckit.plan.md: guardrails already present
+  (skipped)`
+
+---
+
+### Requirement: Scaffold Comment Deduplication
+
+The `/uf-init` command MUST deduplicate scaffold comments
+matching the pattern `<!-- scaffolded by uf ... -->` in
+all files it processes.
+
+When multiple scaffold comments are found:
+- Keep only the LAST occurrence
+- Remove all earlier occurrences
+- Report: `✅ <filename>: deduplicated scaffold comments
+  (N removed)`
+
+When zero or one scaffold comment is found:
+- No action needed
+- Report: `⊘ <filename>: scaffold comments clean`
+
+#### Scenario: File with accumulated scaffold comments
+
+- **GIVEN** a file contains 5 lines matching
+  `<!-- scaffolded by uf ... -->`
+- **WHEN** `/uf-init` runs the deduplication step
+- **THEN** only the last scaffold comment remains
+- **AND** the report shows 4 removed
+
+#### Scenario: File with single scaffold comment
+
+- **GIVEN** a file contains exactly 1 scaffold comment
+- **WHEN** `/uf-init` runs the deduplication step
+- **THEN** no modification is made
+
+---
+
+### Requirement: Legacy Directory Cleanup
+
+The `/uf-init` command MUST remove the legacy
+`unbound/packs/` directory when the current `uf/packs/`
+directory exists and contains core files.
+
+Pre-conditions for removal:
+- `.opencode/uf/packs/` MUST exist
+- `.opencode/uf/packs/default.md` MUST exist
+- `.opencode/uf/packs/severity.md` MUST exist
+
+If pre-conditions are met and `.opencode/unbound/packs/`
+exists, remove `.opencode/unbound/packs/` recursively
+(NOT the parent `unbound/` directory). Then remove
+`.opencode/unbound/` only if it is empty after `packs/`
+removal. If `.opencode/unbound/` contains other content,
+leave it and report a warning.
+
+If pre-conditions are NOT met, report an error and skip.
+
+#### Scenario: Legacy directory present, uf/packs valid
+
+- **GIVEN** `.opencode/unbound/packs/` exists
+- **AND** `.opencode/uf/packs/default.md` exists
+- **AND** `.opencode/uf/packs/severity.md` exists
+- **WHEN** `/uf-init` runs the cleanup step
+- **THEN** `.opencode/unbound/` is removed
+- **AND** the report shows
+  `✅ unbound/packs/: removed (migrated to uf/packs/)`
+
+#### Scenario: Legacy directory absent
+
+- **GIVEN** `.opencode/unbound/packs/` does not exist
+- **WHEN** `/uf-init` runs the cleanup step
+- **THEN** no action is taken
+- **AND** the report shows
+  `⊘ unbound/packs/: not present`
+
+#### Scenario: uf/packs missing core files
+
+- **GIVEN** `.opencode/unbound/packs/` exists
+- **AND** `.opencode/uf/packs/default.md` does NOT exist
+- **WHEN** `/uf-init` runs the cleanup step
+- **THEN** `.opencode/unbound/` is NOT removed
+- **AND** the report shows
+  `❌ unbound/packs/: uf/packs/ missing core files, skipped`
+
+---
+
+## MODIFIED Requirements
+
+### Requirement: Branch Enforcement Idempotency (Step 2)
+
+Previously: The idempotency check searched semantically
+for "any branch management content" (does the file
+describe creating, validating, or cleaning up an
+`opsx/<name>` branch?).
+
+The idempotency check MUST distinguish between three
+branch enforcement variants:
+
+1. **Basic branch check**: Look for `opsx/<name>` or
+   `opsx/<change-name>` as branch references
+2. **Dirty tree check** (propose only): Look for
+   `git status --short` in the context of pre-branch
+   creation. If the basic branch check is present but
+   the dirty tree check is not, insert the dirty tree
+   check only.
+3. **Commit-before-archive** (archive-change only): Look
+   for `git add` and `git commit` appearing before the
+   archive move step. If absent, insert the commit step.
+4. **Branch-switch confirmation** (explore only): Look
+   for `uncommitted changes` in the guardrails section.
+   If absent, insert the guardrail bullet.
+
+Each variant MUST be checked independently. Presence of
+one variant MUST NOT cause other variants to be skipped.
+
+#### Scenario: Basic branch check present, dirty tree missing
+
+- **GIVEN** `openspec-propose/SKILL.md` contains
+  `opsx/<name>` branch references
+- **AND** does NOT contain `git status --short` in a
+  pre-branch context
+- **WHEN** `/uf-init` runs Step 2 for propose
+- **THEN** the dirty tree check is inserted
+- **AND** the basic branch check is NOT re-inserted
+- **AND** the report shows
+  `✅ SKILL.md: dirty tree check inserted`
+  `⊘ SKILL.md: branch check already present`
+
+#### Scenario: Return-to-main present, commit-before-archive missing
+
+- **GIVEN** `openspec-archive-change/SKILL.md` contains
+  `git checkout main`
+- **AND** does NOT contain `git add` and `git commit`
+  before the archive move step
+- **WHEN** `/uf-init` runs Step 2 for archive
+- **THEN** the commit-before-archive step is inserted
+- **AND** the return-to-main content is NOT re-inserted
+
+#### Scenario: Branch-switch confirmation missing in explore
+
+- **GIVEN** `openspec-explore/SKILL.md` has a guardrails
+  section
+- **AND** does NOT contain `uncommitted changes` or
+  `switch branches` in the guardrails
+- **WHEN** `/uf-init` runs Step 2 for explore
+- **THEN** the branch-switch confirmation bullet is
+  appended to the guardrails
+
+#### Scenario: All variants already present
+
+- **GIVEN** all branch enforcement variants are present
+  in their respective files
+- **WHEN** `/uf-init` runs Step 2
+- **THEN** no modifications are made
+- **AND** all variants report skip status
+
+---
+
+### Requirement: Guardrails Injection Variants (Step 6)
+
+Previously: A single Guardrails block was injected into
+all 9 speckit command files identically.
+
+The Guardrails injection MUST use two variants:
+
+**Spec-phase variant** (specify, plan, tasks, analyze,
+checklist, clarify): Includes the standard Guardrails
+block PLUS the review-rationale sentence.
+
+**Execution/utility variant** (implement, constitution,
+taskstoissues): Includes only the standard Guardrails
+block, without the review-rationale sentence.
+
+The idempotency check remains: search for `## Guardrails`
+heading. The review-rationale sentence SHOULD be checked
+separately: if Guardrails exists but the sentence is
+missing on a spec-phase command, append the sentence.
+
+#### Scenario: Guardrails present but review-rationale missing
+
+- **GIVEN** `speckit.tasks.md` has a `## Guardrails`
+  section
+- **AND** does NOT contain "review defeats the purpose"
+- **WHEN** `/uf-init` runs Step 6
+- **THEN** the review-rationale sentence is appended to
+  the existing Guardrails section
+- **AND** the report shows
+  `✅ speckit.tasks.md: review-rationale added`
+
+---
+
+## REMOVED Requirements
+
+None.

--- a/openspec/changes/fix-uf-init-customizations/tasks.md
+++ b/openspec/changes/fix-uf-init-customizations/tasks.md
@@ -1,0 +1,166 @@
+<!--
+  All tasks modify the same file (.opencode/commands/uf-init.md),
+  so no [P] markers — parallel execution would cause merge
+  conflicts. Tasks run sequentially in order.
+-->
+
+## 1. Tighten Branch Enforcement Idempotency (Step 2)
+
+- [x] 1.1 In Step 2 "Branch Enforcement: Propose", split the
+  idempotency check into two independent checks:
+  (a) basic branch check — look for `opsx/<name>` or
+  `opsx/<change-name>` as branch references;
+  (b) dirty tree check — look for `git status --short`
+  in a pre-branch-creation context. If (a) is present but
+  (b) is not, insert only the dirty tree check portion.
+  Update the report to show separate status for each.
+
+- [x] 1.2 In Step 2 "Branch Enforcement: Archive", add an
+  idempotency check for the commit-before-archive flow:
+  look for `git add` and `git commit` appearing before
+  the archive move step. If the basic branch/return-to-main
+  content is present but commit-before-archive is not,
+  insert only the commit step. Add the following insertion
+  content: a step that runs `git status --short`, stages
+  and commits all changes with a descriptive message, and
+  pushes. Mark it CRITICAL: "Do NOT move to archive with
+  uncommitted changes."
+
+- [x] 1.3 In Step 2 "Branch Enforcement: Explore" (currently
+  noted as excluded), add a new sub-section for explore's
+  guardrail-only branch enforcement: check if the explore
+  SKILL.md guardrails section contains "uncommitted changes"
+  or "switch branches". If not, insert a guardrail bullet:
+  "Don't switch branches without confirmation — If
+  exploration leads to creating a proposal (which requires
+  a new `opsx/` branch), check for uncommitted changes
+  first and ask the user before switching."
+
+## 2. Add STOP HERE Block Injection (New Step 10)
+
+- [x] 2.1 Add a new "### Step 10: STOP HERE Blocks" section
+  after Step 9 (Report Results). Define target files as
+  the 6 spec-phase speckit commands: `speckit.specify.md`,
+  `speckit.plan.md`, `speckit.tasks.md`,
+  `speckit.analyze.md`, `speckit.checklist.md`,
+  `speckit.clarify.md`. Explicitly exclude
+  `speckit.implement.md`, `speckit.constitution.md`,
+  `speckit.taskstoissues.md`.
+
+- [x] 2.2 Define the idempotency check: search for "STOP HERE"
+  (case-sensitive). If found, report skip.
+
+- [x] 2.3 Define the insertion content: a bold directive
+  "**STOP HERE. Do NOT proceed to implementation.**"
+  followed by instructions to report results and prompt
+  the user to invoke `/speckit.implement`, `/unleash`,
+  or `/cobalt-crush` for implementation.
+
+- [x] 2.4 Define the insertion point: after the main workflow
+  instructions, before the `## Guardrails` section. If
+  no Guardrails section exists, insert at the end of the
+  file.
+
+## 3. Add Review-Rationale to Guardrails (Modify Step 6)
+
+- [x] 3.1 Modify Step 6 "Speckit Command Guardrails" to define
+  two Guardrails variants. Spec-phase variant (for specify,
+  plan, tasks, analyze, checklist, clarify): includes the
+  standard block PLUS the review-rationale sentence.
+  Execution/utility variant (implement, constitution,
+  taskstoissues): standard block only, no review-rationale.
+
+- [x] 3.2 Add a secondary idempotency check: if `## Guardrails`
+  already exists on a spec-phase command, check whether the
+  review-rationale sentence is present (search for "review
+  defeats the purpose"). If the heading exists but the
+  sentence is missing, append the sentence to the existing
+  Guardrails section. Report:
+  `✅ <filename>: review-rationale added`.
+
+## 4. Add Scaffold Comment Deduplication (New Step 11)
+
+- [x] 4.1 Add a new "### Step 11: Scaffold Comment
+  Deduplication" section. Define the pattern to match:
+  `<!-- scaffolded by uf ... -->` (any version string
+  after "uf").
+
+- [x] 4.2 Define the deduplication logic: if multiple
+  matches are found, keep only the last occurrence, remove
+  all earlier occurrences. Report count of removed
+  duplicates.
+
+- [x] 4.3 Define the target scope: all files that `/uf-init`
+  processes (the 7 OpenSpec files and 9 speckit commands).
+  This step runs after all other insertions to catch any
+  duplicates introduced by earlier steps.
+
+## 5. Add Legacy Directory Cleanup (New Step 12)
+
+- [x] 5.1 Add a new "### Step 12: Legacy Directory Cleanup"
+  section with two sub-tasks:
+
+- [x] 5.2 Sub-task A: `unbound/packs/` removal. Check if
+  `.opencode/unbound/packs/` exists. If yes, verify
+  `.opencode/uf/packs/default.md` and
+  `.opencode/uf/packs/severity.md` exist. If both
+  pre-conditions met, remove `.opencode/unbound/`
+  recursively. Report result.
+
+- [x] 5.3 Sub-task B: `command/` (singular) migration
+  hardening. Add a note to Step 0 that after migration,
+  verify the target files are now findable in `commands/`
+  (plural). If Step 0 ran but speckit commands are still
+  in `command/` (check for `speckit.specify.md` in both
+  directories), report a warning.
+
+## 6. Update Report Template (Step 9)
+
+- [x] 6.1 Add new sections to the Step 9 report template
+  for the three new steps:
+  ```
+  ### STOP HERE Blocks
+    [status] [filename]: [action]
+    ...
+
+  ### Scaffold Comment Deduplication
+    [status] [filename]: [action]
+    ...
+
+  ### Legacy Directory Cleanup
+    [status] [item]: [action]
+    ...
+  ```
+
+- [x] 6.2 Update the Summary line to include the new
+  categories in the count.
+
+## 7. Verification
+
+- [x] 7.1 After all edits to `uf-init.md` are complete,
+  re-read the file and verify: all 12 steps are present
+  (0-8 original + 10-12 new), the report template in
+  Step 9 includes sections for all customization
+  categories, and the file is valid Markdown.
+
+- [x] 7.2 Constitution alignment verification: confirm
+  the change maintains Autonomous Collaboration (all
+  customizations are file-based insertions, no runtime
+  coupling), Composability First (missing-file handling
+  is preserved in all new steps), and Observable Quality
+  (all new steps report status using the existing
+  indicator pattern).
+
+- [x] 7.3 Run `git diff` to review all changes to
+  `uf-init.md` and verify no existing content was
+  accidentally removed or reordered.
+
+- [x] 7.4 Sync the scaffold asset copy: copy the
+  modified `.opencode/commands/uf-init.md` to
+  `internal/scaffold/assets/opencode/commands/uf-init.md`
+  and run `go test -race -count=1 -run
+  TestEmbeddedAssets_MatchSource ./internal/scaffold/`
+  to verify byte-identity.
+
+<!-- spec-review: passed -->
+<!-- code-review: passed -->


### PR DESCRIPTION
## Summary

Fix gaps in the `/uf-init` slash command discovered through cross-repo
comparison between `unbound-force` and `gaze`. The command now reliably
applies all project-specific customizations to downstream repos.

### Changes

- **Step 2 (Branch Enforcement)**: Split the single coarse semantic
  idempotency check into 4 independent variant checks (basic branch,
  dirty tree, commit-before-archive, branch-switch confirmation) so
  partial application is detected and completed
- **Step 6 (Guardrails)**: Split into spec-phase variant (with
  review-rationale sentence) and execution/utility variant
- **Step 10 (new)**: STOP HERE block injection for 6 spec-phase
  speckit commands to prevent premature implementation
- **Step 11 (new)**: Scaffold comment deduplication — removes
  accumulated `<!-- scaffolded by uf ... -->` duplicates
- **Step 12 (new)**: Legacy directory cleanup — removes
  `unbound/packs/` after migration verification, hardens
  `command/` → `commands/` migration

### Spec Review

5 Divisor agents reviewed. 2 HIGH findings fixed:
- `git add -A` replaced with explicit staging (AGENTS.md compliance)
- Scaffold asset sync task added (drift detection)

### Files Changed

| File | Change |
|------|--------|
| `.opencode/commands/uf-init.md` | Core command (+296 lines) |
| `internal/scaffold/assets/.../uf-init.md` | Scaffold copy (byte-identical) |
| `openspec/changes/fix-uf-init-customizations/` | Change artifacts |
| `.uf/dewey/learnings/` | 3 retrospective learnings |