### PR TITLE
feat(commands): add CI causality analysis and soft-gate to review-council

### DIFF
--- a/.opencode/commands/review-council.md
+++ b/.opencode/commands/review-council.md
@@ -127,9 +127,9 @@ Review the current codebase for compliance with the Behavioral Constraints in `A
    MUST execute in order. All three phases apply only
    to Code Review Mode -- Spec Review Mode skips them.
 
-   #### Phase 1a -- Pre-flight Checks (mandatory, hard gate)
+   #### Phase 1a -- Pre-flight Checks (mandatory, soft gate)
 
-   Load the `pre-flight` skill and run in `hard-gate`
+   Load the `pre-flight` skill and run in `soft-gate`
    mode:
 
    a. Invoke the `skill` tool with name `pre-flight` to
@@ -141,20 +141,32 @@ Review the current codebase for compliance with the Behavioral Constraints in `A
       2. Local Tool Detection — check for config files
          and verify binary availability
       3. CI Coverage Matrix — display the matrix (in
-         hard-gate mode, all tools are marked "Run
+         soft-gate mode, all tools are marked "Run
          locally = Yes")
       4. Execution — run all detected and available
-         tools in hard-gate mode
+         tools in soft-gate mode (do NOT stop on first
+         failure; record all results)
+      5. Baseline Establishment (Phase 4a) — if any
+         tools failed, establish a baseline for `main`
+         using the two-tier strategy (CI API first,
+         worktree fallback)
+      6. Causality Classification (Phase 4b) — classify
+         each failure as branch-caused, pre-existing,
+         or unknown
 
-   c. **If the pre-flight verdict is FAIL**: **STOP
-      immediately.** Report each failure as a CRITICAL
-      finding with the full error output. Do NOT
-      proceed to Phase 1b or to step 2 (Divisor agent
-      delegation). The rationale: reviewing code that
-      doesn't compile or pass tests is wasted work.
+   c. **If the pre-flight verdict is FAIL
+      (branch-caused)**: **STOP immediately.** Report
+      each branch-caused failure as a CRITICAL finding
+      with the full error output. Do NOT proceed to
+      Phase 1b or to step 2 (Divisor agent delegation).
+      The rationale: reviewing code that doesn't compile
+      or pass tests is wasted work.
 
-   d. **If the pre-flight verdict is PASS**: report
-      success and proceed to Phase 1b.
+   d. **If the pre-flight verdict is PASS** (including
+      when pre-existing failures exist): report success.
+      If pre-existing failures were detected, record
+      them for inclusion in the final report (Step 6).
+      Proceed to Phase 1b.
 
    #### Phase 1b -- Gaze Quality Analysis (conditional)
 
@@ -288,6 +300,26 @@ Review the current codebase for compliance with the Behavioral Constraints in `A
 
 6. Provide a final report to the user:
    - **Discovery summary**: how many reviewer agents were discovered, which were invoked, and which known reviewer roles were absent (informational, non-blocking)
+   - **Pre-existing CI Failures** (if any were detected
+     in Phase 1a): include an informational section
+     between the discovery summary and the review
+     context summary:
+
+     ```
+     ### Pre-existing CI Failures (informational)
+
+     The following failures exist on `main` and are
+     unrelated to the current branch:
+
+     | Tool | Exit code | Baseline method |
+     |------|-----------|-----------------|
+     | ...  | ...       | ...             |
+
+     These do not block the review verdict.
+     ```
+
+     Omit this section when no pre-existing failures
+     were detected in Phase 1a.
    - **Review context summary**: specification found
      (type, path) or "no spec found", and the
      walkthrough table from Phase 1c (review-context

--- a/.opencode/skills/pre-flight/SKILL.md
+++ b/.opencode/skills/pre-flight/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pre-flight
-description: "Shared pre-flight skill for CI detection and local tool execution. Supports hard-gate and ci-aware execution policies."
+description: "Shared pre-flight skill for CI detection and local tool execution. Supports hard-gate, ci-aware, and soft-gate execution policies."
 ---
 <!-- scaffolded by uf vdev -->
 # Skill: Pre-flight Checks
@@ -14,8 +14,9 @@ an execution policy.
 
 | Mode | Behavior | Typical consumer |
 |------|----------|-----------------|
-| `hard-gate` | Run all detected tools. Stop on first failure. | `/review-council`, `/unleash` |
+| `hard-gate` | Run all detected tools. Stop on first failure. | `/unleash` (phase checkpoints) |
 | `ci-aware` | Build CI coverage matrix against PR check results. Skip tools CI already verified. Run the rest. | `/review-pr` |
+| `soft-gate` | Run all detected tools. Classify failures as branch-caused vs pre-existing. Gate only on branch-caused failures. | `/review-council` |
 
 The consuming command specifies which mode to use.
 
@@ -192,11 +193,174 @@ Record all exit codes and output.
 If no tools are marked "Yes" (all covered by CI): report
 "All tools covered by CI — no local execution needed."
 
+### soft-gate mode
+
+Execute ALL detected and available tools (same as
+hard-gate). Do NOT stop on first failure — record all
+exit codes and output for every tool.
+
+- If ALL tools pass: verdict is PASS. No baseline
+  establishment is needed. Skip Phase 4a and 4b.
+- If ANY tools fail: proceed to Phase 4a (Baseline
+  Establishment) to classify each failure.
+
+---
+
+## Phase 4a: Baseline Establishment (soft-gate only)
+
+This phase runs only in `soft-gate` mode, and only when
+at least one tool failed during Phase 4 execution.
+
+Establish a baseline for the default branch to determine
+which failures are branch-caused vs pre-existing. Use a
+two-tier strategy: CI API first, local worktree fallback.
+
+### Detect the default branch
+
+Before establishing a baseline, detect the repository's
+default branch. Do NOT hardcode `main` — repositories
+may use `master` or another default branch name.
+
+```bash
+DEFAULT_BRANCH=$(git symbolic-ref \
+  refs/remotes/origin/HEAD 2>/dev/null \
+  | sed 's|refs/remotes/origin/||')
+```
+
+If that fails (remote HEAD not set, which happens after
+a fresh clone without
+`git remote set-head origin --auto`), fall back to
+checking for common names:
+
+```bash
+if [ -z "${DEFAULT_BRANCH}" ]; then
+  if git rev-parse --verify origin/main \
+    >/dev/null 2>&1; then
+    DEFAULT_BRANCH="main"
+  elif git rev-parse --verify origin/master \
+    >/dev/null 2>&1; then
+    DEFAULT_BRANCH="master"
+  fi
+fi
+```
+
+If neither resolves, treat the baseline as unavailable
+and fall through to the conservative fallback (all
+failures classified as `unknown` = branch-caused).
+
+### Tier 1 — CI API baseline
+
+Check if the `gh` CLI is available:
+
+```bash
+which gh
+```
+
+If `gh` is available, query the latest check-run results
+for the default branch:
+
+```bash
+gh api \
+  repos/{owner}/{repo}/commits/${DEFAULT_BRANCH}/check-runs \
+  --jq '.check_runs[] | {name, conclusion}'
+```
+
+Use `--arg` for any dynamic values to prevent injection
+(consistent with `/review-pr` Step 3a).
+
+Map CI check names to local tool names using the same
+coverage matrix logic from Phase 3. For each failing
+tool from Phase 4, look up the corresponding CI check
+conclusion on `${DEFAULT_BRANCH}`:
+
+- `conclusion: "success"` → baseline PASS
+- `conclusion: "failure"` → baseline FAIL
+- No matching check → baseline NO DATA
+
+If `gh` is not available, or the API call returns no
+data, or the API call fails: proceed to Tier 2.
+
+### Tier 2 — Local worktree baseline
+
+Create a temporary detached worktree of the default
+branch:
+
+```bash
+SHORT_SHA=$(git rev-parse --short=8 ${DEFAULT_BRANCH})
+git worktree add /tmp/preflight-baseline-${SHORT_SHA} \
+  ${DEFAULT_BRANCH} --detach
+```
+
+Run ONLY the tools that failed on the branch in the
+worktree directory. Tools that passed on the branch
+MUST NOT be run against the baseline — they are not
+branch-caused by definition.
+
+```bash
+# For each failing tool, run it in the worktree:
+cd /tmp/preflight-baseline-${SHORT_SHA}
+<tool-command>
+# Record exit code
+```
+
+After running all failing tools, clean up the worktree:
+
+```bash
+git worktree remove \
+  /tmp/preflight-baseline-${SHORT_SHA} --force
+```
+
+Compare exit codes:
+- Tool fails in worktree → baseline FAIL
+- Tool passes in worktree → baseline PASS
+
+### Fallback — conservative classification
+
+If both Tier 1 and Tier 2 fail (e.g., `gh` unavailable
+AND worktree creation fails due to disk space or dirty
+state), or the default branch could not be detected,
+classify ALL failures as `unknown`. The `unknown`
+classification is treated as branch-caused
+(conservative), matching `/review-pr` behavior.
+
+Record which baseline method was used: `CI API`,
+`worktree`, or `unavailable`.
+
+---
+
+## Phase 4b: Causality Classification (soft-gate only)
+
+This phase runs only in `soft-gate` mode, after Phase 4a
+has established a baseline.
+
+For each failing tool from Phase 4, classify it using
+the baseline result from Phase 4a:
+
+| Baseline status | Branch status | Classification |
+|-----------------|---------------|----------------|
+| Pass            | Fail          | **branch-caused** |
+| Fail            | Fail          | **pre-existing** |
+| No data         | Fail          | **unknown** (treat as branch-caused) |
+
+### Gate decision
+
+After classifying all failures:
+
+- If ANY failures are `branch-caused` or `unknown`:
+  verdict is **FAIL (branch-caused)**. The consuming
+  command MUST NOT proceed past the pre-flight gate.
+- If ALL failures are `pre-existing`: verdict is
+  **PASS**. The consuming command MAY proceed, with
+  pre-existing failures reported as informational
+  findings.
+
 ---
 
 ## Phase 5: Result Format
 
-Present results in a standardized format:
+Present results in a standardized format.
+
+### hard-gate and ci-aware modes
 
 ```
 ## Pre-flight Results
@@ -217,7 +381,42 @@ Present results in a standardized format:
 - **Failures**: [list if any]
 ```
 
+### soft-gate mode
+
+```
+## Pre-flight Results
+
+### CI Coverage Matrix
+| Local tool | CI check | CI status | Run locally? |
+|------------|----------|-----------|--------------|
+| ...        | ...      | ...       | ...          |
+
+### Execution Results
+| Tool | Command | Exit code | Status | Causality |
+|------|---------|-----------|--------|-----------|
+| ...  | ...     | ...       | ...    | ...       |
+
+### Verdict
+- **Mode**: soft-gate
+- **Result**: PASS | FAIL (branch-caused)
+- **Branch-caused failures**: [list if any]
+- **Pre-existing failures**: [list if any]
+- **Baseline method**: CI API | worktree | unavailable
+```
+
+The `Causality` column in the Execution Results table
+contains one of: `branch-caused`, `pre-existing`,
+`unknown`, or `—` (for tools that passed).
+
+The `Result` field is:
+- `PASS` if no branch-caused or unknown failures exist
+  (even if pre-existing failures exist)
+- `FAIL (branch-caused)` if any branch-caused or unknown
+  failures exist
+
 The consuming command uses this result to decide whether
-to proceed (hard-gate: stop on FAIL) or to include
-failure context in AI review (ci-aware: continue with
-context).
+to proceed:
+- `hard-gate`: stop on FAIL
+- `ci-aware`: continue with failure context for AI review
+- `soft-gate`: stop on FAIL (branch-caused), continue
+  with pre-existing failures as informational findings

--- a/.uf/dewey/learnings/ci-causality-soft-gate-20260701T100619-yvonne-devlin.md
+++ b/.uf/dewey/learnings/ci-causality-soft-gate-20260701T100619-yvonne-devlin.md
@@ -1,0 +1,10 @@
+---
+tag: ci-causality-soft-gate
+author: yvonne-devlin
+category: pattern
+created_at: 2026-07-01T10:06:19Z
+identity: ci-causality-soft-gate-20260701T100619-yvonne-devlin
+tier: draft
+---
+
+When adding a new execution mode to a shared skill with multiple consumers, the cleanest approach is a new mode rather than extending an existing mode with optional parameters. The soft-gate addition to the pre-flight skill demonstrated this: adding a third mode alongside hard-gate and ci-aware preserved the principle that each mode has one unambiguous behavior. Extending hard-gate with optional baseline parameters would have made it behave differently depending on context, breaking the clean contract that existing consumers (unleash) depend on. The key design insight was that consumer inheritance works for free: /unleash's code review step delegates to /review-council, which now uses soft-gate, so /unleash inherits the improvement without any direct changes. Only /unleash's phase checkpoints remain hard-gate, which is the correct behavior for mid-implementation stops.

--- a/.uf/dewey/learnings/ci-causality-soft-gate-20260701T100625-yvonne-devlin.md
+++ b/.uf/dewey/learnings/ci-causality-soft-gate-20260701T100625-yvonne-devlin.md
@@ -1,0 +1,10 @@
+---
+tag: ci-causality-soft-gate
+author: yvonne-devlin
+category: pattern
+created_at: 2026-07-01T10:06:25Z
+identity: ci-causality-soft-gate-20260701T100625-yvonne-devlin
+tier: draft
+---
+
+For AI agent instruction files (Markdown skills and commands), the two-tier baseline strategy (CI API first, local worktree fallback) provides good causality classification without doubling execution time. The CI API tier (gh api repos/{owner}/{repo}/commits/main/check-runs) is fast because it reuses data CI already computed. The worktree tier (git worktree add /tmp/preflight-baseline-SHORT_SHA main --detach) is the fallback for environments without gh or CI. A critical optimization is that only failing tools need baseline comparison — passing tools are not branch-caused by definition, so they skip baseline entirely. The conservative fallback (treat unknown as branch-caused) prevents false negatives at the cost of occasional false positives, matching /review-pr's established behavior.

--- a/internal/scaffold/assets/opencode/commands/review-council.md
+++ b/internal/scaffold/assets/opencode/commands/review-council.md
@@ -127,9 +127,9 @@ Review the current codebase for compliance with the Behavioral Constraints in `A
    MUST execute in order. All three phases apply only
    to Code Review Mode -- Spec Review Mode skips them.
 
-   #### Phase 1a -- Pre-flight Checks (mandatory, hard gate)
+   #### Phase 1a -- Pre-flight Checks (mandatory, soft gate)
 
-   Load the `pre-flight` skill and run in `hard-gate`
+   Load the `pre-flight` skill and run in `soft-gate`
    mode:
 
    a. Invoke the `skill` tool with name `pre-flight` to
@@ -141,20 +141,32 @@ Review the current codebase for compliance with the Behavioral Constraints in `A
       2. Local Tool Detection — check for config files
          and verify binary availability
       3. CI Coverage Matrix — display the matrix (in
-         hard-gate mode, all tools are marked "Run
+         soft-gate mode, all tools are marked "Run
          locally = Yes")
       4. Execution — run all detected and available
-         tools in hard-gate mode
+         tools in soft-gate mode (do NOT stop on first
+         failure; record all results)
+      5. Baseline Establishment (Phase 4a) — if any
+         tools failed, establish a baseline for `main`
+         using the two-tier strategy (CI API first,
+         worktree fallback)
+      6. Causality Classification (Phase 4b) — classify
+         each failure as branch-caused, pre-existing,
+         or unknown
 
-   c. **If the pre-flight verdict is FAIL**: **STOP
-      immediately.** Report each failure as a CRITICAL
-      finding with the full error output. Do NOT
-      proceed to Phase 1b or to step 2 (Divisor agent
-      delegation). The rationale: reviewing code that
-      doesn't compile or pass tests is wasted work.
+   c. **If the pre-flight verdict is FAIL
+      (branch-caused)**: **STOP immediately.** Report
+      each branch-caused failure as a CRITICAL finding
+      with the full error output. Do NOT proceed to
+      Phase 1b or to step 2 (Divisor agent delegation).
+      The rationale: reviewing code that doesn't compile
+      or pass tests is wasted work.
 
-   d. **If the pre-flight verdict is PASS**: report
-      success and proceed to Phase 1b.
+   d. **If the pre-flight verdict is PASS** (including
+      when pre-existing failures exist): report success.
+      If pre-existing failures were detected, record
+      them for inclusion in the final report (Step 6).
+      Proceed to Phase 1b.
 
    #### Phase 1b -- Gaze Quality Analysis (conditional)
 
@@ -288,6 +300,26 @@ Review the current codebase for compliance with the Behavioral Constraints in `A
 
 6. Provide a final report to the user:
    - **Discovery summary**: how many reviewer agents were discovered, which were invoked, and which known reviewer roles were absent (informational, non-blocking)
+   - **Pre-existing CI Failures** (if any were detected
+     in Phase 1a): include an informational section
+     between the discovery summary and the review
+     context summary:
+
+     ```
+     ### Pre-existing CI Failures (informational)
+
+     The following failures exist on `main` and are
+     unrelated to the current branch:
+
+     | Tool | Exit code | Baseline method |
+     |------|-----------|-----------------|
+     | ...  | ...       | ...             |
+
+     These do not block the review verdict.
+     ```
+
+     Omit this section when no pre-existing failures
+     were detected in Phase 1a.
    - **Review context summary**: specification found
      (type, path) or "no spec found", and the
      walkthrough table from Phase 1c (review-context

--- a/internal/scaffold/assets/opencode/skills/pre-flight/SKILL.md
+++ b/internal/scaffold/assets/opencode/skills/pre-flight/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pre-flight
-description: "Shared pre-flight skill for CI detection and local tool execution. Supports hard-gate and ci-aware execution policies."
+description: "Shared pre-flight skill for CI detection and local tool execution. Supports hard-gate, ci-aware, and soft-gate execution policies."
 ---
 <!-- scaffolded by uf vdev -->
 # Skill: Pre-flight Checks
@@ -14,8 +14,9 @@ an execution policy.
 
 | Mode | Behavior | Typical consumer |
 |------|----------|-----------------|
-| `hard-gate` | Run all detected tools. Stop on first failure. | `/review-council`, `/unleash` |
+| `hard-gate` | Run all detected tools. Stop on first failure. | `/unleash` (phase checkpoints) |
 | `ci-aware` | Build CI coverage matrix against PR check results. Skip tools CI already verified. Run the rest. | `/review-pr` |
+| `soft-gate` | Run all detected tools. Classify failures as branch-caused vs pre-existing. Gate only on branch-caused failures. | `/review-council` |
 
 The consuming command specifies which mode to use.
 
@@ -192,11 +193,174 @@ Record all exit codes and output.
 If no tools are marked "Yes" (all covered by CI): report
 "All tools covered by CI — no local execution needed."
 
+### soft-gate mode
+
+Execute ALL detected and available tools (same as
+hard-gate). Do NOT stop on first failure — record all
+exit codes and output for every tool.
+
+- If ALL tools pass: verdict is PASS. No baseline
+  establishment is needed. Skip Phase 4a and 4b.
+- If ANY tools fail: proceed to Phase 4a (Baseline
+  Establishment) to classify each failure.
+
+---
+
+## Phase 4a: Baseline Establishment (soft-gate only)
+
+This phase runs only in `soft-gate` mode, and only when
+at least one tool failed during Phase 4 execution.
+
+Establish a baseline for the default branch to determine
+which failures are branch-caused vs pre-existing. Use a
+two-tier strategy: CI API first, local worktree fallback.
+
+### Detect the default branch
+
+Before establishing a baseline, detect the repository's
+default branch. Do NOT hardcode `main` — repositories
+may use `master` or another default branch name.
+
+```bash
+DEFAULT_BRANCH=$(git symbolic-ref \
+  refs/remotes/origin/HEAD 2>/dev/null \
+  | sed 's|refs/remotes/origin/||')
+```
+
+If that fails (remote HEAD not set, which happens after
+a fresh clone without
+`git remote set-head origin --auto`), fall back to
+checking for common names:
+
+```bash
+if [ -z "${DEFAULT_BRANCH}" ]; then
+  if git rev-parse --verify origin/main \
+    >/dev/null 2>&1; then
+    DEFAULT_BRANCH="main"
+  elif git rev-parse --verify origin/master \
+    >/dev/null 2>&1; then
+    DEFAULT_BRANCH="master"
+  fi
+fi
+```
+
+If neither resolves, treat the baseline as unavailable
+and fall through to the conservative fallback (all
+failures classified as `unknown` = branch-caused).
+
+### Tier 1 — CI API baseline
+
+Check if the `gh` CLI is available:
+
+```bash
+which gh
+```
+
+If `gh` is available, query the latest check-run results
+for the default branch:
+
+```bash
+gh api \
+  repos/{owner}/{repo}/commits/${DEFAULT_BRANCH}/check-runs \
+  --jq '.check_runs[] | {name, conclusion}'
+```
+
+Use `--arg` for any dynamic values to prevent injection
+(consistent with `/review-pr` Step 3a).
+
+Map CI check names to local tool names using the same
+coverage matrix logic from Phase 3. For each failing
+tool from Phase 4, look up the corresponding CI check
+conclusion on `${DEFAULT_BRANCH}`:
+
+- `conclusion: "success"` → baseline PASS
+- `conclusion: "failure"` → baseline FAIL
+- No matching check → baseline NO DATA
+
+If `gh` is not available, or the API call returns no
+data, or the API call fails: proceed to Tier 2.
+
+### Tier 2 — Local worktree baseline
+
+Create a temporary detached worktree of the default
+branch:
+
+```bash
+SHORT_SHA=$(git rev-parse --short=8 ${DEFAULT_BRANCH})
+git worktree add /tmp/preflight-baseline-${SHORT_SHA} \
+  ${DEFAULT_BRANCH} --detach
+```
+
+Run ONLY the tools that failed on the branch in the
+worktree directory. Tools that passed on the branch
+MUST NOT be run against the baseline — they are not
+branch-caused by definition.
+
+```bash
+# For each failing tool, run it in the worktree:
+cd /tmp/preflight-baseline-${SHORT_SHA}
+<tool-command>
+# Record exit code
+```
+
+After running all failing tools, clean up the worktree:
+
+```bash
+git worktree remove \
+  /tmp/preflight-baseline-${SHORT_SHA} --force
+```
+
+Compare exit codes:
+- Tool fails in worktree → baseline FAIL
+- Tool passes in worktree → baseline PASS
+
+### Fallback — conservative classification
+
+If both Tier 1 and Tier 2 fail (e.g., `gh` unavailable
+AND worktree creation fails due to disk space or dirty
+state), or the default branch could not be detected,
+classify ALL failures as `unknown`. The `unknown`
+classification is treated as branch-caused
+(conservative), matching `/review-pr` behavior.
+
+Record which baseline method was used: `CI API`,
+`worktree`, or `unavailable`.
+
+---
+
+## Phase 4b: Causality Classification (soft-gate only)
+
+This phase runs only in `soft-gate` mode, after Phase 4a
+has established a baseline.
+
+For each failing tool from Phase 4, classify it using
+the baseline result from Phase 4a:
+
+| Baseline status | Branch status | Classification |
+|-----------------|---------------|----------------|
+| Pass            | Fail          | **branch-caused** |
+| Fail            | Fail          | **pre-existing** |
+| No data         | Fail          | **unknown** (treat as branch-caused) |
+
+### Gate decision
+
+After classifying all failures:
+
+- If ANY failures are `branch-caused` or `unknown`:
+  verdict is **FAIL (branch-caused)**. The consuming
+  command MUST NOT proceed past the pre-flight gate.
+- If ALL failures are `pre-existing`: verdict is
+  **PASS**. The consuming command MAY proceed, with
+  pre-existing failures reported as informational
+  findings.
+
 ---
 
 ## Phase 5: Result Format
 
-Present results in a standardized format:
+Present results in a standardized format.
+
+### hard-gate and ci-aware modes
 
 ```
 ## Pre-flight Results
@@ -217,7 +381,42 @@ Present results in a standardized format:
 - **Failures**: [list if any]
 ```
 
+### soft-gate mode
+
+```
+## Pre-flight Results
+
+### CI Coverage Matrix
+| Local tool | CI check | CI status | Run locally? |
+|------------|----------|-----------|--------------|
+| ...        | ...      | ...       | ...          |
+
+### Execution Results
+| Tool | Command | Exit code | Status | Causality |
+|------|---------|-----------|--------|-----------|
+| ...  | ...     | ...       | ...    | ...       |
+
+### Verdict
+- **Mode**: soft-gate
+- **Result**: PASS | FAIL (branch-caused)
+- **Branch-caused failures**: [list if any]
+- **Pre-existing failures**: [list if any]
+- **Baseline method**: CI API | worktree | unavailable
+```
+
+The `Causality` column in the Execution Results table
+contains one of: `branch-caused`, `pre-existing`,
+`unknown`, or `—` (for tools that passed).
+
+The `Result` field is:
+- `PASS` if no branch-caused or unknown failures exist
+  (even if pre-existing failures exist)
+- `FAIL (branch-caused)` if any branch-caused or unknown
+  failures exist
+
 The consuming command uses this result to decide whether
-to proceed (hard-gate: stop on FAIL) or to include
-failure context in AI review (ci-aware: continue with
-context).
+to proceed:
+- `hard-gate`: stop on FAIL
+- `ci-aware`: continue with failure context for AI review
+- `soft-gate`: stop on FAIL (branch-caused), continue
+  with pre-existing failures as informational findings

--- a/openspec/changes/ci-causality-soft-gate/.openspec.yaml
+++ b/openspec/changes/ci-causality-soft-gate/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: unbound-force
+created: 2026-06-30

--- a/openspec/changes/ci-causality-soft-gate/design.md
+++ b/openspec/changes/ci-causality-soft-gate/design.md
@@ -1,0 +1,238 @@
+## Context
+
+The pre-flight skill currently supports two execution
+policies: `hard-gate` (run all, stop on first failure)
+and `ci-aware` (skip tools CI already covers, don't
+stop). `/review-council` uses `hard-gate`, which blocks
+the entire review council on any failure -- including
+failures pre-existing on `main`.
+
+`/review-pr` has its own causality analysis (Step 3a)
+that classifies failures as PR-caused vs pre-existing
+by querying the GitHub CI API for base branch check
+results. This logic lives in the review-pr command, not
+in the pre-flight skill.
+
+This design adds a third execution policy (`soft-gate`)
+to the pre-flight skill that combines `hard-gate`'s
+"run everything" behavior with causality classification
+to determine which failures should block.
+
+## Goals / Non-Goals
+
+### Goals
+
+- Add `soft-gate` execution policy to the pre-flight
+  skill with baseline establishment and causality
+  classification
+- Update `/review-council` Phase 1a to use `soft-gate`
+- Maintain backward compatibility for `hard-gate` and
+  `ci-aware` consumers
+- Classify failures using the same model as `/review-pr`
+  Step 3a (branch-caused / pre-existing / unknown)
+
+### Non-Goals
+
+- Modifying `/unleash` -- it inherits the improvement
+  via `/review-council` delegation; phase checkpoints
+  remain `hard-gate`
+- Modifying `/review-pr` -- it has its own causality
+  analysis in Step 3a that works against PR check data
+- Baseline result caching -- deferred to a follow-up
+  issue if performance becomes a concern
+- Error output comparison for causality classification
+  -- exit-code-only classification matches `/review-pr`
+  and is sufficient for v1
+- Fix-branch creation for pre-existing failures --
+  deferred; this may become a standalone command
+
+## Decisions
+
+### D1: New mode vs extending `hard-gate`
+
+**Decision**: Add a new `soft-gate` mode rather than
+extending `hard-gate` with optional parameters.
+
+**Rationale**: The existing two modes have clean,
+distinct behaviors. Adding optional baseline parameters
+to `hard-gate` would make it behave differently depending
+on whether baseline data is provided, breaking the
+current clean contract. A third mode preserves the
+principle that each mode has one unambiguous behavior.
+This aligns with Composability First -- existing consumers
+are unaffected.
+
+### D2: Baseline establishment strategy
+
+**Decision**: Two-tier baseline: (1) GitHub CI API first,
+(2) local git worktree fallback.
+
+**Rationale**: Most repositories using `/review-council`
+have CI configured. Querying `gh api` for `main` branch
+check results is fast and avoids running the full tool
+suite twice. When `gh` is unavailable or returns no data
+(no CI configured, private repo without token), the skill
+falls back to creating a temporary git worktree of `main`,
+running the same tools there, and comparing exit codes.
+This ensures the feature works in all environments.
+
+**Tier 1 -- CI API baseline**:
+```bash
+gh api repos/{owner}/{repo}/commits/main/check-runs \
+  --jq '.check_runs[] | {name, conclusion}'
+```
+Maps CI check names to tool names using the same
+coverage matrix logic from Phase 3.
+
+**Tier 2 -- Local worktree baseline**:
+```bash
+git worktree add /tmp/preflight-baseline-<SHORT_SHA> \
+  main --detach
+# Run each failing tool in the worktree
+# Compare exit codes
+git worktree remove /tmp/preflight-baseline-<SHORT_SHA>
+```
+Only tools that failed on the branch need to be run
+against the baseline -- passing tools are not
+branch-caused by definition.
+
+**Fallback to conservative**: If both tiers fail (e.g.,
+`gh` unavailable AND worktree creation fails), classify
+all failures as `unknown` and treat them as branch-caused
+(conservative, matching `/review-pr` behavior).
+
+### D3: Causality classification model
+
+**Decision**: Reuse `/review-pr` Step 3a's classification
+model exactly.
+
+| Baseline status | Branch status | Classification |
+|-----------------|---------------|----------------|
+| Pass | Fail | **branch-caused** |
+| Fail | Fail | **pre-existing** |
+| No data | Fail | **unknown** (treat as branch-caused) |
+
+**Rationale**: Consistency with `/review-pr`. Users see
+the same classification vocabulary in both commands. The
+`unknown` → branch-caused conservative default prevents
+false negatives (missing a real branch-caused failure).
+
+### D4: Gate behavior in `soft-gate` mode
+
+**Decision**: `soft-gate` runs ALL tools (same as
+`hard-gate`). After execution:
+
+- **branch-caused failures**: STOP (hard gate). Report
+  as CRITICAL findings. Do not proceed to council.
+- **pre-existing failures**: CONTINUE. Report as
+  informational findings. Proceed to council with the
+  findings included in context.
+- **unknown failures**: Treat as branch-caused (STOP).
+
+This differs from `hard-gate` (stops on ANY failure)
+and `ci-aware` (never stops, leaves gating to the
+consuming command).
+
+### D5: Execution order within `soft-gate`
+
+**Decision**: Run all tools first, then classify. Do not
+stop on first failure during execution.
+
+**Rationale**: Unlike `hard-gate` which stops on first
+failure, `soft-gate` needs to run all tools to build a
+complete picture before establishing the baseline. A tool
+that fails might be pre-existing, and stopping early
+would prevent discovering branch-caused failures in later
+tools. The baseline is only queried for tools that
+actually failed, minimizing baseline overhead.
+
+### D6: Result format extension
+
+**Decision**: Extend Phase 5's result format with a
+causality column in the Execution Results table and a
+causality breakdown in the Verdict.
+
+```
+### Execution Results
+| Tool | Command | Exit | Status | Causality |
+|------|---------|------|--------|-----------|
+| go test | go test ... | 1 | FAIL | pre-existing |
+| golangci-lint | golangci-lint ... | 1 | FAIL | branch-caused |
+
+### Verdict
+- **Mode**: soft-gate
+- **Result**: FAIL (branch-caused)
+- **Branch-caused failures**: [golangci-lint]
+- **Pre-existing failures**: [go test]
+- **Baseline method**: CI API | worktree | unavailable
+```
+
+The consuming command uses the verdict to decide:
+- If branch-caused failures exist → STOP
+- If only pre-existing failures → CONTINUE with
+  informational findings
+
+### D7: Review-council report changes
+
+**Decision**: Add a "Pre-existing CI Failures" section
+to the final report (Step 6), between the discovery
+summary and the iteration findings.
+
+```
+### Pre-existing CI Failures (informational)
+
+The following failures exist on `main` and are
+unrelated to the current branch:
+
+| Tool | Exit code | Baseline method |
+|------|-----------|-----------------|
+| go test | 1 | CI API |
+
+These do not block the review verdict.
+```
+
+## Risks / Trade-offs
+
+### R1: Baseline execution adds latency
+
+The CI API tier is fast (single HTTP request). The
+worktree tier is slow (creates a worktree, runs tools,
+cleans up). Mitigation: CI API is tried first, and the
+worktree fallback only runs failing tools against the
+baseline (not all tools). Caching is explicitly deferred
+to a follow-up issue.
+
+### R2: False pre-existing classification
+
+If a tool fails on `main` for a different reason than it
+fails on the branch, the failure is classified as
+pre-existing when it may be branch-caused. Mitigation:
+exit-code-only classification is the same approach
+`/review-pr` uses successfully. Error output comparison
+is deferred to a follow-up if this becomes a practical
+problem.
+
+### R3: Worktree creation may fail
+
+Dirty working tree, insufficient disk space, or git
+configuration issues could prevent worktree creation.
+Mitigation: fallback to conservative classification
+(all failures treated as branch-caused / unknown). The
+user sees the same behavior as the current `hard-gate`
+mode in this case.
+
+### R4: `gh` CLI authentication
+
+The CI API tier requires `gh` to be installed and
+authenticated. Mitigation: binary availability is
+checked via `which gh` before attempting the API call.
+If unavailable, the skill falls through to the worktree
+tier silently.
+
+### R5: Flaky tests
+
+A test that passes on `main` intermittently but fails on
+the branch could be misclassified as branch-caused.
+Mitigation: this is inherent to any causality analysis
+based on point-in-time comparison. Accepted as a known
+limitation, consistent with `/review-pr` behavior.

--- a/openspec/changes/ci-causality-soft-gate/proposal.md
+++ b/openspec/changes/ci-causality-soft-gate/proposal.md
@@ -1,0 +1,158 @@
+## Why
+
+`/review-council` Phase 1a runs the pre-flight skill in
+`hard-gate` mode, which stops the entire review council on
+any CI check failure -- including failures that already
+exist on `main` and are unrelated to the current branch.
+This blocks the council from providing value when the
+codebase has pre-existing issues.
+
+`/review-pr` solves this with causality analysis (Step 3a):
+it classifies failures as PR-caused vs pre-existing and
+only blocks on PR-caused failures. This change brings the
+same causality classification to `/review-council` via a
+new `soft-gate` execution policy in the pre-flight skill.
+
+Fixes: #313 (split from #177, Phase 2)
+
+## What Changes
+
+1. Add a third execution policy (`soft-gate`) to the
+   pre-flight skill that runs all tools locally but
+   classifies failures as branch-caused vs pre-existing
+   before deciding whether to stop.
+
+2. Update `/review-council` Phase 1a to use `soft-gate`
+   instead of `hard-gate`.
+
+3. Branch-caused failures remain hard gates (CRITICAL).
+   Pre-existing failures are reported as informational
+   findings in the council report.
+
+## Capabilities
+
+### New Capabilities
+
+- `soft-gate execution policy`: A new pre-flight mode
+  that runs all tools (like `hard-gate`) but classifies
+  failures by causality before gating. Branch-caused
+  failures stop execution. Pre-existing failures are
+  reported as informational findings.
+
+- `baseline establishment`: The `soft-gate` mode
+  establishes a baseline for causality classification
+  using a two-tier strategy: (1) query GitHub CI API
+  via `gh api` for `main` branch check results when
+  available, (2) fall back to running checks in a
+  temporary git worktree of `main` when `gh` is
+  unavailable or no CI data exists.
+
+### Modified Capabilities
+
+- `/review-council` Phase 1a: Changes from `hard-gate`
+  to `soft-gate` mode. Pre-existing failures no longer
+  block the council. The final report includes a new
+  section for pre-existing failures classified as
+  informational.
+
+### Removed Capabilities
+
+- None.
+
+## Impact
+
+### Files Modified
+
+- `.opencode/skills/pre-flight/SKILL.md` -- add
+  `soft-gate` execution policy with baseline
+  establishment, causality classification, and
+  decision rules
+- `internal/scaffold/assets/opencode/skills/pre-flight/SKILL.md`
+  -- scaffold copy (kept in sync by
+  `TestEmbeddedAssets_MatchSource`)
+- `.opencode/commands/review-council.md` -- Phase 1a
+  switches to `soft-gate` mode, final report adds
+  pre-existing failure section
+- `internal/scaffold/assets/opencode/commands/review-council.md`
+  -- scaffold copy (kept in sync by
+  `TestEmbeddedAssets_MatchSource`)
+
+### Consumers Not Modified
+
+- `/unleash`: Uses `hard-gate` for phase checkpoints
+  (mid-implementation, where any failure should stop)
+  and delegates to `/review-council` for code review
+  (inherits `soft-gate` automatically). No direct
+  changes needed.
+- `/review-pr`: Uses `ci-aware` mode with its own
+  causality analysis in Step 3a. Unaffected.
+
+### Behavioral Expansion
+
+This is an intentional behavioral expansion of the
+pre-flight skill (adding a third mode) and of
+`/review-council` (changing gate behavior for
+pre-existing failures). This is NOT strict behavioral
+parity -- the council will now proceed past pre-existing
+failures where it previously stopped. Per the learning
+from the pre-flight skill extraction, this expansion is
+explicitly declared rather than obscured.
+
+## Constitution Alignment
+
+Assessed against the Unbound Force org constitution.
+
+### I. Autonomous Collaboration
+
+**Assessment**: PASS
+
+The pre-flight skill remains a self-contained artifact
+consumed asynchronously by commands. The new `soft-gate`
+mode produces the same standardized result format
+(CI Coverage Matrix, Execution Results, Verdict) with
+an additional causality classification field. No
+runtime coupling is introduced.
+
+### II. Composability First
+
+**Assessment**: PASS
+
+The new mode is additive -- `hard-gate` and `ci-aware`
+continue to work unchanged for their existing consumers.
+No mandatory dependencies are introduced. The `gh` CLI
+is used opportunistically with a local worktree fallback,
+so the feature works with or without GitHub CI.
+
+### III. Observable Quality
+
+**Assessment**: PASS
+
+The `soft-gate` verdict includes machine-parseable
+causality classification for each failure (branch-caused
+vs pre-existing vs unknown). The result format extends
+the existing standardized format with an additional
+column. Provenance is maintained.
+
+### IV. Testability
+
+**Assessment**: PASS
+
+The causality classification logic is deterministic: it
+compares exit codes from the branch run against the
+baseline. Verification is manual (run `/review-council`
+with a known pre-existing failure and confirm it is
+reported as informational rather than blocking). This
+matches the regression verification approach used for the
+pre-flight skill extraction and review-context skill
+migration.
+
+### V. Security by Default
+
+**Assessment**: PASS
+
+The `gh api` command uses `--arg` for check name
+injection safety, consistent with `/review-pr` Step 3a.
+The git worktree fallback creates a temporary directory
+and cleans it up after use. No new dependencies are
+introduced. No secrets or elevated permissions are
+required.

--- a/openspec/changes/ci-causality-soft-gate/specs/pre-flight/spec.md
+++ b/openspec/changes/ci-causality-soft-gate/specs/pre-flight/spec.md
@@ -1,0 +1,273 @@
+## ADDED Requirements
+
+### FR-001: soft-gate Execution Policy
+
+The pre-flight skill MUST support a `soft-gate`
+execution policy in addition to the existing `hard-gate`
+and `ci-aware` policies. The consuming command specifies
+which mode to use.
+
+In `soft-gate` mode, the skill MUST:
+1. Run ALL detected and available tools (same as
+   `hard-gate`). Do NOT stop on first failure during
+   execution.
+2. After execution, establish a baseline for the default
+   branch to classify each failure.
+3. Classify each failing tool as `branch-caused`,
+   `pre-existing`, or `unknown`.
+4. Gate only on `branch-caused` or `unknown` failures.
+   `pre-existing` failures MUST NOT gate.
+
+#### Scenario: Branch-caused failure blocks council
+
+- **GIVEN** a branch with a lint error not present on
+  `main`
+- **WHEN** the pre-flight skill runs in `soft-gate`
+  mode
+- **THEN** the lint failure is classified as
+  `branch-caused`
+- **AND** the verdict is FAIL with
+  `branch-caused failures: [golangci-lint]`
+- **AND** the consuming command MUST NOT proceed past
+  the pre-flight gate
+
+#### Scenario: Pre-existing failure does not block
+
+- **GIVEN** a branch where `go test` fails, and the
+  same test also fails on `main`
+- **WHEN** the pre-flight skill runs in `soft-gate`
+  mode
+- **THEN** the test failure is classified as
+  `pre-existing`
+- **AND** the verdict is PASS (no branch-caused
+  failures)
+- **AND** the pre-existing failure is reported as an
+  informational finding
+- **AND** the consuming command MAY proceed past the
+  pre-flight gate
+
+#### Scenario: Mixed failures
+
+- **GIVEN** a branch where `go test` fails
+  (pre-existing on `main`) and `golangci-lint` fails
+  (not on `main`)
+- **WHEN** the pre-flight skill runs in `soft-gate`
+  mode
+- **THEN** `go test` is classified as `pre-existing`
+- **AND** `golangci-lint` is classified as
+  `branch-caused`
+- **AND** the verdict is FAIL (branch-caused failures
+  exist)
+- **AND** both failures are listed in the verdict with
+  their classification
+
+#### Scenario: All tools pass
+
+- **GIVEN** a branch where all tools pass
+- **WHEN** the pre-flight skill runs in `soft-gate`
+  mode
+- **THEN** no baseline establishment is needed
+- **AND** the verdict is PASS
+- **AND** the behavior is identical to `hard-gate`
+  all-pass
+
+### FR-002: Baseline Establishment (CI API Tier)
+
+When running in `soft-gate` mode, the skill MUST first
+detect the repository's default branch (via
+`git symbolic-ref refs/remotes/origin/HEAD`, falling
+back to checking for `main` then `master`). The skill
+MUST NOT hardcode `main`. If the default branch cannot
+be detected, the skill MUST fall through to the
+conservative fallback (all failures classified as
+`unknown`).
+
+The skill MUST then attempt to establish a baseline
+via the GitHub CI API:
+1. Check `gh` CLI availability via `which gh`.
+2. If available, query the latest check-run results for
+   the default branch:
+   ```bash
+   gh api repos/{owner}/{repo}/commits/${DEFAULT_BRANCH}/check-runs \
+     --jq '.check_runs[] | {name, conclusion}'
+   ```
+3. Use `--arg` for any dynamic values to prevent
+   injection (consistent with `/review-pr` Step 3a).
+4. Map CI check names to local tool names using the
+   existing coverage matrix logic from Phase 3.
+
+If `gh` is not available, or the API call returns no
+data, or the API call fails, the skill MUST fall through
+to FR-003 (worktree baseline).
+
+#### Scenario: CI API provides baseline
+
+- **GIVEN** `gh` is installed and authenticated
+- **AND** the default branch has CI check results
+- **WHEN** a tool fails on the branch
+- **THEN** the skill queries the CI API for the matching
+  check on the default branch
+- **AND** classifies the failure based on the CI API
+  result
+
+#### Scenario: gh CLI not available
+
+- **GIVEN** `gh` is not installed (not in PATH)
+- **WHEN** a tool fails on the branch
+- **THEN** the skill skips the CI API tier silently
+- **AND** proceeds to FR-003 (worktree baseline)
+
+### FR-003: Baseline Establishment (Worktree Tier)
+
+When the CI API tier is unavailable or returns no data,
+the skill MUST fall back to establishing a baseline via
+a temporary git worktree.
+
+The skill MUST:
+1. Create a temporary detached worktree of the default
+   branch (as detected in FR-002):
+   ```bash
+   git worktree add /tmp/preflight-baseline-<SHORT_SHA> \
+     ${DEFAULT_BRANCH} --detach
+   ```
+   where `<SHORT_SHA>` is the first 8 characters of the
+   default branch's HEAD commit SHA.
+2. Run ONLY the tools that failed on the branch in the
+   worktree directory. Tools that passed on the branch
+   MUST NOT be run against the baseline.
+3. Compare exit codes: if a tool also fails in the
+   worktree, classify as `pre-existing`; if it passes,
+   classify as `branch-caused`.
+4. Clean up the worktree after classification:
+   ```bash
+   git worktree remove \
+     /tmp/preflight-baseline-<SHORT_SHA> --force
+   ```
+
+If worktree creation fails, the skill MUST classify all
+failures as `unknown` and treat them as branch-caused
+(conservative fallback).
+
+#### Scenario: Worktree baseline for pre-existing failure
+
+- **GIVEN** `gh` is not available
+- **AND** `go test` fails on the branch
+- **WHEN** the skill creates a worktree of the default
+  branch and runs `go test` there
+- **AND** `go test` also fails in the worktree
+- **THEN** the failure is classified as `pre-existing`
+
+#### Scenario: Worktree baseline for branch-caused failure
+
+- **GIVEN** `gh` is not available
+- **AND** `golangci-lint` fails on the branch
+- **WHEN** the skill creates a worktree of the default
+  branch and runs `golangci-lint` there
+- **AND** `golangci-lint` passes in the worktree
+- **THEN** the failure is classified as `branch-caused`
+
+#### Scenario: Worktree creation fails
+
+- **GIVEN** `gh` is not available
+- **AND** worktree creation fails (disk space, dirty
+  state, etc.)
+- **WHEN** a tool fails on the branch
+- **THEN** the failure is classified as `unknown`
+- **AND** `unknown` is treated as `branch-caused`
+  (conservative)
+
+### FR-004: Extended Result Format
+
+The pre-flight Phase 5 result format MUST be extended
+for `soft-gate` mode to include causality classification.
+
+The Execution Results table MUST include a `Causality`
+column:
+
+```
+| Tool | Command | Exit | Status | Causality |
+|------|---------|------|--------|-----------|
+```
+
+The Verdict section MUST include:
+- `branch-caused failures` list
+- `pre-existing failures` list
+- `baseline method` used (CI API / worktree /
+  unavailable)
+
+The `Result` field in the Verdict MUST be:
+- `PASS` if no branch-caused or unknown failures exist
+  (even if pre-existing failures exist)
+- `FAIL (branch-caused)` if any branch-caused or unknown
+  failures exist
+
+#### Scenario: Verdict with pre-existing only
+
+- **GIVEN** all failures are classified as
+  `pre-existing`
+- **THEN** the verdict Result is `PASS`
+- **AND** the pre-existing failures list is populated
+
+## MODIFIED Requirements
+
+### Phase 1a of `/review-council` (review-council.md)
+
+Phase 1a MUST use `soft-gate` mode instead of
+`hard-gate` mode.
+
+Previously: "Load the `pre-flight` skill and run in
+`hard-gate` mode"
+
+New behavior:
+1. Load the pre-flight skill and run in `soft-gate`
+   mode.
+2. If the verdict is FAIL (branch-caused): STOP
+   immediately. Report each branch-caused failure as a
+   CRITICAL finding. Do NOT proceed to Phase 1b.
+3. If the verdict is PASS (no branch-caused failures):
+   proceed to Phase 1b. If pre-existing failures exist,
+   record them for inclusion in the final report
+   (Step 6).
+
+#### Scenario: Council proceeds past pre-existing failure
+
+- **GIVEN** a branch where `go test` fails but the
+  failure is pre-existing on `main`
+- **WHEN** `/review-council` runs Phase 1a in
+  `soft-gate` mode
+- **THEN** the council proceeds to Phase 1b and
+  Divisor agent delegation
+- **AND** the final report (Step 6) includes a
+  "Pre-existing CI Failures" section listing the
+  failure as informational
+
+### Step 6 of `/review-council` (Final Report)
+
+The final report MUST include a "Pre-existing CI
+Failures" section when pre-existing failures were
+detected in Phase 1a.
+
+Previously: No pre-existing failure section existed.
+
+New behavior: Between the discovery summary and the
+iteration findings, include:
+
+```
+### Pre-existing CI Failures (informational)
+
+The following failures exist on `main` and are
+unrelated to the current branch:
+
+| Tool | Exit code | Baseline method |
+|------|-----------|-----------------|
+| ... | ... | ... |
+
+These do not block the review verdict.
+```
+
+This section MUST be omitted when no pre-existing
+failures were detected.
+
+## REMOVED Requirements
+
+None.

--- a/openspec/changes/ci-causality-soft-gate/tasks.md
+++ b/openspec/changes/ci-causality-soft-gate/tasks.md
@@ -1,0 +1,174 @@
+<!--
+  [P] marks tasks eligible for parallel execution.
+  Add [P] when a task: (a) touches different files from
+  other [P] tasks in the group, (b) has no dependency
+  on prior tasks in the group, (c) can safely execute
+  without ordering constraints.
+  Do NOT add [P] when tasks modify the same file --
+  parallel workers will cause merge conflicts.
+  Tasks without [P] run sequentially first, then [P]
+  tasks run in parallel.
+-->
+
+## 1. Pre-flight Skill: Add `soft-gate` Mode
+
+All tasks in this group modify a single file
+(`.opencode/skills/pre-flight/SKILL.md`), so no tasks
+are parallel-eligible.
+
+- [x] 1.1 Update the Execution Policies table in SKILL.md
+  to add the `soft-gate` row:
+  `| soft-gate | Run all tools. Classify failures as
+  branch-caused vs pre-existing. Gate only on
+  branch-caused. | /review-council |`
+  Update the description line to mention all three
+  policies.
+  **File**: `.opencode/skills/pre-flight/SKILL.md`
+  **Spec**: FR-001
+
+- [x] 1.2 Add Phase 4 `soft-gate` mode section to
+  SKILL.md. After the existing `hard-gate mode` and
+  `ci-aware mode` subsections in Phase 4, add a
+  `soft-gate mode` subsection that describes:
+  (a) Execute all tools without stopping on failure.
+  Record all exit codes and output.
+  (b) If all tools pass, verdict is PASS (no baseline
+  needed).
+  (c) If any tools fail, proceed to baseline
+  establishment (new Phase 4a).
+  **File**: `.opencode/skills/pre-flight/SKILL.md`
+  **Spec**: FR-001, D5
+
+- [x] 1.3 Add Phase 4a: Baseline Establishment section
+  to SKILL.md (new section between Phase 4 and Phase 5).
+  Document the two-tier baseline strategy:
+  **Tier 1 -- CI API**: Check `which gh`. If available,
+  query `gh api repos/{owner}/{repo}/commits/main/check-runs
+  --jq '.check_runs[] | {name, conclusion}'`. Use
+  `--arg` for dynamic values. Map CI check names to
+  local tool names via coverage matrix.
+  **Tier 2 -- Worktree**: If CI API unavailable or no
+  data, create `git worktree add
+  /tmp/preflight-baseline-<SHORT_SHA> main --detach`.
+  Run ONLY failing tools in worktree. Clean up with
+  `git worktree remove ... --force`.
+  **Fallback**: If both tiers fail, classify all
+  failures as `unknown` (treated as branch-caused).
+  **File**: `.opencode/skills/pre-flight/SKILL.md`
+  **Spec**: FR-002, FR-003, D2
+
+- [x] 1.4 Add Phase 4b: Causality Classification section
+  to SKILL.md (after Phase 4a). Document the
+  classification table:
+  | Baseline status | Branch status | Classification |
+  | Pass | Fail | branch-caused |
+  | Fail | Fail | pre-existing |
+  | No data | Fail | unknown (treat as branch-caused) |
+  After classification, apply gate decision:
+  branch-caused or unknown → FAIL verdict.
+  pre-existing only → PASS verdict.
+  **File**: `.opencode/skills/pre-flight/SKILL.md`
+  **Spec**: FR-001, D3, D4
+
+- [x] 1.5 Update Phase 5 result format in SKILL.md to
+  add `soft-gate` output. Extend the Execution Results
+  table with a `Causality` column. Extend the Verdict
+  block with `Branch-caused failures`,
+  `Pre-existing failures`, and `Baseline method` fields.
+  Document that Result is `PASS` when only pre-existing
+  failures exist, and `FAIL (branch-caused)` when any
+  branch-caused or unknown failures exist.
+  **File**: `.opencode/skills/pre-flight/SKILL.md`
+  **Spec**: FR-004, D6
+
+## 2. Review-council: Switch to `soft-gate`
+
+All tasks in this group modify a single file
+(`.opencode/commands/review-council.md`), so no tasks
+are parallel-eligible.
+
+- [x] 2.1 Update Phase 1a in review-council.md to use
+  `soft-gate` instead of `hard-gate`. Change the
+  heading from "Pre-flight Checks (mandatory, hard gate)"
+  to "Pre-flight Checks (mandatory, soft gate)".
+  Update the instruction text to: "Load the `pre-flight`
+  skill and run in `soft-gate` mode."
+  Update the gate logic:
+  (a) If verdict is FAIL (branch-caused): STOP
+  immediately. Report branch-caused failures as
+  CRITICAL findings. Do NOT proceed to Phase 1b.
+  (b) If verdict is PASS (including when pre-existing
+  failures exist): report success, record any
+  pre-existing failures for Step 6, proceed to
+  Phase 1b.
+  **File**: `.opencode/commands/review-council.md`
+  **Spec**: Modified -- Phase 1a
+
+- [x] 2.2 Update Step 6 (final report) in
+  review-council.md to include a "Pre-existing CI
+  Failures (informational)" section. Add this between
+  the discovery summary and the iteration findings.
+  Include a table with Tool, Exit code, and Baseline
+  method columns. Add note: "These do not block the
+  review verdict." Omit the section when no
+  pre-existing failures were detected.
+  **File**: `.opencode/commands/review-council.md`
+  **Spec**: Modified -- Step 6, D7
+
+## 3. Scaffold Sync
+
+These tasks modify different files from each other
+and from groups 1-2, so they are parallel-eligible.
+
+- [x] 3.1 [P] Copy the updated
+  `.opencode/skills/pre-flight/SKILL.md` to
+  `internal/scaffold/assets/opencode/skills/pre-flight/SKILL.md`.
+  The two files MUST be byte-identical. The drift
+  detection test `TestEmbeddedAssets_MatchSource`
+  enforces this at build time.
+  **File**: `internal/scaffold/assets/opencode/skills/pre-flight/SKILL.md`
+
+- [x] 3.2 [P] Copy the updated
+  `.opencode/commands/review-council.md` to
+  `internal/scaffold/assets/opencode/commands/review-council.md`.
+  The two files MUST be byte-identical. The drift
+  detection test `TestEmbeddedAssets_MatchSource`
+  enforces this at build time.
+  **File**: `internal/scaffold/assets/opencode/commands/review-council.md`
+
+## 4. Verification
+
+- [x] 4.1 Run `make check` (build, lint, test) to
+  verify no regressions. The
+  `TestEmbeddedAssets_MatchSource` test MUST pass,
+  confirming scaffold sync.
+
+- [x] 4.2 Constitution alignment verification: confirm
+  the implementation maintains alignment with all five
+  org constitution principles as assessed in the
+  proposal:
+  - I. Autonomous Collaboration: skill remains a
+    self-contained artifact, no runtime coupling added
+  - II. Composability First: `hard-gate` and `ci-aware`
+    unchanged, no mandatory dependencies introduced
+  - III. Observable Quality: result format includes
+    machine-parseable causality classification
+  - IV. Testability: classification logic is
+    deterministic (exit code comparison)
+  - V. Security by Default: `--arg` used for injection
+    safety, worktree cleanup, no new dependencies
+
+- [x] 4.3 Manual verification: test the three key
+  scenarios from the spec:
+  (a) Branch-caused failure: introduce a lint error on
+  the branch (not on `main`), run `/review-council`,
+  confirm it stops with CRITICAL finding.
+  (b) Pre-existing failure: if `main` has a failing
+  check, create a branch, run `/review-council`,
+  confirm it proceeds and reports the failure as
+  informational.
+  (c) All pass: on a clean branch, run
+  `/review-council`, confirm PASS verdict and normal
+  council flow.
+<!-- spec-review: passed -->
+<!-- code-review: passed -->


### PR DESCRIPTION
## Summary

`/review-council` Phase 1a previously ran the pre-flight skill in `hard-gate` mode, blocking the entire review council on any CI check failure -- including failures pre-existing on `main`. This PR adds a new `soft-gate` execution policy to the pre-flight skill that classifies failures as branch-caused vs pre-existing using a two-tier baseline strategy (GitHub CI API first, local git worktree fallback). Only branch-caused failures now block the council; pre-existing failures are reported as informational findings.

Fixes #313

## How to Test

1. **Branch-caused failure**: Introduce a lint error on a branch (not on `main`), run `/review-council`, confirm it stops with a CRITICAL finding.
2. **Pre-existing failure**: If `main` has a failing check, create a branch, run `/review-council`, confirm it proceeds and reports the failure as informational in the final report.
3. **All pass**: On a clean branch, run `/review-council`, confirm PASS verdict and normal council flow.
4. **Scaffold sync**: Run `go test -run TestEmbeddedAssets_MatchSource ./internal/scaffold/` to confirm drift detection passes.

## How to Demo

Run `/review-council` on a branch where `main` has a known CI failure.Observe that the council proceeds past the pre-existing failure and produces a full review report with a "Pre-existing CI Failures
(informational)" section in the final report.

## Key Files Changed

| File | What Changed |
|------|-------------|
| `.opencode/skills/pre-flight/SKILL.md` | Added `soft-gate` mode, Phase 4a (Baseline Establishment), Phase 4b (Causality Classification), extended Phase 5 result format |
| `.opencode/commands/review-council.md` | Phase 1a switched from `hard-gate` to `soft-gate`, Step 6 adds "Pre-existing CI Failures" section |
| `internal/scaffold/assets/opencode/skills/pre-flight/SKILL.md` | Scaffold copy (byte-identical) |
| `internal/scaffold/assets/opencode/commands/review-council.md` | Scaffold copy (byte-identical) |
| `openspec/changes/ci-causality-soft-gate/` | OpenSpec change artifacts (proposal, design, specs, tasks) |

_This PR was generated by /finale (AI-assisted)._