### PR TITLE
refactor: extract shared pre-flight skill for CI detection and local …

### DIFF
--- a/.opencode/commands/review-council.md
+++ b/.opencode/commands/review-council.md
@@ -127,28 +127,34 @@ Review the current codebase for compliance with the Behavioral Constraints in `A
    MUST execute in order. Both phases apply only to
    Code Review Mode -- Spec Review Mode skips them.
 
-   #### Phase 1a -- CI Checks (mandatory, hard gate)
+   #### Phase 1a -- Pre-flight Checks (mandatory, hard gate)
 
-   a. Read all files in `.github/workflows/` to
-      identify the exact commands CI runs. Do not
-      rely on a memorized list -- the workflow files
-      are the source of truth.
+   Load the `pre-flight` skill and run in `hard-gate`
+   mode:
 
-   b. Execute each CI command locally in the order
-      they appear in the workflow (typically:
-      `go build ./...`, `go vet ./...`,
-      `go test -race -count=1 ./...`, plus any
-      coverage ratchet steps).
+   a. Invoke the `skill` tool with name `pre-flight` to
+      load the shared pre-flight check instructions.
 
-   c. **If any command fails**: **STOP immediately.**
-      Report each failure as a CRITICAL finding with
-      the full error output. Do NOT proceed to Phase
-      1b or to step 2 (Divisor agent delegation).
-      The rationale: reviewing code that doesn't
-      compile or pass tests is wasted work.
+   b. Execute the pre-flight skill's phases in order:
+      1. CI Workflow Parsing — discover commands from
+         `.github/workflows/`
+      2. Local Tool Detection — check for config files
+         and verify binary availability
+      3. CI Coverage Matrix — display the matrix (in
+         hard-gate mode, all tools are marked "Run
+         locally = Yes")
+      4. Execution — run all detected and available
+         tools in hard-gate mode
 
-   d. **If all commands pass**: report success and
-      proceed to Phase 1b.
+   c. **If the pre-flight verdict is FAIL**: **STOP
+      immediately.** Report each failure as a CRITICAL
+      finding with the full error output. Do NOT
+      proceed to Phase 1b or to step 2 (Divisor agent
+      delegation). The rationale: reviewing code that
+      doesn't compile or pass tests is wasted work.
+
+   d. **If the pre-flight verdict is PASS**: report
+      success and proceed to Phase 1b.
 
    #### Phase 1b -- Gaze Quality Analysis (conditional)
 

--- a/.opencode/commands/review-pr.md
+++ b/.opencode/commands/review-pr.md
@@ -141,61 +141,36 @@ Record the classification for each failing check. This feeds into Step 8 (AI rev
 
 ### 4. Run Local Deterministic Tools (Pre-flight)
 
-Run the project's own tools as a rapid pre-flight check.
+Load the `pre-flight` skill and run in `ci-aware` mode:
 
-**Detection**: Check which tools are available by looking
-for their configuration files:
+1. Invoke the `skill` tool with name `pre-flight` to
+   load the shared pre-flight check instructions.
 
-```bash
-test -f Makefile && echo "MAKEFILE=yes"
-test -f .golangci.yml && echo "GO_LINT=yes"
-test -f ruff.toml -o -f pyproject.toml && echo "PYTHON_LINT=yes"
-test -f .yamllint.yml && echo "YAML_LINT=yes"
-test -f .pre-commit-config.yaml && echo "PRECOMMIT=yes"
-```
+2. Execute the pre-flight skill's phases in order:
+   a. CI Workflow Parsing — discover commands from
+      `.github/workflows/`
+   b. Local Tool Detection — check for config files
+      and verify binary availability
+   c. CI Coverage Matrix — build the matrix using the
+      CI check results from Step 3. Apply ci-aware
+      decision rules:
+      - CI PASS → skip locally (CI already verified)
+      - CI FAIL → skip locally (failure already
+        captured in Step 3a)
+      - CI NONE → MUST run locally
+      - No CI checks at all → MUST run ALL detected
+        local tools
+   d. Execution — run only tools marked "Yes" in the
+      coverage matrix
 
-**CI coverage check** (mandatory before running any
-tool): Build and display a coverage matrix that maps
-each detected local tool to the CI check from Step 3
-that covers the same verification. Display this matrix
-to make the skip/run decision visible:
+3. **Record results**: Use the pre-flight result format
+   (CI Coverage Matrix, Execution Results, Verdict).
+   If tools pass, skip those categories in the AI
+   review entirely. If tools fail, include the failure
+   output as context for Step 8 (AI review).
 
-| Local tool | CI check that covers it | CI status | Run locally? |
-|------------|------------------------|-----------|--------------|
-| `go test` | e.g., "Local CI / test" | PASS/FAIL/NONE | Yes/No |
-| `golangci-lint` | e.g., "CI Checks / lint" | PASS/FAIL/NONE | Yes/No |
-| ... | ... | ... | ... |
-
-Decision rules:
-- CI status PASS → skip locally ("No" — CI already
-  verified)
-- CI status FAIL → skip locally ("No" — failure already
-  captured in Step 3a, will be analyzed in Step 8d)
-- CI status NONE (no matching check) → MUST run
-  locally ("Yes")
-- No CI checks reported at all → MUST run ALL detected
-  local tools ("Yes" for every row)
-
-**Execution**: Run only the tools marked "Yes" in the
-matrix above:
-
-| Tool detected | Command to run | What it checks |
-|---------------|----------------|----------------|
-| Makefile | `make lint` (or `make check`) | Project-defined lint/format/vet |
-| `.golangci.yml` | `golangci-lint run ./...` | Go lint rules |
-| `ruff.toml` / `pyproject.toml` | `ruff check .` | Python lint rules |
-| `.yamllint.yml` | `yamllint .` | YAML lint rules |
-| `.pre-commit-config.yaml` | `pre-commit run --all-files` | Pre-commit hooks |
-| `go.mod` | `go test ./...` | Go tests |
-| `pyproject.toml` / `setup.py` | `pytest` or `python -m pytest` | Python tests |
-
-**Record results**: Capture tool exit codes and output.
-If tools pass, skip those categories in the AI review
-entirely. If tools fail, include the failure output as
-context.
-
-**If no tools are detected**: Note this and proceed to
-AI-based review for all categories.
+4. **If no tools are detected**: Note this and proceed
+   to AI-based review for all categories.
 
 ### 5. Fetch Diff (Scoped)
 

--- a/.opencode/commands/unleash.md
+++ b/.opencode/commands/unleash.md
@@ -327,12 +327,13 @@ analysis + quality validation) in a single pass.
 Parse `FEATURE_DIR/tasks.md` for phases and execute
 tasks.
 
-**Derive build/test commands**: Read all files in
-`.github/workflows/` to identify the exact CI commands
-(build, test, vet, lint). Do NOT hardcode language-
-specific commands -- the workflow files are the source
-of truth. This is the same pattern used by
-`/review-council` Phase 1a.
+**Derive build/test commands**: Load the `pre-flight`
+skill (invoke the `skill` tool with name `pre-flight`)
+and use its CI Workflow Parsing phase to discover the
+exact CI commands from `.github/workflows/`. Also run
+its Local Tool Detection phase to discover additional
+tools from config files. This is the shared pre-flight
+logic used by `/review-council` and `/review-pr`.
 
 **For each phase in tasks.md**:
 
@@ -448,8 +449,8 @@ of truth. This is the same pattern used by
 
 4. **Phase checkpoint**: after all tasks in the phase
    are complete (both sequential and parallel), run the
-   CI build and test commands derived from
-   `.github/workflows/`.
+   pre-flight skill in `hard-gate` mode to execute all
+   detected CI and local tool commands.
    - If all pass: proceed to the next phase.
    - If any fail: **EXIT** with the failure details:
 
@@ -655,6 +656,6 @@ Format the output as:
 - **NEVER create WorkflowInstance objects** -- `/unleash`
   operates at the Speckit pipeline level, not the hero
   lifecycle workflow level (Specs 008/012/016)
-- **NEVER hardcode build/test commands** -- derive them
-  from `.github/workflows/` (CI files are source of
-  truth)
+- **NEVER hardcode build/test commands** -- load the
+  `pre-flight` skill to derive them from
+  `.github/workflows/` and local tool configs

--- a/.opencode/skills/pre-flight/SKILL.md
+++ b/.opencode/skills/pre-flight/SKILL.md
@@ -1,0 +1,222 @@
+---
+description: "Shared pre-flight skill for CI detection and local tool execution. Supports hard-gate and ci-aware execution policies."
+---
+<!-- scaffolded by uf vdev -->
+# Skill: Pre-flight Checks
+
+Shared logic for CI workflow detection, local tool
+detection, CI coverage matrix generation, and local tool
+execution. Consuming commands load this skill and select
+an execution policy.
+
+## Execution Policies
+
+| Mode | Behavior | Typical consumer |
+|------|----------|-----------------|
+| `hard-gate` | Run all detected tools. Stop on first failure. | `/review-council`, `/unleash` |
+| `ci-aware` | Build CI coverage matrix against PR check results. Skip tools CI already verified. Run the rest. | `/review-pr` |
+
+The consuming command specifies which mode to use.
+
+---
+
+## Phase 1: CI Workflow Parsing
+
+Read all files in `.github/workflows/` to identify the
+exact commands CI runs. Do NOT hardcode language-specific
+commands — the workflow files are the source of truth.
+
+### Extraction rules
+
+- Extract only `run:` step commands from workflow YAML.
+- **Ignore** `uses:` steps — these are GitHub-hosted
+  actions and are not locally executable.
+- **Skip** commands containing unresolvable CI expressions
+  (`${{ secrets.* }}`, `${{ github.* }}`) with a warning
+  noting unresolvable CI expressions. These commands
+  depend on CI runtime context and cannot run locally.
+- Multi-line `run:` blocks: extract each command line
+  individually. Skip lines that are pure shell control
+  flow (if/then/fi, variable assignments used only
+  within the block).
+
+### Output
+
+A list of CI commands discovered from workflows, e.g.:
+
+```
+CI commands discovered from .github/workflows/:
+  - go build ./...        (ci_local.yml)
+  - go test -race -count=1 -coverprofile=coverage.out ./...  (ci_local.yml)
+```
+
+If no `.github/workflows/` directory exists, report
+"No CI workflows found" and proceed to Phase 2.
+
+---
+
+## Phase 2: Local Tool Detection
+
+Check which tools are available by looking for their
+configuration files:
+
+```bash
+test -f Makefile && echo "MAKEFILE=yes"
+test -f .golangci.yml && echo "GO_LINT=yes"
+test -f ruff.toml -o -f pyproject.toml && echo "PYTHON_LINT=yes"
+test -f .yamllint.yml && echo "YAML_LINT=yes"
+test -f .pre-commit-config.yaml && echo "PRECOMMIT=yes"
+test -f go.mod && echo "GO_TEST=yes"
+test -f setup.py && echo "PYTHON_TEST=yes"
+```
+
+When `pyproject.toml` is present, detect both ruff and
+pytest as separate tools.
+
+### Tool-to-command mapping
+
+| Config file | Tool | Command | What it checks |
+|-------------|------|---------|----------------|
+| `Makefile` | Make | `make check` (preferred), else `make lint` | Project-defined lint/format/vet |
+| `.golangci.yml` | golangci-lint | `golangci-lint run ./...` | Go lint rules |
+| `ruff.toml` or `pyproject.toml` | ruff | `ruff check .` | Python lint rules |
+| `.yamllint.yml` | yamllint | `yamllint .` | YAML lint rules |
+| `.pre-commit-config.yaml` | pre-commit | `pre-commit run --all-files` | Pre-commit hooks |
+| `go.mod` | go test | `go test ./...` | Go tests |
+| `pyproject.toml` or `setup.py` | pytest | `pytest` or `python -m pytest` | Python tests |
+
+### Binary availability check
+
+For each detected tool, verify the binary is available:
+
+```bash
+which <binary-name>
+```
+
+If a config file is present but the tool binary is NOT
+in PATH, report the tool as "detected but not available"
+and skip it with a warning. Do NOT treat a missing binary
+as a hard failure.
+
+### Output
+
+A list of detected tools with availability status, e.g.:
+
+```
+Local tools detected:
+  - Make (Makefile) ✓ available
+  - golangci-lint (.golangci.yml) ✓ available
+  - yamllint (.yamllint.yml) ✗ not available (skipped)
+```
+
+If no tools are detected, report "No local tools detected"
+and proceed to Phase 3.
+
+---
+
+## Phase 3: CI Coverage Matrix
+
+Build and display a coverage matrix that maps each
+detected local tool to the CI check that covers the same
+verification. This matrix makes the skip/run decision
+visible and auditable.
+
+### Matrix construction
+
+For each detected and available tool, determine which CI
+check (if any) covers the same verification. Map tool
+names to CI check names by matching on the tool's purpose
+(e.g., `go test` maps to a CI check containing "test",
+`golangci-lint` maps to a check containing "lint").
+
+### Decision rules (ci-aware mode)
+
+| CI status | Run locally? | Rationale |
+|-----------|-------------|-----------|
+| PASS | No | CI already verified |
+| FAIL | No | Failure already captured from CI; will be included in AI review context |
+| NONE (no matching check) | Yes | No CI coverage for this tool |
+| No CI checks at all | Yes (all tools) | Cannot determine CI coverage |
+
+### Decision rules (hard-gate mode)
+
+In hard-gate mode, ALL detected and available tools are
+marked "Run locally = Yes" regardless of CI status. The
+CI status column in the matrix shows the actual status if
+available, or "N/A" if CI results were not provided. The
+coverage matrix is still displayed for visibility, but
+skip decisions are not applied.
+
+### Display format
+
+```
+### CI Coverage Matrix
+| Local tool | CI check | CI status | Run locally? |
+|------------|----------|-----------|--------------|
+| go test | Local CI / test | PASS | No |
+| golangci-lint | CI Checks / lint | PASS | No |
+| yamllint | (none) | NONE | Yes |
+```
+
+---
+
+## Phase 4: Execution
+
+Run only the tools marked "Run locally = Yes" in the
+coverage matrix.
+
+### hard-gate mode
+
+Execute each tool in order. If any tool exits with a
+non-zero exit code:
+
+1. **STOP immediately** — do not run remaining tools.
+2. Report the failure as a CRITICAL finding with the
+   full error output.
+3. The consuming command MUST NOT proceed to AI review
+   or implementation.
+
+If all tools pass, report success.
+
+### ci-aware mode
+
+Execute each tool marked "Yes" in the coverage matrix.
+Record all exit codes and output.
+
+- If tools pass: skip those categories in AI review.
+- If tools fail: include the failure output as context
+  for AI review. Do NOT stop — the consuming command
+  decides how to handle failures.
+
+If no tools are marked "Yes" (all covered by CI): report
+"All tools covered by CI — no local execution needed."
+
+---
+
+## Phase 5: Result Format
+
+Present results in a standardized format:
+
+```
+## Pre-flight Results
+
+### CI Coverage Matrix
+| Local tool | CI check | CI status | Run locally? |
+|------------|----------|-----------|--------------|
+| ...        | ...      | ...       | ...          |
+
+### Execution Results
+| Tool | Command | Exit code | Status |
+|------|---------|-----------|--------|
+| ...  | ...     | ...       | ...    |
+
+### Verdict
+- **Mode**: hard-gate | ci-aware
+- **Result**: PASS | FAIL
+- **Failures**: [list if any]
+```
+
+The consuming command uses this result to decide whether
+to proceed (hard-gate: stop on FAIL) or to include
+failure context in AI review (ci-aware: continue with
+context).

--- a/.uf/dewey/learnings/dewey-20260623T123108-yvonne-devlin.md
+++ b/.uf/dewey/learnings/dewey-20260623T123108-yvonne-devlin.md
@@ -1,0 +1,10 @@
+---
+tag: dewey
+author: yvonne-devlin
+category: gotcha
+created_at: 2026-06-23T12:31:08Z
+identity: dewey-20260623T123108-yvonne-devlin
+tier: draft
+---
+
+The Dewey MCP server configuration in opencode.json was set to "type": "local" which spawns a new dewey serve process on each OpenCode session. In a devcontainer environment where startup.sh already starts dewey serve --http :3333 (which acquires an exclusive SQLite lock on graph.db), the OpenCode-spawned instances cannot access the persistent store and fall back to in-memory mode (persistent: false, 0 pages). The fix is to change opencode.json to "type": "remote" with url "http://localhost:3333/mcp/" to connect to the already-running HTTP server. However, since opencode.json is committed to the repo and affects all contributors, the fix should be applied locally with `git update-index --assume-unchanged` to avoid impacting the remote repo.

--- a/.uf/dewey/learnings/pre-flight-skill-20260623T123057-yvonne-devlin.md
+++ b/.uf/dewey/learnings/pre-flight-skill-20260623T123057-yvonne-devlin.md
@@ -1,0 +1,10 @@
+---
+tag: pre-flight-skill
+author: yvonne-devlin
+category: gotcha
+created_at: 2026-06-23T12:30:57Z
+identity: pre-flight-skill-20260623T123057-yvonne-devlin
+tier: draft
+---
+
+When extracting shared logic from multiple command files into a skill, the scaffold sync requirement extends beyond the consuming commands to the new skill file itself. If a skill is intended to be distributed via `uf init` (like speckit-workflow), it needs a scaffold asset copy at `internal/scaffold/assets/opencode/skills/<name>/SKILL.md` AND an entry in the `expectedAssetPaths` list in `scaffold_test.go`. All 5 Divisor reviewers independently flagged this gap during spec review — the spec originally only included scaffold sync for the three modified command files but missed the new skill file. The drift detection test `TestEmbeddedAssets_MatchSource` catches this at build time, but specifying it upfront in the tasks prevents rework.

--- a/.uf/dewey/learnings/pre-flight-skill-20260623T123105-yvonne-devlin.md
+++ b/.uf/dewey/learnings/pre-flight-skill-20260623T123105-yvonne-devlin.md
@@ -1,0 +1,10 @@
+---
+tag: pre-flight-skill
+author: yvonne-devlin
+category: pattern
+created_at: 2026-06-23T12:31:05Z
+identity: pre-flight-skill-20260623T123105-yvonne-devlin
+tier: draft
+---
+
+When consolidating duplicated logic from multiple commands into a shared skill, be explicit about whether the unified approach is "strict behavioral parity" or "intentional behavioral expansion." In the pre-flight skill extraction, combining workflow-driven detection (from review-council) with config-file detection (from review-pr) means each consumer gains the other's detection capabilities — review-council may discover tools like yamllint it previously missed, and review-pr may discover CI-only commands like coverage ratchets. The spec review caught that the original spec simultaneously claimed "no behavioral regression" while the design acknowledged this expansion. The fix was to explicitly state that expanded detection is an intentional improvement, not strict parity, and to update acceptance scenarios accordingly. This prevents implementers and future reviewers from treating newly-discovered tools as regressions.

--- a/cmd/unbound-force/main_test.go
+++ b/cmd/unbound-force/main_test.go
@@ -30,11 +30,11 @@ func TestRunInit_FreshDir(t *testing.T) {
 	}
 
 	// Verify the summary includes a non-trivial file count
-	// 39 = 38 prior + 1 triage-issue command.
+	// 40 = 39 prior + 1 pre-flight skill.
 	// (devcontainer excluded — OS-specific, generated
 	// per-user by uf sandbox init).
-	if !strings.Contains(output, "39 files processed") {
-		t.Errorf("expected '39 files processed' in output, got:\n%s", output)
+	if !strings.Contains(output, "40 files processed") {
+		t.Errorf("expected '40 files processed' in output, got:\n%s", output)
 	}
 
 	// Verify a user-owned file was created

--- a/internal/scaffold/assets/opencode/commands/review-council.md
+++ b/internal/scaffold/assets/opencode/commands/review-council.md
@@ -127,28 +127,34 @@ Review the current codebase for compliance with the Behavioral Constraints in `A
    MUST execute in order. Both phases apply only to
    Code Review Mode -- Spec Review Mode skips them.
 
-   #### Phase 1a -- CI Checks (mandatory, hard gate)
+   #### Phase 1a -- Pre-flight Checks (mandatory, hard gate)
 
-   a. Read all files in `.github/workflows/` to
-      identify the exact commands CI runs. Do not
-      rely on a memorized list -- the workflow files
-      are the source of truth.
+   Load the `pre-flight` skill and run in `hard-gate`
+   mode:
 
-   b. Execute each CI command locally in the order
-      they appear in the workflow (typically:
-      `go build ./...`, `go vet ./...`,
-      `go test -race -count=1 ./...`, plus any
-      coverage ratchet steps).
+   a. Invoke the `skill` tool with name `pre-flight` to
+      load the shared pre-flight check instructions.
 
-   c. **If any command fails**: **STOP immediately.**
-      Report each failure as a CRITICAL finding with
-      the full error output. Do NOT proceed to Phase
-      1b or to step 2 (Divisor agent delegation).
-      The rationale: reviewing code that doesn't
-      compile or pass tests is wasted work.
+   b. Execute the pre-flight skill's phases in order:
+      1. CI Workflow Parsing — discover commands from
+         `.github/workflows/`
+      2. Local Tool Detection — check for config files
+         and verify binary availability
+      3. CI Coverage Matrix — display the matrix (in
+         hard-gate mode, all tools are marked "Run
+         locally = Yes")
+      4. Execution — run all detected and available
+         tools in hard-gate mode
 
-   d. **If all commands pass**: report success and
-      proceed to Phase 1b.
+   c. **If the pre-flight verdict is FAIL**: **STOP
+      immediately.** Report each failure as a CRITICAL
+      finding with the full error output. Do NOT
+      proceed to Phase 1b or to step 2 (Divisor agent
+      delegation). The rationale: reviewing code that
+      doesn't compile or pass tests is wasted work.
+
+   d. **If the pre-flight verdict is PASS**: report
+      success and proceed to Phase 1b.
 
    #### Phase 1b -- Gaze Quality Analysis (conditional)
 

--- a/internal/scaffold/assets/opencode/commands/review-pr.md
+++ b/internal/scaffold/assets/opencode/commands/review-pr.md
@@ -141,61 +141,36 @@ Record the classification for each failing check. This feeds into Step 8 (AI rev
 
 ### 4. Run Local Deterministic Tools (Pre-flight)
 
-Run the project's own tools as a rapid pre-flight check.
+Load the `pre-flight` skill and run in `ci-aware` mode:
 
-**Detection**: Check which tools are available by looking
-for their configuration files:
+1. Invoke the `skill` tool with name `pre-flight` to
+   load the shared pre-flight check instructions.
 
-```bash
-test -f Makefile && echo "MAKEFILE=yes"
-test -f .golangci.yml && echo "GO_LINT=yes"
-test -f ruff.toml -o -f pyproject.toml && echo "PYTHON_LINT=yes"
-test -f .yamllint.yml && echo "YAML_LINT=yes"
-test -f .pre-commit-config.yaml && echo "PRECOMMIT=yes"
-```
+2. Execute the pre-flight skill's phases in order:
+   a. CI Workflow Parsing — discover commands from
+      `.github/workflows/`
+   b. Local Tool Detection — check for config files
+      and verify binary availability
+   c. CI Coverage Matrix — build the matrix using the
+      CI check results from Step 3. Apply ci-aware
+      decision rules:
+      - CI PASS → skip locally (CI already verified)
+      - CI FAIL → skip locally (failure already
+        captured in Step 3a)
+      - CI NONE → MUST run locally
+      - No CI checks at all → MUST run ALL detected
+        local tools
+   d. Execution — run only tools marked "Yes" in the
+      coverage matrix
 
-**CI coverage check** (mandatory before running any
-tool): Build and display a coverage matrix that maps
-each detected local tool to the CI check from Step 3
-that covers the same verification. Display this matrix
-to make the skip/run decision visible:
+3. **Record results**: Use the pre-flight result format
+   (CI Coverage Matrix, Execution Results, Verdict).
+   If tools pass, skip those categories in the AI
+   review entirely. If tools fail, include the failure
+   output as context for Step 8 (AI review).
 
-| Local tool | CI check that covers it | CI status | Run locally? |
-|------------|------------------------|-----------|--------------|
-| `go test` | e.g., "Local CI / test" | PASS/FAIL/NONE | Yes/No |
-| `golangci-lint` | e.g., "CI Checks / lint" | PASS/FAIL/NONE | Yes/No |
-| ... | ... | ... | ... |
-
-Decision rules:
-- CI status PASS → skip locally ("No" — CI already
-  verified)
-- CI status FAIL → skip locally ("No" — failure already
-  captured in Step 3a, will be analyzed in Step 8d)
-- CI status NONE (no matching check) → MUST run
-  locally ("Yes")
-- No CI checks reported at all → MUST run ALL detected
-  local tools ("Yes" for every row)
-
-**Execution**: Run only the tools marked "Yes" in the
-matrix above:
-
-| Tool detected | Command to run | What it checks |
-|---------------|----------------|----------------|
-| Makefile | `make lint` (or `make check`) | Project-defined lint/format/vet |
-| `.golangci.yml` | `golangci-lint run ./...` | Go lint rules |
-| `ruff.toml` / `pyproject.toml` | `ruff check .` | Python lint rules |
-| `.yamllint.yml` | `yamllint .` | YAML lint rules |
-| `.pre-commit-config.yaml` | `pre-commit run --all-files` | Pre-commit hooks |
-| `go.mod` | `go test ./...` | Go tests |
-| `pyproject.toml` / `setup.py` | `pytest` or `python -m pytest` | Python tests |
-
-**Record results**: Capture tool exit codes and output.
-If tools pass, skip those categories in the AI review
-entirely. If tools fail, include the failure output as
-context.
-
-**If no tools are detected**: Note this and proceed to
-AI-based review for all categories.
+4. **If no tools are detected**: Note this and proceed
+   to AI-based review for all categories.
 
 ### 5. Fetch Diff (Scoped)
 

--- a/internal/scaffold/assets/opencode/commands/unleash.md
+++ b/internal/scaffold/assets/opencode/commands/unleash.md
@@ -327,12 +327,13 @@ analysis + quality validation) in a single pass.
 Parse `FEATURE_DIR/tasks.md` for phases and execute
 tasks.
 
-**Derive build/test commands**: Read all files in
-`.github/workflows/` to identify the exact CI commands
-(build, test, vet, lint). Do NOT hardcode language-
-specific commands -- the workflow files are the source
-of truth. This is the same pattern used by
-`/review-council` Phase 1a.
+**Derive build/test commands**: Load the `pre-flight`
+skill (invoke the `skill` tool with name `pre-flight`)
+and use its CI Workflow Parsing phase to discover the
+exact CI commands from `.github/workflows/`. Also run
+its Local Tool Detection phase to discover additional
+tools from config files. This is the shared pre-flight
+logic used by `/review-council` and `/review-pr`.
 
 **For each phase in tasks.md**:
 
@@ -448,8 +449,8 @@ of truth. This is the same pattern used by
 
 4. **Phase checkpoint**: after all tasks in the phase
    are complete (both sequential and parallel), run the
-   CI build and test commands derived from
-   `.github/workflows/`.
+   pre-flight skill in `hard-gate` mode to execute all
+   detected CI and local tool commands.
    - If all pass: proceed to the next phase.
    - If any fail: **EXIT** with the failure details:
 
@@ -655,6 +656,6 @@ Format the output as:
 - **NEVER create WorkflowInstance objects** -- `/unleash`
   operates at the Speckit pipeline level, not the hero
   lifecycle workflow level (Specs 008/012/016)
-- **NEVER hardcode build/test commands** -- derive them
-  from `.github/workflows/` (CI files are source of
-  truth)
+- **NEVER hardcode build/test commands** -- load the
+  `pre-flight` skill to derive them from
+  `.github/workflows/` and local tool configs

--- a/internal/scaffold/assets/opencode/skills/pre-flight/SKILL.md
+++ b/internal/scaffold/assets/opencode/skills/pre-flight/SKILL.md
@@ -1,0 +1,222 @@
+---
+description: "Shared pre-flight skill for CI detection and local tool execution. Supports hard-gate and ci-aware execution policies."
+---
+<!-- scaffolded by uf vdev -->
+# Skill: Pre-flight Checks
+
+Shared logic for CI workflow detection, local tool
+detection, CI coverage matrix generation, and local tool
+execution. Consuming commands load this skill and select
+an execution policy.
+
+## Execution Policies
+
+| Mode | Behavior | Typical consumer |
+|------|----------|-----------------|
+| `hard-gate` | Run all detected tools. Stop on first failure. | `/review-council`, `/unleash` |
+| `ci-aware` | Build CI coverage matrix against PR check results. Skip tools CI already verified. Run the rest. | `/review-pr` |
+
+The consuming command specifies which mode to use.
+
+---
+
+## Phase 1: CI Workflow Parsing
+
+Read all files in `.github/workflows/` to identify the
+exact commands CI runs. Do NOT hardcode language-specific
+commands — the workflow files are the source of truth.
+
+### Extraction rules
+
+- Extract only `run:` step commands from workflow YAML.
+- **Ignore** `uses:` steps — these are GitHub-hosted
+  actions and are not locally executable.
+- **Skip** commands containing unresolvable CI expressions
+  (`${{ secrets.* }}`, `${{ github.* }}`) with a warning
+  noting unresolvable CI expressions. These commands
+  depend on CI runtime context and cannot run locally.
+- Multi-line `run:` blocks: extract each command line
+  individually. Skip lines that are pure shell control
+  flow (if/then/fi, variable assignments used only
+  within the block).
+
+### Output
+
+A list of CI commands discovered from workflows, e.g.:
+
+```
+CI commands discovered from .github/workflows/:
+  - go build ./...        (ci_local.yml)
+  - go test -race -count=1 -coverprofile=coverage.out ./...  (ci_local.yml)
+```
+
+If no `.github/workflows/` directory exists, report
+"No CI workflows found" and proceed to Phase 2.
+
+---
+
+## Phase 2: Local Tool Detection
+
+Check which tools are available by looking for their
+configuration files:
+
+```bash
+test -f Makefile && echo "MAKEFILE=yes"
+test -f .golangci.yml && echo "GO_LINT=yes"
+test -f ruff.toml -o -f pyproject.toml && echo "PYTHON_LINT=yes"
+test -f .yamllint.yml && echo "YAML_LINT=yes"
+test -f .pre-commit-config.yaml && echo "PRECOMMIT=yes"
+test -f go.mod && echo "GO_TEST=yes"
+test -f setup.py && echo "PYTHON_TEST=yes"
+```
+
+When `pyproject.toml` is present, detect both ruff and
+pytest as separate tools.
+
+### Tool-to-command mapping
+
+| Config file | Tool | Command | What it checks |
+|-------------|------|---------|----------------|
+| `Makefile` | Make | `make check` (preferred), else `make lint` | Project-defined lint/format/vet |
+| `.golangci.yml` | golangci-lint | `golangci-lint run ./...` | Go lint rules |
+| `ruff.toml` or `pyproject.toml` | ruff | `ruff check .` | Python lint rules |
+| `.yamllint.yml` | yamllint | `yamllint .` | YAML lint rules |
+| `.pre-commit-config.yaml` | pre-commit | `pre-commit run --all-files` | Pre-commit hooks |
+| `go.mod` | go test | `go test ./...` | Go tests |
+| `pyproject.toml` or `setup.py` | pytest | `pytest` or `python -m pytest` | Python tests |
+
+### Binary availability check
+
+For each detected tool, verify the binary is available:
+
+```bash
+which <binary-name>
+```
+
+If a config file is present but the tool binary is NOT
+in PATH, report the tool as "detected but not available"
+and skip it with a warning. Do NOT treat a missing binary
+as a hard failure.
+
+### Output
+
+A list of detected tools with availability status, e.g.:
+
+```
+Local tools detected:
+  - Make (Makefile) ✓ available
+  - golangci-lint (.golangci.yml) ✓ available
+  - yamllint (.yamllint.yml) ✗ not available (skipped)
+```
+
+If no tools are detected, report "No local tools detected"
+and proceed to Phase 3.
+
+---
+
+## Phase 3: CI Coverage Matrix
+
+Build and display a coverage matrix that maps each
+detected local tool to the CI check that covers the same
+verification. This matrix makes the skip/run decision
+visible and auditable.
+
+### Matrix construction
+
+For each detected and available tool, determine which CI
+check (if any) covers the same verification. Map tool
+names to CI check names by matching on the tool's purpose
+(e.g., `go test` maps to a CI check containing "test",
+`golangci-lint` maps to a check containing "lint").
+
+### Decision rules (ci-aware mode)
+
+| CI status | Run locally? | Rationale |
+|-----------|-------------|-----------|
+| PASS | No | CI already verified |
+| FAIL | No | Failure already captured from CI; will be included in AI review context |
+| NONE (no matching check) | Yes | No CI coverage for this tool |
+| No CI checks at all | Yes (all tools) | Cannot determine CI coverage |
+
+### Decision rules (hard-gate mode)
+
+In hard-gate mode, ALL detected and available tools are
+marked "Run locally = Yes" regardless of CI status. The
+CI status column in the matrix shows the actual status if
+available, or "N/A" if CI results were not provided. The
+coverage matrix is still displayed for visibility, but
+skip decisions are not applied.
+
+### Display format
+
+```
+### CI Coverage Matrix
+| Local tool | CI check | CI status | Run locally? |
+|------------|----------|-----------|--------------|
+| go test | Local CI / test | PASS | No |
+| golangci-lint | CI Checks / lint | PASS | No |
+| yamllint | (none) | NONE | Yes |
+```
+
+---
+
+## Phase 4: Execution
+
+Run only the tools marked "Run locally = Yes" in the
+coverage matrix.
+
+### hard-gate mode
+
+Execute each tool in order. If any tool exits with a
+non-zero exit code:
+
+1. **STOP immediately** — do not run remaining tools.
+2. Report the failure as a CRITICAL finding with the
+   full error output.
+3. The consuming command MUST NOT proceed to AI review
+   or implementation.
+
+If all tools pass, report success.
+
+### ci-aware mode
+
+Execute each tool marked "Yes" in the coverage matrix.
+Record all exit codes and output.
+
+- If tools pass: skip those categories in AI review.
+- If tools fail: include the failure output as context
+  for AI review. Do NOT stop — the consuming command
+  decides how to handle failures.
+
+If no tools are marked "Yes" (all covered by CI): report
+"All tools covered by CI — no local execution needed."
+
+---
+
+## Phase 5: Result Format
+
+Present results in a standardized format:
+
+```
+## Pre-flight Results
+
+### CI Coverage Matrix
+| Local tool | CI check | CI status | Run locally? |
+|------------|----------|-----------|--------------|
+| ...        | ...      | ...       | ...          |
+
+### Execution Results
+| Tool | Command | Exit code | Status |
+|------|---------|-----------|--------|
+| ...  | ...     | ...       | ...    |
+
+### Verdict
+- **Mode**: hard-gate | ci-aware
+- **Result**: PASS | FAIL
+- **Failures**: [list if any]
+```
+
+The consuming command uses this result to decide whether
+to proceed (hard-gate: stop on FAIL) or to include
+failure context in AI review (ci-aware: continue with
+context).

--- a/internal/scaffold/scaffold_test.go
+++ b/internal/scaffold/scaffold_test.go
@@ -175,7 +175,8 @@ var expectedAssetPaths = []string{
 	"openspec/schemas/unbound-force/templates/spec.md",
 	"openspec/schemas/unbound-force/templates/design.md",
 	"openspec/schemas/unbound-force/templates/tasks.md",
-	// Swarm skills (1)
+	// Swarm skills (2)
+	"opencode/skills/pre-flight/SKILL.md",
 	"opencode/skills/speckit-workflow/SKILL.md",
 }
 

--- a/openspec/changes/pre-flight-skill/.openspec.yaml
+++ b/openspec/changes/pre-flight-skill/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: unbound-force
+created: 2026-06-23

--- a/openspec/changes/pre-flight-skill/design.md
+++ b/openspec/changes/pre-flight-skill/design.md
@@ -1,0 +1,228 @@
+## Context
+
+Three commands (`/review-council`, `/review-pr`, `/unleash`) each
+independently implement CI workflow detection and local tool
+execution logic. The duplication manifests as two distinct
+approaches:
+
+1. **Workflow-driven** (`/review-council` Phase 1a, `/unleash`
+   Step 5): Parse `.github/workflows/*.yml` to discover the exact
+   commands CI runs, then replay them locally.
+2. **Config-file-driven** (`/review-pr` Step 4): Detect tools by
+   checking for configuration files (`Makefile`, `.golangci.yml`,
+   `ruff.toml`, etc.), then build a CI coverage matrix against
+   GitHub PR check results to decide what to skip.
+
+Both approaches share the same goal — run local quality checks
+before proceeding — but neither command benefits from the other's
+strengths.
+
+See proposal.md for motivation and constitution alignment.
+
+## Goals / Non-Goals
+
+### Goals
+- Single source of truth for CI detection and local tool execution
+- Both execution policies (`hard-gate`, `ci-aware`) available to
+  all consumers
+- CI coverage matrix output available in both modes
+- No behavioral regression for previously-detected tools; expanded
+  detection for tools missed by single-strategy approaches is an
+  intentional improvement
+- Scaffold copies stay in sync with command and skill sources
+
+### Non-Goals
+- Executable code (Go package, script) — this is an agent
+  instruction skill only
+- `detect-only` mode for `/agent-brief` — tracked as follow-up
+  per issue #175
+- Gaze integration — `/review-council` Phase 1b (Gaze quality
+  analysis) remains in the command; it is not CI detection logic
+- Changing which tools are detected or which commands are run —
+  the skill consolidates existing behavior, not new behavior
+
+## Decisions
+
+### D1: Skill file, not Go code
+
+The pre-flight logic lives entirely in agent instruction files
+(markdown). There is no compiled code to extract. The skill will
+be a `.opencode/skills/pre-flight/SKILL.md` file that consuming
+commands reference via the `skill` tool.
+
+**Rationale**: Matches the existing pattern — all current skills
+are SKILL.md instruction files. No new tooling or runtime
+infrastructure needed. Aligns with Composability First: any
+command can load the skill independently.
+
+### D2: Unify both detection approaches
+
+The skill will use **both** detection strategies in sequence:
+
+1. **Workflow parsing** (primary): Read `.github/workflows/*.yml`
+   to discover CI commands. This is the source of truth for what
+   CI actually runs.
+2. **Config-file detection** (supplementary): Check for tool
+   configuration files to discover tools that may not appear in
+   CI workflows (e.g., a `.yamllint.yml` with no CI job).
+
+This unified approach gives every consumer the most complete
+picture. Currently `/review-council` only does (1) and
+`/review-pr` only does (2).
+
+**Rationale**: Neither approach alone is sufficient. Workflow
+parsing misses tools not in CI. Config-file detection misses
+CI-only checks (e.g., coverage ratchets). Combining them
+produces a superset.
+
+### D3: Two execution policies via mode parameter
+
+The skill defines two modes that consuming commands select:
+
+| Mode | Behavior | Current consumer |
+|------|----------|-----------------|
+| `hard-gate` | Run all detected tools. Stop on first failure. | `/review-council`, `/unleash` |
+| `ci-aware` | Build CI coverage matrix against PR check results. Skip tools CI already verified. Run the rest. | `/review-pr` |
+
+The mode is selected by the consuming command's instructions,
+not by the skill itself. The skill describes both policies; the
+command tells the agent which to use.
+
+**Rationale**: The two modes serve different lifecycle stages
+(pre-PR vs. post-PR). Forcing a single mode would break
+existing behavior. Making the mode a parameter preserves
+behavioral parity.
+
+### D4: Standardized result format
+
+The skill defines a standard output structure for pre-flight
+results:
+
+```
+## Pre-flight Results
+
+### CI Coverage Matrix
+| Local tool | CI check | CI status | Run locally? |
+|------------|----------|-----------|--------------|
+| ...        | ...      | ...       | ...          |
+
+### Execution Results
+| Tool | Command | Exit code | Status |
+|------|---------|-----------|--------|
+| ...  | ...     | ...       | ...    |
+
+### Verdict
+- **Mode**: hard-gate | ci-aware
+- **Result**: PASS | FAIL
+- **Failures**: [list if any]
+```
+
+This format is consumed by the calling command to decide whether
+to proceed (hard-gate) or to include failure context in AI review
+(ci-aware).
+
+**Rationale**: Aligns with Observable Quality — standardized,
+structured output that any consumer can parse and act on
+consistently.
+
+### D5: Consuming commands reference skill, keep policy selection
+
+Each consuming command replaces its inline pre-flight logic with:
+
+1. A reference to load the `pre-flight` skill
+2. The mode selection (`hard-gate` or `ci-aware`)
+3. Command-specific behavior on the result (stop vs. continue
+   with context)
+
+The skill does NOT replace command-specific logic that happens
+after pre-flight (e.g., `/review-council` Phase 1b Gaze analysis,
+`/review-pr` Step 5 diff fetching).
+
+### D6: Scaffold sync as explicit task
+
+Both `.opencode/commands/` and
+`internal/scaffold/assets/opencode/commands/` contain identical
+copies of each command file. Changes to command files MUST be
+mirrored to the scaffold copies. This is enforced by existing
+drift detection tests.
+
+### D7: Pre-flight skill is scaffold-deployed
+
+The pre-flight skill is distributed via `uf init` (like
+`speckit-workflow`), not local-only (like the Replicator
+skills). This means:
+
+1. A scaffold asset copy MUST exist at
+   `internal/scaffold/assets/opencode/skills/pre-flight/SKILL.md`
+2. The path MUST be added to `expectedAssetPaths` in
+   `scaffold_test.go`
+3. Drift detection tests enforce sync between the live
+   skill and the scaffold copy
+
+**Rationale**: The pre-flight skill is useful in any project
+that uses the review commands — it should be scaffolded into
+new projects alongside the commands that consume it.
+
+### D8: Workflow command extraction boundaries
+
+When parsing `.github/workflows/*.yml`, the skill extracts
+only `run:` step commands. It does NOT execute:
+
+- Action references (`uses:` steps) — these are GitHub-hosted
+  and not locally executable
+- Commands containing unresolvable CI expressions
+  (`${{ secrets.* }}`, `${{ github.* }}`) — these depend on
+  CI runtime context
+- Commands that reference CI-only tools not available locally
+  — these are reported as "not locally available" rather than
+  treated as failures
+
+When a config file is detected but the corresponding tool
+binary is not in PATH, the tool is reported as "detected but
+not available" and skipped with a warning rather than treated
+as a hard failure. This preserves the existing behavior where
+developers may not have all tools installed locally.
+
+## Risks / Trade-offs
+
+### R1: Skill loading adds indirection
+
+Commands that previously had self-contained pre-flight logic now
+depend on loading a skill. If the skill file is missing or
+malformed, the command will fail differently than before.
+
+**Mitigation**: The skill is checked into the repository and
+synced via scaffold. Drift detection tests catch missing or
+out-of-sync files.
+
+### R2: Unified detection may change behavior
+
+Combining workflow parsing + config-file detection means
+`/review-council` may discover tools it previously missed (e.g.,
+yamllint), and `/review-pr` may discover CI commands it previously
+missed (e.g., coverage ratchets).
+
+**Mitigation**: This is a net positive — more complete detection
+is better. However, the behavioral change should be noted in
+testing. Consumers should verify that newly-discovered tools
+do not cause unexpected failures.
+
+### R3: Instruction-only skill cannot be unit tested
+
+The skill is markdown instructions, not executable code. There
+are no functions to test in isolation.
+
+**Mitigation**: Verification is behavioral — run each consuming
+command against a real branch before and after the change,
+confirm identical outcomes for existing tools and improved
+detection for previously-missed tools.
+
+### R4: Single point of failure
+
+A defect in the skill affects all three consumers
+simultaneously. Previously, a bug in one command's pre-flight
+logic only affected that command.
+
+**Mitigation**: Git revert restores the previous inline logic.
+The skill is instruction-only, so no binary rebuild is needed.
+The risk is acceptable given the consolidation benefit.

--- a/openspec/changes/pre-flight-skill/proposal.md
+++ b/openspec/changes/pre-flight-skill/proposal.md
@@ -1,0 +1,119 @@
+## Why
+
+Three commands (`/review-council`, `/review-pr`, `/unleash`) each
+independently implement logic for detecting CI workflows, discovering
+local tools, and executing quality checks before AI review or
+implementation proceeds. This duplication means:
+
+- Changes to CI detection logic must be replicated in 3+ places
+- `/review-council` lacks the CI coverage matrix optimization that
+  `/review-pr` has (wastes time re-running tools CI already verified)
+- `/review-pr` lacks the hard-gate option that `/review-council` has
+- Bug fixes or improvements to one command don't propagate to others
+
+Fixes: https://github.com/unbound-force/unbound-force/issues/175
+
+## What Changes
+
+Extract the duplicated CI detection and local tool execution logic
+into a shared OpenCode skill at `.opencode/skills/pre-flight/SKILL.md`.
+Update the three consuming commands to reference the skill instead of
+inlining the logic.
+
+## Capabilities
+
+### New Capabilities
+- `pre-flight skill`: Shared skill encapsulating CI workflow parsing,
+  local tool detection, CI coverage matrix generation, and two
+  execution policies (`hard-gate` and `ci-aware`)
+
+### Modified Capabilities
+- `/review-council`: Phase 1a replaced with skill reference in
+  `hard-gate` mode; gains CI coverage matrix optimization
+- `/review-pr`: Step 4 replaced with skill reference in `ci-aware`
+  mode; gains hard-gate option for stricter local review
+- `/unleash`: Step 5 CI derivation and phase checkpoint replaced
+  with skill reference in `hard-gate` mode
+
+### Removed Capabilities
+- None — no capabilities removed. The unified detection
+  approach may discover additional tools compared to
+  individual command implementations; this is an intentional
+  improvement (see design decision D2)
+
+## Impact
+
+### Files Changed
+- `.opencode/skills/pre-flight/SKILL.md` (new)
+- `.opencode/commands/review-council.md` (Phase 1a extraction)
+- `.opencode/commands/review-pr.md` (Step 4 extraction)
+- `.opencode/commands/unleash.md` (Step 5 + phase checkpoint)
+- `internal/scaffold/assets/opencode/commands/review-council.md`
+  (scaffold sync)
+- `internal/scaffold/assets/opencode/commands/review-pr.md`
+  (scaffold sync)
+- `internal/scaffold/assets/opencode/commands/unleash.md`
+  (scaffold sync)
+- `internal/scaffold/assets/opencode/skills/pre-flight/SKILL.md`
+  (scaffold sync for new skill)
+- `internal/scaffold/scaffold_test.go` (add to
+  expectedAssetPaths)
+
+### Follow-up
+`/agent-brief` (L61-70) reads `.github/workflows/` and config files
+for discovery (not execution). A `detect-only` mode could serve this
+use case but is a different lifecycle stage. Tracked separately per
+issue #175.
+
+## Constitution Alignment
+
+Assessed against the Unbound Force org constitution (v1.2.0).
+
+### I. Autonomous Collaboration
+
+**Assessment**: N/A
+
+This change affects agent instruction files (skills and commands),
+not inter-hero artifact communication. No artifact formats, metadata,
+or exchange patterns are modified.
+
+### II. Composability First
+
+**Assessment**: PASS
+
+The skill is independently loadable — any command can reference it
+without requiring other commands or skills to be present. Commands
+that do not use the skill continue to function unchanged. The skill
+adds value when composed with review/implementation commands but
+creates no mandatory dependencies.
+
+### III. Observable Quality
+
+**Assessment**: PASS
+
+The skill defines a standardized result format (CI coverage matrix)
+that makes skip/run decisions visible and auditable. Both execution
+policies produce structured output that consuming commands can
+display and act on consistently.
+
+### IV. Testability
+
+**Assessment**: PASS
+
+The skill is an instruction file (no compiled code), so traditional
+unit testing does not apply. However, the behavioral parity
+requirement in the acceptance criteria ensures that both commands
+produce identical outcomes before and after the extraction — this
+is verifiable by running `/review-council` and `/review-pr` against
+a real branch and comparing results.
+
+### V. Security by Default
+
+**Assessment**: PASS
+
+The skill reads workflow files and derives commands for local
+execution, inheriting the same security posture as the existing
+inline implementations. No new input vectors are introduced.
+The design (D8) specifies extraction boundaries: only `run:`
+steps are extracted, CI expressions are skipped, and action
+references are ignored.

--- a/openspec/changes/pre-flight-skill/specs/pre-flight-skill.md
+++ b/openspec/changes/pre-flight-skill/specs/pre-flight-skill.md
@@ -1,0 +1,310 @@
+## ADDED Requirements
+
+### Requirement: FR-001 Pre-flight Skill File
+
+The system MUST provide a shared skill file at
+`.opencode/skills/pre-flight/SKILL.md` that encapsulates
+CI workflow detection, local tool detection, CI coverage
+matrix generation, and local tool execution.
+
+#### Scenario: Skill file exists and is loadable
+
+- **GIVEN** the repository contains
+  `.opencode/skills/pre-flight/SKILL.md`
+- **WHEN** a command invokes the `skill` tool with
+  name `pre-flight`
+- **THEN** the skill instructions are injected into
+  the agent's context
+
+### Requirement: FR-002 CI Workflow Parsing
+
+The pre-flight skill MUST read all files in
+`.github/workflows/` to identify the exact commands
+CI runs. The skill MUST NOT hardcode language-specific
+commands — the workflow files are the source of truth.
+
+#### Scenario: Workflow-driven command discovery
+
+- **GIVEN** a repository with `.github/workflows/ci_local.yml`
+  containing `go test -race -count=1 ./...`
+- **WHEN** the pre-flight skill parses CI workflows
+- **THEN** `go test -race -count=1 ./...` appears in the
+  discovered CI commands list
+
+#### Scenario: No workflow files present
+
+- **GIVEN** a repository with no `.github/workflows/` directory
+- **WHEN** the pre-flight skill parses CI workflows
+- **THEN** the CI commands list is empty and the skill
+  proceeds to config-file detection only
+
+The skill MUST extract only `run:` step commands from
+workflow YAML. Action references (`uses:` steps) MUST
+be ignored — they are GitHub-hosted and not locally
+executable. Commands containing unresolvable CI
+expressions (`${{ secrets.* }}`, `${{ github.* }}`)
+MUST be skipped with a warning.
+
+#### Scenario: Workflow with unresolvable expressions
+
+- **GIVEN** a workflow step containing
+  `curl -H "Authorization: ${{ secrets.TOKEN }}" ...`
+- **WHEN** the pre-flight skill parses CI workflows
+- **THEN** the command is skipped with a warning noting
+  unresolvable CI expressions
+- **AND** the command does not appear in the execution list
+
+### Requirement: FR-003 Local Tool Detection
+
+The pre-flight skill MUST detect available local tools by
+checking for their configuration files. The following
+mappings MUST be supported:
+
+| Config file | Tool | Command |
+|-------------|------|---------|
+| `Makefile` | Make | `make check` (preferred), else `make lint` |
+| `.golangci.yml` | golangci-lint | `golangci-lint run ./...` |
+| `ruff.toml` or `pyproject.toml` | ruff | `ruff check .` |
+| `.yamllint.yml` | yamllint | `yamllint .` |
+| `.pre-commit-config.yaml` | pre-commit | `pre-commit run --all-files` |
+| `go.mod` | go test | `go test ./...` |
+| `pyproject.toml` or `setup.py` | pytest | `pytest` or `python -m pytest` |
+
+#### Scenario: Multiple tools detected
+
+- **GIVEN** a repository containing `Makefile`,
+  `.golangci.yml`, and `go.mod`
+- **WHEN** the pre-flight skill detects local tools
+- **THEN** three tools are reported: Make, golangci-lint,
+  and go test
+
+When `pyproject.toml` is present, both ruff and pytest
+SHOULD be detected as separate tools.
+
+#### Scenario: No tool configuration files present
+
+- **GIVEN** a repository with no recognized config files
+- **WHEN** the pre-flight skill detects local tools
+- **THEN** the detected tools list is empty and the skill
+  reports "no tools detected" before proceeding
+
+#### Scenario: Config file present but tool not installed
+
+- **GIVEN** a repository containing `.golangci.yml`
+- **AND** `golangci-lint` is not in PATH
+- **WHEN** the pre-flight skill detects local tools
+- **THEN** golangci-lint is reported as "detected but not
+  available" and skipped with a warning
+- **AND** the tool does not appear in the execution list
+
+### Requirement: FR-004 CI Coverage Matrix
+
+The pre-flight skill MUST build a CI coverage matrix
+mapping each detected local tool to its corresponding
+CI check. The matrix MUST display the CI status and
+the skip/run decision for each tool.
+
+#### Scenario: CI-aware mode with passing CI checks
+
+- **GIVEN** a PR where CI check "Local CI / test" has
+  status PASS
+- **AND** `go.mod` is detected (maps to `go test`)
+- **WHEN** the pre-flight skill builds the coverage
+  matrix in `ci-aware` mode
+- **THEN** the matrix shows `go test` with CI status
+  PASS and Run locally = No
+
+#### Scenario: CI-aware mode with no CI checks
+
+- **GIVEN** a PR with no CI check results available
+- **WHEN** the pre-flight skill builds the coverage
+  matrix in `ci-aware` mode
+- **THEN** all detected tools show Run locally = Yes
+
+#### Scenario: Hard-gate mode ignores CI status
+
+- **GIVEN** any CI check status (PASS, FAIL, or NONE)
+- **WHEN** the pre-flight skill builds the coverage
+  matrix in `hard-gate` mode
+- **THEN** all detected tools show Run locally = Yes
+  (hard-gate always runs everything)
+
+### Requirement: FR-005 Hard-Gate Execution Policy
+
+The pre-flight skill MUST support a `hard-gate` execution
+policy that runs all detected tools and stops on the first
+failure. This policy MUST NOT skip tools based on CI status.
+
+#### Scenario: All tools pass in hard-gate mode
+
+- **GIVEN** the pre-flight skill is invoked in
+  `hard-gate` mode
+- **AND** all detected tools exit with code 0
+- **WHEN** execution completes
+- **THEN** the verdict is PASS and the consuming command
+  proceeds
+
+#### Scenario: Tool failure in hard-gate mode
+
+- **GIVEN** the pre-flight skill is invoked in
+  `hard-gate` mode
+- **AND** `golangci-lint run ./...` exits with code 1
+- **WHEN** the failure is detected
+- **THEN** execution stops immediately with verdict FAIL
+- **AND** the full error output is included in the result
+- **AND** the consuming command MUST NOT proceed to
+  AI review or implementation
+
+### Requirement: FR-006 CI-Aware Execution Policy
+
+The pre-flight skill MUST support a `ci-aware` execution
+policy that consults the CI coverage matrix and skips tools
+already verified by passing CI checks.
+
+#### Scenario: Some tools skipped in ci-aware mode
+
+- **GIVEN** the pre-flight skill is invoked in
+  `ci-aware` mode
+- **AND** CI check "CI Checks / lint" has status PASS
+  (covers `golangci-lint`)
+- **AND** no CI check covers `yamllint`
+- **WHEN** the coverage matrix is evaluated
+- **THEN** `golangci-lint` is skipped (CI verified)
+- **AND** `yamllint` is run locally
+
+#### Scenario: CI failure in ci-aware mode
+
+- **GIVEN** the pre-flight skill is invoked in
+  `ci-aware` mode
+- **AND** CI check "Local CI / test" has status FAIL
+- **WHEN** the coverage matrix is evaluated
+- **THEN** `go test` is skipped locally (failure already
+  captured from CI)
+- **AND** the CI failure is included in the result
+  context for AI review
+
+### Requirement: FR-007 Standardized Result Format
+
+The pre-flight skill MUST produce results in a standardized
+format containing: CI coverage matrix, execution results
+table, and verdict (mode, result, failures list).
+
+#### Scenario: Result format is parseable by consumer
+
+- **GIVEN** the pre-flight skill completes execution
+- **WHEN** the result is returned to the consuming command
+- **THEN** the result contains a CI Coverage Matrix table,
+  an Execution Results table, and a Verdict section with
+  mode, result (PASS/FAIL), and failures list
+
+## MODIFIED Requirements
+
+### Requirement: FR-008 /review-council Phase 1a
+
+`/review-council` Phase 1a MUST be replaced with a
+reference to the pre-flight skill in `hard-gate` mode.
+Phase 1b (Gaze quality analysis) MUST remain in the
+command unchanged.
+
+Previously: Phase 1a contained inline logic to read
+`.github/workflows/`, execute CI commands, and stop on
+failure (lines 130-151 of `review-council.md`).
+
+#### Scenario: review-council uses pre-flight skill
+
+- **GIVEN** the `/review-council` command is invoked in
+  Code Review Mode
+- **WHEN** Phase 1a executes
+- **THEN** the agent loads the `pre-flight` skill
+- **AND** runs pre-flight checks in `hard-gate` mode
+- **AND** stops on failure (same behavior as before)
+- **AND** proceeds to Phase 1b on success
+
+Note: The unified detection approach (D2) means
+`/review-council` may discover additional tools via
+config-file detection that it previously missed (e.g.,
+yamllint). This is an intentional improvement, not a
+regression. The tool set MAY be a superset of what
+the previous inline implementation detected.
+
+### Requirement: FR-009 /review-pr Step 4
+
+`/review-pr` Step 4 MUST be replaced with a reference to
+the pre-flight skill in `ci-aware` mode. The Step 4
+decision rules (CI PASS = skip, CI FAIL = skip, CI NONE =
+run, No CI = run all) MUST be preserved.
+
+Previously: Step 4 contained inline logic for config-file
+detection, CI coverage matrix construction, and conditional
+tool execution (lines 142-198 of `review-pr.md`).
+
+#### Scenario: review-pr uses pre-flight skill
+
+- **GIVEN** the `/review-pr` command is invoked on PR #42
+- **AND** Step 3 has fetched CI check results
+- **WHEN** Step 4 executes
+- **THEN** the agent loads the `pre-flight` skill
+- **AND** runs pre-flight checks in `ci-aware` mode with
+  the CI check results from Step 3
+- **AND** skips tools already verified by CI
+- **AND** records results for use in Step 8 (AI review)
+
+### Requirement: FR-010 /unleash Step 5 and Phase Checkpoint
+
+`/unleash` Step 5 CI command derivation and phase checkpoint
+execution MUST be replaced with references to the pre-flight
+skill in `hard-gate` mode.
+
+Previously: Step 5 contained inline logic to read
+`.github/workflows/` and derive build/test commands
+(lines 330-335), and the phase checkpoint ran those commands
+(lines 449-452 of `unleash.md`).
+
+#### Scenario: unleash uses pre-flight skill
+
+- **GIVEN** the `/unleash` command reaches Step 5
+- **WHEN** it derives build/test commands
+- **THEN** the agent loads the `pre-flight` skill
+- **AND** uses workflow parsing to discover CI commands
+- **AND** runs the phase checkpoint in `hard-gate` mode
+- **AND** stops on failure (same behavior as before)
+
+### Requirement: FR-011 Scaffold Sync
+
+All modified command files and the new skill file MUST be
+synced to their corresponding copies in
+`internal/scaffold/assets/`. The new skill file MUST be
+added to `expectedAssetPaths` in `scaffold_test.go`.
+Existing drift detection tests MUST pass after sync.
+
+#### Scenario: Command scaffold copies match source
+
+- **GIVEN** `review-council.md`, `review-pr.md`, and
+  `unleash.md` have been updated in `.opencode/commands/`
+- **WHEN** the scaffold copies are synced
+- **THEN** `internal/scaffold/assets/opencode/commands/review-council.md`
+  matches `.opencode/commands/review-council.md`
+- **AND** `internal/scaffold/assets/opencode/commands/review-pr.md`
+  matches `.opencode/commands/review-pr.md`
+- **AND** `internal/scaffold/assets/opencode/commands/unleash.md`
+  matches `.opencode/commands/unleash.md`
+- **AND** drift detection tests pass
+
+#### Scenario: Skill scaffold copy matches source
+
+- **GIVEN** `.opencode/skills/pre-flight/SKILL.md` has been
+  created
+- **WHEN** the scaffold copy is synced
+- **THEN** `internal/scaffold/assets/opencode/skills/pre-flight/SKILL.md`
+  matches `.opencode/skills/pre-flight/SKILL.md`
+- **AND** `expectedAssetPaths` in `scaffold_test.go` includes
+  the new skill path
+- **AND** drift detection tests pass
+
+## REMOVED Requirements
+
+None — this change consolidates existing behavior without
+removing any capabilities. The unified detection approach
+may discover additional tools compared to individual
+command implementations; this is expected and intentional
+(see design decision D2).

--- a/openspec/changes/pre-flight-skill/tasks.md
+++ b/openspec/changes/pre-flight-skill/tasks.md
@@ -1,0 +1,83 @@
+<!--
+  [P] marks tasks eligible for parallel execution.
+  Add [P] when a task: (a) touches different files from
+  other [P] tasks in the group, (b) has no dependency
+  on prior tasks in the group, (c) can safely execute
+  without ordering constraints.
+  Do NOT add [P] when tasks modify the same file —
+  parallel workers will cause merge conflicts.
+  Tasks without [P] run sequentially first, then [P]
+  tasks run in parallel.
+-->
+
+## 1. Create Pre-flight Skill
+
+- [x] 1.1 Create `.opencode/skills/pre-flight/SKILL.md`
+  with the unified pre-flight logic covering:
+  - CI workflow parsing (read `.github/workflows/*.yml`)
+  - Local tool detection (config file checks)
+  - CI coverage matrix generation
+  - `hard-gate` execution policy
+  - `ci-aware` execution policy
+  - Standardized result format
+  Implements: FR-001, FR-002, FR-003, FR-004, FR-005,
+  FR-006, FR-007
+
+## 2. Update Consuming Commands
+
+- [x] 2.1 [P] Update `/review-council` (`review-council.md`):
+  replace Phase 1a inline CI logic (lines 130-151) with a
+  reference to load the `pre-flight` skill in `hard-gate`
+  mode. Keep Phase 1b (Gaze analysis) unchanged.
+  Implements: FR-008
+
+- [x] 2.2 [P] Update `/review-pr` (`review-pr.md`): replace
+  Step 4 inline pre-flight logic (lines 142-198) with a
+  reference to load the `pre-flight` skill in `ci-aware`
+  mode. Ensure Step 3 CI check results are passed as input.
+  Implements: FR-009
+
+- [x] 2.3 [P] Update `/unleash` (`unleash.md`): replace
+  Step 5 CI command derivation (lines 330-335) and phase
+  checkpoint execution (lines 449-452) with references to
+  load the `pre-flight` skill in `hard-gate` mode.
+  Implements: FR-010
+
+## 3. Scaffold Sync
+
+- [x] 3.1 [P] Sync `review-council.md` to
+  `internal/scaffold/assets/opencode/commands/review-council.md`
+  Implements: FR-011
+
+- [x] 3.2 [P] Sync `review-pr.md` to
+  `internal/scaffold/assets/opencode/commands/review-pr.md`
+  Implements: FR-011
+
+- [x] 3.3 [P] Sync `unleash.md` to
+  `internal/scaffold/assets/opencode/commands/unleash.md`
+  Implements: FR-011
+
+- [x] 3.4 [P] Sync `.opencode/skills/pre-flight/SKILL.md` to
+  `internal/scaffold/assets/opencode/skills/pre-flight/SKILL.md`
+  and add the path to `expectedAssetPaths` in
+  `internal/scaffold/scaffold_test.go`
+  Implements: FR-011
+
+## 4. Verification
+
+- [x] 4.1 Run `make check` to verify build, lint, and
+  tests pass (CI parity gate)
+
+- [x] 4.2 Run drift detection tests to confirm scaffold
+  copies match command sources and skill sources
+
+- [x] 4.3 Behavioral verification: run `/review-council`
+  in code review mode on the current branch to confirm
+  pre-flight skill produces expected behavior (tools
+  detected, execution order, pass/fail verdict)
+
+- [x] 4.4 Documentation assessment: check whether
+  AGENTS.md project structure or CLAUDE.md available
+  skills list need updates for the new pre-flight skill
+<!-- spec-review: passed -->
+<!-- code-review: passed -->


### PR DESCRIPTION
## Summary

Extract duplicated CI detection and local tool execution logic from three commands (`/review-council`, `/review-pr`, `/unleash`) into a shared OpenCode skill at `.opencode/skills/pre-flight/SKILL.md`.

Fixes unbound-force/unbound-force#175

## What Changed

### New
- `.opencode/skills/pre-flight/SKILL.md` — shared skill providing:
  - CI workflow parsing (discover commands from `.github/workflows/*.yml`)
  - Local tool detection (config file checks + binary availability)
  - CI coverage matrix generation
  - Two execution policies: `hard-gate` (stop on failure) and `ci-aware` (skip CI-verified tools)
  - Standardized result format

### Modified
- `/review-council` — Phase 1a replaced with skill reference in `hard-gate` mode
- `/review-pr` — Step 4 replaced with skill reference in `ci-aware` mode
- `/unleash` — Step 5 + phase checkpoint replaced with skill reference in `hard-gate` mode
- Scaffold copies synced for all modified commands and the new skill
- `scaffold_test.go` — added `pre-flight/SKILL.md` to `expectedAssetPaths`

### OpenSpec Artifacts
- `openspec/changes/pre-flight-skill/` — proposal, design, specs (11 FRs with Given/When/Then), tasks

## Spec Review
5 Divisor agents reviewed the spec artifacts. Key findings addressed:
- Scaffold sync for skill file (added D7 decision, task 3.4)
- Behavioral expansion acknowledgment (unified detection may discover additional tools — documented as intentional improvement)
- Workflow extraction boundaries (D8 — only `run:` steps, skip CI expressions)
- Missing tool binary handling (skip with warning)

## Verification
- `go build ./...` — PASS
- `go vet ./...` — PASS
- `golangci-lint run` — 0 issues
- `TestEmbeddedAssets_MatchSource` — PASS
- `TestAssetPaths_MatchExpected` — PASS
- `TestCanonicalSources_AreEmbedded` — PASS

## Follow-up
`/agent-brief` (L61-70) reads `.github/workflows/` for discovery (not execution). A `detect-only` mode could serve this use case but is tracked separately per issue #175.