### PR TITLE
feat(commands): migrate /review-council to consume review-context skill

### DIFF
--- a/.opencode/commands/review-council.md
+++ b/.opencode/commands/review-council.md
@@ -181,6 +181,44 @@ Review the current codebase for compliance with the Behavioral Constraints in `A
 
       Proceed to step 2 without Gaze data.
 
+   #### Phase 1c -- Discover Review Context (mandatory)
+
+   Load the `review-context` skill for spec artifact
+   discovery, path classification, and walkthrough
+   generation:
+
+   a. Invoke the `skill` tool with name `review-context`
+      to load the shared context discovery instructions.
+
+   b. Execute the skill's protocols in order:
+      1. Protocol 1 (Spec Artifact Discovery) — locate
+         the specification matching the current branch
+         using the branch name from auto-detection and
+         the changed file list.
+      2. Protocol 2 (Issue Linking) — **skip**. This
+         protocol requires a PR body;
+         `/review-council` is a local pre-PR command
+         with no PR body to parse.
+      3. Protocol 3 (Path-Based Focus Heuristics) —
+         classify each changed file from the
+         auto-detection step for review emphasis.
+      4. Protocol 4 (Walkthrough Generation) — generate
+         per-file change summaries from the branch
+         diff (`git diff main...HEAD`).
+
+   c. **Record results**: Use the skill's Review Context
+      output format (Specification, File Classification,
+      Walkthrough). This context is used in step 2
+      (Divisor agent delegation) and step 6 (final
+      report).
+
+   d. **If the skill fails to load**: **STOP
+      immediately.** Report the error as a CRITICAL
+      finding. Do NOT proceed to step 2. The
+      `review-context` skill is a hard dependency,
+      consistent with the `pre-flight` skill
+      consumption pattern — no inline fallback.
+
 2. Delegate the review to all **discovered** reviewer agents in parallel using the Task tool. For each discovered agent, use the focus area from the Known Reviewer Roles reference table to provide targeted context. For any discovered agent not in the table, use a generic prompt: "Review the current changes for quality, correctness, and compliance. Return your verdict (APPROVE or REQUEST CHANGES) along with all findings."
 
    **CRITICAL — Review Scope Rule**: The review scope is
@@ -195,19 +233,30 @@ Review the current codebase for compliance with the Behavioral Constraints in `A
    produces incomplete reviews that miss findings in
    earlier commits on the branch.
 
-   **When Gaze data is available** (from Phase 1b):
-   append a "Quality Context" section to each Divisor
-   agent's review prompt containing the Gaze Report
-   summary. This gives agents -- particularly
-   `divisor-testing` -- access to concrete CRAP
-   scores, coverage percentages, quadrant
-   distributions, and prioritized recommendations.
-   Instruct agents to reference this data in their
-   findings where relevant.
+   **Review context enrichment**: Append the following
+   context sections to each Divisor agent's review
+   prompt:
 
-   **When Gaze data is NOT available**: use the
-   standard prompt without a "Quality Context"
-   section. Agents review based on file reading only.
+   - **Review Context** (from Phase 1c): Include the
+     spec artifact summary, file classifications, and
+     walkthrough from the `review-context` skill output.
+     This gives agents spec alignment context and
+     per-file focus heuristics. Instruct agents to
+     reference spec requirements and file
+     classifications in their findings where relevant.
+
+   - **Quality Context** (from Phase 1b, when Gaze data
+     is available): Include the Gaze Report summary.
+     This gives agents -- particularly
+     `divisor-testing` -- access to concrete CRAP
+     scores, coverage percentages, quadrant
+     distributions, and prioritized recommendations.
+     Instruct agents to reference this data in their
+     findings where relevant.
+
+   **When Gaze data is NOT available**: include only
+   the Review Context section. Agents review based on
+   file reading plus spec/classification context.
 
    For each agent, instruct it to review the full branch diff (all changed files vs `main`) and return its verdict (**APPROVE** or **REQUEST CHANGES**) along with all findings.
 
@@ -239,6 +288,10 @@ Review the current codebase for compliance with the Behavioral Constraints in `A
 
 6. Provide a final report to the user:
    - **Discovery summary**: how many reviewer agents were discovered, which were invoked, and which known reviewer roles were absent (informational, non-blocking)
+   - **Review context summary**: specification found
+     (type, path) or "no spec found", and the
+     walkthrough table from Phase 1c (review-context
+     skill, Protocol 4)
    - What was found in each iteration
    - What was fixed
    - If stopped early, the current set of outstanding **REQUEST CHANGES**

--- a/.opencode/commands/review-council.md
+++ b/.opencode/commands/review-council.md
@@ -123,9 +123,9 @@ Review the current codebase for compliance with the Behavioral Constraints in `A
 ### Instructions
 
 1. **Run local quality gates before delegating to
-   council agents.** This step has two phases that
-   MUST execute in order. Both phases apply only to
-   Code Review Mode -- Spec Review Mode skips them.
+   council agents.** This step has three phases that
+   MUST execute in order. All three phases apply only
+   to Code Review Mode -- Spec Review Mode skips them.
 
    #### Phase 1a -- Pre-flight Checks (mandatory, hard gate)
 

--- a/.opencode/skills/review-context/SKILL.md
+++ b/.opencode/skills/review-context/SKILL.md
@@ -16,7 +16,7 @@ walkthrough summaries are discovered and formatted.
 | Command | How it loads | Notes |
 |---------|-------------|-------|
 | `/review-pr` | Skill tool | Replaces inline Steps 6-8 logic |
-| `/review-council` | Skill tool | Gains context discovery it currently lacks |
+| `/review-council` | Skill tool | Phase 1c — Protocols 1, 3, 4 (skips Protocol 2: no PR body) |
 | `/address-feedback` | Skill tool | Replaces inline fallback (line 143) |
 
 The consuming command specifies which protocols to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ Each entry follows the format: `- <change-name>: <summary>`.
 ## Unreleased
 
 ### Changed
+- `/review-council` Code Review Mode: added Phase 1c
+  (review-context skill) for spec artifact discovery,
+  path classification, and walkthrough generation;
+  restructured Step 2 context enrichment to pass review
+  context and quality context to Divisor agents; added
+  review context summary to Step 6 final report
+  (Fixes: #296)
 - `/finale` PR body generation: structured sections (Summary,
   How to Test, How to Demo, Key Files Changed) replacing
   minimal bullet-point summary; PR template detection and

--- a/internal/scaffold/assets/opencode/commands/review-council.md
+++ b/internal/scaffold/assets/opencode/commands/review-council.md
@@ -181,6 +181,44 @@ Review the current codebase for compliance with the Behavioral Constraints in `A
 
       Proceed to step 2 without Gaze data.
 
+   #### Phase 1c -- Discover Review Context (mandatory)
+
+   Load the `review-context` skill for spec artifact
+   discovery, path classification, and walkthrough
+   generation:
+
+   a. Invoke the `skill` tool with name `review-context`
+      to load the shared context discovery instructions.
+
+   b. Execute the skill's protocols in order:
+      1. Protocol 1 (Spec Artifact Discovery) — locate
+         the specification matching the current branch
+         using the branch name from auto-detection and
+         the changed file list.
+      2. Protocol 2 (Issue Linking) — **skip**. This
+         protocol requires a PR body;
+         `/review-council` is a local pre-PR command
+         with no PR body to parse.
+      3. Protocol 3 (Path-Based Focus Heuristics) —
+         classify each changed file from the
+         auto-detection step for review emphasis.
+      4. Protocol 4 (Walkthrough Generation) — generate
+         per-file change summaries from the branch
+         diff (`git diff main...HEAD`).
+
+   c. **Record results**: Use the skill's Review Context
+      output format (Specification, File Classification,
+      Walkthrough). This context is used in step 2
+      (Divisor agent delegation) and step 6 (final
+      report).
+
+   d. **If the skill fails to load**: **STOP
+      immediately.** Report the error as a CRITICAL
+      finding. Do NOT proceed to step 2. The
+      `review-context` skill is a hard dependency,
+      consistent with the `pre-flight` skill
+      consumption pattern — no inline fallback.
+
 2. Delegate the review to all **discovered** reviewer agents in parallel using the Task tool. For each discovered agent, use the focus area from the Known Reviewer Roles reference table to provide targeted context. For any discovered agent not in the table, use a generic prompt: "Review the current changes for quality, correctness, and compliance. Return your verdict (APPROVE or REQUEST CHANGES) along with all findings."
 
    **CRITICAL — Review Scope Rule**: The review scope is
@@ -195,19 +233,30 @@ Review the current codebase for compliance with the Behavioral Constraints in `A
    produces incomplete reviews that miss findings in
    earlier commits on the branch.
 
-   **When Gaze data is available** (from Phase 1b):
-   append a "Quality Context" section to each Divisor
-   agent's review prompt containing the Gaze Report
-   summary. This gives agents -- particularly
-   `divisor-testing` -- access to concrete CRAP
-   scores, coverage percentages, quadrant
-   distributions, and prioritized recommendations.
-   Instruct agents to reference this data in their
-   findings where relevant.
+   **Review context enrichment**: Append the following
+   context sections to each Divisor agent's review
+   prompt:
 
-   **When Gaze data is NOT available**: use the
-   standard prompt without a "Quality Context"
-   section. Agents review based on file reading only.
+   - **Review Context** (from Phase 1c): Include the
+     spec artifact summary, file classifications, and
+     walkthrough from the `review-context` skill output.
+     This gives agents spec alignment context and
+     per-file focus heuristics. Instruct agents to
+     reference spec requirements and file
+     classifications in their findings where relevant.
+
+   - **Quality Context** (from Phase 1b, when Gaze data
+     is available): Include the Gaze Report summary.
+     This gives agents -- particularly
+     `divisor-testing` -- access to concrete CRAP
+     scores, coverage percentages, quadrant
+     distributions, and prioritized recommendations.
+     Instruct agents to reference this data in their
+     findings where relevant.
+
+   **When Gaze data is NOT available**: include only
+   the Review Context section. Agents review based on
+   file reading plus spec/classification context.
 
    For each agent, instruct it to review the full branch diff (all changed files vs `main`) and return its verdict (**APPROVE** or **REQUEST CHANGES**) along with all findings.
 
@@ -239,6 +288,10 @@ Review the current codebase for compliance with the Behavioral Constraints in `A
 
 6. Provide a final report to the user:
    - **Discovery summary**: how many reviewer agents were discovered, which were invoked, and which known reviewer roles were absent (informational, non-blocking)
+   - **Review context summary**: specification found
+     (type, path) or "no spec found", and the
+     walkthrough table from Phase 1c (review-context
+     skill, Protocol 4)
    - What was found in each iteration
    - What was fixed
    - If stopped early, the current set of outstanding **REQUEST CHANGES**

--- a/internal/scaffold/assets/opencode/commands/review-council.md
+++ b/internal/scaffold/assets/opencode/commands/review-council.md
@@ -123,9 +123,9 @@ Review the current codebase for compliance with the Behavioral Constraints in `A
 ### Instructions
 
 1. **Run local quality gates before delegating to
-   council agents.** This step has two phases that
-   MUST execute in order. Both phases apply only to
-   Code Review Mode -- Spec Review Mode skips them.
+   council agents.** This step has three phases that
+   MUST execute in order. All three phases apply only
+   to Code Review Mode -- Spec Review Mode skips them.
 
    #### Phase 1a -- Pre-flight Checks (mandatory, hard gate)
 

--- a/internal/scaffold/assets/opencode/skills/review-context/SKILL.md
+++ b/internal/scaffold/assets/opencode/skills/review-context/SKILL.md
@@ -16,7 +16,7 @@ walkthrough summaries are discovered and formatted.
 | Command | How it loads | Notes |
 |---------|-------------|-------|
 | `/review-pr` | Skill tool | Replaces inline Steps 6-8 logic |
-| `/review-council` | Skill tool | Gains context discovery it currently lacks |
+| `/review-council` | Skill tool | Phase 1c — Protocols 1, 3, 4 (skips Protocol 2: no PR body) |
 | `/address-feedback` | Skill tool | Replaces inline fallback (line 143) |
 
 The consuming command specifies which protocols to


### PR DESCRIPTION
Fixes #296
Split from #176

## Summary

Migrates `/review-council` Code Review Mode to consume the `review-context` skill for spec artifact discovery, path classification, and walkthrough generation — capabilities the command previously lacked entirely. This brings context discovery parity with `/review-pr` for local pre-PR reviews.

Part of the #176 decomposition (#294 producer, #295 `/review-pr` consumer, #296 `/review-council` consumer).

Spec Review Mode is intentionally unchanged — it already has its own artifact location logic. A follow-up issue has been filed to evaluate whether the skill adds value there.

### Note on #296 acceptance criteria discrepancy

The issue's acceptance criteria originally included "Gains issue linking (linked issue detection and acceptance criteria extraction)" and reference "Protocols 1-4". This PR intentionally skips Protocol 2 (Issue Linking) because `/review-council` is a local pre-PR command — there is no PR body to parse for `Fixes #N` / `Closes #N` references. The `review-context` skill itself documents this: "For local reviews without a PR, skip this protocol." This was resolved during triage before implementation began. 

Acceptance criteria on #296 have been updated to reflect this (see #296).

- "Protocols 1-4" → "Protocols 1, 3, 4 (Protocol 2 skipped — no PR body)"
- "Gains issue linking" → removed (not applicable to local pre-PR reviews)

## How to Test

1. Run `make test` — all packages pass, including `TestEmbeddedAssets_MatchSource` scaffold drift detection
2. Open `.opencode/commands/review-council.md` — Phase 1c now loads the `review-context` skill; Step 2 passes review context + quality context to Divisor agents; Step 6 includes a review context summary
3. Open `.opencode/skills/review-context/SKILL.md` — consumer table row for `/review-council` updated from migration-delta to steady-state description
4. Verify `CHANGELOG.md` has an entry under `## Unreleased > ### Changed`
5. Optionally run `/review-council` on any feature branch to verify output

## How to Demo

Checkout a feature branch with code changes and run `/review-council`. The review output now includes:
- Spec artifact discovery (branch name → spec directory mapping)
- Per-file focus classifications (test-quality, cli-ux, security, etc.)
- Walkthrough table in the final report
- All context passed to Divisor agents alongside Gaze quality data

## Key Files Changed

| File | Change |
|------|--------|
| `.opencode/commands/review-council.md` | Phase 1c (review-context skill), Step 2 restructured context enrichment, Step 6 report summary, phase count fix ("two" → "three") |
| `.opencode/skills/review-context/SKILL.md` | Consumer table: `/review-council` row updated to steady-state description |
| `CHANGELOG.md` | Unreleased entry for the migration |
| `internal/scaffold/assets/opencode/commands/review-council.md` | Scaffold mirror |
| `internal/scaffold/assets/opencode/skills/review-context/SKILL.md` | Scaffold mirror |

## Design Decisions

- **Protocols 1, 3, 4 executed; Protocol 2 skipped**: `/review-council` is a local pre-PR command with no PR body to parse. The skill's own documentation says "For local reviews without a PR, skip this protocol."
- **Hard dependency, no fallback**: Consistent with the `pre-flight` skill pattern. Skills distributed via `uf init` are structurally guaranteed present; `TestEmbeddedAssets_MatchSource` catches sync issues at build time.
- **Code Review Mode only**: Spec Review Mode already has its own scope determination. Follow-up issue filed for evaluation.
- **Insertion point**: After Phase 1b (Gaze), before Step 2 (Divisor delegation) — consistent with `/review-pr` Step 6 placement.

## Review Council Results

Ran `/review-council` on the branch. 9 Divisor agents reviewed; 3 findings addressed:

| Finding | Severity | Source | Fix |
|---------|----------|-------|-----|
| Stale phase count ("two" → "three") | CRITICAL | Scribe + Herald | Updated line 126 |
| Missing CHANGELOG entry | MEDIUM | Curator | Added |
| Stale skill consumer table | MEDIUM | Curator | Updated |

Signed-off-by: Yvonne Devlin <ydevlin@redhat.com>
Assisted-by: OpenCode (claude-opus-4-6)