### PR TITLE
fix(triage-issue): gate all label mutations behind AskUserQuestion

### DIFF
--- a/.opencode/commands/triage-issue.md
+++ b/.opencode/commands/triage-issue.md
@@ -232,7 +232,7 @@ Split:        <"recommended" with count, or "not recommended">
 <For each agent: name, verdict, category, brief reasoning>
 
 ── Proposed Actions ──
-• Label: <label> (auto-apply / requires confirmation)
+• Label: <label> (requires confirmation)
 • Comment: <tone tier> (requires confirmation)
 • Split: <N child issues> (requires confirmation, if applicable)
 ──────────────────────────────────────────
@@ -240,7 +240,7 @@ Split:        <"recommended" with count, or "not recommended">
 
 ### 4.2 Label Application
 
-Labels are applied **automatically without user confirmation**, with one exception: the `duplicate` label requires user confirmation because it carries implicit "close" semantics.
+**All label mutations require user confirmation.** Before creating or applying any label, use the **AskUserQuestion tool** to obtain explicit confirmation. The `duplicate` label has an additional supplementary confirmation gate because it carries implicit "close" semantics.
 
 **Label mapping**:
 
@@ -256,24 +256,41 @@ Labels are applied **automatically without user confirmation**, with one excepti
 
 **Re-run check**: If the target label is already applied (detected in Phase 1.2), skip label application and note "label already present."
 
-**Label existence check**: Before applying, verify the label exists in the repository. If it does not exist, create it:
+**Label existence check and confirmation**: Before applying, verify the label exists in the repository. The following two paths are **mutually exclusive** (not sequential):
+
+**Path A — Label does NOT exist in the repository**:
+
+Inform the user: "The label '<label>' does not exist in the repository." Use the **AskUserQuestion tool** with options `["Yes -- create and apply label '<label>'", "No -- skip"]`.
+
+If the user selects "No -- skip", skip both label creation and application. Record `labels_applied: []` and `label_creation_failed: false` in `actions_taken`. Proceed to Section 4.3.
+
+If the user confirms, create and then apply the label:
 
 ```bash
 gh label create "<label>" --description "<description>" --color "<color>"
 ```
 
-If label creation fails due to insufficient permissions, report the specific label that could not be created, skip that label, and continue with remaining actions. Record the failure in `actions_taken`.
+If label creation fails due to insufficient permissions, report the specific label that could not be created, skip that label, and continue with remaining actions. Record the failure in `actions_taken`. Proceed to Section 4.3.
 
-**Apply the label**:
+If label creation succeeds, apply it to the issue:
 
 ```bash
 gh issue edit <ISSUE_NUMBER> --add-label "<label>"
 ```
 
-**For `duplicate` label only**: Inform the user that the
-`duplicate` label signals the issue should be closed.
-Use the **AskUserQuestion tool** with options
-`["Yes -- apply duplicate label", "No -- skip"]`.
+**Path B — Label already EXISTS in the repository**:
+
+Use the **AskUserQuestion tool** with options `["Yes -- apply label '<label>'", "No -- skip"]`.
+
+If the user selects "No -- skip", skip label application. Record `labels_applied: []` in `actions_taken`. Proceed to Section 4.3.
+
+If the user confirms, apply the label:
+
+```bash
+gh issue edit <ISSUE_NUMBER> --add-label "<label>"
+```
+
+**For `duplicate` label only** (supplementary gate, applies after either Path A or Path B confirmation): Inform the user that the `duplicate` label signals the issue should be closed. Use the **AskUserQuestion tool** with options `["Yes -- apply duplicate label", "No -- skip"]`. Only execute the `gh issue edit --add-label` command if the user confirms this supplementary gate. If the user declines, skip label application, record `labels_applied: []` in `actions_taken`, and proceed to Section 4.3.
 
 ### 4.3 Comment Composition and Posting
 
@@ -461,7 +478,7 @@ Fields may be `null` when not applicable (e.g., `duplicate_of` when the issue is
 
 ## Guardrails
 
-1. **No auto-close**: MUST NOT close or lock any issue under any circumstances. The parent issue remains open even after splitting. The `duplicate` label is applied only with user confirmation.
+1. **No auto-close**: MUST NOT close or lock any issue under any circumstances. The parent issue remains open even after splitting. All labels are applied only with user confirmation.
 
 2. **No comments without confirmation**: Every issue comment is shown to the user before posting. No autonomous public communication.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ Each entry follows the format: `- <change-name>: <summary>`.
 ## Unreleased
 
 ### Changed
+- `/triage-issue` label gates: all label mutations (create
+  and apply) now require explicit user confirmation via
+  AskUserQuestion, not just the `duplicate` label. Duplicate
+  label retains supplementary close-semantics confirmation.
+  (Spec: openspec/changes/review-council-label-gates/,
+  Fixes: #352)
 - `/review-council` Code Review Mode: added optional
   Step 7 (GitHub Review Posting) for posting consolidated
   multi-persona council findings as a GitHub PR review;

--- a/internal/scaffold/assets/opencode/commands/triage-issue.md
+++ b/internal/scaffold/assets/opencode/commands/triage-issue.md
@@ -232,7 +232,7 @@ Split:        <"recommended" with count, or "not recommended">
 <For each agent: name, verdict, category, brief reasoning>
 
 ── Proposed Actions ──
-• Label: <label> (auto-apply / requires confirmation)
+• Label: <label> (requires confirmation)
 • Comment: <tone tier> (requires confirmation)
 • Split: <N child issues> (requires confirmation, if applicable)
 ──────────────────────────────────────────
@@ -240,7 +240,7 @@ Split:        <"recommended" with count, or "not recommended">
 
 ### 4.2 Label Application
 
-Labels are applied **automatically without user confirmation**, with one exception: the `duplicate` label requires user confirmation because it carries implicit "close" semantics.
+**All label mutations require user confirmation.** Before creating or applying any label, use the **AskUserQuestion tool** to obtain explicit confirmation. The `duplicate` label has an additional supplementary confirmation gate because it carries implicit "close" semantics.
 
 **Label mapping**:
 
@@ -256,24 +256,41 @@ Labels are applied **automatically without user confirmation**, with one excepti
 
 **Re-run check**: If the target label is already applied (detected in Phase 1.2), skip label application and note "label already present."
 
-**Label existence check**: Before applying, verify the label exists in the repository. If it does not exist, create it:
+**Label existence check and confirmation**: Before applying, verify the label exists in the repository. The following two paths are **mutually exclusive** (not sequential):
+
+**Path A — Label does NOT exist in the repository**:
+
+Inform the user: "The label '<label>' does not exist in the repository." Use the **AskUserQuestion tool** with options `["Yes -- create and apply label '<label>'", "No -- skip"]`.
+
+If the user selects "No -- skip", skip both label creation and application. Record `labels_applied: []` and `label_creation_failed: false` in `actions_taken`. Proceed to Section 4.3.
+
+If the user confirms, create and then apply the label:
 
 ```bash
 gh label create "<label>" --description "<description>" --color "<color>"
 ```
 
-If label creation fails due to insufficient permissions, report the specific label that could not be created, skip that label, and continue with remaining actions. Record the failure in `actions_taken`.
+If label creation fails due to insufficient permissions, report the specific label that could not be created, skip that label, and continue with remaining actions. Record the failure in `actions_taken`. Proceed to Section 4.3.
 
-**Apply the label**:
+If label creation succeeds, apply it to the issue:
 
 ```bash
 gh issue edit <ISSUE_NUMBER> --add-label "<label>"
 ```
 
-**For `duplicate` label only**: Inform the user that the
-`duplicate` label signals the issue should be closed.
-Use the **AskUserQuestion tool** with options
-`["Yes -- apply duplicate label", "No -- skip"]`.
+**Path B — Label already EXISTS in the repository**:
+
+Use the **AskUserQuestion tool** with options `["Yes -- apply label '<label>'", "No -- skip"]`.
+
+If the user selects "No -- skip", skip label application. Record `labels_applied: []` in `actions_taken`. Proceed to Section 4.3.
+
+If the user confirms, apply the label:
+
+```bash
+gh issue edit <ISSUE_NUMBER> --add-label "<label>"
+```
+
+**For `duplicate` label only** (supplementary gate, applies after either Path A or Path B confirmation): Inform the user that the `duplicate` label signals the issue should be closed. Use the **AskUserQuestion tool** with options `["Yes -- apply duplicate label", "No -- skip"]`. Only execute the `gh issue edit --add-label` command if the user confirms this supplementary gate. If the user declines, skip label application, record `labels_applied: []` in `actions_taken`, and proceed to Section 4.3.
 
 ### 4.3 Comment Composition and Posting
 
@@ -461,7 +478,7 @@ Fields may be `null` when not applicable (e.g., `duplicate_of` when the issue is
 
 ## Guardrails
 
-1. **No auto-close**: MUST NOT close or lock any issue under any circumstances. The parent issue remains open even after splitting. The `duplicate` label is applied only with user confirmation.
+1. **No auto-close**: MUST NOT close or lock any issue under any circumstances. The parent issue remains open even after splitting. All labels are applied only with user confirmation.
 
 2. **No comments without confirmation**: Every issue comment is shown to the user before posting. No autonomous public communication.
 

--- a/openspec/changes/review-council-label-gates/.openspec.yaml
+++ b/openspec/changes/review-council-label-gates/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: unbound-force
+created: 2026-07-31

--- a/openspec/changes/review-council-label-gates/design.md
+++ b/openspec/changes/review-council-label-gates/design.md
@@ -1,0 +1,119 @@
+## Context
+
+The `/triage-issue` command in `.opencode/commands/triage-issue.md`
+performs GitHub label mutations in Section 4.2 (Label Application).
+Currently, labels are applied automatically without user
+confirmation, with a single exception: the `duplicate` label
+requires AskUserQuestion confirmation at lines 273-276.
+
+Per org policy from issue #346: all irreversible external actions
+(T1 weakness type) require AskUserQuestion gates. Label mutations
+are irreversible without manual reversal.
+
+The proposal (see `proposal.md`) establishes that all label
+mutations MUST be gated. This design documents how to implement
+that gate consistently.
+
+## Goals / Non-Goals
+
+### Goals
+- Gate ALL label create operations behind AskUserQuestion
+- Gate ALL label apply operations behind AskUserQuestion
+- Preserve the existing `duplicate`-specific messaging about
+  close semantics as a supplementary gate
+- Maintain the existing re-run check (skip if label already
+  applied)
+- Keep the user flow efficient: present label name and
+  action in the confirmation prompt
+
+### Non-Goals
+- Batch multiple labels into a single confirmation (each label
+  gets its own gate, matching the existing single-label-per-
+  triage pattern)
+- Changes to `/review-council` (that command does not perform
+  label mutations)
+- Changes to label removal operations (out of scope for #352)
+- Refactoring the triage command beyond Section 4.2
+
+## Decisions
+
+### D1: Single confirmation flow per label operation
+
+Rather than separating "create" and "apply" into two sequential
+confirmations, combine them into a single flow:
+
+1. If the label does not exist: ask
+   `["Yes -- create and apply label '<label>'", "No -- skip"]`
+2. If the label exists: ask
+   `["Yes -- apply label '<label>'", "No -- skip"]`
+
+**Rationale**: Two confirmations for the same label (create
+then apply) adds friction without safety benefit. The user
+understands they are approving the label being present on
+the issue.
+
+### D2: Preserve duplicate-specific gate as supplementary
+
+The existing `duplicate` gate (lines 273-276) carries
+additional messaging about close semantics. This is preserved
+as an additional layer after the general label confirmation.
+The flow for `duplicate` becomes:
+
+1. General gate: "Yes -- apply label 'duplicate'" / "No -- skip"
+2. If confirmed: supplementary gate about close semantics
+   (existing behavior at lines 273-276)
+
+**Rationale**: The `duplicate` label has unique side effects
+(signals closure). The supplementary gate provides context
+that the general gate does not.
+
+### D3: Skip-on-decline semantics
+
+When the user selects "No -- skip":
+- Record the skip in `actions_taken` (existing pattern)
+- Continue to Section 4.3 (Comment Composition)
+- Do NOT treat a label skip as a triage abort
+
+**Rationale**: The user may want to post a triage comment
+without applying a label. The label and comment are
+independent actions.
+
+### D4: Observable Quality alignment
+
+Per constitution Principle III, the AskUserQuestion gate
+produces an observable audit trail: every label mutation
+is explicitly confirmed by the user. The `actions_taken`
+JSON artifact already records which labels were applied;
+adding confirmation tracking strengthens provenance.
+
+## Coverage Strategy
+
+This change modifies agent command instructions (markdown
+only). No Go source code is added or modified. Coverage
+strategy per Constitution Principle IV is not applicable.
+Behavioral verification is defined in tasks.md task 5.1.
+
+## Risks / Trade-offs
+
+### Added friction
+
+Every triage now requires at least one additional
+confirmation step for the label. This is an accepted
+trade-off: the org policy from #346 prioritizes preventing
+accidental mutations over speed.
+
+### Duplicate label gets two confirmations
+
+The `duplicate` category will see two AskUserQuestion
+prompts (general + close-semantics). This is intentional --
+the supplementary gate carries unique information. If user
+feedback indicates this is excessive, the supplementary
+gate could be merged into the general gate's messaging in
+a future change.
+
+### No batching
+
+If future triage supports multi-label application, each
+label will require its own gate. This is consistent with
+the current single-label-per-triage pattern and can be
+revisited if the pattern changes.

--- a/openspec/changes/review-council-label-gates/proposal.md
+++ b/openspec/changes/review-council-label-gates/proposal.md
@@ -1,0 +1,104 @@
+## Why
+
+The `/triage-issue` command applies GitHub labels automatically
+without user confirmation for all categories except `duplicate`.
+This is an irreversible external action (GitHub label mutation)
+that violates org policy established by issue #346: ALL label
+mutations require AskUserQuestion confirmation.
+
+The inconsistency is a T1 weakness -- the `duplicate` label
+gate at lines 273-276 of `triage-issue.md` demonstrates the
+correct pattern, but it is not applied to the remaining six
+label categories (`bug`, `enhancement`, `question`,
+`design-discussion`, `needs-info`).
+
+Fixes: #352
+Related: #346 (parent audit)
+
+## What Changes
+
+Generalize the existing `duplicate` label AskUserQuestion
+gate in `.opencode/commands/triage-issue.md` to cover ALL
+label mutations:
+
+1. Before `gh label create`: require AskUserQuestion
+   confirmation with options
+   `["Yes -- create label", "No -- skip"]`.
+2. Before `gh issue edit --add-label`: require
+   AskUserQuestion confirmation with options
+   `["Yes -- apply label", "No -- skip"]`.
+3. Preserve the existing `duplicate`-specific gate (lines
+   273-276) as an additional layer with its own messaging
+   about close semantics.
+
+## Capabilities
+
+### New Capabilities
+- `label-mutation-gate`: All label create and label apply
+  operations in `/triage-issue` require explicit user
+  confirmation via AskUserQuestion before execution.
+
+### Modified Capabilities
+- `triage-issue/label-application`: Section 4.2 changes from
+  auto-apply (with duplicate exception) to confirm-all with
+  a single AskUserQuestion presenting the proposed label.
+
+### Removed Capabilities
+- None
+
+## Impact
+
+- **File**: `.opencode/commands/triage-issue.md` (Section 4.2,
+  lines ~241-276)
+- **Behavior**: Users will now be asked to confirm every label
+  operation, not just `duplicate`. This adds one confirmation
+  step per label applied but prevents accidental/unwanted
+  label mutations.
+- **No code changes**: This is a command instruction change
+  only (markdown), no Go source modifications.
+
+## Constitution Alignment
+
+Assessed against the Unbound Force org constitution.
+
+### I. Autonomous Collaboration
+
+**Assessment**: N/A
+
+This change modifies agent command instructions (markdown).
+It does not affect artifact-based communication between heroes
+or self-describing outputs.
+
+### II. Composability First
+
+**Assessment**: N/A
+
+This change is internal to the `/triage-issue` command. It
+does not introduce dependencies between heroes or affect
+standalone functionality.
+
+### III. Observable Quality
+
+**Assessment**: PASS
+
+The AskUserQuestion gate produces observable audit trail --
+every label mutation is explicitly confirmed by the user,
+improving provenance of GitHub state changes.
+
+### IV. Testability
+
+**Assessment**: N/A
+
+This change modifies agent behavioral instructions (markdown
+only). No Go source code is added or modified. Coverage
+strategy per Constitution Principle IV is not applicable.
+Behavioral verification is defined in tasks.md task 5.1.
+
+### V. Security by Default
+
+**Assessment**: N/A
+
+No new dependencies, no new external inputs, no supply chain
+changes. The AskUserQuestion gate strengthens the least-
+privilege posture by requiring explicit user authorization
+before irreversible external mutations (label create/apply).

--- a/openspec/changes/review-council-label-gates/specs/label-gates.md
+++ b/openspec/changes/review-council-label-gates/specs/label-gates.md
@@ -1,0 +1,157 @@
+## ADDED Requirements
+
+### Requirement: FR-001 Label creation confirmation gate
+
+Before executing `gh label create`, the agent MUST use the
+AskUserQuestion tool to obtain explicit user confirmation.
+
+The prompt MUST present the label name and include options:
+`["Yes -- create and apply label '<label>'", "No -- skip"]`.
+
+If the user selects "No -- skip", the agent MUST skip both
+label creation and label application, record the skip in
+`actions_taken`, and continue to the next triage action.
+
+#### Scenario: Label does not exist and user confirms
+
+- **GIVEN** the triage classification maps to label `question`
+- **AND** the label `question` does not exist in the repository
+- **WHEN** the agent presents AskUserQuestion with
+  `["Yes -- create and apply label 'question'", "No -- skip"]`
+- **AND** the user selects "Yes -- create and apply label
+  'question'"
+- **THEN** the agent SHALL execute `gh label create "question"`
+- **AND** the agent SHALL execute
+  `gh issue edit <N> --add-label "question"`
+
+#### Scenario: Label does not exist and user declines
+
+- **GIVEN** the triage classification maps to label `question`
+- **AND** the label `question` does not exist in the repository
+- **WHEN** the agent presents AskUserQuestion with
+  `["Yes -- create and apply label 'question'", "No -- skip"]`
+- **AND** the user selects "No -- skip"
+- **THEN** the agent SHALL NOT execute `gh label create`
+- **AND** the agent SHALL NOT execute `gh issue edit --add-label`
+- **AND** the agent SHALL record `labels_applied: []` in
+  `actions_taken`
+- **AND** the agent SHALL proceed to Section 4.3
+
+#### Scenario: Label does not exist, user confirms, but creation fails
+
+- **GIVEN** the triage classification maps to label `question`
+- **AND** the label `question` does not exist in the repository
+- **WHEN** the agent presents AskUserQuestion with
+  `["Yes -- create and apply label 'question'", "No -- skip"]`
+- **AND** the user selects "Yes -- create and apply label
+  'question'"
+- **AND** `gh label create "question"` fails due to
+  insufficient permissions
+- **THEN** the agent SHALL report the specific label that
+  could not be created
+- **AND** the agent SHALL NOT execute
+  `gh issue edit --add-label`
+- **AND** the agent SHALL record `label_creation_failed: true`
+  in `actions_taken`
+- **AND** the agent SHALL proceed to Section 4.3
+
+The confirmation gate applies uniformly to all label
+categories in the mapping table (bug, feature, enhancement,
+question, opinion, duplicate, needs-clarification). Scenarios
+use representative labels; the behavior is identical for all
+categories.
+
+### Requirement: FR-002 Label application confirmation gate
+
+Before executing `gh issue edit --add-label`, when the label
+already exists in the repository, the agent MUST use the
+AskUserQuestion tool to obtain explicit user confirmation.
+
+The prompt MUST present the label name and include options:
+`["Yes -- apply label '<label>'", "No -- skip"]`.
+
+#### Scenario: Label exists and user confirms
+
+- **GIVEN** the triage classification maps to label `bug`
+- **AND** the label `bug` exists in the repository
+- **WHEN** the agent presents AskUserQuestion with
+  `["Yes -- apply label 'bug'", "No -- skip"]`
+- **AND** the user selects "Yes -- apply label 'bug'"
+- **THEN** the agent SHALL execute
+  `gh issue edit <N> --add-label "bug"`
+
+#### Scenario: Label exists and user declines
+
+- **GIVEN** the triage classification maps to label `bug`
+- **AND** the label `bug` exists in the repository
+- **WHEN** the agent presents AskUserQuestion with
+  `["Yes -- apply label 'bug'", "No -- skip"]`
+- **AND** the user selects "No -- skip"
+- **THEN** the agent SHALL NOT execute `gh issue edit --add-label`
+- **AND** the agent SHALL record `labels_applied: []` in
+  `actions_taken`
+- **AND** the agent SHALL proceed to Section 4.3
+
+Note: FR-001 and FR-002 are alternative flows (not
+sequential). FR-001 applies when the label does not exist
+in the repository (combined create-and-apply gate). FR-002
+applies when the label already exists (apply-only gate).
+
+## MODIFIED Requirements
+
+### Requirement: FR-003 Section 4.2 auto-apply policy
+
+Previously: "Labels are applied automatically without user
+confirmation, with one exception: the `duplicate` label requires
+user confirmation because it carries implicit 'close' semantics."
+
+New text: ALL label mutations (create and apply) MUST require
+explicit user confirmation via AskUserQuestion before execution.
+The `duplicate` label retains its supplementary confirmation
+gate about close semantics in addition to the general
+confirmation gate.
+
+#### Scenario: Duplicate label gets two confirmations
+
+- **GIVEN** the triage classification maps to label `duplicate`
+- **AND** the label `duplicate` exists in the repository
+- **WHEN** the agent presents the general AskUserQuestion with
+  `["Yes -- apply label 'duplicate'", "No -- skip"]`
+- **AND** the user selects "Yes -- apply label 'duplicate'"
+- **THEN** the agent SHALL present the supplementary
+  AskUserQuestion informing that the `duplicate` label signals
+  the issue should be closed, with options
+  `["Yes -- apply duplicate label", "No -- skip"]`
+- **AND** only if the user confirms the supplementary gate
+  SHALL the agent execute
+  `gh issue edit <N> --add-label "duplicate"`
+
+#### Scenario: Duplicate label -- user confirms general gate but declines supplementary gate
+
+- **GIVEN** the triage classification maps to label `duplicate`
+- **AND** the label `duplicate` exists in the repository
+- **WHEN** the agent presents the general AskUserQuestion with
+  `["Yes -- apply label 'duplicate'", "No -- skip"]`
+- **AND** the user selects "Yes -- apply label 'duplicate'"
+- **AND** the agent presents the supplementary AskUserQuestion
+  with options
+  `["Yes -- apply duplicate label", "No -- skip"]`
+- **AND** the user selects "No -- skip"
+- **THEN** the agent SHALL NOT execute
+  `gh issue edit <N> --add-label "duplicate"`
+- **AND** the agent SHALL record `labels_applied: []` in
+  `actions_taken`
+- **AND** the agent SHALL proceed to Section 4.3
+
+#### Scenario: Re-run with label already applied
+
+- **GIVEN** the label `bug` is already applied to the issue
+  (detected in Phase 1.2)
+- **WHEN** the triage classification maps to label `bug`
+- **THEN** the agent SHALL skip label application
+- **AND** the agent SHALL note "label already present"
+- **AND** the agent SHALL NOT present AskUserQuestion
+
+## REMOVED Requirements
+
+None.

--- a/openspec/changes/review-council-label-gates/tasks.md
+++ b/openspec/changes/review-council-label-gates/tasks.md
@@ -1,0 +1,124 @@
+<!--
+  [P] marks tasks eligible for parallel execution.
+  Add [P] when a task: (a) touches different files from
+  other [P] tasks in the group, (b) has no dependency
+  on prior tasks in the group, (c) can safely execute
+  without ordering constraints.
+  Do NOT add [P] when tasks modify the same file --
+  parallel workers will cause merge conflicts.
+  Tasks without [P] run sequentially first, then [P]
+  tasks run in parallel.
+
+  All tasks in groups 1-5 modify the same file:
+  .opencode/commands/triage-issue.md
+  Group 6 (scaffold sync) modifies a different file but
+  depends on groups 1-4 completing first.
+  Therefore NO tasks are parallel-eligible.
+-->
+
+## 1. Replace auto-apply policy and summary template
+
+- [x] 1.1 In `.opencode/commands/triage-issue.md`, replace
+  the auto-apply statement in Section 4.2 ("Labels are
+  applied **automatically without user confirmation**, with
+  one exception...") with text requiring AskUserQuestion
+  confirmation for ALL label mutations. New text:
+
+  "**All label mutations require user confirmation.**
+  Before creating or applying any label, use the
+  **AskUserQuestion tool** to obtain explicit confirmation."
+
+- [x] 1.2 In Section 4.1 (Proposed Actions summary
+  template), update the label display line from
+  `• Label: <label> (auto-apply / requires confirmation)`
+  to `• Label: <label> (requires confirmation)` since all
+  labels now require confirmation.
+
+## 2. Add label creation confirmation gate
+
+- [x] 2.1 In `.opencode/commands/triage-issue.md`, before
+  the `gh label create` block (line 262), add an
+  AskUserQuestion gate:
+
+  Before creating the label, present: "The label '<label>'
+  does not exist in the repository." Use the
+  **AskUserQuestion tool** with options
+  `["Yes -- create and apply label '<label>'",
+  "No -- skip"]`.
+
+  If the user selects "No -- skip", skip both label
+  creation and application. Record `labels_applied: []`
+  and `label_creation_failed: false` in `actions_taken`.
+  Proceed to Section 4.3.
+
+## 3. Add label application confirmation gate
+
+- [x] 3.1 In `.opencode/commands/triage-issue.md`, before
+  the `gh issue edit --add-label` block (line 270), add
+  an AskUserQuestion gate for cases where the label
+  already exists:
+
+  Use the **AskUserQuestion tool** with options
+  `["Yes -- apply label '<label>'", "No -- skip"]`.
+
+  If the user selects "No -- skip", skip label
+  application. Record `labels_applied: []` in
+  `actions_taken`. Proceed to Section 4.3.
+
+## 4. Preserve duplicate supplementary gate and update Guardrail 1
+
+- [x] 4.1 In `.opencode/commands/triage-issue.md`, verify
+  that the existing `duplicate`-specific AskUserQuestion
+  gate (in Section 4.2, after the apply block) remains
+  intact as a supplementary gate. Update the surrounding
+  text to clarify that the `duplicate` label receives both
+  the general confirmation (from task 3.1) AND the
+  supplementary close-semantics confirmation.
+
+- [x] 4.2 In Guardrail 1 (Section 4.5), update the text
+  from "The `duplicate` label is applied only with user
+  confirmation" to "All labels are applied only with user
+  confirmation" to match the new Section 4.2 policy.
+
+## 5. Verification
+
+- [x] 5.1 Read the modified `triage-issue.md` end-to-end
+  through Sections 4.1, 4.2, and 4.5 and verify:
+  - The string "automatically without user confirmation"
+    does NOT appear in Section 4.2
+  - The string "auto-apply" does NOT appear in Section 4.1
+  - "AskUserQuestion" appears at least 3 times in
+    Section 4.2 (general create gate, general apply gate,
+    duplicate supplementary gate)
+  - The duplicate supplementary gate is preserved
+  - Re-run check (skip if label already applied) is
+    preserved
+  - Permission failure handling is preserved
+  - The `actions_taken` recording pattern is consistent
+  - Guardrail 1 says "All labels" not "The `duplicate`
+    label"
+
+- [x] 5.2 Verify constitution alignment against all five
+  principles:
+  - Principle I (Autonomous Collaboration): N/A
+  - Principle II (Composability First): N/A
+  - Principle III (Observable Quality): PASS -- all label
+    mutations now produce an observable user-confirmed
+    audit trail
+  - Principle IV (Testability): N/A -- no Go source
+    changes
+  - Principle V (Security by Default): N/A -- no new
+    dependencies or external inputs
+
+## 6. Scaffold asset sync
+
+- [x] 6.1 Copy the modified `.opencode/commands/triage-issue.md`
+  to its scaffold asset location at
+  `internal/scaffold/assets/opencode/commands/triage-issue.md`
+  to maintain byte-identical sync.
+
+- [x] 6.2 Run `go test ./internal/scaffold/... -race -count=1`
+  to verify `TestEmbeddedAssets_MatchSource` passes.
+
+<!-- spec-review: passed -->
+<!-- code-review: passed -->


### PR DESCRIPTION
## Summary

The `/triage-issue` command applied GitHub labels automatically
without user confirmation for all categories except `duplicate`.
This was a T1 security weakness (irreversible external action
without mandatory AskUserQuestion gate), violating org policy
from #346.

This change generalizes the existing `duplicate`-label-only
AskUserQuestion gate to cover ALL label mutations (create and
apply), with explicit Path A/Path B mutual-exclusivity structure
for clarity.

Fixes #352
Fixes #354

## How to Test

1. Run `/triage-issue` on any GitHub issue
2. Verify that label application prompts AskUserQuestion
   for ALL categories (bug, enhancement, question, etc.),
   not just `duplicate`
3. For `duplicate` labels, verify two confirmation steps:
   general gate + supplementary close-semantics gate
4. Decline a label -- verify triage continues to comment
   composition without applying the label
5. Verify re-run behavior: if label is already applied,
   no AskUserQuestion is presented

## How to Demo

Run `/triage-issue 352` and observe that every label
operation now requires explicit user confirmation via
AskUserQuestion before execution.

## Key Files Changed

| File | Change |
|------|--------|
| `.opencode/commands/triage-issue.md` | Section 4.1: remove "auto-apply" from summary template. Section 4.2: replace auto-apply policy with universal confirmation gate (Path A/Path B). Guardrail 1: update to "All labels" |
| `internal/scaffold/assets/opencode/commands/triage-issue.md` | Byte-identical scaffold copy |
| `CHANGELOG.md` | Add Unreleased entry for label gate change |
| `openspec/changes/review-council-label-gates/` | Full OpenSpec artifacts: proposal, design, specs (FR-001/002/003), tasks |

_This PR was generated by /finale (AI-assisted)._

