### PR TITLE
fix: finale secrets check gate prose only

### DIFF
--- a/.opencode/commands/finale.md
+++ b/.opencode/commands/finale.md
@@ -76,8 +76,13 @@ Run `git status --short` to inspect the working tree.
   > Proceed with staging all files? These files will be
   > included in the commit."
 
-  Ask for confirmation. If the user declines, stop and
-  let them handle it manually.
+  Use the **AskUserQuestion tool** to ask the user how
+  to proceed. Present these options:
+  - "Yes -- stage all files including flagged ones"
+  - "No -- stop and let me handle it manually"
+
+  If the user selects "No -- stop and let me handle it
+  manually", STOP immediately. Do NOT run `git add .`.
 
 - **Stage all changes**: `git add .`
 

--- a/internal/scaffold/assets/opencode/commands/finale.md
+++ b/internal/scaffold/assets/opencode/commands/finale.md
@@ -76,8 +76,13 @@ Run `git status --short` to inspect the working tree.
   > Proceed with staging all files? These files will be
   > included in the commit."
 
-  Ask for confirmation. If the user declines, stop and
-  let them handle it manually.
+  Use the **AskUserQuestion tool** to ask the user how
+  to proceed. Present these options:
+  - "Yes -- stage all files including flagged ones"
+  - "No -- stop and let me handle it manually"
+
+  If the user selects "No -- stop and let me handle it
+  manually", STOP immediately. Do NOT run `git add .`.
 
 - **Stage all changes**: `git add .`
 

--- a/openspec/changes/finale-secrets-askuser/.openspec.yaml
+++ b/openspec/changes/finale-secrets-askuser/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: unbound-force
+created: 2026-07-29

--- a/openspec/changes/finale-secrets-askuser/design.md
+++ b/openspec/changes/finale-secrets-askuser/design.md
@@ -1,0 +1,99 @@
+## Context
+
+The `/finale` command (`.opencode/commands/finale.md`) has a
+secrets check gate in Step 2 (lines 63-80) that warns the user
+about potential secret files before staging. The confirmation
+is expressed as prose: "Ask for confirmation. If the user
+declines, stop and let them handle it manually."
+
+This T3 weakness (prose-only gate) means an agent can skip the
+confirmation under context compression. The sibling change
+`askuser-tool-confirmations` established the pattern for
+converting free-text confirmations to AskUserQuestion tool
+calls across `/review-pr`, `/address-feedback`, and
+`/triage-issue`. This change applies the same pattern to
+`/finale`.
+
+## Goals / Non-Goals
+
+### Goals
+- Replace the prose-only secrets confirmation in `/finale`
+  Step 2 with an explicit AskUserQuestion tool call
+- Preserve the existing safety semantics (never stage secret
+  files without user confirmation)
+- Follow the conventions established by the
+  `askuser-tool-confirmations` change (D1, D2, D5 decisions)
+- Keep scaffold asset byte-identical to command file
+
+### Non-Goals
+- Adding new interaction points or changing `/finale` workflow
+  logic
+- Modifying any other confirmation gates in `/finale` (commit
+  message approval, PR approval, CI failure handling)
+- Modifying the AskUserQuestion tool itself
+- Changing any Go source code beyond the scaffold asset copy
+
+## Decisions
+
+### D1: AskUserQuestion with action-descriptive options
+
+Replace lines 79-80 with an explicit AskUserQuestion tool call
+using two options:
+- "Yes -- stage all files including flagged ones"
+- "No -- stop and let me handle it manually"
+
+If the user selects "No", the agent MUST stop immediately and
+not run `git add .`.
+
+**Rationale**: Follows the D2 convention from the sibling
+change -- option labels describe what will happen, not just
+bare yes/no. The structured selection is unambiguous and
+cannot be skipped by an agent under context compression.
+
+### D2: Preserve warning message format
+
+The existing warning block (lines 70-77) that lists detected
+secret files remains unchanged. Only the confirmation
+mechanism (lines 79-80) is replaced.
+
+**Rationale**: The warning text is informative and correctly
+formatted. Changing it would expand scope beyond the T3 fix.
+
+### D3: Scaffold asset updated in lockstep
+
+The scaffold asset at
+`internal/scaffold/assets/opencode/commands/finale.md` MUST
+be updated with the identical change. The existing drift
+detection test (`TestEmbeddedAssets_MatchSource`) enforces
+byte-identical copies.
+
+**Rationale**: Required by the scaffold pattern (D4 from the
+sibling change). Existing test infrastructure validates this
+automatically.
+
+### D4: Bold formatting convention
+
+The AskUserQuestion tool is referenced as
+`**AskUserQuestion tool**` (bold, PascalCase) in the command
+text, matching the convention in `opsx-propose.md`,
+`opsx-apply.md`, and `opsx-archive.md` (D5 from the sibling
+change).
+
+**Rationale**: Consistency with established convention.
+
+## Risks / Trade-offs
+
+### R1: Minimal scope reduces risk
+
+This change modifies exactly two lines in one command file
+(plus its scaffold copy). The risk of behavioral regression
+is minimal. The scaffold drift test provides automated
+verification.
+
+### R2: Single interaction point
+
+Unlike the sibling change which converts 15 interaction
+points across three commands, this change converts exactly
+one interaction point. The implementation is straightforward
+with no complex sequencing or multi-step interactions.
+<!-- scaffolded by uf vdev -->

--- a/openspec/changes/finale-secrets-askuser/proposal.md
+++ b/openspec/changes/finale-secrets-askuser/proposal.md
@@ -1,0 +1,107 @@
+## Why
+
+The `/finale` command's secrets check gate (Step 2, lines 63-80)
+warns the user about potential secret files but relies on
+prose-only confirmation: "Ask for confirmation. If the user
+declines, stop and let them handle it manually."
+
+This is a T3 weakness (confirmation gate is inline text only).
+Under context compression or fast-path reasoning, an agent can
+treat this prose as informational and proceed to `git add .`
+without explicit user confirmation, potentially staging files
+that contain secrets.
+
+The sibling change `askuser-tool-confirmations` (issue #346)
+addresses this same T3 pattern in `/review-pr`,
+`/address-feedback`, and `/triage-issue`. This change applies
+the same fix to `/finale`, which was identified as a separate
+issue (#347) because it involves a different command with
+distinct safety semantics (staging files vs. posting reviews).
+
+## What Changes
+
+Replace the prose-only confirmation at lines 79-80 of
+`.opencode/commands/finale.md` with an explicit AskUserQuestion
+tool call that presents structured options. The user must
+deliberately select whether to proceed with staging or stop.
+
+## Capabilities
+
+### New Capabilities
+- None (no new functionality)
+
+### Modified Capabilities
+- `/finale`: The secrets check confirmation in Step 2 is
+  converted from prose instructions ("Ask for confirmation")
+  to an explicit AskUserQuestion tool call with structured
+  options
+
+### Removed Capabilities
+- None
+
+## Impact
+
+**Files modified** (2 files -- command + scaffold asset):
+- `.opencode/commands/finale.md`
+- `internal/scaffold/assets/opencode/commands/finale.md`
+
+**Behavioral change**: The secrets check gate retains its
+safety semantics (never stage secret files without user
+confirmation). Only the confirmation mechanism changes from
+prose text to a structured AskUserQuestion tool call with
+predefined options.
+
+**Scaffold drift**: The command file and its scaffold asset
+must be kept byte-identical. Both copies must be updated
+together. The existing drift detection test
+(`TestEmbeddedAssets_MatchSource`) enforces this.
+
+## Constitution Alignment
+
+Assessed against the Unbound Force org constitution.
+
+### I. Autonomous Collaboration
+
+**Assessment**: N/A
+
+This change modifies agent prompt instructions (a slash command
+markdown file), not inter-hero artifact exchange. No artifact
+formats, envelopes, or hero interfaces are affected.
+
+### II. Composability First
+
+**Assessment**: N/A
+
+No hero dependencies are introduced or modified. The `/finale`
+command remains independently usable. The AskUserQuestion tool
+is a built-in OpenCode capability, not a hero dependency.
+
+### III. Observable Quality
+
+**Assessment**: N/A
+
+No machine-parseable outputs or provenance metadata are
+affected. The commit, push, and PR creation behaviors remain
+unchanged.
+
+### IV. Testability
+
+**Assessment**: PASS
+
+The scaffold drift detection test
+(`TestEmbeddedAssets_MatchSource`) will verify that the command
+file and its scaffold asset remain synchronized. No new test
+infrastructure is needed.
+
+### V. Security by Default
+
+**Assessment**: PASS
+
+This change strengthens a security-relevant confirmation gate
+by converting a prose-only instruction (which can be skipped
+under context compression) to a structured AskUserQuestion
+tool call that requires explicit user selection. This makes
+the secrets check gate a structural property of the command
+rather than a review-time afterthought, directly supporting
+the principle's intent.
+<!-- scaffolded by uf vdev -->

--- a/openspec/changes/finale-secrets-askuser/specs/secrets-confirmation.md
+++ b/openspec/changes/finale-secrets-askuser/specs/secrets-confirmation.md
@@ -1,0 +1,71 @@
+## ADDED Requirements
+
+### Requirement: Structured secrets confirmation gate
+
+The `/finale` command's secrets check in Step 2 MUST use the
+**AskUserQuestion tool** with predefined options when potential
+secret files are detected. The agent MUST NOT proceed to
+`git add .` without receiving an explicit structured response
+from the user.
+
+Options presented MUST be:
+1. "Yes -- stage all files including flagged ones"
+2. "No -- stop and let me handle it manually"
+
+If the user selects "No", the agent MUST stop immediately.
+The agent MUST NOT fall back to prose-based confirmation or
+proceed without user selection.
+
+#### Scenario: Secret files detected and user approves
+
+- **GIVEN** the working tree contains files matching secret
+  patterns (`.env`, `*.key`, `*.pem`, `credentials.json`,
+  `secrets.json`)
+- **WHEN** the agent reaches the secrets check in Step 2
+- **THEN** the agent MUST present the **AskUserQuestion tool**
+  with the two predefined options
+- **AND** if the user selects "Yes -- stage all files
+  including flagged ones", the agent MUST proceed to
+  `git add .`
+
+#### Scenario: Secret files detected and user declines
+
+- **GIVEN** the working tree contains files matching secret
+  patterns
+- **WHEN** the agent presents the **AskUserQuestion tool**
+  and the user selects "No -- stop and let me handle it
+  manually"
+- **THEN** the agent MUST stop immediately
+- **AND** the agent MUST NOT run `git add .`
+- **AND** the agent MUST NOT attempt any alternative staging
+  approach
+
+#### Scenario: No secret files detected
+
+- **GIVEN** the working tree contains only non-secret files
+- **WHEN** the agent reaches the secrets check in Step 2
+- **THEN** the agent MUST proceed directly to `git add .`
+  without presenting the AskUserQuestion prompt
+
+## MODIFIED Requirements
+
+### Requirement: Secrets check confirmation mechanism
+
+The secrets check confirmation MUST use the
+**AskUserQuestion tool** instead of prose-based instructions.
+
+Previously: "Ask for confirmation. If the user declines,
+stop and let them handle it manually." (free-text prose)
+
+### Requirement: Scaffold asset synchronization
+
+The scaffold asset at
+`internal/scaffold/assets/opencode/commands/finale.md`
+MUST be updated with the identical change to maintain
+byte-identical copies. The `TestEmbeddedAssets_MatchSource`
+test MUST verify this.
+
+## REMOVED Requirements
+
+None.
+<!-- scaffolded by uf vdev -->

--- a/openspec/changes/finale-secrets-askuser/tasks.md
+++ b/openspec/changes/finale-secrets-askuser/tasks.md
@@ -1,0 +1,44 @@
+<!--
+  [P] marks tasks eligible for parallel execution.
+  Add [P] when a task: (a) touches different files from
+  other [P] tasks in the group, (b) has no dependency
+  on prior tasks in the group, (c) can safely execute
+  without ordering constraints.
+  Do NOT add [P] when tasks modify the same file --
+  parallel workers will cause merge conflicts.
+  Tasks without [P] run sequentially first, then [P]
+  tasks run in parallel.
+-->
+
+## 1. Replace prose confirmation with AskUserQuestion
+
+- [x] 1.1 [P] In `.opencode/commands/finale.md`, replace
+  lines 79-80 (the prose "Ask for confirmation..." text)
+  with an explicit **AskUserQuestion tool** call. Use
+  options: "Yes -- stage all files including flagged
+  ones" and "No -- stop and let me handle it manually".
+  Add a conditional: if the user selects "No", STOP
+  immediately and do not run `git add .`.
+  **File**: `.opencode/commands/finale.md`
+
+- [x] 1.2 [P] Apply the identical change to the scaffold
+  asset at
+  `internal/scaffold/assets/opencode/commands/finale.md`.
+  The file MUST be byte-identical to the command file
+  after both edits.
+  **File**: `internal/scaffold/assets/opencode/commands/finale.md`
+
+## 2. Verification
+
+- [ ] 2.1 Run `make test` to verify the scaffold drift
+  detection test (`TestEmbeddedAssets_MatchSource`) passes
+  with both files updated.
+
+- [ ] 2.2 Verify constitution alignment: confirm no
+  artifact formats, hero interfaces, or machine-parseable
+  outputs were modified (Autonomous Collaboration,
+  Composability First, Observable Quality -- all N/A).
+  Confirm the scaffold drift test covers Testability
+  (PASS).
+<!-- spec-review: passed -->
+<!-- scaffolded by uf vdev -->


### PR DESCRIPTION
Fixes https://github.com/unbound-force/unbound-force/issues/347

Replaces the prose-only secrets confirmation gate in `/finale` Step 2 with an explicit `AskUserQuestion` tool call. Under context compression, the prose "Ask for confirmation" instruction could be skipped. The structured tool call is observable and auditable.

### Changes
- `.opencode/commands/finale.md`: Convert inline prose gate to AskUserQuestion with \["Yes -- stage all files", "No -- stop and handle manually"\]
- `internal/scaffold/assets/opencode/commands/finale.md`: Scaffold mirror in lockstep
- `openspec/changes/finale-secrets-askuser/`: OpenSpec proposal, design, specs, and tasks artifacts

Automated fix from batch-fix script.