### PR TITLE
docs: document --no-embeddings default during uf init

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -32,6 +32,11 @@ uf init [flags]
 | `--divisor` | bool | `false` | Deploy only Divisor review agents and convention packs |
 | `--lang` | string | `""` | Project language for convention pack (auto-detected from go.mod, package.json, etc. if omitted) |
 
+> **Note:** Dewey indexing during init uses `--no-embeddings` for
+> fast metadata-only indexing. Run `dewey index` separately to
+> generate embeddings for semantic search. To skip Dewey entirely,
+> set `setup.tools.dewey.method: skip` in `.uf/config.yaml`.
+
 **Example**
 
 ```bash

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -218,6 +218,21 @@ Edit the `*-custom.md` files to add project-specific
 rules. Tool-owned files are auto-updated by `uf init`;
 custom files are never overwritten.
 
+## Dewey Knowledge Layer
+
+During `uf init`, Dewey performs a **metadata-only index**
+(`--no-embeddings`) for fast initialization. Semantic
+search embeddings are not generated automatically.
+
+To enable semantic search after scaffolding:
+
+```bash
+dewey index
+```
+
+To skip Dewey entirely during init, set
+`setup.tools.dewey.method: skip` in `.uf/config.yaml`.
+
 ## CLI Commands
 
 Unbound Force also provides terminal CLI commands


### PR DESCRIPTION
## Summary

- Add a "Dewey Knowledge Layer" section to `docs/usage.md` explaining that `uf init` performs metadata-only indexing (`--no-embeddings`) and users run `dewey index` separately for semantic search
- Add a note to the `uf init` flags table in `docs/cli-reference.md` with the same guidance and the config-based skip mechanism (`setup.tools.dewey.method: skip`)

## Related Issues

- Closes #319

## Review Hints

- Two small doc additions, no code changes
- Scope reduced from original issue: the proposed `--no-index` flag was superseded by the `--no-embeddings` default in PR #321 (see [comment](https://github.com/unbound-force/unbound-force/issues/319#issuecomment-4991849130))