### PR TITLE
fix(scaffold): prevent uf init --force from hanging on Dewey reindexing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,12 @@ Each entry follows the format: `- <change-name>: <summary>`.
   `unknown-model` fallback with user warning
   (Spec: openspec/changes/improve-finale-pr-description/)
 
+### Fixed
+- `uf init --force` no longer hangs on Dewey re-indexing.
+  Dewey indexing now runs with `--no-embeddings` for a fast
+  metadata-only pass. Run `dewey index` separately to
+  generate embeddings for semantic search. (Fixes: #163)
+
 ### Added
 - `/triage-issue` slash command for multi-agent GitHub issue
   triage using the Divisor review panel. Classifies issues

--- a/internal/scaffold/scaffold.go
+++ b/internal/scaffold/scaffold.go
@@ -1511,8 +1511,8 @@ func initDewey(opts *Options, logf func(string, ...interface{})) []subToolResult
 			results = append(results, *sr)
 		}
 
-		logf("  Indexing Dewey sources (this may take a moment)...\n")
-		if out, idxErr := opts.ExecCmd("dewey", "index"); idxErr != nil {
+		logf("  Indexing Dewey sources (without embeddings)...\n")
+		if out, idxErr := opts.ExecCmd("dewey", "index", "--no-embeddings"); idxErr != nil {
 			results = append(results, subToolResult{
 				name: "dewey index", action: "failed",
 				detail:  fmt.Sprintf("dewey index: %s", idxErr),
@@ -1523,6 +1523,7 @@ func initDewey(opts *Options, logf func(string, ...interface{})) []subToolResult
 			results = append(results, subToolResult{
 				name: "dewey index", action: "completed"})
 		}
+		logf("  Run 'dewey index' separately to generate embeddings for semantic search.\n")
 		return results
 	}
 
@@ -1531,8 +1532,9 @@ func initDewey(opts *Options, logf func(string, ...interface{})) []subToolResult
 		if sr := generateDeweySources(opts, true); sr != nil {
 			results = append(results, *sr)
 		}
-		logf("  Re-indexing Dewey sources...\n")
-		if out, idxErr := opts.ExecCmd("dewey", "index"); idxErr != nil {
+
+		logf("  Re-indexing Dewey sources (without embeddings)...\n")
+		if out, idxErr := opts.ExecCmd("dewey", "index", "--no-embeddings"); idxErr != nil {
 			results = append(results, subToolResult{
 				name: "dewey index", action: "failed",
 				detail:  fmt.Sprintf("dewey index: %s", idxErr),
@@ -1543,6 +1545,7 @@ func initDewey(opts *Options, logf func(string, ...interface{})) []subToolResult
 			results = append(results, subToolResult{
 				name: "dewey index", action: "re-indexed"})
 		}
+		logf("  Run 'dewey index' separately to generate embeddings for semantic search.\n")
 	}
 	return results
 }

--- a/internal/scaffold/scaffold_test.go
+++ b/internal/scaffold/scaffold_test.go
@@ -1914,7 +1914,7 @@ func TestInitSubTools_DeweyAvailable(t *testing.T) {
 	}
 
 	// Verify commands were called.
-	expectedCalls := []string{"dewey init", "dewey index"}
+	expectedCalls := []string{"dewey init", "dewey index --no-embeddings"}
 	for _, expected := range expectedCalls {
 		found := false
 		for _, call := range rec.calls {
@@ -2022,7 +2022,7 @@ func TestInitSubTools_DeweyInitFails(t *testing.T) {
 
 	// dewey index should NOT have been called.
 	for _, call := range rec.calls {
-		if call == "dewey index" {
+		if strings.HasPrefix(call, "dewey index") {
 			t.Error("dewey index should NOT be called when dewey init fails")
 		}
 	}
@@ -3427,15 +3427,15 @@ func TestInitSubTools_DeweyForceReindex(t *testing.T) {
 		t.Errorf("expected dewey index re-indexed result, got %v", results)
 	}
 
-	// Verify dewey index was called.
+	// Verify dewey index --no-embeddings was called.
 	indexCalled := false
 	for _, call := range rec.calls {
-		if call == "dewey index" {
+		if call == "dewey index --no-embeddings" {
 			indexCalled = true
 		}
 	}
 	if !indexCalled {
-		t.Errorf("expected dewey index command, got calls: %v", rec.calls)
+		t.Errorf("expected 'dewey index --no-embeddings' command, got calls: %v", rec.calls)
 	}
 
 	// Verify dewey init was NOT called (.uf/dewey/ already exists).
@@ -3482,7 +3482,7 @@ func TestInitSubTools_DeweyExistsNoForce(t *testing.T) {
 
 	// Verify no dewey commands were called.
 	for _, call := range rec.calls {
-		if call == "dewey init" || call == "dewey index" {
+		if call == "dewey init" || strings.HasPrefix(call, "dewey index") {
 			t.Errorf("unexpected dewey command when Force=false: %s", call)
 		}
 	}
@@ -3513,7 +3513,7 @@ func TestInitSubTools_DeweySkippedByConfig(t *testing.T) {
 
 	// Dewey commands should NOT have been called.
 	for _, call := range rec.calls {
-		if call == "dewey init" || call == "dewey index" {
+		if call == "dewey init" || strings.HasPrefix(call, "dewey index") {
 			t.Errorf("dewey command should NOT be called when method is skip: %s", call)
 		}
 	}
@@ -3561,7 +3561,7 @@ func TestInitSubTools_DeweySkippedByConfig_ForceIgnored(t *testing.T) {
 
 	// Even with Force=true, skip config should prevent re-index.
 	for _, call := range rec.calls {
-		if call == "dewey init" || call == "dewey index" {
+		if call == "dewey init" || strings.HasPrefix(call, "dewey index") {
 			t.Errorf("dewey command should NOT be called when method is skip (even with Force): %s", call)
 		}
 	}
@@ -3705,7 +3705,7 @@ func TestInitSubTools_ConcurrentAllResults(t *testing.T) {
 	rec.mu.Unlock()
 
 	expectedCmds := []string{
-		"dewey init", "dewey index",
+		"dewey init", "dewey index --no-embeddings",
 		"replicator init", "specify init",
 		"openspec init --tools opencode", "gaze init",
 	}
@@ -3825,7 +3825,7 @@ func TestInitSubTools_ConcurrentOneFailureNoBlock(t *testing.T) {
 	// Verify dewey index was NOT called (init failed).
 	rec.mu.Lock()
 	for _, call := range rec.calls {
-		if call == "dewey index" {
+		if strings.HasPrefix(call, "dewey index") {
 			t.Error("dewey index should not run when dewey init fails")
 		}
 	}

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -2487,7 +2487,7 @@ func TestSetupRun_DryRunNewSteps(t *testing.T) {
 
 	// Verify no install/init commands were actually executed.
 	for _, call := range rec.calls {
-		if strings.Contains(call, "install") || strings.Contains(call, "setup") || call == "dewey init" || call == "dewey index" {
+		if strings.Contains(call, "install") || strings.Contains(call, "setup") || call == "dewey init" || strings.HasPrefix(call, "dewey index") {
 			t.Errorf("unexpected command in dry-run: %s", call)
 		}
 	}


### PR DESCRIPTION
## Summary

`uf init --force` hangs indefinitely at "Re-indexing Dewey sources..." because it triggers a full embedding generation pass (Ollama + granite-embedding:30m), which is very slow for large workspaces (~2300 pages, 40 sources).

This PR fixes the issue by passing `--no-embeddings` to `dewey index` during init. Embedding generation is the slow part — structural indexing (metadata, page content) is fast. Users can run `dewey index` separately afterward to generate embeddings for semantic search.

## How to Test

```bash
# Should no longer hang — fast metadata-only indexing
uf init --force

# Generate embeddings separately when ready
dewey index
```

## Key Files Changed

| File | Change |
|------|--------|
| `internal/scaffold/scaffold.go` | Pass `--no-embeddings` to `dewey index`, add guidance message |
| `internal/scaffold/scaffold_test.go` | Update 7 tests to expect `dewey index --no-embeddings` |
| `internal/setup/setup_test.go` | Update negative assertion for consistency |
| `CHANGELOG.md` | Added Fixed entry |

Fixes #163