### PR TITLE
chore: improve CODEOWNERS check in /review-pr and /review-council

### DIFF
--- a/.opencode/commands/review-council.md
+++ b/.opencode/commands/review-council.md
@@ -471,13 +471,42 @@ Review the current codebase for compliance with the Behavioral Constraints in `A
    > return to REVIEW_REQUIRED. You may need to re-run
    > `/review-council` after final commits."
 
-   If `require_codeowners` is true, check for CODEOWNERS:
+   If `require_codeowners` is true, check for CODEOWNERS
+   file. Try each path in order, short-circuiting on the
+   first success:
+
+   ```bash
+   gh api repos/{owner}/{repo}/contents/.github/CODEOWNERS \
+     --jq '.name'
+   ```
+
+   If that returns 404, try the next path:
+
    ```bash
    gh api repos/{owner}/{repo}/contents/CODEOWNERS \
-     --jq '.name' 2>/dev/null || \
-   gh api repos/{owner}/{repo}/contents/.github/CODEOWNERS \
-     --jq '.name' 2>/dev/null
+     --jq '.name'
    ```
+
+   If that also returns 404, try the third path:
+
+   ```bash
+   gh api repos/{owner}/{repo}/contents/docs/CODEOWNERS \
+     --jq '.name'
+   ```
+
+   **Error handling**:
+   - **404 response**: treat as "file not found at this
+     path" and try the next path. This is expected and
+     silent.
+   - **Non-404 error** (network failure, 500, 429, etc.):
+     stop checking further paths and display:
+     ```
+     Note: CODEOWNERS check was inconclusive (API error).
+     Could not determine if this repo uses CODEOWNERS.
+     ```
+   - **Success** (any path returns the file name): stop
+     checking further paths. CODEOWNERS exists.
+
    If CODEOWNERS exists:
    > "Warning: This repo requires code owner reviews.
    > This APPROVE may not satisfy branch protection if

--- a/.opencode/commands/review-pr.md
+++ b/.opencode/commands/review-pr.md
@@ -800,14 +800,40 @@ final commits.
 ```
 
 If `require_codeowners` is true, check for CODEOWNERS
-file:
+file. Try each path in order, short-circuiting on the
+first success:
+
+```bash
+gh api repos/{owner}/{repo}/contents/.github/CODEOWNERS \
+  --jq '.name'
+```
+
+If that returns 404, try the next path:
 
 ```bash
 gh api repos/{owner}/{repo}/contents/CODEOWNERS \
-  --jq '.name' 2>/dev/null || \
-gh api repos/{owner}/{repo}/contents/.github/CODEOWNERS \
-  --jq '.name' 2>/dev/null
+  --jq '.name'
 ```
+
+If that also returns 404, try the third path:
+
+```bash
+gh api repos/{owner}/{repo}/contents/docs/CODEOWNERS \
+  --jq '.name'
+```
+
+**Error handling**:
+- **404 response**: treat as "file not found at this
+  path" and try the next path. This is expected and
+  silent.
+- **Non-404 error** (network failure, 500, 429, etc.):
+  stop checking further paths and display:
+  ```
+  Note: CODEOWNERS check was inconclusive (API error).
+  Could not determine if this repo uses CODEOWNERS.
+  ```
+- **Success** (any path returns the file name): stop
+  checking further paths. CODEOWNERS exists.
 
 If CODEOWNERS exists and `require_code_owner_reviews` is
 true, display:
@@ -816,8 +842,6 @@ Warning: This repo requires code owner reviews. This
 APPROVE may not satisfy branch protection if this
 account is not listed in CODEOWNERS.
 ```
-
-If any API call fails: skip silently.
 
 1. **Prepare comments**: For each finding that maps to a
    specific file and line range in the diff, prepare an

--- a/internal/scaffold/assets/opencode/commands/review-council.md
+++ b/internal/scaffold/assets/opencode/commands/review-council.md
@@ -471,13 +471,42 @@ Review the current codebase for compliance with the Behavioral Constraints in `A
    > return to REVIEW_REQUIRED. You may need to re-run
    > `/review-council` after final commits."
 
-   If `require_codeowners` is true, check for CODEOWNERS:
+   If `require_codeowners` is true, check for CODEOWNERS
+   file. Try each path in order, short-circuiting on the
+   first success:
+
+   ```bash
+   gh api repos/{owner}/{repo}/contents/.github/CODEOWNERS \
+     --jq '.name'
+   ```
+
+   If that returns 404, try the next path:
+
    ```bash
    gh api repos/{owner}/{repo}/contents/CODEOWNERS \
-     --jq '.name' 2>/dev/null || \
-   gh api repos/{owner}/{repo}/contents/.github/CODEOWNERS \
-     --jq '.name' 2>/dev/null
+     --jq '.name'
    ```
+
+   If that also returns 404, try the third path:
+
+   ```bash
+   gh api repos/{owner}/{repo}/contents/docs/CODEOWNERS \
+     --jq '.name'
+   ```
+
+   **Error handling**:
+   - **404 response**: treat as "file not found at this
+     path" and try the next path. This is expected and
+     silent.
+   - **Non-404 error** (network failure, 500, 429, etc.):
+     stop checking further paths and display:
+     ```
+     Note: CODEOWNERS check was inconclusive (API error).
+     Could not determine if this repo uses CODEOWNERS.
+     ```
+   - **Success** (any path returns the file name): stop
+     checking further paths. CODEOWNERS exists.
+
    If CODEOWNERS exists:
    > "Warning: This repo requires code owner reviews.
    > This APPROVE may not satisfy branch protection if

--- a/internal/scaffold/assets/opencode/commands/review-pr.md
+++ b/internal/scaffold/assets/opencode/commands/review-pr.md
@@ -800,14 +800,40 @@ final commits.
 ```
 
 If `require_codeowners` is true, check for CODEOWNERS
-file:
+file. Try each path in order, short-circuiting on the
+first success:
+
+```bash
+gh api repos/{owner}/{repo}/contents/.github/CODEOWNERS \
+  --jq '.name'
+```
+
+If that returns 404, try the next path:
 
 ```bash
 gh api repos/{owner}/{repo}/contents/CODEOWNERS \
-  --jq '.name' 2>/dev/null || \
-gh api repos/{owner}/{repo}/contents/.github/CODEOWNERS \
-  --jq '.name' 2>/dev/null
+  --jq '.name'
 ```
+
+If that also returns 404, try the third path:
+
+```bash
+gh api repos/{owner}/{repo}/contents/docs/CODEOWNERS \
+  --jq '.name'
+```
+
+**Error handling**:
+- **404 response**: treat as "file not found at this
+  path" and try the next path. This is expected and
+  silent.
+- **Non-404 error** (network failure, 500, 429, etc.):
+  stop checking further paths and display:
+  ```
+  Note: CODEOWNERS check was inconclusive (API error).
+  Could not determine if this repo uses CODEOWNERS.
+  ```
+- **Success** (any path returns the file name): stop
+  checking further paths. CODEOWNERS exists.
 
 If CODEOWNERS exists and `require_code_owner_reviews` is
 true, display:
@@ -816,8 +842,6 @@ Warning: This repo requires code owner reviews. This
 APPROVE may not satisfy branch protection if this
 account is not listed in CODEOWNERS.
 ```
-
-If any API call fails: skip silently.
 
 1. **Prepare comments**: For each finding that maps to a
    specific file and line range in the diff, prepare an

--- a/openspec/changes/improve-codeowners-check/.openspec.yaml
+++ b/openspec/changes/improve-codeowners-check/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: unbound-force
+created: 2026-07-06

--- a/openspec/changes/improve-codeowners-check/design.md
+++ b/openspec/changes/improve-codeowners-check/design.md
@@ -1,0 +1,113 @@
+## Context
+
+The CODEOWNERS existence check in `/review-pr` (Step 11a,
+lines 802-820) and `/review-council` (Step 7c, lines 474-484)
+uses `2>/dev/null` to suppress stderr from `gh api` calls.
+This masks all errors — not just 404 — making non-404 failures
+(network, 500, 429 rate limits) invisible. Additionally, only
+two of the three valid GitHub CODEOWNERS paths are checked.
+
+Both commands use identical logic. The scaffold source copies
+under `internal/scaffold/assets/opencode/commands/` mirror the
+active copies exactly. All four files must be updated together.
+
+The proposal's constitution alignment confirmed this change
+improves Observable Quality (Principle III) by surfacing
+previously-hidden errors.
+
+## Goals / Non-Goals
+
+### Goals
+- Distinguish 404 (no file) from non-404 errors in `gh api`
+  responses
+- Check all three valid GitHub CODEOWNERS locations:
+  `CODEOWNERS`, `.github/CODEOWNERS`, `docs/CODEOWNERS`
+- Display a warning when a non-404 error occurs so the user
+  knows the check was inconclusive
+- Keep `/review-pr` and `/review-council` CODEOWNERS logic
+  identical
+- Sync scaffold source copies with active command copies
+
+### Non-Goals
+- Changing the CODEOWNER warning message text itself
+- Making the CODEOWNERS check a blocking gate (it remains
+  advisory)
+- Parsing CODEOWNERS file contents to validate entries
+- Adding retry logic for transient API failures
+
+## Decisions
+
+### D1: Error handling approach
+
+The agent commands are markdown instructions interpreted by
+an LLM, not executable shell scripts. The `gh api` bash
+snippets serve as illustrative pseudocode for the agent.
+
+**Decision**: Replace the `2>/dev/null` pattern with
+explicit error-handling instructions. The updated text will:
+
+1. Instruct the agent to call `gh api` for each of the three
+   paths.
+2. Treat 404 responses as "file not found" (silent, expected).
+3. Treat any non-404 error as an inconclusive check and
+   display a warning to the user.
+4. Consider CODEOWNERS found if any of the three paths
+   returns successfully.
+
+The bash snippet will use `--silent` (suppress progress) with
+response code inspection rather than blanket stderr
+suppression.
+
+### D2: Path ordering
+
+**Decision**: Check paths in order of convention prevalence:
+`.github/CODEOWNERS` (most common), `CODEOWNERS` (root),
+`docs/CODEOWNERS` (least common). Short-circuit on first
+success — if found at the first path, skip remaining checks.
+
+### D3: Warning message for inconclusive checks
+
+**Decision**: Add a new warning message for non-404 errors:
+
+```
+Note: CODEOWNERS check was inconclusive (API error).
+Could not determine if this repo uses CODEOWNERS.
+```
+
+This is distinct from the existing CODEOWNER review warning
+and uses "Note:" severity (informational, not blocking).
+
+### D4: Four-file update strategy
+
+**Decision**: Update all four files in a single change:
+- `.opencode/commands/review-pr.md` (active copy)
+- `.opencode/commands/review-council.md` (active copy)
+- `internal/scaffold/assets/opencode/commands/review-pr.md`
+  (scaffold source)
+- `internal/scaffold/assets/opencode/commands/review-council.md`
+  (scaffold source)
+
+The scaffold drift detection tests will verify consistency
+after the change.
+
+## Risks / Trade-offs
+
+### R1: LLM interpretation variance
+
+The CODEOWNERS check is agent instructions, not compiled code.
+Different LLMs may interpret error-handling instructions with
+slight variation. Mitigation: keep the instructions concrete
+with explicit bash pseudocode and clear conditional logic.
+
+### R2: API call count increase
+
+Adding `docs/CODEOWNERS` increases the maximum `gh api` calls
+from 2 to 3 per review. Mitigation: short-circuit on first
+success. Most repos use `.github/CODEOWNERS`, so the typical
+case remains 1 call.
+
+### R3: Low severity change
+
+This is an advisory check improvement. The risk of regression
+is minimal since the CODEOWNERS check does not affect the
+review verdict.

--- a/openspec/changes/improve-codeowners-check/proposal.md
+++ b/openspec/changes/improve-codeowners-check/proposal.md
@@ -1,0 +1,99 @@
+## Why
+
+The CODEOWNERS existence check in `/review-pr` (Step 11a) and
+`/review-council` (Step 7c) has two issues identified in
+[#324](https://github.com/unbound-force/unbound-force/issues/324):
+
+1. **Stderr suppression**: `2>/dev/null` on `gh api` calls masks
+   all errors, not just 404. Non-404 errors (network failures,
+   500 server errors, 429 rate limits) are silently swallowed,
+   causing the CODEOWNER warning to be skipped without the user
+   knowing the check failed.
+2. **Missing path**: Only `CODEOWNERS` and `.github/CODEOWNERS`
+   are checked. GitHub also supports `docs/CODEOWNERS` as a
+   valid location.
+
+Both commands share this pattern — `/review-council` inherited
+it from `/review-pr` during the Step 7 transplant in #314. The
+fix should be applied to both commands together to maintain
+consistency.
+
+## What Changes
+
+Update the CODEOWNERS check logic in both `/review-pr` and
+`/review-council` agent command files, plus their scaffold
+source copies:
+
+1. Replace `2>/dev/null` with error-aware handling that
+   distinguishes 404 (no file) from other errors (network,
+   500, 429).
+2. Add `docs/CODEOWNERS` as a third valid location.
+3. Instruct agents to log a warning when `gh api` returns a
+   non-404 error so the user knows the check was inconclusive.
+4. Keep identical logic in both commands.
+
+## Capabilities
+
+### New Capabilities
+- `codeowners-error-visibility`: Non-404 errors from `gh api`
+  produce a visible warning instead of being silently
+  suppressed.
+- `docs-codeowners-path`: `docs/CODEOWNERS` is checked as a
+  valid location alongside the existing two paths.
+
+### Modified Capabilities
+- `codeowners-check`: Updated error handling and path coverage
+  in both `/review-pr` and `/review-council`.
+
+### Removed Capabilities
+- None.
+
+## Impact
+
+- **Files**: `.opencode/commands/review-pr.md`,
+  `.opencode/commands/review-council.md`, and their scaffold
+  source copies under `internal/scaffold/assets/opencode/
+  commands/`.
+- **Behavior**: Agents running `/review-pr` or `/review-council`
+  will now see a warning when CODEOWNERS checks fail for
+  non-404 reasons, rather than silently skipping. The existing
+  CODEOWNER warning message itself is unchanged.
+- **Risk**: Low. This is an advisory check, not a security gate.
+  The change improves observability without altering the review
+  verdict logic.
+
+## Constitution Alignment
+
+Assessed against the Unbound Force org constitution.
+
+### I. Autonomous Collaboration
+
+**Assessment**: N/A
+
+This change modifies agent command instructions (markdown files).
+It does not affect artifact-based communication or inter-hero
+collaboration patterns.
+
+### II. Composability First
+
+**Assessment**: PASS
+
+Both commands remain independently usable. The CODEOWNERS check
+remains self-contained within each command file — no new
+dependencies are introduced.
+
+### III. Observable Quality
+
+**Assessment**: PASS
+
+This change directly improves observability by surfacing errors
+that were previously suppressed. Agents will now report
+inconclusive checks rather than silently skipping them.
+
+### IV. Testability
+
+**Assessment**: N/A
+
+The changed files are agent instruction markdown, not executable
+code. The scaffold drift detection tests will verify that the
+active command copies match their scaffold sources.

--- a/openspec/changes/improve-codeowners-check/specs/codeowners-check.md
+++ b/openspec/changes/improve-codeowners-check/specs/codeowners-check.md
@@ -1,0 +1,94 @@
+## ADDED Requirements
+
+### Requirement: docs-codeowners-path
+
+The CODEOWNERS check MUST search `docs/CODEOWNERS` in
+addition to `CODEOWNERS` and `.github/CODEOWNERS`.
+
+#### Scenario: CODEOWNERS exists in docs directory
+
+- **GIVEN** a repository with a `docs/CODEOWNERS` file and
+  no `CODEOWNERS` or `.github/CODEOWNERS` file
+- **WHEN** the agent performs the CODEOWNERS existence check
+- **THEN** the agent MUST detect the file and display the
+  CODEOWNER review warning if `require_code_owner_reviews`
+  is true
+
+### Requirement: non-404-error-warning
+
+When a `gh api` call returns a non-404 error during the
+CODEOWNERS check, the agent MUST display an informational
+warning indicating the check was inconclusive.
+
+#### Scenario: API returns 500 server error
+
+- **GIVEN** a repository with `require_codeowners` enabled
+- **WHEN** the agent calls `gh api` to check for CODEOWNERS
+  and receives a 500 error
+- **THEN** the agent MUST display:
+  "Note: CODEOWNERS check was inconclusive (API error).
+  Could not determine if this repo uses CODEOWNERS."
+- **AND** the agent MUST NOT display the CODEOWNER review
+  warning (since existence is unknown)
+
+#### Scenario: API returns 429 rate limit
+
+- **GIVEN** a repository with `require_codeowners` enabled
+- **WHEN** the agent calls `gh api` to check for CODEOWNERS
+  and receives a 429 rate-limit error
+- **THEN** the agent MUST display the inconclusive warning
+- **AND** the agent MUST NOT skip the check silently
+
+### Requirement: short-circuit-on-success
+
+The CODEOWNERS check SHOULD short-circuit on the first
+successful path. If `.github/CODEOWNERS` is found, the
+agent SHOULD NOT check `CODEOWNERS` or `docs/CODEOWNERS`.
+
+#### Scenario: CODEOWNERS found at first path
+
+- **GIVEN** a repository with `.github/CODEOWNERS`
+- **WHEN** the agent performs the CODEOWNERS existence check
+- **THEN** the agent SHOULD issue only one `gh api` call
+- **AND** the agent MUST treat CODEOWNERS as found
+
+## MODIFIED Requirements
+
+### Requirement: codeowners-error-handling
+
+The CODEOWNERS check MUST distinguish between 404 responses
+(file not found) and other error responses. 404 errors MUST
+be handled silently. Non-404 errors MUST produce a visible
+warning.
+
+Previously: "If any API call fails: skip silently."
+
+#### Scenario: 404 response handled silently
+
+- **GIVEN** a repository with no CODEOWNERS file at any of
+  the three valid paths
+- **WHEN** each `gh api` call returns a 404 response
+- **THEN** the agent MUST treat this as "no CODEOWNERS file"
+- **AND** the agent MUST NOT display any error or warning
+  about the check itself
+
+### Requirement: scaffold-sync
+
+Active command copies MUST match their scaffold source copies.
+Both `/review-pr` and `/review-council` MUST use identical
+CODEOWNERS check logic.
+
+Previously: The commands used identical logic but this was
+not an explicit requirement.
+
+#### Scenario: scaffold drift detection
+
+- **GIVEN** updated active copies of `review-pr.md` and
+  `review-council.md`
+- **WHEN** scaffold drift detection tests run
+- **THEN** the active copies MUST match the scaffold source
+  copies under `internal/scaffold/assets/opencode/commands/`
+
+## REMOVED Requirements
+
+None.

--- a/openspec/changes/improve-codeowners-check/tasks.md
+++ b/openspec/changes/improve-codeowners-check/tasks.md
@@ -1,0 +1,69 @@
+<!--
+  [P] marks tasks eligible for parallel execution.
+  Add [P] when a task: (a) touches different files from
+  other [P] tasks in the group, (b) has no dependency
+  on prior tasks in the group, (c) can safely execute
+  without ordering constraints.
+  Do NOT add [P] when tasks modify the same file —
+  parallel workers will cause merge conflicts.
+  Tasks without [P] run sequentially first, then [P]
+  tasks run in parallel.
+-->
+
+## 1. Update CODEOWNERS check in active command copies
+
+- [x] 1.1 [P] Update `/review-pr` CODEOWNERS check
+  - File: `.opencode/commands/review-pr.md`
+  - Lines 802-820: Replace the `2>/dev/null` bash snippet
+    and "skip silently" instruction with:
+    - Three-path check: `.github/CODEOWNERS`, `CODEOWNERS`,
+      `docs/CODEOWNERS` (short-circuit on first success)
+    - 404 handling: treat as "not found" (silent)
+    - Non-404 error handling: display inconclusive warning
+    - Remove line 820 ("If any API call fails: skip
+      silently.")
+
+- [x] 1.2 [P] Update `/review-council` CODEOWNERS check
+  - File: `.opencode/commands/review-council.md`
+  - Lines 474-484: Replace the `2>/dev/null` bash snippet
+    with the same updated logic as review-pr:
+    - Three-path check with short-circuit
+    - 404 vs non-404 error distinction
+    - Inconclusive warning for non-404 errors
+  - Ensure the CODEOWNERS check text is identical to the
+    `/review-pr` version (adjusted for indentation context)
+
+## 2. Sync scaffold source copies
+
+- [x] 2.1 [P] Sync scaffold review-pr.md
+  - File: `internal/scaffold/assets/opencode/commands/
+    review-pr.md`
+  - Copy the updated CODEOWNERS check section from
+    `.opencode/commands/review-pr.md` to match exactly
+
+- [x] 2.2 [P] Sync scaffold review-council.md
+  - File: `internal/scaffold/assets/opencode/commands/
+    review-council.md`
+  - Copy the updated CODEOWNERS check section from
+    `.opencode/commands/review-council.md` to match exactly
+
+## 3. Verification
+
+- [x] 3.1 Verify scaffold drift detection
+  - Run `make test` to confirm scaffold drift detection
+    tests pass (active copies match scaffold sources)
+
+- [x] 3.2 Verify constitution alignment
+  - Confirm Observable Quality (Principle III) is satisfied:
+    non-404 errors are now surfaced rather than suppressed
+  - Confirm no other constitution principles are violated
+
+- [x] 3.3 Verify acceptance criteria from issue #324
+  - All three CODEOWNERS paths checked
+  - Non-404 errors produce a visible warning
+  - 404 errors handled silently
+  - `/review-pr` and `/review-council` use identical logic
+  - Scaffold copies synced
+  - No change to the CODEOWNER warning message itself
+<!-- spec-review: passed -->
+<!-- code-review: passed -->


### PR DESCRIPTION
## Summary

Fixes #324

Improves the CODEOWNERS existence check in `/review-pr` (Step 11a) and `/review-council` (Step 7c):

- **Error-aware handling**: Replaced blanket `2>/dev/null` stderr suppression with explicit 404 vs non-404 error distinction. Non-404 errors (network failures, 500, 429 rate limits) now produce a visible warning instead of being silently swallowed.
- **Third path**: Added `docs/CODEOWNERS` as a valid location alongside `.github/CODEOWNERS` and `CODEOWNERS`.
- **Short-circuit**: Paths checked in order of convention prevalence, stopping at first success.
- **Scaffold sync**: Active copies and scaffold source copies updated identically.

## Changes

| File | Change |
|------|--------|
| `.opencode/commands/review-pr.md` | Updated CODEOWNERS check (lines 802-820) |
| `.opencode/commands/review-council.md` | Updated CODEOWNERS check (lines 474-484) |
| `internal/scaffold/assets/opencode/commands/review-pr.md` | Scaffold source sync |
| `internal/scaffold/assets/opencode/commands/review-council.md` | Scaffold source sync |
| `openspec/changes/improve-codeowners-check/` | OpenSpec planning artifacts |

## Testing

- `go build ./...` -- pass
- `go test -race -count=1 ./...` -- 20/20 packages pass
- Scaffold drift detection tests pass