### PR TITLE
feat: add speckit/ folder prefix to Speckit branches

### DIFF
--- a/.opencode/commands/address-feedback.md
+++ b/.opencode/commands/address-feedback.md
@@ -138,6 +138,7 @@ Load context for evidence-based classification (D10, FR-010):
 3. `AGENTS.md` coding and testing conventions
 4. Spec artifacts for the PR branch:
    - Speckit: `specs/NNN-*/` matching branch pattern
+     (branch may be `speckit/NNN-*` or `NNN-*` legacy)
    - OpenSpec: `openspec/changes/*/` matching branch
 5. Linked issues from PR description (`Fixes #N`, `Closes #N`, `Resolves #N`) — load acceptance criteria
 6. Invoke the `skill` tool with name `review-context` to load standardized context discovery (spec artifacts, linked issues, path classification).

--- a/.opencode/commands/agent-brief.md
+++ b/.opencode/commands/agent-brief.md
@@ -79,7 +79,8 @@ Build & Test section in Audit mode):
 **Governance & Context Detection**:
 15. `.specify/memory/constitution.md` → constitution exists
     (triggers Behavioral Rules section)
-16. `specs/` → check for `NNN-*/` subdirectories (Speckit)
+16. `specs/` → check for `NNN-*/` subdirectories (Speckit;
+    branches use `speckit/NNN-*` or legacy `NNN-*`)
 17. `openspec/config.yaml` or `openspec/` → OpenSpec configured
     (triggers Specification Workflow section)
 18. `.opencode/uf/packs/` → convention packs deployed
@@ -198,7 +199,8 @@ These rules are non-negotiable. Violations are CRITICAL severity.
 #### Section 7: Specification Workflow (verbatim template, conditional)
 
 **Condition**: Insert ONLY when `specs/` directory has numbered
-subdirectories (`NNN-*/`) OR `openspec/` directory exists. If
+subdirectories (`NNN-*/`) OR `openspec/` directory exists
+(Speckit branches use `speckit/NNN-<name>`). If
 neither is detected, omit this section entirely.
 
 Insert this verbatim:
@@ -220,7 +222,7 @@ analyze → checklist → implement`
 before tasks. Tasks before implementation. Spec artifacts MUST
 be committed/pushed before implementation begins.
 
-**Branches**: Speckit: `NNN-<name>`. OpenSpec: `opsx/<name>`.
+**Branches**: Speckit: `speckit/NNN-<name>`. OpenSpec: `opsx/<name>`.
 
 **Task bookkeeping**: Mark checkboxes `[x]` immediately on
 completion. `[P]` marks parallel-eligible tasks.

--- a/.opencode/commands/cobalt-crush.md
+++ b/.opencode/commands/cobalt-crush.md
@@ -90,7 +90,7 @@ implementation command to the `cobalt-crush-dev` agent:
    > - `/unleash` — Autonomous pipeline (parallel swarm,
    >   recommended for multi-task changes)
    > - `/speckit.implement` — Strategic spec implementation
-   >   (requires a feature branch with `specs/NNN-*/tasks.md`)
+   >   (requires a `speckit/NNN-*` branch with `specs/NNN-*/tasks.md`)
    > - `/opsx-apply` — Tactical change implementation
    >   (requires an active change in `openspec/changes/`)
 

--- a/.opencode/commands/finale.md
+++ b/.opencode/commands/finale.md
@@ -21,7 +21,8 @@ Automate the end-of-branch workflow. Stages all changes,
 generates a conventional commit message, pushes, creates
 a PR, watches CI checks, and returns to `main`. The PR
 stays open for human review. Works with both Speckit
-(`NNN-*`) and OpenSpec (`opsx/*`) branches.
+(`speckit/NNN-*` or `NNN-*` legacy) and OpenSpec
+(`opsx/*`) branches.
 
 ## Usage
 
@@ -42,7 +43,7 @@ git rev-parse --abbrev-ref HEAD
 
 - If on `main`: **STOP** with error:
   > "Cannot run /finale on main. Switch to a feature
-  > branch (e.g., `opsx/*` or `NNN-*`) first."
+   > branch (e.g., `opsx/*` or `speckit/NNN-*`) first."
 - Otherwise: proceed. Note the branch name for the
   summary.
 
@@ -244,7 +245,8 @@ gh pr view --json number,url 2>/dev/null
     If on an `opsx/*` branch, read
     `openspec/changes/*/specs/*.md` for acceptance
     scenarios and translate them into concrete
-    verification commands. If on an `NNN-*` branch,
+    verification commands. If on a `speckit/NNN-*` or
+    `NNN-*` (legacy) branch,
     check for `quickstart.md` in the feature directory.
     Otherwise, synthesize test steps from the diff.
   - `## How to Demo` — walkthrough for demonstrating

--- a/.opencode/commands/review-council.md
+++ b/.opencode/commands/review-council.md
@@ -57,7 +57,7 @@ examining the current branch and workspace:
 
 4. **Detect the workflow tier** from the branch name:
    - Branch matches `opsx/*`: **OpenSpec** (tactical)
-   - Branch matches `NNN-*` (digits then dash): **Speckit** (strategic)
+   - Branch matches `speckit/NNN-*` or `NNN-*` (legacy) (digits then dash): **Speckit** (strategic)
    - Branch is `main` or other: no active workflow
 
 5. **Select mode based on classification**:
@@ -73,7 +73,7 @@ examining the current branch and workspace:
    which mode was selected and why, including the
    workflow tier:
    > "Detected **Code Review Mode** (Speckit) — found N
-   > code files changed on branch `012-swarm-delegation`
+   > code files changed on branch `speckit/012-swarm-delegation`
    > vs `main`."
    >
    > Or: "Detected **Spec Review Mode** (OpenSpec) — only
@@ -342,7 +342,7 @@ depends on the detected workflow tier.
 Based on the workflow tier detected in the auto-detection
 step, determine which artifacts to review:
 
-- **Speckit** (branch `NNN-*`): Review the active spec
+- **Speckit** (branch `speckit/NNN-*` or `NNN-*`): Review the active spec
   directory at `specs/NNN-<name>/` (spec.md, plan.md,
   tasks.md, contracts/, data-model.md, checklists/),
   plus `.specify/memory/constitution.md` and `AGENTS.md`.

--- a/.opencode/commands/unleash.md
+++ b/.opencode/commands/unleash.md
@@ -54,7 +54,7 @@ git rev-parse --abbrev-ref HEAD
 
 - If on `main`: **STOP** with error:
   > "Cannot run /unleash on main. Must be on a Speckit
-  > (`NNN-*`) or OpenSpec (`opsx/*`) feature branch."
+  > (`speckit/NNN-*`) or OpenSpec (`opsx/*`) feature branch."
 
 - If on `opsx/*`: **OpenSpec mode detected.**
   Extract the change name from the branch:
@@ -69,8 +69,8 @@ git rev-parse --abbrev-ref HEAD
 
   Announce: "Detected OpenSpec change: `<name>`"
 
-- If the branch matches `NNN-*` (digits followed by a
-  dash): **Speckit mode detected.**
+- If the branch matches `speckit/NNN-*` or `NNN-*` (legacy)
+  (digits followed by a dash): **Speckit mode detected.**
 
   Validate that spec.md exists by running from the repo
   root:
@@ -88,11 +88,11 @@ git rev-parse --abbrev-ref HEAD
   is the working directory for all subsequent steps.
   Set `WORKFLOW_TIER = speckit`.
 
-- If the branch does not match `NNN-*` or `opsx/*`:
-  **STOP** with error:
+- If the branch does not match `speckit/NNN-*`, `NNN-*`
+  (legacy), or `opsx/*`: **STOP** with error:
   > "Unrecognized branch pattern. /unleash requires a
-  > Speckit feature branch (`NNN-*`) or OpenSpec branch
-  > (`opsx/*`). Run `/speckit.specify` or
+  > Speckit feature branch (`speckit/NNN-*`) or OpenSpec
+  > branch (`opsx/*`). Run `/speckit.specify` or
   > `/opsx-propose` to create one."
 
 ### 2. Resumability Detection
@@ -284,7 +284,7 @@ analysis + quality validation) in a single pass.
    Mode** -- review the spec artifacts in `FEATURE_DIR`,
    not code." The review council auto-detects the
    workflow tier from the branch name (`opsx/*` vs
-   `NNN-*`).
+   `speckit/NNN-*` or `NNN-*`).
 3. Collect the review results.
 
 **Processing results**:
@@ -557,7 +557,7 @@ memory.
 3. **If Dewey is available** (`dewey_store_learning` tool
    exists): store each learning via `dewey_store_learning`
    with tags including:
-   - The branch name (e.g., `018-unleash-command`)
+   - The branch name (e.g., `speckit/018-unleash-command`)
    - The current date (e.g., `2026-03-29`)
    - The learning category (e.g., `pattern`, `gotcha`,
      `review-insight`, `file-specific`)
@@ -637,7 +637,8 @@ Format the output as:
 ## Guardrails
 
 - **NEVER run on `main`** -- the command is for Speckit
-  (`NNN-*`) and OpenSpec (`opsx/*`) feature branches
+  (`speckit/NNN-*` or `NNN-*` legacy) and OpenSpec
+  (`opsx/*`) feature branches
 - **NEVER skip spec review exit on HIGH/CRITICAL** --
   these findings block implementation to prevent wasted
   effort on a flawed spec

--- a/.opencode/commands/workflow-advance.md
+++ b/.opencode/commands/workflow-advance.md
@@ -87,7 +87,7 @@ with spec review enabled:
 Specification drafted: wf-feat-csv-export-20260326T143000
 
 Muti-Mind has drafted the specification.
-Review at: specs/NNN-feature-name/spec.md
+Review at: specs/NNN-feature-name/spec.md  (branch: speckit/NNN-feature-name)
 
 Awaiting spec review. Run /workflow advance to approve.
 ```

--- a/.opencode/commands/workflow-status.md
+++ b/.opencode/commands/workflow-status.md
@@ -108,6 +108,6 @@ Stages:
   ○ accept      (muti-mind)     pending          [human]
   ○ reflect     (mx-f)          pending          [swarm]
 
-Spec review: specs/NNN-csv-export/spec.md
+Spec review: specs/NNN-csv-export/spec.md  (branch: speckit/NNN-csv-export)
 Run /workflow advance to approve the spec and continue.
 ```

--- a/.opencode/skills/review-context/SKILL.md
+++ b/.opencode/skills/review-context/SKILL.md
@@ -38,7 +38,7 @@ or PR branch name:
 
 | Branch pattern | Spec location |
 |---------------|---------------|
-| `NNN-<name>` (digits then dash) | `specs/<branch-name>/spec.md` (Speckit) |
+| `speckit/NNN-<name>` or `NNN-<name>` (legacy) | `specs/<name>/spec.md` (Speckit; strip `speckit/` prefix) |
 | `opsx/<name>` | `openspec/changes/<name>/proposal.md` (OpenSpec changes) |
 | `opsx/<name>` | `openspec/specs/<name>/spec.md` (OpenSpec specs) |
 
@@ -46,7 +46,7 @@ or PR branch name:
 
 If no spec is found via branch name and a PR description
 is available, scan for explicit spec references (e.g.,
-"See spec 012" or "Implements specs/012-swarm/spec.md").
+"See spec 012" or "Implements specs/012-swarm/spec.md" or "branch speckit/012-swarm").
 
 ### Step 3: Changed-file detection
 

--- a/.specify/scripts/bash/check-prerequisites.sh
+++ b/.specify/scripts/bash/check-prerequisites.sh
@@ -80,17 +80,17 @@ source "$SCRIPT_DIR/common.sh"
 
 # Get feature paths and validate branch
 get_feature_paths
-check_feature_branch "$CURRENT_BRANCH" "$HAS_GIT" || exit 1
+check_feature_branch "$CURRENT_FEATURE" "$HAS_GIT" || exit 1
 
 # If paths-only mode, output paths and exit (support JSON + paths-only combined)
 if $PATHS_ONLY; then
     if $JSON_MODE; then
         # Minimal JSON paths payload (no validation performed)
         printf '{"REPO_ROOT":"%s","BRANCH":"%s","FEATURE_DIR":"%s","FEATURE_SPEC":"%s","IMPL_PLAN":"%s","TASKS":"%s"}\n' \
-            "$REPO_ROOT" "$CURRENT_BRANCH" "$FEATURE_DIR" "$FEATURE_SPEC" "$IMPL_PLAN" "$TASKS"
+            "$REPO_ROOT" "$CURRENT_FEATURE" "$FEATURE_DIR" "$FEATURE_SPEC" "$IMPL_PLAN" "$TASKS"
     else
         echo "REPO_ROOT: $REPO_ROOT"
-        echo "BRANCH: $CURRENT_BRANCH"
+        echo "BRANCH: $CURRENT_FEATURE"
         echo "FEATURE_DIR: $FEATURE_DIR"
         echo "FEATURE_SPEC: $FEATURE_SPEC"
         echo "IMPL_PLAN: $IMPL_PLAN"

--- a/.specify/scripts/bash/common.sh
+++ b/.specify/scripts/bash/common.sh
@@ -12,8 +12,10 @@ get_repo_root() {
     fi
 }
 
-# Get current branch, with fallback for non-git repositories
-get_current_branch() {
+# Get current feature name (NNN-<name>), with fallback for non-git
+# repositories. Returns the spec feature name, not the git branch ref —
+# the speckit/ prefix is stripped so consumers can map to specs/NNN-<name>/.
+get_current_feature() {
     # First check if SPECIFY_FEATURE environment variable is set
     if [[ -n "${SPECIFY_FEATURE:-}" ]]; then
         # Strip speckit/ prefix so downstream consumers get NNN-<name>
@@ -76,9 +78,10 @@ check_feature_branch() {
         return 0
     fi
 
-    if [[ ! "$branch" =~ ^(speckit/)?[0-9]{3}- ]]; then
-        echo "ERROR: Not on a feature branch. Current branch: $branch" >&2
-        echo "Feature branches should be named like: speckit/001-feature-name" >&2
+    # Input is already stripped of speckit/ prefix by get_current_feature()
+    if [[ ! "$branch" =~ ^[0-9]{3}- ]]; then
+        echo "ERROR: Not on a feature branch. Current feature: $branch" >&2
+        echo "Feature names should match: 001-feature-name" >&2
         return 1
     fi
 
@@ -139,8 +142,8 @@ find_feature_dir_by_prefix() {
 get_feature_paths() {
     local repo_root
     repo_root=$(get_repo_root)
-    local current_branch
-    current_branch=$(get_current_branch)
+    local current_feature
+    current_feature=$(get_current_feature)
     local has_git_repo="false"
 
     if has_git; then
@@ -149,12 +152,12 @@ get_feature_paths() {
 
     # Use prefix-based lookup to support multiple branches per spec
     local feature_dir
-    feature_dir=$(find_feature_dir_by_prefix "$repo_root" "$current_branch")
+    feature_dir=$(find_feature_dir_by_prefix "$repo_root" "$current_feature")
 
     # Set variables directly in the caller's shell — no eval needed
     # shellcheck disable=SC2034
     REPO_ROOT="$repo_root"
-    CURRENT_BRANCH="$current_branch"
+    CURRENT_FEATURE="$current_feature"
     HAS_GIT="$has_git_repo"
     FEATURE_DIR="$feature_dir"
     FEATURE_SPEC="$feature_dir/spec.md"

--- a/.specify/scripts/bash/common.sh
+++ b/.specify/scripts/bash/common.sh
@@ -16,13 +16,17 @@ get_repo_root() {
 get_current_branch() {
     # First check if SPECIFY_FEATURE environment variable is set
     if [[ -n "${SPECIFY_FEATURE:-}" ]]; then
-        echo "$SPECIFY_FEATURE"
+        # Strip speckit/ prefix so downstream consumers get NNN-<name>
+        echo "${SPECIFY_FEATURE#speckit/}"
         return
     fi
 
     # Then check git if available
     if git rev-parse --abbrev-ref HEAD >/dev/null 2>&1; then
-        git rev-parse --abbrev-ref HEAD
+        local branch
+        branch=$(git rev-parse --abbrev-ref HEAD)
+        # Strip speckit/ prefix so downstream consumers get NNN-<name>
+        echo "${branch#speckit/}"
         return
     fi
 
@@ -72,9 +76,9 @@ check_feature_branch() {
         return 0
     fi
 
-    if [[ ! "$branch" =~ ^[0-9]{3}- ]]; then
+    if [[ ! "$branch" =~ ^(speckit/)?[0-9]{3}- ]]; then
         echo "ERROR: Not on a feature branch. Current branch: $branch" >&2
-        echo "Feature branches should be named like: 001-feature-name" >&2
+        echo "Feature branches should be named like: speckit/001-feature-name" >&2
         return 1
     fi
 
@@ -89,6 +93,9 @@ find_feature_dir_by_prefix() {
     local repo_root="$1"
     local branch_name="$2"
     local specs_dir="$repo_root/specs"
+
+    # Strip speckit/ prefix if present before matching
+    branch_name="${branch_name#speckit/}"
 
     # Extract numeric prefix from branch (e.g., "004" from "004-whatever")
     if [[ ! "$branch_name" =~ ^([0-9]{3})- ]]; then

--- a/.specify/scripts/bash/create-new-feature.sh
+++ b/.specify/scripts/bash/create-new-feature.sh
@@ -112,6 +112,8 @@ get_highest_from_branches() {
             # Clean branch name: remove leading markers and remote prefixes
             clean_branch=$(echo "$branch" | sed 's/^[* ]*//; s|^remotes/[^/]*/||')
             
+            # Strip speckit/ prefix if present before matching
+            clean_branch="${clean_branch#speckit/}"
             # Extract feature number if branch matches pattern ###-*
             if echo "$clean_branch" | grep -q '^[0-9]\{3\}-'; then
                 number=$(echo "$clean_branch" | grep -o '^[0-9]\{3\}' || echo "0")
@@ -248,15 +250,15 @@ fi
 
 # Force base-10 interpretation to prevent octal conversion (e.g., 010 → 8 in octal, but should be 10 in decimal)
 FEATURE_NUM=$(printf "%03d" "$((10#$BRANCH_NUMBER))")
-BRANCH_NAME="${FEATURE_NUM}-${BRANCH_SUFFIX}"
+BRANCH_NAME="speckit/${FEATURE_NUM}-${BRANCH_SUFFIX}"
 
 # GitHub enforces a 244-byte limit on branch names
 # Validate and truncate if necessary
 MAX_BRANCH_LENGTH=244
 if [ ${#BRANCH_NAME} -gt $MAX_BRANCH_LENGTH ]; then
     # Calculate how much we need to trim from suffix
-    # Account for: feature number (3) + hyphen (1) = 4 chars
-    MAX_SUFFIX_LENGTH=$((MAX_BRANCH_LENGTH - 4))
+    # Account for: speckit/ (8) + feature number (3) + hyphen (1) = 12 chars
+    MAX_SUFFIX_LENGTH=$((MAX_BRANCH_LENGTH - 12))
     
     # Truncate suffix at word boundary if possible
     TRUNCATED_SUFFIX=$(echo "$BRANCH_SUFFIX" | cut -c1-$MAX_SUFFIX_LENGTH)
@@ -264,7 +266,7 @@ if [ ${#BRANCH_NAME} -gt $MAX_BRANCH_LENGTH ]; then
     TRUNCATED_SUFFIX=$(echo "$TRUNCATED_SUFFIX" | sed 's/-$//')
     
     ORIGINAL_BRANCH_NAME="$BRANCH_NAME"
-    BRANCH_NAME="${FEATURE_NUM}-${TRUNCATED_SUFFIX}"
+    BRANCH_NAME="speckit/${FEATURE_NUM}-${TRUNCATED_SUFFIX}"
     
     >&2 echo "[specify] Warning: Branch name exceeded GitHub's 244-byte limit"
     >&2 echo "[specify] Original: $ORIGINAL_BRANCH_NAME (${#ORIGINAL_BRANCH_NAME} bytes)"
@@ -277,7 +279,8 @@ else
     >&2 echo "[specify] Warning: Git repository not detected; skipped branch creation for $BRANCH_NAME"
 fi
 
-FEATURE_DIR="$SPECS_DIR/$BRANCH_NAME"
+# Strip speckit/ prefix for filesystem path — directory stays as NNN-<name>
+FEATURE_DIR="$SPECS_DIR/${BRANCH_NAME#speckit/}"
 mkdir -p "$FEATURE_DIR"
 
 TEMPLATE="$REPO_ROOT/.specify/templates/spec-template.md"

--- a/.specify/scripts/bash/setup-plan.sh
+++ b/.specify/scripts/bash/setup-plan.sh
@@ -31,7 +31,7 @@ source "$SCRIPT_DIR/common.sh"
 get_feature_paths
 
 # Check if we're on a proper feature branch (only for git repos)
-check_feature_branch "$CURRENT_BRANCH" "$HAS_GIT" || exit 1
+check_feature_branch "$CURRENT_FEATURE" "$HAS_GIT" || exit 1
 
 # Ensure the feature directory exists
 mkdir -p "$FEATURE_DIR"
@@ -50,12 +50,12 @@ fi
 # Output results
 if $JSON_MODE; then
     printf '{"FEATURE_SPEC":"%s","IMPL_PLAN":"%s","SPECS_DIR":"%s","BRANCH":"%s","HAS_GIT":"%s"}\n' \
-        "$FEATURE_SPEC" "$IMPL_PLAN" "$FEATURE_DIR" "$CURRENT_BRANCH" "$HAS_GIT"
+        "$FEATURE_SPEC" "$IMPL_PLAN" "$FEATURE_DIR" "$CURRENT_FEATURE" "$HAS_GIT"
 else
     echo "FEATURE_SPEC: $FEATURE_SPEC"
     echo "IMPL_PLAN: $IMPL_PLAN" 
     echo "SPECS_DIR: $FEATURE_DIR"
-    echo "BRANCH: $CURRENT_BRANCH"
+    echo "BRANCH: $CURRENT_FEATURE"
     echo "HAS_GIT: $HAS_GIT"
 fi
 

--- a/.specify/scripts/bash/update-agent-context.sh
+++ b/.specify/scripts/bash/update-agent-context.sh
@@ -123,7 +123,7 @@ trap cleanup EXIT INT TERM
 
 validate_environment() {
     # Check if we have a current branch/feature (git or non-git)
-    if [[ -z "$CURRENT_BRANCH" ]]; then
+    if [[ -z "$CURRENT_FEATURE" ]]; then
         log_error "Unable to determine current feature"
         if [[ "$HAS_GIT" == "true" ]]; then
             log_info "Make sure you're on a feature branch"
@@ -305,7 +305,7 @@ create_new_agent_file() {
     # Escape special characters for sed by using a different delimiter or escaping
     local escaped_lang=$(printf '%s\n' "$NEW_LANG" | sed 's/[\[\.*^$()+{}|]/\\&/g')
     local escaped_framework=$(printf '%s\n' "$NEW_FRAMEWORK" | sed 's/[\[\.*^$()+{}|]/\\&/g')
-    local escaped_branch=$(printf '%s\n' "$CURRENT_BRANCH" | sed 's/[\[\.*^$()+{}|]/\\&/g')
+    local escaped_branch=$(printf '%s\n' "$CURRENT_FEATURE" | sed 's/[\[\.*^$()+{}|]/\\&/g')
     
     # Build technology stack and recent change strings conditionally
     local tech_stack
@@ -381,9 +381,9 @@ update_existing_agent_file() {
     
     # Prepare new change entry
     if [[ -n "$tech_stack" ]]; then
-        new_change_entry="- $CURRENT_BRANCH: Added $tech_stack"
+        new_change_entry="- $CURRENT_FEATURE: Added $tech_stack"
     elif [[ -n "$NEW_DB" ]] && [[ "$NEW_DB" != "N/A" ]] && [[ "$NEW_DB" != "NEEDS CLARIFICATION" ]]; then
-        new_change_entry="- $CURRENT_BRANCH: Added $NEW_DB"
+        new_change_entry="- $CURRENT_FEATURE: Added $NEW_DB"
     fi
     
     # Check if Recent Changes section exists in CHANGELOG.md
@@ -738,7 +738,7 @@ main() {
     # Validate environment before proceeding
     validate_environment
     
-    log_info "=== Updating agent context files for feature $CURRENT_BRANCH ==="
+    log_info "=== Updating agent context files for feature $CURRENT_FEATURE ==="
     
     # Parse the plan file to extract project information
     if ! parse_plan_data "$NEW_PLAN"; then

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -236,7 +236,7 @@ analyze → checklist → implement`
 before tasks. Tasks before implementation. Spec artifacts MUST
 be committed/pushed before implementation begins.
 
-**Branches**: Speckit: `NNN-<name>`. OpenSpec: `opsx/<name>`.
+**Branches**: Speckit: `speckit/NNN-<name>`. OpenSpec: `opsx/<name>`.
 
 **Task bookkeeping**: Mark checkboxes `[x]` immediately on
 completion. `[P]` marks parallel-eligible tasks.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -444,7 +444,7 @@ user stories. Creates artifacts in
 
 Runs the full pipeline autonomously -- clarify, plan,
 tasks, spec review, implement, code review, and
-retrospective. Works with both Speckit (`NNN-*` branches)
+retrospective. Works with both Speckit (`speckit/NNN-*` branches)
 and OpenSpec (`opsx/*` branches). Exits to human judgment
 only when it encounters ambiguity, review failures, or
 merge conflicts.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -136,7 +136,7 @@ the spec), `/speckit.analyze` (consistency check),
 
 Runs the full pipeline autonomously: clarify, plan,
 tasks, spec review, implement, code review, and
-retrospective. Works with both Speckit (`NNN-*` branches)
+retrospective. Works with both Speckit (`speckit/NNN-*` branches)
 and OpenSpec (`opsx/*` branches). Exits to human
 judgment only when it encounters ambiguity, review
 failures, or merge conflicts.

--- a/internal/scaffold/assets/opencode/commands/address-feedback.md
+++ b/internal/scaffold/assets/opencode/commands/address-feedback.md
@@ -138,6 +138,7 @@ Load context for evidence-based classification (D10, FR-010):
 3. `AGENTS.md` coding and testing conventions
 4. Spec artifacts for the PR branch:
    - Speckit: `specs/NNN-*/` matching branch pattern
+     (branch may be `speckit/NNN-*` or `NNN-*` legacy)
    - OpenSpec: `openspec/changes/*/` matching branch
 5. Linked issues from PR description (`Fixes #N`, `Closes #N`, `Resolves #N`) — load acceptance criteria
 6. Invoke the `skill` tool with name `review-context` to load standardized context discovery (spec artifacts, linked issues, path classification).

--- a/internal/scaffold/assets/opencode/commands/agent-brief.md
+++ b/internal/scaffold/assets/opencode/commands/agent-brief.md
@@ -79,7 +79,8 @@ Build & Test section in Audit mode):
 **Governance & Context Detection**:
 15. `.specify/memory/constitution.md` → constitution exists
     (triggers Behavioral Rules section)
-16. `specs/` → check for `NNN-*/` subdirectories (Speckit)
+16. `specs/` → check for `NNN-*/` subdirectories (Speckit;
+    branches use `speckit/NNN-*` or legacy `NNN-*`)
 17. `openspec/config.yaml` or `openspec/` → OpenSpec configured
     (triggers Specification Workflow section)
 18. `.opencode/uf/packs/` → convention packs deployed
@@ -198,7 +199,8 @@ These rules are non-negotiable. Violations are CRITICAL severity.
 #### Section 7: Specification Workflow (verbatim template, conditional)
 
 **Condition**: Insert ONLY when `specs/` directory has numbered
-subdirectories (`NNN-*/`) OR `openspec/` directory exists. If
+subdirectories (`NNN-*/`) OR `openspec/` directory exists
+(Speckit branches use `speckit/NNN-<name>`). If
 neither is detected, omit this section entirely.
 
 Insert this verbatim:
@@ -220,7 +222,7 @@ analyze → checklist → implement`
 before tasks. Tasks before implementation. Spec artifacts MUST
 be committed/pushed before implementation begins.
 
-**Branches**: Speckit: `NNN-<name>`. OpenSpec: `opsx/<name>`.
+**Branches**: Speckit: `speckit/NNN-<name>`. OpenSpec: `opsx/<name>`.
 
 **Task bookkeeping**: Mark checkboxes `[x]` immediately on
 completion. `[P]` marks parallel-eligible tasks.

--- a/internal/scaffold/assets/opencode/commands/cobalt-crush.md
+++ b/internal/scaffold/assets/opencode/commands/cobalt-crush.md
@@ -90,7 +90,7 @@ implementation command to the `cobalt-crush-dev` agent:
    > - `/unleash` — Autonomous pipeline (parallel swarm,
    >   recommended for multi-task changes)
    > - `/speckit.implement` — Strategic spec implementation
-   >   (requires a feature branch with `specs/NNN-*/tasks.md`)
+   >   (requires a `speckit/NNN-*` branch with `specs/NNN-*/tasks.md`)
    > - `/opsx-apply` — Tactical change implementation
    >   (requires an active change in `openspec/changes/`)
 

--- a/internal/scaffold/assets/opencode/commands/finale.md
+++ b/internal/scaffold/assets/opencode/commands/finale.md
@@ -21,7 +21,8 @@ Automate the end-of-branch workflow. Stages all changes,
 generates a conventional commit message, pushes, creates
 a PR, watches CI checks, and returns to `main`. The PR
 stays open for human review. Works with both Speckit
-(`NNN-*`) and OpenSpec (`opsx/*`) branches.
+(`speckit/NNN-*` or `NNN-*` legacy) and OpenSpec
+(`opsx/*`) branches.
 
 ## Usage
 
@@ -42,7 +43,7 @@ git rev-parse --abbrev-ref HEAD
 
 - If on `main`: **STOP** with error:
   > "Cannot run /finale on main. Switch to a feature
-  > branch (e.g., `opsx/*` or `NNN-*`) first."
+   > branch (e.g., `opsx/*` or `speckit/NNN-*`) first."
 - Otherwise: proceed. Note the branch name for the
   summary.
 
@@ -244,7 +245,8 @@ gh pr view --json number,url 2>/dev/null
     If on an `opsx/*` branch, read
     `openspec/changes/*/specs/*.md` for acceptance
     scenarios and translate them into concrete
-    verification commands. If on an `NNN-*` branch,
+    verification commands. If on a `speckit/NNN-*` or
+    `NNN-*` (legacy) branch,
     check for `quickstart.md` in the feature directory.
     Otherwise, synthesize test steps from the diff.
   - `## How to Demo` — walkthrough for demonstrating

--- a/internal/scaffold/assets/opencode/commands/review-council.md
+++ b/internal/scaffold/assets/opencode/commands/review-council.md
@@ -57,7 +57,7 @@ examining the current branch and workspace:
 
 4. **Detect the workflow tier** from the branch name:
    - Branch matches `opsx/*`: **OpenSpec** (tactical)
-   - Branch matches `NNN-*` (digits then dash): **Speckit** (strategic)
+   - Branch matches `speckit/NNN-*` or `NNN-*` (legacy) (digits then dash): **Speckit** (strategic)
    - Branch is `main` or other: no active workflow
 
 5. **Select mode based on classification**:
@@ -73,7 +73,7 @@ examining the current branch and workspace:
    which mode was selected and why, including the
    workflow tier:
    > "Detected **Code Review Mode** (Speckit) — found N
-   > code files changed on branch `012-swarm-delegation`
+   > code files changed on branch `speckit/012-swarm-delegation`
    > vs `main`."
    >
    > Or: "Detected **Spec Review Mode** (OpenSpec) — only
@@ -342,7 +342,7 @@ depends on the detected workflow tier.
 Based on the workflow tier detected in the auto-detection
 step, determine which artifacts to review:
 
-- **Speckit** (branch `NNN-*`): Review the active spec
+- **Speckit** (branch `speckit/NNN-*` or `NNN-*`): Review the active spec
   directory at `specs/NNN-<name>/` (spec.md, plan.md,
   tasks.md, contracts/, data-model.md, checklists/),
   plus `.specify/memory/constitution.md` and `AGENTS.md`.

--- a/internal/scaffold/assets/opencode/commands/unleash.md
+++ b/internal/scaffold/assets/opencode/commands/unleash.md
@@ -54,7 +54,7 @@ git rev-parse --abbrev-ref HEAD
 
 - If on `main`: **STOP** with error:
   > "Cannot run /unleash on main. Must be on a Speckit
-  > (`NNN-*`) or OpenSpec (`opsx/*`) feature branch."
+  > (`speckit/NNN-*`) or OpenSpec (`opsx/*`) feature branch."
 
 - If on `opsx/*`: **OpenSpec mode detected.**
   Extract the change name from the branch:
@@ -69,8 +69,8 @@ git rev-parse --abbrev-ref HEAD
 
   Announce: "Detected OpenSpec change: `<name>`"
 
-- If the branch matches `NNN-*` (digits followed by a
-  dash): **Speckit mode detected.**
+- If the branch matches `speckit/NNN-*` or `NNN-*` (legacy)
+  (digits followed by a dash): **Speckit mode detected.**
 
   Validate that spec.md exists by running from the repo
   root:
@@ -88,11 +88,11 @@ git rev-parse --abbrev-ref HEAD
   is the working directory for all subsequent steps.
   Set `WORKFLOW_TIER = speckit`.
 
-- If the branch does not match `NNN-*` or `opsx/*`:
-  **STOP** with error:
+- If the branch does not match `speckit/NNN-*`, `NNN-*`
+  (legacy), or `opsx/*`: **STOP** with error:
   > "Unrecognized branch pattern. /unleash requires a
-  > Speckit feature branch (`NNN-*`) or OpenSpec branch
-  > (`opsx/*`). Run `/speckit.specify` or
+  > Speckit feature branch (`speckit/NNN-*`) or OpenSpec
+  > branch (`opsx/*`). Run `/speckit.specify` or
   > `/opsx-propose` to create one."
 
 ### 2. Resumability Detection
@@ -284,7 +284,7 @@ analysis + quality validation) in a single pass.
    Mode** -- review the spec artifacts in `FEATURE_DIR`,
    not code." The review council auto-detects the
    workflow tier from the branch name (`opsx/*` vs
-   `NNN-*`).
+   `speckit/NNN-*` or `NNN-*`).
 3. Collect the review results.
 
 **Processing results**:
@@ -557,7 +557,7 @@ memory.
 3. **If Dewey is available** (`dewey_store_learning` tool
    exists): store each learning via `dewey_store_learning`
    with tags including:
-   - The branch name (e.g., `018-unleash-command`)
+   - The branch name (e.g., `speckit/018-unleash-command`)
    - The current date (e.g., `2026-03-29`)
    - The learning category (e.g., `pattern`, `gotcha`,
      `review-insight`, `file-specific`)
@@ -637,7 +637,8 @@ Format the output as:
 ## Guardrails
 
 - **NEVER run on `main`** -- the command is for Speckit
-  (`NNN-*`) and OpenSpec (`opsx/*`) feature branches
+  (`speckit/NNN-*` or `NNN-*` legacy) and OpenSpec
+  (`opsx/*`) feature branches
 - **NEVER skip spec review exit on HIGH/CRITICAL** --
   these findings block implementation to prevent wasted
   effort on a flawed spec

--- a/internal/scaffold/assets/opencode/skills/review-context/SKILL.md
+++ b/internal/scaffold/assets/opencode/skills/review-context/SKILL.md
@@ -38,7 +38,7 @@ or PR branch name:
 
 | Branch pattern | Spec location |
 |---------------|---------------|
-| `NNN-<name>` (digits then dash) | `specs/<branch-name>/spec.md` (Speckit) |
+| `speckit/NNN-<name>` or `NNN-<name>` (legacy) | `specs/<name>/spec.md` (Speckit; strip `speckit/` prefix) |
 | `opsx/<name>` | `openspec/changes/<name>/proposal.md` (OpenSpec changes) |
 | `opsx/<name>` | `openspec/specs/<name>/spec.md` (OpenSpec specs) |
 
@@ -46,7 +46,7 @@ or PR branch name:
 
 If no spec is found via branch name and a PR description
 is available, scan for explicit spec references (e.g.,
-"See spec 012" or "Implements specs/012-swarm/spec.md").
+"See spec 012" or "Implements specs/012-swarm/spec.md" or "branch speckit/012-swarm").
 
 ### Step 3: Changed-file detection
 

--- a/openspec/changes/speckit-branch-prefix/.openspec.yaml
+++ b/openspec/changes/speckit-branch-prefix/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: unbound-force
+created: 2026-07-06

--- a/openspec/changes/speckit-branch-prefix/design.md
+++ b/openspec/changes/speckit-branch-prefix/design.md
@@ -1,0 +1,130 @@
+## Context
+
+Speckit branches use flat `NNN-<name>` names while OpenSpec
+branches use the `opsx/` folder prefix. Issue #149 requests
+parity. The proposal selects `speckit/` as the prefix after
+evaluating `spec/` (confusable with `specs/` directory via
+singular/plural), `specs/` (double-path risk in shell scripts
+that do `$SPECS_DIR/$BRANCH_NAME`), and `speckit/` (zero
+ambiguity, fails fast if prefix strip is missed).
+
+The shell scripts in `.specify/scripts/bash/common.sh`
+interpolate branch names directly into filesystem paths via
+`get_feature_dir()` and `find_feature_dir_by_prefix()`. Any
+prefix that collides with or is similar to the `specs/`
+directory creates a subtle double-path bug (`specs/specs/...`).
+`speckit/` avoids this entirely -- a missed strip produces
+`specs/speckit/001-feature/`, which fails fast and obviously.
+
+## Goals / Non-Goals
+
+### Goals
+- New Speckit branches are created as `speckit/NNN-<name>`
+- All branch-detection logic accepts both `NNN-<name>`
+  (legacy) and `speckit/NNN-<name>` (new)
+- Branch-to-directory mapping correctly strips the `speckit/`
+  prefix before constructing `specs/NNN-<name>/` paths
+- Documentation, commands, skills, agents, and scaffold assets
+  reflect the new convention
+- Upstream Speckit issue #1382 receives a comment proposing
+  `branch_prefix` as a config key in the git extension
+
+### Non-Goals
+- Renaming existing remote branches (they remain as-is)
+- Modifying historical spec artifacts or archived OpenSpec
+  changes
+- Changing the `specs/` directory structure on disk
+- Modifying the OpenSpec `opsx/` convention
+- Submitting an upstream PR (comment/proposal only)
+- Adding a configurable prefix mechanism locally (hardcode
+  `speckit/` for now; migrate to config-driven if upstream
+  adds `branch_prefix` support)
+
+## Decisions
+
+### D1: Prefix is `speckit/` (not `spec/` or `specs/`)
+
+**Rationale**: `spec/` is confusable with the `specs/`
+directory (singular vs plural). `specs/` causes a double-path
+bug in `common.sh` where `get_feature_dir()` does
+`$repo_root/specs/$branch_name` -- if the branch is
+`specs/001-feature`, the result is
+`$repo_root/specs/specs/001-feature`. `speckit/` has zero
+collision risk: a missed prefix strip produces
+`specs/speckit/001-feature/` which fails fast and obviously.
+
+### D2: Backward-compatible detection (accept both patterns)
+
+**Rationale**: Existing branches should continue to work.
+Detection regexes change from `^[0-9]{3}-` to
+`^(speckit/)?[0-9]{3}-` in shell scripts, and from `NNN-*`
+to `speckit/NNN-*` (with legacy fallback) in command/skill
+prose. This is a non-breaking change.
+
+### D3: Prefix stripping in common.sh
+
+The `find_feature_dir_by_prefix()` function and
+`get_current_branch()` must strip the `speckit/` prefix
+before path construction. The strip happens early -- at the
+point where the branch name enters the path-construction
+pipeline -- rather than at each consumer site.
+
+Implementation:
+```bash
+# In get_current_branch() or find_feature_dir_by_prefix():
+branch_name="${branch_name#speckit/}"
+```
+
+This uses bash parameter expansion to strip the prefix only
+if present, making it safe for both old and new branch names.
+
+### D4: Spec directory names on disk are unchanged
+
+Branch `speckit/001-feature` maps to directory
+`specs/001-feature/`. The `create-new-feature.sh` script
+sets `BRANCH_NAME="speckit/${FEATURE_NUM}-${BRANCH_SUFFIX}"`
+for git but uses `FEATURE_DIR="$SPECS_DIR/${FEATURE_NUM}-${BRANCH_SUFFIX}"`
+(without the prefix) for the filesystem directory.
+
+### D5: Historical artifacts are not modified
+
+Completed specs in `specs/016-*`, `specs/018-*`,
+`specs/030-*`, `specs/031-*` and archived OpenSpec changes
+document conventions as they were at time of writing.
+Modifying them would be revisionist and create unnecessary
+churn.
+
+### D6: `internal/doctor/checks.go` is unchanged
+
+The `hasSpecNumberedDirs()` function's regex `^\d{3}-` scans
+immediate children of the `specs/` directory, not branch
+names. Spec directories continue to be named `NNN-<name>/`
+on disk, so no change is needed.
+
+## Risks / Trade-offs
+
+### R1: Upstream divergence (LOW)
+
+The change modifies `.specify/scripts/bash/create-new-feature.sh`
+and `common.sh`, which are scaffolded from upstream Speckit.
+This increases divergence. Mitigated by:
+- The change is isolated to 2 local scripts
+- If upstream adds `branch_prefix` config support, we migrate
+  to the config-driven approach and drop local overrides
+- A comment on upstream #1382 proposes this feature
+
+### R2: Missed pattern in a command file (LOW)
+
+With ~100 edits across ~56 files, it is possible to miss a
+pattern. Mitigated by:
+- Backward-compatible regex means old patterns still work
+- A grep sweep in the verification phase catches stragglers
+- Scaffold drift detection tests catch mismatches between
+  live files and `internal/scaffold/assets/` copies
+
+### R3: Branch name with `/` in shell scripts (LOW)
+
+Git handles `/` in branch names natively (it creates
+subdirectories under `.git/refs/heads/`). The `speckit/`
+prefix is no different from how `opsx/` already works.
+No special handling needed.

--- a/openspec/changes/speckit-branch-prefix/proposal.md
+++ b/openspec/changes/speckit-branch-prefix/proposal.md
@@ -1,0 +1,122 @@
+## Why
+
+Speckit branches currently use a flat `NNN-<name>` naming
+convention (e.g., `001-org-constitution`, `031-unleash-openspec`),
+while OpenSpec branches are organized under the `opsx/` folder
+prefix (e.g., `opsx/sandbox-uid-mapping`). This inconsistency
+means Speckit branches pollute the top-level branch namespace,
+making `git branch` output harder to scan, and the two workflow
+types are not visually distinguishable at a glance.
+
+Upstream Speckit (github/spec-kit) has open issues requesting
+custom branch namespacing (#1382, #3081) but no resolution yet.
+
+Fixes: https://github.com/unbound-force/unbound-force/issues/149
+
+## What Changes
+
+Add a `speckit/` folder prefix to all newly created Speckit
+feature branches. The branch naming convention changes from
+`NNN-<name>` to `speckit/NNN-<name>`.
+
+All branch-detection logic becomes backward-compatible,
+accepting both the legacy `NNN-<name>` pattern and the new
+`speckit/NNN-<name>` pattern. Existing branches are not
+renamed.
+
+The `specs/` directory structure on disk is unchanged --
+spec artifacts continue to live at `specs/NNN-<name>/`.
+
+## Capabilities
+
+### New Capabilities
+- `speckit/ branch prefix`: New Speckit branches are created
+  as `speckit/NNN-<name>`, organizing them under a folder in
+  the git branch namespace
+
+### Modified Capabilities
+- `Branch detection`: All commands and skills that detect
+  Speckit branches (unleash, review-council, finale,
+  address-feedback, agent-brief, cobalt-crush, review-context,
+  speckit-workflow) accept both `NNN-<name>` and
+  `speckit/NNN-<name>` patterns
+- `Prefix stripping`: Branch-to-directory mapping strips the
+  `speckit/` prefix before constructing filesystem paths to
+  `specs/NNN-<name>/`
+
+### Removed Capabilities
+- None
+
+## Impact
+
+- **Shell scripts** (2 files): `create-new-feature.sh` branch
+  name construction, `common.sh` validation regexes and
+  branch-to-directory mapping
+- **Commands** (8 files): Branch detection patterns and error
+  messages in unleash, review-council, finale,
+  address-feedback, agent-brief, cobalt-crush, and workflow
+  status/advance commands
+- **Skills** (1 file): review-context branch-to-spec mapping
+  table (speckit-workflow only has filesystem paths, unchanged)
+- **Scaffold assets** (7 files): Mirrors of updated commands
+  and skills under `internal/scaffold/assets/`
+- **Documentation** (3 files): AGENTS.md, docs/usage.md,
+  docs/architecture.md
+- **Total**: 21 modified files + 4 new OpenSpec artifacts
+
+Note: Initial estimate was ~56 files / ~100 edits. Actual
+scope is smaller because Speckit command guardrails (11
+files), agent file examples (7 files), constitution, and
+doctor_test.go only reference `specs/NNN-*/` filesystem
+paths, not branch names, so they required no changes.
+
+Historical spec artifacts and archived OpenSpec changes are
+NOT modified.
+
+## Constitution Alignment
+
+Assessed against the Unbound Force org constitution.
+
+### I. Autonomous Collaboration
+
+**Assessment**: PASS
+
+This change affects branch naming conventions only. All
+artifact-based communication (spec files, reports, schemas)
+remains unchanged. Spec artifacts continue to be written to
+`specs/NNN-<name>/` on disk. No inter-hero communication
+patterns are affected.
+
+### II. Composability First
+
+**Assessment**: PASS
+
+The change is internal to the Unbound Force meta-repository.
+No hero's standalone functionality is affected. The backward-
+compatible detection logic ensures that existing branches
+created by any hero continue to work without modification.
+
+### III. Observable Quality
+
+**Assessment**: N/A
+
+This change does not affect machine-parseable output, artifact
+formats, or provenance metadata. It is a developer-workflow
+convention change.
+
+### IV. Testability
+
+**Assessment**: PASS
+
+The backward-compatible regex patterns are testable in
+isolation. The `internal/doctor/checks.go` directory-name
+regex (`^\d{3}-`) scans filesystem entries, not branch names,
+and requires no change. Test fixtures in `doctor_test.go` that
+reference branch name patterns will be updated.
+
+### V. Security by Default
+
+**Assessment**: N/A
+
+No new dependencies, inputs, or privilege changes. Branch
+naming is a developer convention with no security surface.

--- a/openspec/changes/speckit-branch-prefix/specs/branch-prefix/spec.md
+++ b/openspec/changes/speckit-branch-prefix/specs/branch-prefix/spec.md
@@ -1,0 +1,113 @@
+## ADDED Requirements
+
+### FR-001: Speckit branch folder prefix
+
+New Speckit feature branches MUST be created with the
+`speckit/` folder prefix. The branch name format SHALL be
+`speckit/NNN-<name>` where `NNN` is a zero-padded 3-digit
+sequential number and `<name>` is the kebab-case feature
+name.
+
+#### Scenario: New feature branch creation
+
+- **GIVEN** a developer runs the Speckit `create-new-feature`
+  script with description "add user auth"
+- **WHEN** the script generates the branch name
+- **THEN** the branch name MUST be `speckit/NNN-user-auth`
+  (e.g., `speckit/035-user-auth`)
+- **AND** the spec directory on disk MUST be
+  `specs/NNN-user-auth/` (without the `speckit/` prefix)
+
+### FR-002: Backward-compatible branch detection
+
+All branch-detection logic MUST accept both the legacy
+`NNN-<name>` pattern and the new `speckit/NNN-<name>`
+pattern. Legacy branches MUST NOT be rejected or require
+migration.
+
+#### Scenario: Legacy branch detected by unleash command
+
+- **GIVEN** a developer is on branch `031-unleash-openspec`
+  (legacy format)
+- **WHEN** the `/unleash` command detects the branch type
+- **THEN** the command MUST identify it as a Speckit branch
+- **AND** the command MUST locate spec artifacts at
+  `specs/031-unleash-openspec/`
+
+#### Scenario: New-format branch detected by unleash command
+
+- **GIVEN** a developer is on branch
+  `speckit/035-user-auth` (new format)
+- **WHEN** the `/unleash` command detects the branch type
+- **THEN** the command MUST identify it as a Speckit branch
+- **AND** the command MUST locate spec artifacts at
+  `specs/035-user-auth/` (prefix stripped)
+
+### FR-003: Prefix stripping for path construction
+
+When mapping a branch name to a filesystem path, the
+`speckit/` prefix MUST be stripped before constructing the
+spec directory path. The stripping MUST occur in
+`common.sh` functions (`find_feature_dir_by_prefix`,
+`get_current_branch`) so that downstream consumers
+receive a clean `NNN-<name>` identifier.
+
+#### Scenario: Prefix stripped for spec directory lookup
+
+- **GIVEN** the current branch is `speckit/035-user-auth`
+- **WHEN** `find_feature_dir_by_prefix()` resolves the
+  feature directory
+- **THEN** it MUST return `$REPO_ROOT/specs/035-user-auth`
+- **AND** it MUST NOT return
+  `$REPO_ROOT/specs/speckit/035-user-auth`
+
+#### Scenario: Legacy branch needs no stripping
+
+- **GIVEN** the current branch is `031-unleash-openspec`
+- **WHEN** `find_feature_dir_by_prefix()` resolves the
+  feature directory
+- **THEN** it MUST return
+  `$REPO_ROOT/specs/031-unleash-openspec`
+
+### FR-004: Spec directory naming unchanged
+
+Spec directories on disk MUST continue to use the
+`NNN-<name>` naming convention under `specs/`. The
+`speckit/` prefix applies only to git branch names, not
+to filesystem directories.
+
+#### Scenario: Directory created without prefix
+
+- **GIVEN** the `create-new-feature` script runs for a new
+  feature
+- **WHEN** the spec directory is created
+- **THEN** the directory MUST be at
+  `specs/NNN-<name>/` (e.g., `specs/035-user-auth/`)
+- **AND** the directory MUST NOT be at
+  `specs/speckit/NNN-<name>/`
+
+## MODIFIED Requirements
+
+### Requirement: Branch naming convention documentation
+
+All documentation, commands, skills, and agent files that
+reference the Speckit branch convention MUST be updated to
+show `speckit/NNN-<name>` as the primary format. Legacy
+`NNN-<name>` SHOULD be noted as accepted for backward
+compatibility.
+
+Previously: Documentation referenced `NNN-<name>` as the
+sole branch naming convention for Speckit.
+
+### Requirement: Scaffold asset synchronization
+
+All scaffold assets under `internal/scaffold/assets/` that
+mirror live command, skill, or agent files MUST be updated
+in sync with their live counterparts. Scaffold drift
+detection tests MUST pass after the update.
+
+Previously: Scaffold assets referenced `NNN-<name>` patterns.
+
+## REMOVED Requirements
+
+None.

--- a/openspec/changes/speckit-branch-prefix/tasks.md
+++ b/openspec/changes/speckit-branch-prefix/tasks.md
@@ -1,0 +1,133 @@
+<!--
+  [P] marks tasks eligible for parallel execution.
+  Add [P] when a task: (a) touches different files from
+  other [P] tasks in the group, (b) has no dependency
+  on prior tasks in the group, (c) can safely execute
+  without ordering constraints.
+  Do NOT add [P] when tasks modify the same file --
+  parallel workers will cause merge conflicts.
+  Tasks without [P] run sequentially first, then [P]
+  tasks run in parallel.
+-->
+
+## 1. Core shell script logic (FR-001, FR-002, FR-003, FR-004)
+
+- [x] 1.1 [P] Update `.specify/scripts/bash/create-new-feature.sh`:
+  change branch name construction at line 251 from
+  `BRANCH_NAME="${FEATURE_NUM}-${BRANCH_SUFFIX}"` to
+  `BRANCH_NAME="speckit/${FEATURE_NUM}-${BRANCH_SUFFIX}"`.
+  Ensure `FEATURE_DIR` continues to use
+  `$SPECS_DIR/${FEATURE_NUM}-${BRANCH_SUFFIX}` (no prefix
+  on filesystem). Update any branch-name regex patterns
+  (lines 116-117) to accept `speckit/` prefix.
+- [x] 1.2 [P] Update `.specify/scripts/bash/common.sh`:
+  (a) In `get_current_branch()`, strip `speckit/` prefix
+  using `branch="${branch#speckit/}"` before returning.
+  (b) Update `validate_branch()` regex from `^[0-9]{3}-`
+  to `^(speckit/)?[0-9]{3}-` (line 75).
+  (c) Update `find_feature_dir_by_prefix()` to strip
+  `speckit/` from `$branch_name` before regex matching
+  and path construction.
+  (d) Update error message example (line 77) to show
+  `speckit/001-feature-name`.
+
+## 2. Command branch detection (FR-002)
+
+- [x] 2.1 [P] Update `.opencode/commands/unleash.md`:
+  change `NNN-*` pattern references to
+  `speckit/NNN-*` with backward-compatible detection.
+  Update error messages and examples (lines 57, 72, 91,
+  94, 287, 560, 640).
+- [x] 2.2 [P] Update `.opencode/commands/review-council.md`:
+  change branch classification pattern from `NNN-*` to
+  `speckit/NNN-*` (lines 79, 95, 667, 668).
+- [x] 2.3 [P] Update `.opencode/commands/finale.md`:
+  change branch detection and error messages (lines 24,
+  45, 247).
+- [x] 2.4 [P] Update `.opencode/commands/address-feedback.md`:
+  change spec artifact discovery pattern (line 140).
+- [x] 2.5 [P] Update `.opencode/commands/agent-brief.md`:
+  change detection logic and governance templates
+  (lines 82, 201, 213, 223).
+- [x] 2.6 [P] Update `.opencode/commands/cobalt-crush.md`:
+  change branch requirement message (line 93).
+- [x] 2.7 [P] Update `.opencode/commands/workflow-status.md`:
+  change hardcoded example (line 111).
+- [x] 2.8 [P] Update `.opencode/commands/workflow-advance.md`:
+  change hardcoded example (line 90).
+
+## 3. Skill updates (FR-002, FR-003)
+
+- [x] 3.1 [P] Update
+  `.opencode/skills/review-context/SKILL.md`:
+  change branch-to-spec mapping table to show
+  `speckit/NNN-<name>` pattern with prefix stripping
+  (lines 41, 49, 236).
+- [x] 3.2 [P] Update
+  `.opencode/skills/speckit-workflow/SKILL.md`:
+  change task file discovery path (line 22).
+  No change needed — only contains filesystem path
+  `specs/NNN-*/tasks.md`, not branch names.
+
+## 4. Speckit command guardrail blocks
+
+- [x] 4.1-4.11: All guardrail blocks verified. They
+  reference `specs/NNN-*/` filesystem paths, not branch
+  names. No changes needed — filesystem directory naming
+  is unchanged.
+
+## 5. Agent file examples
+
+- [x] 5.1-5.7: All agent files verified. They reference
+  `specs/NNN-feature/artifact.md` filesystem paths in
+  finding templates, not branch names. No changes
+  needed — filesystem directory naming is unchanged.
+
+## 6. Scaffold asset synchronization
+
+- [x] 6.1 Sync all `internal/scaffold/assets/opencode/`
+  copies with their live counterparts updated in tasks
+  2.x, 3.x, 4.x, and 5.x. Files to sync:
+  `commands/unleash.md`, `commands/review-council.md`,
+  `commands/finale.md`, `commands/address-feedback.md`,
+  `commands/agent-brief.md`, `commands/cobalt-crush.md`,
+  `commands/uf-init.md`,
+  `skills/review-context/SKILL.md`,
+  `skills/speckit-workflow/SKILL.md`,
+  `agents/divisor-guard.md`,
+  `agents/divisor-architect.md`,
+  `agents/divisor-adversary.md`,
+  `agents/divisor-testing.md`,
+  `agents/divisor-sre.md`,
+  `agents/divisor-curator.md`.
+  Note: no [P] marker because this task depends on
+  prior tasks completing first.
+
+## 7. Top-level documentation
+
+- [x] 7.1 [P] Update `AGENTS.md`: change branch naming
+  convention Branches line (line 239).
+- [x] 7.2 [P] `.specify/memory/constitution.md` verified.
+  References `specs/NNN-*/` filesystem path in Phase
+  Discipline rule. No change needed.
+- [x] 7.3 [P] Update `docs/usage.md`: change branch
+  pattern reference (line 139).
+- [x] 7.4 [P] Update `docs/architecture.md`: change
+  branch pattern reference (line 447).
+
+## 8. Verification
+
+- [x] 8.1 Run `make check` (build, lint, tests). Confirm
+  scaffold drift detection tests pass. PASSED: 0 lint
+  issues, all 20 test packages pass, build succeeds.
+- [x] 8.2 Grep sweep: searched for remaining `NNN-<name>`
+  branch references. All remaining references are either:
+  (a) filesystem paths (`specs/NNN-*/`), (b) already
+  updated to show `speckit/NNN-*` with legacy fallback,
+  or (c) in excluded historical files.
+- [x] 8.3 Constitution alignment verified: I=PASS (no
+  artifact format changes), II=PASS (no hero dependency
+  changes), III=N/A (no output format changes), IV=PASS
+  (all tests pass), V=N/A (no security surface changes).
+
+<!-- spec-review: passed -->


### PR DESCRIPTION
# Summary

Add a `speckit/` folder prefix to new Speckit feature branches, changing the naming convention from `NNN-<name>` to `speckit/NNN-<name>`. This organizes Speckit branches under a folder in the git branch namespace, matching the pattern already used by OpenSpec (`opsx/`).

All branch detection is backward-compatible — legacy `NNN-<name>` branches continue to work without modification. Existing remote branches are not renamed. Spec directories on disk remain `specs/NNN-<name>/`.

Fixes #149

## How to Test

Verify the shell script changes by dry-running branch creation:

```bash
bash .specify/scripts/bash/create-new-feature.sh --short-name "test-prefix" "Test the prefix" --json
# Expected: BRANCH_NAME starts with speckit/
```

Verify backward compatibility — `common.sh` should strip the `speckit/` prefix:

```bash
source .specify/scripts/bash/common.sh
# get_current_branch on a speckit/* branch returns NNN-<name>
# without the prefix
```

Run the full test suite:

```bash
make check
```

## How to Demo

After merging, the next time `/speckit.specify` creates a new feature branch, it will be named `speckit/NNN-<name>` instead of `NNN-<name>`. Run `git branch` to see the organized folder structure. Existing branches like `031-unleash-openspec` continue to work normally.

## Key Files Changed

**Core logic:**
- `.specify/scripts/bash/create-new-feature.sh` — Branch name construction now prepends `speckit/`; filesystem path strips prefix
- `.specify/scripts/bash/common.sh` — `get_current_branch()` strips prefix; validation and path lookup accept both patterns

**Commands (8 files):**
- `unleash.md`, `review-council.md`, `finale.md`, `address-feedback.md`, `agent-brief.md`, `cobalt-crush.md`, `workflow-status.md`, `workflow-advance.md` — Branch detection patterns, error messages, and examples updated

**Skills (1 file):**
- `review-context/SKILL.md` — Branch-to-spec mapping table

**Documentation (3 files):**
- `AGENTS.md`, `docs/usage.md`, `docs/architecture.md`

**Scaffold assets (7 files):**
- Synchronized with live command/skill files

**OpenSpec artifacts (4 new files):**
- `openspec/changes/speckit-branch-prefix/` — proposal, design, specs, tasks

_This PR was generated by /finale (AI-assisted)._