### PR TITLE
fix(speckit): move STOP HERE gates to preamble position

### DIFF
--- a/.opencode/commands/speckit.plan.md
+++ b/.opencode/commands/speckit.plan.md
@@ -21,6 +21,13 @@ You **MUST** consider the user input before proceeding (if not empty).
 
 ## Outline
 
+**STOP HERE. Do NOT proceed to implementation.**
+
+Your job is done. Report the results and prompt the
+user. The user will invoke a separate command
+(/unleash, /cobalt-crush, or /opsx-apply) when they
+are ready to implement.
+
 1. **Setup**: Run `.specify/scripts/bash/setup-plan.sh --json` from repo root and parse JSON for FEATURE_SPEC, IMPL_PLAN, SPECS_DIR, BRANCH. For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
 
 2. **Load context**: Read FEATURE_SPEC and `.specify/memory/constitution.md`. Load IMPL_PLAN template (already copied).
@@ -35,13 +42,6 @@ You **MUST** consider the user input before proceeding (if not empty).
    - Re-evaluate Constitution Check post-design
 
 4. **Stop and report**: Command ends after Phase 2 planning. Report branch, IMPL_PLAN path, and generated artifacts.
-
-**STOP HERE. Do NOT proceed to implementation.**
-
-Your job is done. Report the results and prompt the
-user. The user will invoke a separate command
-(/unleash, /cobalt-crush, or /opsx-apply) when they
-are ready to implement.
 
 ## Phases
 

--- a/.opencode/commands/speckit.tasks.md
+++ b/.opencode/commands/speckit.tasks.md
@@ -22,6 +22,13 @@ You **MUST** consider the user input before proceeding (if not empty).
 
 ## Outline
 
+**STOP HERE. Do NOT proceed to implementation.**
+
+Your job is done. Report the results and prompt the
+user. The user will invoke a separate command
+(/unleash, /cobalt-crush, or /opsx-apply) when they
+are ready to implement.
+
 1. **Setup**: Run `.specify/scripts/bash/check-prerequisites.sh --json` from repo root and parse FEATURE_DIR and AVAILABLE_DOCS list. All paths must be absolute. For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
 
 2. **Dewey Discovery** (optional): Before generating
@@ -66,13 +73,6 @@ You **MUST** consider the user input before proceeding (if not empty).
    - Dependencies section showing story completion order
    - Parallel execution examples per story
    - Implementation strategy section (MVP first, incremental delivery)
-
-**STOP HERE. Do NOT proceed to implementation.**
-
-Your job is done. Report the results and prompt the
-user. The user will invoke a separate command
-(/unleash, /cobalt-crush, or /opsx-apply) when they
-are ready to implement.
 
 6. **Report**: Output path to generated tasks.md and summary:
    - Total task count

--- a/openspec/changes/fix-stop-here-gate-placement/.openspec.yaml
+++ b/openspec/changes/fix-stop-here-gate-placement/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: unbound-force
+created: 2026-07-30

--- a/openspec/changes/fix-stop-here-gate-placement/design.md
+++ b/openspec/changes/fix-stop-here-gate-placement/design.md
@@ -1,0 +1,77 @@
+## Context
+
+The `2026-04-28-inline-stop-instructions` change added STOP
+HERE gates to 9 spec-phase commands. However, in two files
+(`speckit.tasks.md` and `speckit.plan.md`), the gate was
+placed after the workflow steps rather than before them.
+
+An LLM agent processes command files sequentially. When the
+STOP instruction appears after a numbered workflow, the agent
+completes all steps and enters "what next?" mode before it
+encounters the boundary. The fix is to reposition the gate
+as a preamble so the agent reads it before executing the
+workflow.
+
+## Goals / Non-Goals
+
+### Goals
+- Move STOP HERE gate in `speckit.tasks.md` from after
+  step 5 to a bolded preamble before step 1
+- Move STOP HERE gate in `speckit.plan.md` from after
+  step 4 to a bolded preamble before step 1
+- Preserve the existing wording and intent of the gate
+- Establish a preamble placement pattern for STOP gates
+  (no commands currently use preamble placement; this
+  change creates the pattern for the 2 files cited in
+  #363, with a follow-up for the remaining 5)
+
+### Non-Goals
+- Modifying the gate text or adding new guardrail language
+- Changing any other command files (the other 5 speckit
+  commands have the same post-workflow placement but are
+  not cited in issue #363; a follow-up issue should be
+  filed to address them)
+- Adding runtime enforcement of phase boundaries (this is
+  a behavioral instruction fix only)
+
+## Decisions
+
+**D1: Preamble placement, not duplication**
+
+Move the STOP block rather than duplicating it. Each file
+should have exactly one inline STOP instruction to avoid
+confusion about which is authoritative. The end-of-workflow
+position is removed and the preamble position is added.
+
+**D2: Position immediately after Outline heading**
+
+Place the STOP block as the first content after the
+`## Outline` heading, before step 1. This is the earliest
+point where the agent has workflow context and ensures
+the boundary is read before any workflow steps execute.
+
+**D3: Preserve existing wording**
+
+Use the exact same STOP HERE text that is already in the
+files. The wording is consistent across all spec-phase
+commands.
+
+## Risks / Trade-offs
+
+**Low risk**: This is a text repositioning change within
+2 Markdown files. No code, no tests, no schema changes.
+
+**Trade-off**: Placing the gate at the very top of the
+Outline means the agent reads it before it has context
+about what the workflow does. However, this follows the
+explicit recommendation in issue #363 and establishes
+a pattern that can be applied to the remaining commands
+in a follow-up.
+
+**Known limitation**: The same post-workflow STOP gate
+placement exists in 5 other speckit commands
+(`speckit.specify.md`, `speckit.clarify.md`,
+`speckit.analyze.md`, `speckit.checklist.md`,
+`speckit.testreview.md`). This change fixes only the
+2 files cited in #363. A follow-up issue should be
+filed to apply the preamble pattern consistently.

--- a/openspec/changes/fix-stop-here-gate-placement/proposal.md
+++ b/openspec/changes/fix-stop-here-gate-placement/proposal.md
@@ -1,0 +1,84 @@
+## Why
+
+In `speckit.tasks.md` and `speckit.plan.md`, the "STOP HERE.
+Do NOT proceed to implementation." gate appears AFTER the
+workflow steps it governs. An agent executing the workflow
+reads through artifact-creation steps, completes them, and
+by the time it encounters the STOP instruction, momentum
+has already carried it past the boundary.
+
+This is a T2 weakness: a CRITICAL/MANDATORY rule placed
+after the workflow it governs. The prior fix (archived
+change `2026-04-28-inline-stop-instructions`) added inline
+STOP blocks to all 9 spec-phase commands, but positioned
+them at the end of the numbered workflow steps rather than
+before them as a preamble.
+
+Fixes #363 (parent audit: #346 root cause analysis).
+
+## What Changes
+
+### New Capabilities
+- None
+
+### Modified Capabilities
+- `speckit.tasks.md`: Move STOP HERE block from between
+  step 5 (task generation) and step 6 (report) to a
+  bolded preamble immediately after the Outline heading,
+  before Step 1.
+- `speckit.plan.md`: Move STOP HERE block from after step
+  4 (plan workflow) to a bolded preamble immediately
+  after the Outline heading, before Step 1.
+
+### Removed Capabilities
+- None
+
+## Impact
+
+- 2 Markdown files modified (`.opencode/commands/speckit.tasks.md`,
+  `.opencode/commands/speckit.plan.md`)
+- No Go code changes
+- No scaffold asset syncs needed (files are command
+  definitions, not embedded assets)
+- No test changes
+
+## Constitution Alignment
+
+Assessed against the Unbound Force org constitution.
+
+### I. Autonomous Collaboration
+
+**Assessment**: N/A
+
+This change modifies agent behavioral instructions in
+Markdown command files. No artifact formats, inter-hero
+communication, or artifact envelopes are affected.
+
+### II. Composability First
+
+**Assessment**: N/A
+
+No hero dependencies, extension points, or standalone
+functionality are affected. This is an internal
+instruction-ordering fix.
+
+### III. Observable Quality
+
+**Assessment**: N/A
+
+No machine-parseable output, provenance metadata, or
+quality evidence is affected.
+
+### IV. Testability
+
+**Assessment**: N/A
+
+No testable components are modified. The change is to
+agent instruction text only.
+
+### V. Security by Default
+
+**Assessment**: N/A
+
+No code, dependencies, or security-sensitive operations
+are affected.

--- a/openspec/changes/fix-stop-here-gate-placement/specs/stop-gate-placement.md
+++ b/openspec/changes/fix-stop-here-gate-placement/specs/stop-gate-placement.md
@@ -1,0 +1,43 @@
+## ADDED Requirements
+
+None.
+
+## MODIFIED Requirements
+
+### Requirement: STOP-GATE-001 — Gate Positioning
+
+Phase-boundary STOP instructions in spec-phase command
+files MUST appear as a preamble before step 1 of the
+workflow, not after the final workflow step.
+
+Previously: STOP instructions were positioned after the
+main workflow steps (between steps 5 and 6 in
+`speckit.tasks.md`, after step 4 in `speckit.plan.md`).
+Note: the same post-workflow placement exists in 5 other
+speckit commands; those are out of scope for this change
+and should be addressed in a follow-up issue.
+
+#### Scenario: Agent executes speckit.tasks workflow
+
+- **GIVEN** an agent is executing `speckit.tasks.md`
+- **WHEN** the agent reads the Outline section
+- **THEN** the STOP HERE instruction MUST be the first
+  content after the `## Outline` heading, before step 1
+
+#### Scenario: Agent executes speckit.plan workflow
+
+- **GIVEN** an agent is executing `speckit.plan.md`
+- **WHEN** the agent reads the Outline section
+- **THEN** the STOP HERE instruction MUST be the first
+  content after the `## Outline` heading, before step 1
+
+#### Scenario: STOP gate text is preserved
+
+- **GIVEN** the STOP HERE block is repositioned
+- **WHEN** comparing the text before and after the move
+- **THEN** the wording MUST be identical to the existing
+  gate text (no additions, no removals)
+
+## REMOVED Requirements
+
+None.

--- a/openspec/changes/fix-stop-here-gate-placement/tasks.md
+++ b/openspec/changes/fix-stop-here-gate-placement/tasks.md
@@ -1,0 +1,49 @@
+<!--
+  [P] marks tasks eligible for parallel execution.
+  Add [P] when a task: (a) touches different files from
+  other [P] tasks in the group, (b) has no dependency
+  on prior tasks in the group, (c) can safely execute
+  without ordering constraints.
+  Do NOT add [P] when tasks modify the same file —
+  parallel workers will cause merge conflicts.
+  Tasks without [P] run sequentially first, then [P]
+  tasks run in parallel.
+-->
+
+## 1. Move STOP HERE Gates
+
+- [x] 1.1 [P] In `.opencode/commands/speckit.tasks.md`,
+  remove the STOP HERE block (the block starting with
+  `**STOP HERE. Do NOT proceed to implementation.**`)
+  from between step 5 and step 6 (approximately lines
+  70-75) and insert it as a bolded preamble immediately
+  after the `## Outline` heading, before step 1
+- [x] 1.2 [P] In `.opencode/commands/speckit.plan.md`,
+  remove the STOP HERE block (the block starting with
+  `**STOP HERE. Do NOT proceed to implementation.**`)
+  from after step 4 (approximately lines 39-44) and
+  insert it as a bolded preamble immediately after the
+  `## Outline` heading, before step 1
+
+## 2. Verification
+
+- [x] 2.1 Verify both files have the STOP HERE block
+  positioned before step 1 (grep for "STOP HERE" and
+  confirm line numbers precede workflow steps)
+- [x] 2.2 Verify no duplicate STOP HERE blocks exist
+  in either file (each file should have exactly one)
+- [x] 2.3 Verify STOP HERE text is identical to the
+  original (no wording changes)
+- [x] 2.4 Verify constitution alignment: all principles
+  are N/A for this text-only change (no code, no
+  artifacts, no test changes)
+- [x] 2.5 Verify no Go source, test files, or schema
+  files were modified by this change
+- [x] 2.6 File a follow-up issue (#386) to apply
+  preamble placement to the remaining 5 speckit commands
+  (`speckit.specify.md`, `speckit.clarify.md`,
+  `speckit.analyze.md`, `speckit.checklist.md`,
+  `speckit.testreview.md`)
+
+<!-- spec-review: passed -->
+<!-- code-review: passed -->


### PR DESCRIPTION
## Summary

Repositions the STOP HERE phase-boundary gate in `speckit.tasks.md`
and `speckit.plan.md` from post-workflow placement to a preamble
before step 1 of the Outline section.

This fixes a T2 weakness (issue #363, parent audit #346) where
agents complete workflow steps before encountering the boundary
instruction, causing them to cross phase boundaries into
implementation without user review.

Fixes #363

## How to Test

Verify STOP block positioning (should appear before step 1):
```bash
grep -n "STOP HERE\|## Outline\|^1\. " .opencode/commands/speckit.tasks.md | head -3
grep -n "STOP HERE\|## Outline\|^1\. " .opencode/commands/speckit.plan.md | head -3
```

Verify exactly one STOP block per file (no duplicates):
```bash
grep -c "STOP HERE" .opencode/commands/speckit.tasks.md  # expect: 1
grep -c "STOP HERE" .opencode/commands/speckit.plan.md   # expect: 1
```

Verify build passes:
```bash
go build ./...
```

## How to Demo

Open `.opencode/commands/speckit.tasks.md` — the STOP HERE block
should be visible immediately after the `## Outline` heading (line
25), well before step 1 (line 32). Previously it was at line 70,
after step 5. Same pattern in `speckit.plan.md` (line 24 vs
formerly line 39).

## Key Files Changed

**.opencode/commands/** (implementation — 2 files):
- `speckit.plan.md` — STOP block moved from line 39 to line 24
- `speckit.tasks.md` — STOP block moved from line 70 to line 25

**openspec/changes/fix-stop-here-gate-placement/** (spec artifacts — 5 files):
- `.openspec.yaml` — change metadata
- `proposal.md` — motivation and constitution alignment
- `design.md` — 3 design decisions, known limitations
- `specs/stop-gate-placement.md` — STOP-GATE-001 requirement with scenarios
- `tasks.md` — 8 tasks (all complete), both review markers

## Known Issues

The following findings from the review council were acknowledged
but not resolved (pre-existing, tracked in follow-up):

- **MEDIUM**: 5 other speckit commands have the same post-workflow
  STOP placement (tracked in #386)
- **MEDIUM**: `uf-init.md` scaffold template documents stale
  placement guidance (should be addressed alongside #386)

_This PR was generated by /finale (AI-assisted)._
