### PR TITLE
fix: add missing name field to 8 skill frontmatter

### DIFF
--- a/.opencode/skills/always-on-guidance/SKILL.md
+++ b/.opencode/skills/always-on-guidance/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: always-on-guidance
 description: Global coding rules and tool usage discipline
 tags: [always-on, coding, quality]
 ---

--- a/.opencode/skills/forge-coordination/SKILL.md
+++ b/.opencode/skills/forge-coordination/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: forge-coordination
 description: Multi-agent coordination patterns for forge sessions
 tags: [forge, coordination, multi-agent]
 ---

--- a/.opencode/skills/forge-global/SKILL.md
+++ b/.opencode/skills/forge-global/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: forge-global
 description: Cross-project forge coordination patterns
 tags: [forge, global, coordination]
 ---

--- a/.opencode/skills/learning-systems/SKILL.md
+++ b/.opencode/skills/learning-systems/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: learning-systems
 description: How the forge learns from outcomes
 tags: [learning, forge, insights]
 ---

--- a/.opencode/skills/pre-flight/SKILL.md
+++ b/.opencode/skills/pre-flight/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: pre-flight
 description: "Shared pre-flight skill for CI detection and local tool execution. Supports hard-gate and ci-aware execution policies."
 ---
 <!-- scaffolded by uf vdev -->

--- a/.opencode/skills/replicator-cli/SKILL.md
+++ b/.opencode/skills/replicator-cli/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: replicator-cli
 description: Replicator CLI quick reference
 tags: [cli, reference, replicator]
 ---

--- a/.opencode/skills/system-design/SKILL.md
+++ b/.opencode/skills/system-design/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: system-design
 description: System design principles for clean architecture
 tags: [design, architecture, principles]
 ---

--- a/.opencode/skills/testing-patterns/SKILL.md
+++ b/.opencode/skills/testing-patterns/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: testing-patterns
 description: Go testing patterns for the replicator project
 tags: [testing, go, patterns]
 ---

--- a/internal/scaffold/assets/opencode/skills/pre-flight/SKILL.md
+++ b/internal/scaffold/assets/opencode/skills/pre-flight/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: pre-flight
 description: "Shared pre-flight skill for CI detection and local tool execution. Supports hard-gate and ci-aware execution policies."
 ---
 <!-- scaffolded by uf vdev -->


### PR DESCRIPTION
## Summary

Add the required `name` field to YAML frontmatter for 8 skills that were not discoverable by OpenCode's `skill` tool. OpenCode's skill discovery requires both `name` and `description` fields to register a skill as available. Without `name`, these skills were invisible — commands that depend on them (notably `/review-council`, `/review-pr`, `/unleash`) failed with "Skill not found" when attempting to load `pre-flight`.

The root cause is that these 8 skills were scaffolded before OpenCode enforced the `name` frontmatter requirement. The 4 OpenSpec-originated skills (`openspec-apply-change`, `openspec-archive-change`, `openspec-explore`, `openspec-propose`) already had `name` and were unaffected.

## What's included

| File | Change |
|------|--------|
| `.opencode/skills/always-on-guidance/SKILL.md` | Add `name: always-on-guidance` |
| `.opencode/skills/forge-coordination/SKILL.md` | Add `name: forge-coordination` |
| `.opencode/skills/forge-global/SKILL.md` | Add `name: forge-global` |
| `.opencode/skills/learning-systems/SKILL.md` | Add `name: learning-systems` |
| `.opencode/skills/pre-flight/SKILL.md` | Add `name: pre-flight` |
| `.opencode/skills/replicator-cli/SKILL.md` | Add `name: replicator-cli` |
| `.opencode/skills/system-design/SKILL.md` | Add `name: system-design` |
| `.opencode/skills/testing-patterns/SKILL.md` | Add `name: testing-patterns` |
| `internal/scaffold/assets/opencode/skills/pre-flight/SKILL.md` | Add `name: pre-flight` (scaffold copy, kept in sync) |

Only `pre-flight` has a scaffold source in this repo (embedded in the binary via `internal/scaffold/assets/`). The other 7 are replicator-scaffolded skills with no embedded copy here.

## Test verification

TestEmbeddedAssets_MatchSource    PASS  (live and scaffold pre-flight copies match)
TestAssetPaths_MatchExpected      PASS  (embedded asset manifest unchanged)
TestCanonicalSources_AreEmbedded  PASS  (all canonical sources accounted for)
go test ./... (excl. sandbox)     PASS  (19/19 packages)

## Related issues

| Issue | Repo | Purpose |
|-------|------|---------|
| #309 | `unbound-force/unbound-force` | This fix |
| [replicator#28](https://github.com/unbound-force/replicator/issues/28) | `unbound-force/replicator` | Fix 7 skill templates at scaffold source |
| #316 | `unbound-force/unbound-force` | Propagate fix to downstream repos via `uf init` + `replicator init` |
| #315 | `unbound-force/unbound-force` | Delete stray `internal/scaffold/.opencode/skills/` directory |


Fixes #309

Signed-off-by: Yvonne Devlin <ydevlin@redhat.com>
Assisted-by: OpenCode (claude-opus-4-6)