### PR TITLE
refactor(commands): migrate /review-pr to review-context skill

### DIFF
--- a/.opencode/commands/address-feedback.md
+++ b/.opencode/commands/address-feedback.md
@@ -140,7 +140,7 @@ Load context for evidence-based classification (D10, FR-010):
    - Speckit: `specs/NNN-*/` matching branch pattern
    - OpenSpec: `openspec/changes/*/` matching branch
 5. Linked issues from PR description (`Fixes #N`, `Closes #N`, `Resolves #N`) — load acceptance criteria
-6. If `review-context` convention pack exists, use it for standardized discovery. Otherwise inline the discovery logic above.
+6. Invoke the `skill` tool with name `review-context` to load standardized context discovery (spec artifacts, linked issues, path classification).
 
 ### 2.2 Tiered Assessment
 

--- a/.opencode/commands/review-pr.md
+++ b/.opencode/commands/review-pr.md
@@ -250,71 +250,36 @@ targeting the PR's head ref (`git show`, `git fetch`,
 `git checkout`, `git diff` with remote refs) is
 prohibited.
 
-### 6. Locate Associated Specification
+### 6. Discover Review Context
 
-Search for a specification that matches this PR across all spec directories:
+Load the `review-context` skill for spec artifact
+discovery, issue linking, path classification, and
+walkthrough generation:
 
-- Check if the PR branch name matches a spec directory:
-  - `specs/<branch-name>/spec.md` (Speckit output)
-  - `openspec/specs/<branch-name>/spec.md` (OpenSpec specs)
-  - `openspec/changes/<branch-name>/proposal.md` (OpenSpec changes)
-- Check if the PR description references a spec
-- If not found locally, check the PR's changed file
-  list (from Step 2 metadata) for spec artifacts. The
-  spec may be introduced by the PR itself. If found
-  in the changed file list, read the spec content from
-  the saved diff (Step 5) rather than from the
-  filesystem.
-- If a Speckit spec is found, read only the **Functional Requirements** and **User Stories** sections (not the entire spec) to minimize token usage
-- If an OpenSpec proposal is found, read only the **Capabilities** and **Impact** sections
-- If no spec is found in any directory or in the PR's changed files, note this and use the PR title and description as the intent source
+1. Invoke the `skill` tool with name `review-context`
+   to load the shared context discovery instructions.
 
-#### 6a. Resolve Linked Issues
+2. Execute the skill's protocols in order:
+   a. Protocol 1 (Spec Artifact Discovery) — locate
+      the specification matching this PR using branch
+      name from Step 2 metadata, PR description, and
+      changed file list. If a spec is found in the
+      changed file list, read from the saved diff
+      (Step 5) rather than the filesystem.
+   b. Protocol 2 (Issue Linking) — parse the PR body
+      from Step 2 metadata for linked issues, validate,
+      fetch, sanitize, and extract acceptance criteria.
+   c. Protocol 3 (Path-Based Focus Heuristics) —
+      classify each changed file from the Step 2
+      metadata for review emphasis.
+   d. Protocol 4 (Walkthrough Generation) — generate
+      per-file change summaries while analyzing the
+      diff from Step 5.
 
-Parse the PR body (from Step 2 metadata) for issue
-references using case-insensitive regex:
-- `Fixes #N`, `Closes #N`, `Resolves #N`
-- GitHub URL variants:
-  `Fixes https://github.com/<owner>/<repo>/issues/N`
-
-**Validation and limits**:
-- Validate each parsed issue number as a positive
-  integer (digits only). Discard non-numeric values.
-- URL-format references: validate they belong to the
-  same `{owner}/{repo}` as the PR. List cross-repo
-  references in the output as "cross-repo — not
-  validated" but do NOT fetch them.
-- Limit to 5 linked issues maximum. If more than 5
-  are found, list extras as "listed but not fetched"
-  in the output.
-
-**Fetching**: For each in-scope linked issue:
-
-```bash
-gh issue view <N> --json title,body,labels
-```
-
-**Untrusted input handling**: Issue body content is
-user-controlled. Before incorporating into the review
-context:
-- Truncate to a maximum of 2000 characters.
-
-**Error handling**: If `gh issue view` returns 404,
-403, or times out, log the error, skip that issue, and
-note in the `### Linked Issues` section as "fetch
-failed". The review continues without blocking.
-
-**Acceptance criteria extraction**: From each fetched
-issue body, extract:
-- Checkbox lines (`- [ ]` or `- [x]`)
-- Content under an `## Acceptance Criteria` heading
-
-If neither exists, use the issue title and body as
-general intent context for the alignment check
-(Step 8a).
-
-Record the linked issues and their acceptance criteria
-for use in Step 8a and Step 9.
+3. **Record results**: Use the skill's Review Context
+   output format (Specification, Linked Issues, File
+   Classification, Walkthrough). This context is used
+   in Step 8 (AI review) and Step 9 (output).
 
 ### 7. Load Convention Packs (Optional)
 
@@ -419,38 +384,13 @@ analysis. For each finding:
   have additional context or a different severity
   assessment. Annotate, don't hide.
 
-**Path-based review focus**: Before starting the review,
-classify each changed file against these built-in
-heuristics. Record the focus category for each file
-(used in the Walkthrough output and as additive review
-context):
-
-| Path pattern | Focus category | Additional emphasis |
-|-------------|---------------|-------------------|
-| `*_test.go`, `*_test.py`, `**/__tests__/**`, `**/*_spec.*` | `test-quality` | Edge cases, assertion strength, mock isolation, test naming |
-| `**/cmd/**`, `**/cli/**` | `cli-ux` | Error messages, flag validation, help text |
-| `**/api/**`, `**/handler/**`, `**/middleware/**`, `**/routes/**` | `security` | Auth, input validation, injection |
-| `*.md`, `docs/**` | `documentation` | Clarity, accuracy, broken links |
-| `.github/workflows/**`, `Dockerfile*` | `ci-cd` | Permissions, pinned versions, secrets exposure |
-| `go.mod`, `package.json`, `requirements.txt` | `dependencies` | Maintenance status, license, scope |
-| Everything else | `standard` | Architecture, SOLID, coupling, baseline security |
-
-Path focus is **additive** — it supplements the standard
-review categories (alignment, security, constitution),
-not replaces them. Step 8b (Security Review) applies to
-ALL changed files regardless of path heuristic.
-
-When reviewing each file, append the matched focus
-instruction to the review context for that file.
-
-**Walkthrough generation**: While analyzing each file's
-diff, generate a one-line change summary describing
-what changed (e.g., "Add error handling for null
-inputs"), not how (no code snippets). Record the
-summary and focus category for each file — these are
-used in the `### Walkthrough` output section (Step 9).
-For PRs with 30+ files, generate directory-level
-summaries instead of per-file summaries.
+**Path-based review focus and walkthrough**: Use the
+file classifications and walkthrough summaries from
+Step 6 (review-context skill, Protocols 3 and 4).
+When reviewing each file, apply the matched focus
+instruction as additive review context. Step 8b
+(Security Review) applies to ALL changed files
+regardless of path heuristic.
 
 #### 8a. Alignment Check
 
@@ -460,7 +400,7 @@ Compare the PR intent (title + description + linked spec + linked issues) agains
 - **Requirement coverage**: For each requirement in the spec (if found), verify the code changes address it. Flag uncovered requirements.
 - **Completeness**: Are there partial implementations that could leave the system in an inconsistent state?
 - **Drift detection**: Does the code do anything NOT described in the intent/spec? Flag undocumented behavioral changes.
-- **Issue criteria coverage**: For each acceptance criterion from linked issues (Step 6a), verify the code changes address it. Report uncovered criteria as MEDIUM findings with per-criterion status (COVERED / NOT COVERED / PARTIAL).
+- **Issue criteria coverage**: For each acceptance criterion from linked issues (Step 6, Protocol 2), verify the code changes address it. Report uncovered criteria as MEDIUM findings with per-criterion status (COVERED / NOT COVERED / PARTIAL).
 - **Issue suggestion gap detection**: After checking
   acceptance criteria, scan each linked issue body for
   explicit code suggestions — fenced code blocks
@@ -640,7 +580,7 @@ Present findings in this structured format:
 | `internal/gateway/` | 3 | Token refresh and provider detection | security |
 
 ### Linked Issues
-<Only include this section if Step 6a found linked issues>
+<Only include this section if Step 6 found linked issues>
 | Issue | Title | Criteria |
 |-------|-------|----------|
 | #38 | Export metrics to CSV | 3/4 COVERED |

--- a/.uf/dewey/learnings/pre-flight-skill-20260623T130130-yvonne-devlin.md
+++ b/.uf/dewey/learnings/pre-flight-skill-20260623T130130-yvonne-devlin.md
@@ -1,0 +1,10 @@
+---
+tag: pre-flight-skill
+author: yvonne-devlin
+category: gotcha
+created_at: 2026-06-23T13:01:30Z
+identity: pre-flight-skill-20260623T130130-yvonne-devlin
+tier: draft
+---
+
+When adding a new scaffold asset (e.g., a new skill file under .opencode/skills/), the expectedAssetPaths list in scaffold_test.go is not the only place that needs updating. The TestRunInit_FreshDir test in cmd/unbound-force/main_test.go hardcodes the total file count produced by uf init (e.g., "39 files processed"). Adding a scaffold asset bumps this count. The scaffold-specific tests (TestEmbeddedAssets_MatchSource, TestAssetPaths_MatchExpected) will pass because they verify structure, not count — but the integration test in cmd/unbound-force will fail. Always run the full make check (or at minimum go test ./cmd/unbound-force/...) after adding scaffold assets, not just the scaffold package tests.

--- a/.uf/dewey/learnings/review-context-skill-20260629T125308-yvonne-devlin.md
+++ b/.uf/dewey/learnings/review-context-skill-20260629T125308-yvonne-devlin.md
@@ -1,0 +1,10 @@
+---
+tag: review-context-skill
+author: yvonne-devlin
+category: pattern
+created_at: 2026-06-29T12:53:08Z
+identity: review-context-skill-20260629T125308-yvonne-devlin
+tier: draft
+---
+
+When migrating a consuming command to load a shared skill instead of inlining logic, the triage phase is critical for resolving design questions upfront. For the review-context skill migration (#295), the triage identified three key decisions before any spec was written: (1) hard dependency vs. graceful degradation — resolved by examining the pre-flight skill precedent, where all three consumers already treat it as a hard dependency with no fallback; (2) behavioral parity vs. expansion — resolved by side-by-side comparison of the skill's protocols against the inline logic, confirming 1:1 extraction; (3) regression verification method — accepted as manual, matching the pre-flight risk profile. Resolving these during triage prevented the spec review from raising the same questions later, resulting in a clean 5/5 APPROVE with zero HIGH/CRITICAL findings.

--- a/.uf/dewey/learnings/review-context-skill-20260629T125311-yvonne-devlin.md
+++ b/.uf/dewey/learnings/review-context-skill-20260629T125311-yvonne-devlin.md
@@ -1,0 +1,10 @@
+---
+tag: review-context-skill
+author: yvonne-devlin
+category: gotcha
+created_at: 2026-06-29T12:53:11Z
+identity: review-context-skill-20260629T125311-yvonne-devlin
+tier: draft
+---
+
+The issue acceptance criteria for skill migrations should not include "graceful degradation: if the skill is absent, current inline behavior is preserved as fallback" when the project's established pattern is hard dependencies. The pre-flight skill has three consumers (review-pr, review-council, unleash) and none implement fallback logic. Skills embedded in the scaffold and distributed via uf init are structurally guaranteed to be present — the drift detection test TestEmbeddedAssets_MatchSource catches any sync issues at build time. Including unnecessary fallback logic creates a dual-path maintenance burden and risks stale inline code becoming a silent security regression, as identified by the divisor-adversary during triage.

--- a/internal/scaffold/assets/opencode/commands/address-feedback.md
+++ b/internal/scaffold/assets/opencode/commands/address-feedback.md
@@ -140,7 +140,7 @@ Load context for evidence-based classification (D10, FR-010):
    - Speckit: `specs/NNN-*/` matching branch pattern
    - OpenSpec: `openspec/changes/*/` matching branch
 5. Linked issues from PR description (`Fixes #N`, `Closes #N`, `Resolves #N`) — load acceptance criteria
-6. If `review-context` convention pack exists, use it for standardized discovery. Otherwise inline the discovery logic above.
+6. Invoke the `skill` tool with name `review-context` to load standardized context discovery (spec artifacts, linked issues, path classification).
 
 ### 2.2 Tiered Assessment
 

--- a/internal/scaffold/assets/opencode/commands/review-pr.md
+++ b/internal/scaffold/assets/opencode/commands/review-pr.md
@@ -250,71 +250,36 @@ targeting the PR's head ref (`git show`, `git fetch`,
 `git checkout`, `git diff` with remote refs) is
 prohibited.
 
-### 6. Locate Associated Specification
+### 6. Discover Review Context
 
-Search for a specification that matches this PR across all spec directories:
+Load the `review-context` skill for spec artifact
+discovery, issue linking, path classification, and
+walkthrough generation:
 
-- Check if the PR branch name matches a spec directory:
-  - `specs/<branch-name>/spec.md` (Speckit output)
-  - `openspec/specs/<branch-name>/spec.md` (OpenSpec specs)
-  - `openspec/changes/<branch-name>/proposal.md` (OpenSpec changes)
-- Check if the PR description references a spec
-- If not found locally, check the PR's changed file
-  list (from Step 2 metadata) for spec artifacts. The
-  spec may be introduced by the PR itself. If found
-  in the changed file list, read the spec content from
-  the saved diff (Step 5) rather than from the
-  filesystem.
-- If a Speckit spec is found, read only the **Functional Requirements** and **User Stories** sections (not the entire spec) to minimize token usage
-- If an OpenSpec proposal is found, read only the **Capabilities** and **Impact** sections
-- If no spec is found in any directory or in the PR's changed files, note this and use the PR title and description as the intent source
+1. Invoke the `skill` tool with name `review-context`
+   to load the shared context discovery instructions.
 
-#### 6a. Resolve Linked Issues
+2. Execute the skill's protocols in order:
+   a. Protocol 1 (Spec Artifact Discovery) — locate
+      the specification matching this PR using branch
+      name from Step 2 metadata, PR description, and
+      changed file list. If a spec is found in the
+      changed file list, read from the saved diff
+      (Step 5) rather than the filesystem.
+   b. Protocol 2 (Issue Linking) — parse the PR body
+      from Step 2 metadata for linked issues, validate,
+      fetch, sanitize, and extract acceptance criteria.
+   c. Protocol 3 (Path-Based Focus Heuristics) —
+      classify each changed file from the Step 2
+      metadata for review emphasis.
+   d. Protocol 4 (Walkthrough Generation) — generate
+      per-file change summaries while analyzing the
+      diff from Step 5.
 
-Parse the PR body (from Step 2 metadata) for issue
-references using case-insensitive regex:
-- `Fixes #N`, `Closes #N`, `Resolves #N`
-- GitHub URL variants:
-  `Fixes https://github.com/<owner>/<repo>/issues/N`
-
-**Validation and limits**:
-- Validate each parsed issue number as a positive
-  integer (digits only). Discard non-numeric values.
-- URL-format references: validate they belong to the
-  same `{owner}/{repo}` as the PR. List cross-repo
-  references in the output as "cross-repo — not
-  validated" but do NOT fetch them.
-- Limit to 5 linked issues maximum. If more than 5
-  are found, list extras as "listed but not fetched"
-  in the output.
-
-**Fetching**: For each in-scope linked issue:
-
-```bash
-gh issue view <N> --json title,body,labels
-```
-
-**Untrusted input handling**: Issue body content is
-user-controlled. Before incorporating into the review
-context:
-- Truncate to a maximum of 2000 characters.
-
-**Error handling**: If `gh issue view` returns 404,
-403, or times out, log the error, skip that issue, and
-note in the `### Linked Issues` section as "fetch
-failed". The review continues without blocking.
-
-**Acceptance criteria extraction**: From each fetched
-issue body, extract:
-- Checkbox lines (`- [ ]` or `- [x]`)
-- Content under an `## Acceptance Criteria` heading
-
-If neither exists, use the issue title and body as
-general intent context for the alignment check
-(Step 8a).
-
-Record the linked issues and their acceptance criteria
-for use in Step 8a and Step 9.
+3. **Record results**: Use the skill's Review Context
+   output format (Specification, Linked Issues, File
+   Classification, Walkthrough). This context is used
+   in Step 8 (AI review) and Step 9 (output).
 
 ### 7. Load Convention Packs (Optional)
 
@@ -419,38 +384,13 @@ analysis. For each finding:
   have additional context or a different severity
   assessment. Annotate, don't hide.
 
-**Path-based review focus**: Before starting the review,
-classify each changed file against these built-in
-heuristics. Record the focus category for each file
-(used in the Walkthrough output and as additive review
-context):
-
-| Path pattern | Focus category | Additional emphasis |
-|-------------|---------------|-------------------|
-| `*_test.go`, `*_test.py`, `**/__tests__/**`, `**/*_spec.*` | `test-quality` | Edge cases, assertion strength, mock isolation, test naming |
-| `**/cmd/**`, `**/cli/**` | `cli-ux` | Error messages, flag validation, help text |
-| `**/api/**`, `**/handler/**`, `**/middleware/**`, `**/routes/**` | `security` | Auth, input validation, injection |
-| `*.md`, `docs/**` | `documentation` | Clarity, accuracy, broken links |
-| `.github/workflows/**`, `Dockerfile*` | `ci-cd` | Permissions, pinned versions, secrets exposure |
-| `go.mod`, `package.json`, `requirements.txt` | `dependencies` | Maintenance status, license, scope |
-| Everything else | `standard` | Architecture, SOLID, coupling, baseline security |
-
-Path focus is **additive** — it supplements the standard
-review categories (alignment, security, constitution),
-not replaces them. Step 8b (Security Review) applies to
-ALL changed files regardless of path heuristic.
-
-When reviewing each file, append the matched focus
-instruction to the review context for that file.
-
-**Walkthrough generation**: While analyzing each file's
-diff, generate a one-line change summary describing
-what changed (e.g., "Add error handling for null
-inputs"), not how (no code snippets). Record the
-summary and focus category for each file — these are
-used in the `### Walkthrough` output section (Step 9).
-For PRs with 30+ files, generate directory-level
-summaries instead of per-file summaries.
+**Path-based review focus and walkthrough**: Use the
+file classifications and walkthrough summaries from
+Step 6 (review-context skill, Protocols 3 and 4).
+When reviewing each file, apply the matched focus
+instruction as additive review context. Step 8b
+(Security Review) applies to ALL changed files
+regardless of path heuristic.
 
 #### 8a. Alignment Check
 
@@ -460,7 +400,7 @@ Compare the PR intent (title + description + linked spec + linked issues) agains
 - **Requirement coverage**: For each requirement in the spec (if found), verify the code changes address it. Flag uncovered requirements.
 - **Completeness**: Are there partial implementations that could leave the system in an inconsistent state?
 - **Drift detection**: Does the code do anything NOT described in the intent/spec? Flag undocumented behavioral changes.
-- **Issue criteria coverage**: For each acceptance criterion from linked issues (Step 6a), verify the code changes address it. Report uncovered criteria as MEDIUM findings with per-criterion status (COVERED / NOT COVERED / PARTIAL).
+- **Issue criteria coverage**: For each acceptance criterion from linked issues (Step 6, Protocol 2), verify the code changes address it. Report uncovered criteria as MEDIUM findings with per-criterion status (COVERED / NOT COVERED / PARTIAL).
 - **Issue suggestion gap detection**: After checking
   acceptance criteria, scan each linked issue body for
   explicit code suggestions — fenced code blocks
@@ -640,7 +580,7 @@ Present findings in this structured format:
 | `internal/gateway/` | 3 | Token refresh and provider detection | security |
 
 ### Linked Issues
-<Only include this section if Step 6a found linked issues>
+<Only include this section if Step 6 found linked issues>
 | Issue | Title | Criteria |
 |-------|-------|----------|
 | #38 | Export metrics to CSV | 3/4 COVERED |

--- a/openspec/changes/migrate-review-pr-context-skill/.openspec.yaml
+++ b/openspec/changes/migrate-review-pr-context-skill/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: unbound-force
+created: 2026-06-29

--- a/openspec/changes/migrate-review-pr-context-skill/design.md
+++ b/openspec/changes/migrate-review-pr-context-skill/design.md
@@ -1,0 +1,146 @@
+## Context
+
+The `/review-pr` command contains inline context discovery
+logic across ~100 lines (Steps 6, 6a, and Step 8 preamble)
+that has been extracted into the `review-context` skill
+(PR #303, issue #294). The skill provides four protocols:
+
+1. Spec Artifact Discovery (branch name matching, PR
+   description parsing, changed-file detection)
+2. Issue Linking (regex parsing, validation, fetching,
+   sanitization, acceptance criteria extraction)
+3. Path-Based Focus Heuristics (file classification table)
+4. Walkthrough Generation (per-file change summaries)
+
+The `/review-pr` command already loads the `pre-flight`
+skill at Step 4 using the established invocation pattern.
+This change adds a second skill invocation at Step 6,
+following the identical pattern.
+
+## Goals / Non-Goals
+
+### Goals
+
+- Replace inline Steps 6/6a with a `review-context` skill
+  invocation using the established `pre-flight` pattern
+- Replace inline path heuristics and walkthrough generation
+  in Step 8 preamble with a back-reference to the skill
+  output from Step 6
+- Update all forward references from "Step 6a" to
+  "Step 6, Protocol 2" and "Step 6" throughout the command
+- Update `/address-feedback` line 143 from "convention
+  pack" fallback to hard skill dependency
+- Mirror all changes to scaffold copies
+
+### Non-Goals
+
+- Modifying the `review-context` skill itself (owned by
+  #294, already closed)
+- Migrating `/review-council` (owned by #296)
+- Adding new protocols or capabilities to the skill
+- Changing convention pack loading (Step 7) — this is a
+  separate concern from context discovery
+- Adding graceful degradation / inline fallback
+
+## Decisions
+
+### D1: Hard dependency, no inline fallback
+
+The `review-context` skill is a hard dependency. No
+inline fallback logic is preserved when the skill is
+absent.
+
+**Rationale**: The `pre-flight` skill (the only other
+skill consumed by `/review-pr`) uses the same pattern —
+all three consumers (`/review-pr`, `/review-council`,
+`/unleash`) treat it as a hard dependency with no
+fallback. The skill is embedded in the scaffold and
+distributed via `uf init`, making absence effectively
+impossible. Adding a fallback would create a dual-path
+maintenance burden and risk stale inline logic becoming
+a silent security regression (per triage finding from
+divisor-adversary).
+
+### D2: Skill invocation at Step 6, not Step 5
+
+The skill invocation replaces the current Step 6
+(spec discovery) and Step 6a (issue linking). It is
+placed after Step 5 (Fetch Diff) because Protocol 3
+(Path-Based Focus Heuristics) needs the changed file
+list from Step 2 metadata, and Protocol 1 (Spec
+Discovery) may need to read spec content from the
+saved diff (Step 5).
+
+Convention pack loading (Step 7) stays as a separate
+step because packs are a distinct concern — they
+provide code quality rules, not context discovery.
+
+### D3: Step 8 heuristics replaced with back-reference
+
+The path-based focus heuristic table and walkthrough
+generation instructions currently live in the Step 8
+preamble (lines 422-453). These are replaced with a
+compact back-reference to the skill output from Step 6,
+not a second skill invocation.
+
+**Rationale**: The skill is loaded once at Step 6. Its
+output (file classifications, walkthrough summaries) is
+consumed by Step 8. Invoking the skill again would be
+redundant. The back-reference keeps Step 8 focused on
+AI review logic while delegating classification to the
+skill.
+
+### D4: Behavioral parity, not expansion
+
+This is a strict behavioral parity migration. The skill
+reproduces the exact logic from `/review-pr`'s current
+inline implementation. Protocol 4 (Walkthrough
+Generation) adds explicit Markdown table templates but
+the actual behavior is semantically identical.
+
+**Rationale**: Per prior learning
+`pre-flight-skill-20260623T123105`, skill extractions
+must explicitly state whether the approach is "strict
+parity" or "intentional expansion." This migration is
+strict parity — the skill was designed as a 1:1
+extraction verified by side-by-side comparison during
+triage.
+
+### D5: Forward reference updates are in-scope
+
+All references to "Step 6a" throughout the command must
+be updated to reference the new structure. Two known
+locations:
+
+- Line 463: `(Step 6a)` in acceptance criteria coverage
+- Line 643: `Step 6a` in Linked Issues output section
+
+These are updated as part of this change to avoid
+leaving stale references to removed logic.
+
+## Risks / Trade-offs
+
+### R1: Skill loading adds one tool call
+
+Loading the `review-context` skill adds one `skill`
+tool invocation. This is the same cost as the existing
+`pre-flight` skill load. The trade-off is a marginal
+increase in tool calls for a significant reduction in
+inline instruction size (~100 lines removed from
+`/review-pr`).
+
+### R2: Scaffold sync surface
+
+Four files must be updated in lockstep. The drift
+detection test (`TestEmbeddedAssets_MatchSource`)
+catches mismatches at build time, mitigating the risk
+of partial updates.
+
+### R3: No automated behavioral regression test
+
+These are Markdown prompt-engineering artifacts. There
+are no unit tests for behavioral output. Verification
+is manual — run `/review-pr` against a reference PR
+before and after the change. This is the same risk
+profile as the `pre-flight` skill extraction and is
+accepted.

--- a/openspec/changes/migrate-review-pr-context-skill/proposal.md
+++ b/openspec/changes/migrate-review-pr-context-skill/proposal.md
@@ -1,0 +1,135 @@
+## Why
+
+The `/review-pr` command (992 lines) contains inline logic
+for spec artifact discovery (Step 6), issue linking with
+input sanitization (Step 6a), and path-based focus
+heuristics with walkthrough generation (Step 8 preamble).
+This logic is duplicated in concept across `/review-pr`,
+`/address-feedback`, and `/review-council`.
+
+Issue #294 (closed, PR #303) created the `review-context`
+skill at `.opencode/skills/review-context/SKILL.md` which
+extracts this shared logic into four reusable protocols.
+This change migrates `/review-pr` to consume the skill
+instead of inlining the logic — the consumer side of the
+#176 decomposition (#294 producer, #295 consumer, #296
+review-council consumer).
+
+## What Changes
+
+Replace inline context discovery logic in `/review-pr`
+with a `review-context` skill invocation, following the
+same pattern established by the `pre-flight` skill
+(Step 4). Update forward references throughout the
+command, and update the `/address-feedback` terminology
+from "convention pack" to "skill".
+
+## Capabilities
+
+### New Capabilities
+
+- None. This is a refactoring — no new user-facing
+  behavior.
+
+### Modified Capabilities
+
+- `/review-pr` Step 6: Inline spec discovery and issue
+  linking replaced by `review-context` skill invocation
+  (Protocols 1 and 2). Behavioral parity — the skill's
+  logic is a 1:1 extraction of the current inline logic.
+- `/review-pr` Step 8 preamble: Inline path-based focus
+  heuristics and walkthrough generation replaced by
+  back-reference to skill output (Protocols 3 and 4).
+- `/address-feedback` Step 2.1 item 6: Forward reference
+  updated from "convention pack" fallback to hard skill
+  dependency.
+
+### Removed Capabilities
+
+- Inline spec discovery logic (Steps 6, 6a): Removed
+  from `/review-pr`, now provided by skill Protocol 1
+  and Protocol 2.
+- Inline path heuristic table and walkthrough generation
+  instructions: Removed from Step 8 preamble, now
+  provided by skill Protocols 3 and 4.
+- Graceful degradation for absent skill: Not implemented.
+  The skill is a hard dependency, consistent with
+  `pre-flight` skill consumption. The skill is embedded
+  in the scaffold and shipped via `uf init`.
+
+## Impact
+
+**Files modified** (4 total, 2 live + 2 scaffold copies):
+
+| File | Change |
+|------|--------|
+| `.opencode/commands/review-pr.md` | Replace Steps 6/6a with skill invocation; replace Step 8 heuristics/walkthrough with back-reference; update forward references |
+| `internal/scaffold/assets/opencode/commands/review-pr.md` | Mirror of above |
+| `.opencode/commands/address-feedback.md` | Update line 143 terminology |
+| `internal/scaffold/assets/opencode/commands/address-feedback.md` | Mirror of above |
+
+**No Go source changes.** No CI changes. No schema
+changes. The scaffold drift detection test
+(`TestEmbeddedAssets_MatchSource`) validates sync
+automatically.
+
+**Related issues**: Fixes #295. Part of #176
+decomposition.
+
+## Constitution Alignment
+
+Assessed against the Unbound Force org constitution.
+
+### I. Autonomous Collaboration
+
+**Assessment**: N/A
+
+This change modifies agent command files (prompt
+engineering artifacts). It does not affect inter-hero
+artifact exchange formats or communication patterns.
+
+### II. Composability First
+
+**Assessment**: PASS
+
+This change improves composability by extracting shared
+logic into a reusable skill. The `review-context` skill
+provides a single source of truth for context discovery
+that multiple commands can consume independently. The
+skill is embedded in the scaffold and distributed via
+`uf init`, ensuring availability without cross-repo
+dependencies.
+
+### III. Observable Quality
+
+**Assessment**: N/A
+
+This change does not affect machine-parseable output
+formats or provenance metadata. The review output
+structure (walkthrough table, linked issues section,
+findings) remains unchanged.
+
+### IV. Testability
+
+**Assessment**: PASS
+
+The scaffold drift detection test
+(`TestEmbeddedAssets_MatchSource`) validates that live
+command files and scaffold copies stay in sync. The
+`review-context` skill's logic is a 1:1 extraction of
+the current inline logic, verified by side-by-side
+comparison during triage. Behavioral verification is
+manual (run `/review-pr` against a reference PR before
+and after the change).
+
+### V. Security by Default
+
+**Assessment**: PASS
+
+Input sanitization controls (regex validation, positive
+integer validation, same-repo URL scoping, 5-issue
+fetch limit, 2000-character body truncation) are
+preserved in the skill's Protocol 2. The skill is the
+single source of truth for these controls, eliminating
+the risk of drift between duplicated inline
+implementations.

--- a/openspec/changes/migrate-review-pr-context-skill/specs/review-pr/spec.md
+++ b/openspec/changes/migrate-review-pr-context-skill/specs/review-pr/spec.md
@@ -1,0 +1,142 @@
+## ADDED Requirements
+
+### Requirement: Review Context Skill Invocation
+
+The `/review-pr` command MUST invoke the `review-context`
+skill via the `skill` tool at Step 6, after fetching the
+diff (Step 5) and before loading convention packs
+(Step 7).
+
+The invocation MUST execute all four protocols:
+
+1. Protocol 1 (Spec Artifact Discovery)
+2. Protocol 2 (Issue Linking)
+3. Protocol 3 (Path-Based Focus Heuristics)
+4. Protocol 4 (Walkthrough Generation)
+
+The skill's output MUST be recorded for use in Step 8
+(AI Review) and Step 9 (Output).
+
+#### Scenario: Skill loaded successfully
+
+- **GIVEN** the `review-context` skill exists at
+  `.opencode/skills/review-context/SKILL.md`
+- **WHEN** `/review-pr` reaches Step 6
+- **THEN** the command invokes the `skill` tool with
+  name `review-context` and executes Protocols 1-4
+  using PR metadata from Step 2 and the saved diff
+  from Step 5
+
+### Requirement: Step 8 Consumes Skill Output
+
+Step 8 (AI Review) MUST reference the file
+classifications and walkthrough summaries produced by
+Step 6 (review-context skill, Protocols 3 and 4)
+instead of computing them inline.
+
+Security review (Step 8b) MUST continue to apply to
+ALL changed files regardless of path heuristic.
+
+Behavioral verification is manual — run `/review-pr`
+against a reference PR before and after the change to
+confirm output parity. This is consistent with the
+verification approach used for the `pre-flight` skill
+extraction. The scaffold drift test provides the
+automated verification layer.
+
+#### Scenario: Path focus applied from skill output
+
+- **GIVEN** Step 6 produced file classifications via
+  Protocol 3
+- **WHEN** Step 8 reviews a file classified as
+  `security`
+- **THEN** the review applies the `security` focus
+  emphasis (auth, input validation, injection) as
+  additive context alongside standard review categories
+
+## MODIFIED Requirements
+
+### Requirement: Forward References to Issue Linking
+
+Previously: Step 8a referenced "linked issues
+(Step 6a)" and the Linked Issues output section
+referenced "Step 6a".
+
+All references to "Step 6a" MUST be updated to
+reference "Step 6" or "Step 6, Protocol 2" as
+appropriate. Specifically:
+
+- Step 8a acceptance criteria coverage MUST reference
+  "Step 6, Protocol 2" instead of "Step 6a"
+- The Linked Issues output section MUST reference
+  "Step 6" instead of "Step 6a"
+
+#### Scenario: Acceptance criteria coverage reference
+
+- **GIVEN** the inline Step 6a has been removed
+- **WHEN** Step 8a performs acceptance criteria coverage
+- **THEN** the instruction references linked issues
+  from "Step 6, Protocol 2"
+
+### Requirement: Address-Feedback Context Discovery
+
+Previously: `/address-feedback` Step 2.1 item 6 read:
+"If `review-context` convention pack exists, use it
+for standardized discovery. Otherwise inline the
+discovery logic above."
+
+The `/address-feedback` command MUST reference the
+`review-context` skill (not "convention pack") as a
+hard dependency for context discovery in Step 2.1.
+
+#### Scenario: Address-feedback loads skill
+
+- **GIVEN** `/address-feedback` reaches Step 2.1
+- **WHEN** loading project context
+- **THEN** item 6 instructs the agent to invoke the
+  `skill` tool with name `review-context` for
+  standardized context discovery
+
+### Requirement: Scaffold Sync
+
+All changes to live command files MUST be mirrored to
+their scaffold copies under
+`internal/scaffold/assets/opencode/commands/`. The
+drift detection test (`TestEmbeddedAssets_MatchSource`)
+MUST pass.
+
+#### Scenario: Scaffold copies match live files
+
+- **GIVEN** changes are made to
+  `.opencode/commands/review-pr.md` and
+  `.opencode/commands/address-feedback.md`
+- **WHEN** `make test` is run
+- **THEN** `TestEmbeddedAssets_MatchSource` passes,
+  confirming scaffold copies are identical
+
+## REMOVED Requirements
+
+### Requirement: Inline Spec Discovery (Steps 6, 6a)
+
+The inline spec discovery logic (branch name matching,
+PR description parsing, changed-file detection) and
+issue linking logic (regex parsing, validation,
+fetching, sanitization, acceptance criteria extraction)
+are removed from `/review-pr`. These capabilities are
+now provided by the `review-context` skill Protocols 1
+and 2.
+
+### Requirement: Inline Path Heuristics and Walkthrough
+
+The inline path-based focus heuristic table and
+walkthrough generation instructions are removed from
+the Step 8 preamble. These capabilities are now
+provided by the `review-context` skill Protocols 3
+and 4.
+
+### Requirement: Graceful Degradation for Absent Skill
+
+No graceful degradation or inline fallback is
+implemented for the `review-context` skill. The skill
+is a hard dependency, consistent with the `pre-flight`
+skill consumption pattern across all consumers.

--- a/openspec/changes/migrate-review-pr-context-skill/tasks.md
+++ b/openspec/changes/migrate-review-pr-context-skill/tasks.md
@@ -1,0 +1,80 @@
+<!--
+  [P] marks tasks eligible for parallel execution.
+  Add [P] when a task: (a) touches different files from
+  other [P] tasks in the group, (b) has no dependency
+  on prior tasks in the group, (c) can safely execute
+  without ordering constraints.
+  Do NOT add [P] when tasks modify the same file —
+  parallel workers will cause merge conflicts.
+  Tasks without [P] run sequentially first, then [P]
+  tasks run in parallel.
+-->
+
+## 1. Migrate `/review-pr` to `review-context` skill
+
+All tasks in this group modify the same file
+(`.opencode/commands/review-pr.md`) — no parallel
+execution.
+
+- [x] 1.1 Replace Steps 6 and 6a (lines 253-317) with
+  a new Step 6 that invokes the `review-context` skill
+  via the `skill` tool, following the same invocation
+  pattern as Step 4 (pre-flight). The new step MUST
+  execute Protocols 1-4 and record the output for use
+  in Step 8 and Step 9. Remove all inline spec
+  discovery, issue linking, and sanitization logic.
+
+- [x] 1.2 Replace the path-based focus heuristic table
+  and walkthrough generation instructions in the Step 8
+  preamble (lines 422-453) with a compact back-reference
+  to the skill output from Step 6 (Protocols 3 and 4).
+  Preserve the existing review deduplication logic
+  (lines 403-420) and the note that Step 8b security
+  review applies to ALL files regardless of heuristic.
+
+- [x] 1.3 Update forward references:
+  - Line 463: change `(Step 6a)` to
+    `(Step 6, Protocol 2)`
+  - Line 643: change `Step 6a` to `Step 6`
+
+## 2. Update `/address-feedback` terminology
+
+- [x] 2.1 [P] In `.opencode/commands/address-feedback.md`,
+  replace line 143 ("If `review-context` convention pack
+  exists, use it for standardized discovery. Otherwise
+  inline the discovery logic above.") with: "Invoke the
+  `skill` tool with name `review-context` to load
+  standardized context discovery (spec artifacts, linked
+  issues, path classification)."
+
+## 3. Scaffold sync
+
+These tasks mirror changes from groups 1 and 2 to
+scaffold copies. Each touches a different scaffold file.
+
+- [x] 3.1 [P] Copy the updated
+  `.opencode/commands/review-pr.md` content to
+  `internal/scaffold/assets/opencode/commands/review-pr.md`
+  (must be byte-identical).
+
+- [x] 3.2 [P] Copy the updated
+  `.opencode/commands/address-feedback.md` content to
+  `internal/scaffold/assets/opencode/commands/address-feedback.md`
+  (must be byte-identical).
+
+## 4. Verification
+
+- [x] 4.1 Run `make test` — the drift detection test
+  `TestEmbeddedAssets_MatchSource` MUST pass, confirming
+  scaffold copies match live files.
+
+- [x] 4.2 Verify constitution alignment: Composability
+  First (II) — the skill invocation uses the standard
+  `skill` tool pattern, maintaining independent
+  usability. Testability (IV) — scaffold drift test
+  provides automated verification. Security by Default
+  (V) — sanitization controls are preserved in the
+  skill's Protocol 2.
+
+<!-- spec-review: passed -->
+<!-- code-review: passed -->


### PR DESCRIPTION
## Summary

Migrates `/review-pr` to consume the `review-context` skill for context discovery instead of inlining the logic. Replaces
~65 lines of inline spec discovery (Step 6), issue linking (Step 6a), path-based focus heuristics, and walkthrough generation (Step 8 preamble) with a skill invocation following the established `pre-flight` pattern. Updates `/address-feedback`
terminology from "convention pack" to "skill".

Part of the #176 decomposition (#294 producer, #295 consumer, #296 review-council consumer).

Fixes #295

## How to Test

1. Run `make test` — all 20 packages pass, including`TestEmbeddedAssets_MatchSource` scaffold drift detection
2. Open `.opencode/commands/review-pr.md` — Step 6 now invokes the `review-context` skill; Step 8 uses a back-reference;no "Step 6a" references remain
3. Open `.opencode/commands/address-feedback.md` line 143 — references skill, not convention pack
4. Optionally run `/review-pr` on any open PR to verify output

## How to Demo

Run `/review-pr <N>` on any open PR. The review output should be identical — spec discovery, linked issues, path-focused review, and walkthrough table all work as before, now sourced from the `review-context` skill.

## Key Files Changed

| File | Change |
|------|--------|
| `.opencode/commands/review-pr.md` | Skill invocation, back-reference, forward ref updates (-138 lines inline logic) |
| `.opencode/commands/address-feedback.md` | Line 143: convention pack → skill |
| `internal/scaffold/assets/opencode/commands/review-pr.md` | Scaffold mirror |
| `internal/scaffold/assets/opencode/commands/address-feedback.md` | Scaffold mirror |
| `openspec/changes/migrate-review-pr-context-skill/` | Proposal, design, spec, tasks |
| `.uf/dewey/learnings/` | 3 learnings (pre-flight pattern, review-context gotcha) |

Signed-off-by: Yvonne Devlin <ydevlin@redhat.com>
Assisted-by: OpenCode (claude-opus)