### PR TITLE
fix(agents): move branch safety guardrails to pre-conditions

### DIFF
--- a/.opencode/agents/cobalt-crush-dev.md
+++ b/.opencode/agents/cobalt-crush-dev.md
@@ -47,6 +47,14 @@ When making non-trivial design choices:
 
 When your implementation cannot meet a quality gate (coverage threshold, CRAP score, CI check, convention pack MUST rule, review iteration limit), you MUST stop and report the conflict. NEVER modify the gate to make the implementation pass. Gates exist to protect quality — weakening them to unblock work defeats their purpose. Report what gate is blocking, why, and let the human decide whether to adjust the gate or rework the implementation.
 
+### Pre-conditions
+
+**CRITICAL**: Before switching branches or suggesting a branch switch, you MUST:
+
+1. Run `git status --short` to check for uncommitted changes.
+2. If uncommitted changes exist (staged, unstaged, or untracked files that appear related to work): **STOP** and ask the user for confirmation before proceeding. Show what uncommitted changes exist and warn that switching branches with a dirty working tree may cause changes to be carried to the wrong branch or lost entirely.
+3. Never silently switch branches with a dirty working tree. All work MUST be committed and pushed on the current branch before any branch switch occurs.
+
 ## Code Implementation Checklist
 
 ### 1. Convention Pack Adherence [PACK]

--- a/.opencode/skills/openspec-apply-change/SKILL.md
+++ b/.opencode/skills/openspec-apply-change/SKILL.md
@@ -15,6 +15,8 @@ Implement tasks from an OpenSpec change.
 
 **Steps**
 
+**Pre-condition**: Before any step, verify: NEVER switch branches or suggest archiving with uncommitted changes. Run `git status --short` if branch state is uncertain. All work MUST be committed and pushed on the current `opsx/<name>` branch before any branch switch occurs.
+
 1. **Select the change**
 
    If a name is provided, use it. Otherwise:
@@ -209,7 +211,6 @@ What would you like to do?
 - Update task checkbox immediately after completing each task
 - Pause on errors, blockers, or unclear requirements - don't guess
 - Use contextFiles from CLI output, don't assume specific file names
-- **NEVER switch branches or suggest archiving with uncommitted changes** -- all work must be committed and pushed on the current `opsx/<name>` branch before any branch switch occurs
 
 **Fluid Workflow Integration**
 

--- a/.opencode/skills/speckit-workflow/SKILL.md
+++ b/.opencode/skills/speckit-workflow/SKILL.md
@@ -27,6 +27,22 @@ Check for a `tasks.md` file in the active spec directory:
 If `tasks.md` exists, follow the instructions below. If no
 `tasks.md` exists, proceed with standard CASS decomposition.
 
+## Pre-conditions
+
+**CRITICAL**: All work MUST be committed and pushed on the
+current feature branch before any branch switch occurs.
+
+- After completing all phases, commit and push all changes
+  before suggesting PR creation, merging, or switching to
+  `main`.
+- Before creating a new feature branch (via `/speckit.specify`),
+  check `git status --short` for uncommitted changes. If
+  uncommitted changes exist, **STOP** and ask the user for
+  confirmation before switching branches.
+- Never silently switch branches with a dirty working tree.
+  Uncommitted changes may follow to the wrong branch or be
+  lost entirely.
+
 ## Reading tasks.md
 
 ### Phase Structure
@@ -110,22 +126,6 @@ After all tasks in a phase are complete:
 2. If tests fail, create a new cell to fix the failure
    before advancing to the next phase
 3. Report phase completion via `swarm_status()`
-
-## Branch Safety
-
-**CRITICAL**: All work MUST be committed and pushed on the
-current feature branch before any branch switch occurs.
-
-- After completing all phases, commit and push all changes
-  before suggesting PR creation, merging, or switching to
-  `main`.
-- Before creating a new feature branch (via `/speckit.specify`),
-  check `git status --short` for uncommitted changes. If
-  uncommitted changes exist, **STOP** and ask the user for
-  confirmation before switching branches.
-- Never silently switch branches with a dirty working tree.
-  Uncommitted changes may follow to the wrong branch or be
-  lost entirely.
 
 ## Prerequisite Skill
 

--- a/internal/scaffold/assets/opencode/agents/cobalt-crush-dev.md
+++ b/internal/scaffold/assets/opencode/agents/cobalt-crush-dev.md
@@ -47,6 +47,14 @@ When making non-trivial design choices:
 
 When your implementation cannot meet a quality gate (coverage threshold, CRAP score, CI check, convention pack MUST rule, review iteration limit), you MUST stop and report the conflict. NEVER modify the gate to make the implementation pass. Gates exist to protect quality — weakening them to unblock work defeats their purpose. Report what gate is blocking, why, and let the human decide whether to adjust the gate or rework the implementation.
 
+### Pre-conditions
+
+**CRITICAL**: Before switching branches or suggesting a branch switch, you MUST:
+
+1. Run `git status --short` to check for uncommitted changes.
+2. If uncommitted changes exist (staged, unstaged, or untracked files that appear related to work): **STOP** and ask the user for confirmation before proceeding. Show what uncommitted changes exist and warn that switching branches with a dirty working tree may cause changes to be carried to the wrong branch or lost entirely.
+3. Never silently switch branches with a dirty working tree. All work MUST be committed and pushed on the current branch before any branch switch occurs.
+
 ## Code Implementation Checklist
 
 ### 1. Convention Pack Adherence [PACK]

--- a/internal/scaffold/assets/opencode/skills/speckit-workflow/SKILL.md
+++ b/internal/scaffold/assets/opencode/skills/speckit-workflow/SKILL.md
@@ -27,6 +27,22 @@ Check for a `tasks.md` file in the active spec directory:
 If `tasks.md` exists, follow the instructions below. If no
 `tasks.md` exists, proceed with standard CASS decomposition.
 
+## Pre-conditions
+
+**CRITICAL**: All work MUST be committed and pushed on the
+current feature branch before any branch switch occurs.
+
+- After completing all phases, commit and push all changes
+  before suggesting PR creation, merging, or switching to
+  `main`.
+- Before creating a new feature branch (via `/speckit.specify`),
+  check `git status --short` for uncommitted changes. If
+  uncommitted changes exist, **STOP** and ask the user for
+  confirmation before switching branches.
+- Never silently switch branches with a dirty working tree.
+  Uncommitted changes may follow to the wrong branch or be
+  lost entirely.
+
 ## Reading tasks.md
 
 ### Phase Structure
@@ -110,22 +126,6 @@ After all tasks in a phase are complete:
 2. If tests fail, create a new cell to fix the failure
    before advancing to the next phase
 3. Report phase completion via `swarm_status()`
-
-## Branch Safety
-
-**CRITICAL**: All work MUST be committed and pushed on the
-current feature branch before any branch switch occurs.
-
-- After completing all phases, commit and push all changes
-  before suggesting PR creation, merging, or switching to
-  `main`.
-- Before creating a new feature branch (via `/speckit.specify`),
-  check `git status --short` for uncommitted changes. If
-  uncommitted changes exist, **STOP** and ask the user for
-  confirmation before switching branches.
-- Never silently switch branches with a dirty working tree.
-  Uncommitted changes may follow to the wrong branch or be
-  lost entirely.
 
 ## Prerequisite Skill
 

--- a/openspec/changes/branch-safety-guardrails-t2-fix/.openspec.yaml
+++ b/openspec/changes/branch-safety-guardrails-t2-fix/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: unbound-force
+created: 2026-07-31

--- a/openspec/changes/branch-safety-guardrails-t2-fix/design.md
+++ b/openspec/changes/branch-safety-guardrails-t2-fix/design.md
@@ -1,0 +1,92 @@
+## Context
+
+Three agent instruction files place CRITICAL branch safety
+rules at the end of the file, after all workflow instructions
+they govern. This is a Type T2 weakness: an agent processing
+instructions sequentially may execute branch operations before
+encountering the constraints that should prevent unsafe behavior.
+
+The root cause was identified during issue #346 analysis.
+The three affected files are:
+- `.opencode/agents/cobalt-crush-dev.md` — has no branch safety
+  section at all
+- `.opencode/skills/openspec-apply-change/SKILL.md` — branch
+  safety rule at line 212 of 219 (Guardrails section)
+- `.opencode/skills/speckit-workflow/SKILL.md` — Branch Safety
+  section at line 114 of 148
+
+## Goals / Non-Goals
+
+### Goals
+- Move branch safety constraints to appear BEFORE the workflow
+  instructions they govern in all three files
+- Follow each issue's prescribed fix structure (Pre-conditions
+  block pattern)
+- Maintain the existing constraint text — no weakening or
+  strengthening of the rules themselves
+
+### Non-Goals
+- Auditing other agent/skill files for T2 weaknesses (separate
+  effort)
+- Changing the substance of branch safety rules
+- Modifying Go source code, CI workflows, or schemas
+- Adding automated enforcement (e.g., git hooks) — this is a
+  prompt engineering fix only
+
+## Decisions
+
+### D1: Pre-conditions pattern for all three files
+
+Each file will get a "Pre-conditions" block placed immediately
+before the first workflow step or instruction section. This is
+consistent with the fix structure proposed in all three issues.
+
+**Rationale**: The pre-conditions pattern is a well-established
+technique in agent prompt engineering — placing constraints
+before actions ensures they are processed in the correct order.
+
+### D2: File-specific placement
+
+- **cobalt-crush-dev.md**: Add a "Pre-conditions" subsection
+  before "Code Implementation Checklist" (line 50). This is
+  the first section where the agent begins taking action. The
+  "Engineering Philosophy" and "Source Documents" sections above
+  are declarative context, not actionable workflow steps.
+
+- **openspec-apply-change/SKILL.md**: Add a "Pre-condition"
+  block after "Steps" (line 16) and before Step 1 (line 18).
+  Remove the duplicate rule from the Guardrails section at
+  line 212.
+
+- **speckit-workflow/SKILL.md**: Move the "Branch Safety"
+  section content to a new "Pre-conditions" section before
+  "Reading tasks.md" (line 30). Remove the original section
+  from lines 114-128.
+
+### D3: Content preservation with minor formatting
+
+The constraint text is moved, not rewritten. Minor formatting
+adjustments (heading level changes from ## to ###, or adding
+bold emphasis) are acceptable for structural consistency.
+
+## Risks / Trade-offs
+
+### Low risk: content duplication
+
+If the original text is not fully removed from the Guardrails
+section, constraints could appear twice. Mitigated by explicit
+task steps to remove the original text after adding the
+pre-condition block.
+
+### Low risk: heading hierarchy disruption
+
+Adding a new section may shift the document outline. Mitigated
+by using appropriate heading levels (### within ## sections)
+and verifying the document reads coherently after the change.
+
+### Accepted trade-off: longer preamble before action
+
+Moving constraints earlier means agents read more text before
+reaching actionable instructions. This is the correct trade-off
+— safety constraints MUST be processed before actions, even at
+the cost of slightly longer preamble.

--- a/openspec/changes/branch-safety-guardrails-t2-fix/proposal.md
+++ b/openspec/changes/branch-safety-guardrails-t2-fix/proposal.md
@@ -1,0 +1,98 @@
+## Why
+
+Three agent instruction files contain branch safety rules placed
+at the END of the file, after all workflow instructions they govern
+(Type T2 weakness). An agent following instructions sequentially
+can reach and execute branch operations without ever seeing the
+CRITICAL safety constraints.
+
+This is a systemic issue identified during root cause analysis of
+issue #346 (review-pr command skips Step 11 confirmation gate when
+session context is compressed). The same T2 pattern appears in
+three files:
+
+- `cobalt-crush-dev.md` (#355) — no branch safety guardrails at all
+- `openspec-apply-change/SKILL.md` (#359) — "NEVER switch branches"
+  rule at line 212 of 219
+- `speckit-workflow/SKILL.md` (#361) — "Branch Safety" section at
+  line 114 of 148, after the full workflow
+
+Fixes: #355, #359, #361
+
+## What Changes
+
+Elevate branch safety rules from end-of-file guardrails to
+pre-condition blocks placed before the workflow instructions they
+govern, ensuring agents encounter constraints before actions.
+
+## Capabilities
+
+### New Capabilities
+- None
+
+### Modified Capabilities
+- `cobalt-crush-dev agent`: Gains a Pre-conditions section with
+  branch safety guardrails before the Code Implementation Checklist
+- `openspec-apply-change skill`: Branch safety rule moved from
+  Guardrails (line 212) to a Pre-condition block before Step 1
+- `speckit-workflow skill`: Branch Safety section moved from end
+  of file to a Pre-conditions section before "Reading tasks.md"
+
+### Removed Capabilities
+- None
+
+## Impact
+
+- **Files affected**: 3 agent/skill instruction files
+  - `.opencode/agents/cobalt-crush-dev.md`
+  - `.opencode/skills/openspec-apply-change/SKILL.md`
+  - `.opencode/skills/speckit-workflow/SKILL.md`
+- **Risk**: Low — text-only changes to agent instructions; no
+  Go source code, no CI changes, no schema changes
+- **Behavioral change**: Agents will encounter branch safety
+  rules earlier in their instruction processing, reducing risk
+  of branch operations with dirty working trees
+
+## Constitution Alignment
+
+Assessed against the Unbound Force org constitution.
+
+### I. Autonomous Collaboration
+
+**Assessment**: N/A
+
+This change modifies agent instruction files (prompt engineering).
+It does not alter artifact-based communication, output formats,
+or inter-hero coordination.
+
+### II. Composability First
+
+**Assessment**: N/A
+
+No changes to hero installation, standalone functionality, or
+integration points. Agent instruction files are internal to
+the meta repository.
+
+### III. Observable Quality
+
+**Assessment**: N/A
+
+No changes to machine-parseable output, provenance metadata,
+or quality metrics. This is a documentation/instruction fix.
+
+### IV. Testability
+
+**Assessment**: N/A
+
+No code changes requiring test coverage. Agent instruction
+files are not compiled or executed as code — they are prompt
+engineering documents.
+
+### V. Security by Default
+
+**Assessment**: PASS
+
+This change strengthens operational safety by ensuring branch
+safety constraints are encountered before the actions they
+govern, reducing the risk of data loss from uncommitted changes
+being carried to the wrong branch.

--- a/openspec/changes/branch-safety-guardrails-t2-fix/specs/branch-safety-placement.md
+++ b/openspec/changes/branch-safety-guardrails-t2-fix/specs/branch-safety-placement.md
@@ -1,0 +1,83 @@
+## ADDED Requirements
+
+### Requirement: Branch Safety Pre-conditions in cobalt-crush-dev
+
+The `cobalt-crush-dev.md` agent file MUST contain a
+Pre-conditions subsection with branch safety guardrails.
+This section MUST appear before the "Code Implementation
+Checklist" section. The pre-condition MUST instruct the
+agent to verify branch state and check for uncommitted
+changes before any branch switch operation.
+
+#### Scenario: Agent encounters branch operation during implementation
+
+- **GIVEN** the cobalt-crush-dev agent is processing
+  instructions from `cobalt-crush-dev.md`
+- **WHEN** the agent reaches any instruction that involves
+  switching branches or suggesting a branch switch
+- **THEN** the agent SHALL have already processed the
+  Pre-conditions section containing branch safety rules
+  AND the agent MUST check `git status --short` for
+  uncommitted changes before proceeding
+
+## MODIFIED Requirements
+
+### Requirement: Branch safety rule placement in openspec-apply-change
+
+The branch safety rule in `openspec-apply-change/SKILL.md`
+MUST appear as a Pre-condition block immediately after the
+"Steps" heading and before Step 1, rather than in the
+Guardrails section at the end of the file.
+
+Previously: The rule "NEVER switch branches or suggest
+archiving with uncommitted changes" appeared at line 212
+within the Guardrails section, after all workflow steps.
+
+#### Scenario: Agent processes apply-change workflow
+
+- **GIVEN** the openspec-apply-change skill is loaded
+- **WHEN** the agent begins processing the Steps section
+- **THEN** the agent SHALL encounter the branch safety
+  pre-condition before Step 1 (Select the change)
+  AND the pre-condition MUST state: "NEVER switch branches
+  or suggest archiving with uncommitted changes"
+
+#### Scenario: Guardrails section after modification
+
+- **GIVEN** the branch safety rule has been moved to
+  Pre-conditions
+- **WHEN** reviewing the Guardrails section
+- **THEN** the Guardrails section MUST NOT contain a
+  duplicate of the branch safety rule
+
+### Requirement: Branch safety section placement in speckit-workflow
+
+The Branch Safety content in `speckit-workflow/SKILL.md`
+MUST appear as a "Pre-conditions" section before the
+"Reading tasks.md" section, rather than as a standalone
+section at the end of the file.
+
+Previously: The "Branch Safety" section appeared at
+line 114, after the full workflow (lines 18-113).
+
+#### Scenario: Agent processes speckit workflow
+
+- **GIVEN** the speckit-workflow skill is loaded
+- **WHEN** the agent begins reading the skill instructions
+- **THEN** the agent SHALL encounter the Pre-conditions
+  section with branch safety rules BEFORE the
+  "Reading tasks.md" section
+  AND the pre-condition MUST state that all work MUST
+  be committed and pushed before any branch switch
+
+#### Scenario: Original Branch Safety section removal
+
+- **GIVEN** the branch safety content has been moved to
+  Pre-conditions
+- **WHEN** reviewing the file structure
+- **THEN** the original "Branch Safety" section (previously
+  at lines 114-128) SHALL be removed
+
+## REMOVED Requirements
+
+None.

--- a/openspec/changes/branch-safety-guardrails-t2-fix/tasks.md
+++ b/openspec/changes/branch-safety-guardrails-t2-fix/tasks.md
@@ -1,0 +1,31 @@
+<!--
+  [P] marks tasks eligible for parallel execution.
+  Add [P] when a task: (a) touches different files from
+  other [P] tasks in the group, (b) has no dependency
+  on prior tasks in the group, (c) can safely execute
+  without ordering constraints.
+  Do NOT add [P] when tasks modify the same file —
+  parallel workers will cause merge conflicts.
+  Tasks without [P] run sequentially first, then [P]
+  tasks run in parallel.
+-->
+
+## 1. Add branch safety pre-conditions to agent/skill files
+
+Each task modifies a different file and has no ordering
+dependency on the others.
+
+- [x] 1.1 [P] Add Pre-conditions section to `.opencode/agents/cobalt-crush-dev.md` — insert a "### Pre-conditions" subsection immediately before the "## Code Implementation Checklist" heading (line 50). Content MUST instruct the agent to: (a) run `git status --short` before any branch switch, (b) STOP and ask for confirmation if uncommitted changes exist, (c) never silently switch branches with a dirty working tree. Reference the same guardrail language used in the other two files for consistency.
+
+- [x] 1.2 [P] Move branch safety rule in `.opencode/skills/openspec-apply-change/SKILL.md` — add a "**Pre-condition**" block after the "**Steps**" heading (line 16) and before Step 1 (line 18). Content: "Before any step, verify: NEVER switch branches or suggest archiving with uncommitted changes. Run `git status --short` if branch state is uncertain." Then remove the duplicate rule from the Guardrails bullet at line 212 ("NEVER switch branches or suggest archiving with uncommitted changes...").
+
+- [x] 1.3 [P] Move Branch Safety section in `.opencode/skills/speckit-workflow/SKILL.md` — add a "## Pre-conditions" section before "## Reading tasks.md" (line 30). Move the content from the current "## Branch Safety" section (lines 114-128) into this new section. Then remove the original "## Branch Safety" section (lines 114-128) entirely.
+
+## 2. Verification
+
+- [x] 2.1 Verify each modified file reads coherently — review the three files to ensure heading hierarchy is correct, no duplicate constraints exist, and pre-conditions appear before all workflow instructions. Concrete checks: `grep -c "NEVER switch branches" .opencode/skills/openspec-apply-change/SKILL.md` returns `1` (not `2`); `grep -c "## Branch Safety" .opencode/skills/speckit-workflow/SKILL.md` returns `0` (section removed); `grep -n "### Pre-conditions" .opencode/agents/cobalt-crush-dev.md` returns a line number before the "## Code Implementation Checklist" heading.
+
+- [x] 2.2 Verify constitution alignment — confirm changes are text-only (no Go source, CI, or schema modifications) and align with Security by Default (PASS) as documented in the proposal.
+
+<!-- spec-review: passed -->
+<!-- code-review: passed -->


### PR DESCRIPTION
## Summary

Fixes the Type T2 weakness (CRITICAL rules placed after
the actions they govern) in three agent/skill instruction
files. Branch safety guardrails are relocated from
end-of-file positions to Pre-conditions sections before
the workflow instructions they govern.

This ensures agents encounter branch safety constraints
before any branch operations, preventing the scenario
where an agent executes branch switches without having
processed the safety rules.

Fixes #355, #359, #361

## How to Test

```bash
# Verify Pre-conditions appears before Code Implementation Checklist
grep -n "Pre-conditions\|Code Implementation Checklist" \
  .opencode/agents/cobalt-crush-dev.md
# Expected: Pre-conditions at line 50, Checklist at line 58

# Verify no duplicate branch safety rule
grep -c "NEVER switch branches" \
  .opencode/skills/openspec-apply-change/SKILL.md
# Expected: 1

# Verify Branch Safety section removed
grep -c "## Branch Safety" \
  .opencode/skills/speckit-workflow/SKILL.md
# Expected: 0

# Run full check suite (includes scaffold drift detection)
make check
```

## How to Demo

This is a prompt engineering fix -- no runtime behavior
to demo. Open each of the three modified files and
verify the branch safety constraints appear before the
workflow instructions they govern.

## Key Files Changed

**Agent/skill instruction files (3 source files):**
- `.opencode/agents/cobalt-crush-dev.md` -- Added
  `### Pre-conditions` section with branch safety
  guardrails before `## Code Implementation Checklist`
- `.opencode/skills/openspec-apply-change/SKILL.md` --
  Added `**Pre-condition**` block after `**Steps**`,
  removed duplicate from Guardrails section
- `.opencode/skills/speckit-workflow/SKILL.md` -- Moved
  `## Branch Safety` to `## Pre-conditions` before
  `## Reading tasks.md`, removed original section

**Scaffold copies (2 synced files):**
- `internal/scaffold/assets/opencode/agents/cobalt-crush-dev.md`
- `internal/scaffold/assets/opencode/skills/speckit-workflow/SKILL.md`

**OpenSpec change artifacts (5 new files):**
- `openspec/changes/branch-safety-guardrails-t2-fix/`
  -- proposal, design, specs, tasks

_This PR was generated by /finale (AI-assisted)._
