### PR TITLE
fix(opsx-archive): add branch switch gate and clarify mv guard

### DIFF
--- a/.opencode/commands/opsx-archive.md
+++ b/.opencode/commands/opsx-archive.md
@@ -71,16 +71,30 @@ Archive a completed change in the experimental workflow.
    - If yes: Fail with error, suggest renaming existing archive or using different date
    - If no: Move the change directory to archive
 
+   Execute the following **only if the target does not already exist**:
+
    ```bash
    mv openspec/changes/<name> openspec/changes/archive/YYYY-MM-DD-<name>
    ```
 
 6. **Return to main branch**
 
-   After the archive move completes:
+   After the archive move completes, use the
+   **AskUserQuestion tool** to confirm branch switching:
+
+   > The archive is complete. Would you like to return
+   > to the main branch?
+
+   Options: `["Return to main", "Stay on branch"]`
+
+   **If "Return to main":**
    ```bash
    git checkout main
    ```
+
+   **If "Stay on branch":**
+   Skip the `git checkout main`. Note in the summary
+   that the user remained on the `opsx/<name>` branch.
 
    The `opsx/<name>` branch still exists locally. Note
    in the summary that the developer can delete it
@@ -93,7 +107,7 @@ Archive a completed change in the experimental workflow.
    - Schema that was used
    - Archive location
    - Spec sync status (synced / sync skipped / no delta specs)
-   - Branch status (returned to main)
+   - Branch status (returned to main / remained on opsx/<name>)
    - Note about any warnings (incomplete artifacts/tasks)
 
 **Output On Success**
@@ -105,6 +119,7 @@ Archive a completed change in the experimental workflow.
 **Schema:** <schema-name>
 **Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
 **Specs:** ✓ Synced to main specs
+**Branch:** returned to main | stayed on opsx/<name>
 
 All artifacts complete. All tasks complete.
 ```
@@ -118,6 +133,7 @@ All artifacts complete. All tasks complete.
 **Schema:** <schema-name>
 **Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
 **Specs:** No delta specs
+**Branch:** returned to main | stayed on opsx/<name>
 
 All artifacts complete. All tasks complete.
 ```
@@ -131,6 +147,7 @@ All artifacts complete. All tasks complete.
 **Schema:** <schema-name>
 **Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
 **Specs:** Sync skipped (user chose to skip)
+**Branch:** returned to main | stayed on opsx/<name>
 
 **Warnings:**
 - Archived with 2 incomplete artifacts

--- a/.opencode/skills/openspec-archive-change/SKILL.md
+++ b/.opencode/skills/openspec-archive-change/SKILL.md
@@ -101,6 +101,7 @@ Archive a completed change in the experimental workflow.
    - If yes: Fail with error, suggest renaming existing archive or using different date
    - If no: Move the change directory to archive
 
+   Execute the following only if the target does not already exist:
    ```bash
    mv openspec/changes/<name> openspec/changes/archive/YYYY-MM-DD-<name>
    ```
@@ -114,7 +115,11 @@ Archive a completed change in the experimental workflow.
    git push
    ```
 
-   Then switch branches:
+   Then use the **AskUserQuestion tool** to confirm
+   before switching branches:
+   - **Options**: `["Return to main", "Stay on branch"]`
+
+   **If "Return to main":**
    ```bash
    git checkout main
    ```
@@ -123,6 +128,11 @@ Archive a completed change in the experimental workflow.
    in the summary that the developer can delete it
    manually with `git branch -d opsx/<name>` if desired.
 
+   **If "Stay on branch":**
+   Skip the checkout. Note in the summary that the
+   developer remained on `opsx/<name>` and can switch
+   to main manually with `git checkout main` when ready.
+
 8. **Display summary**
 
    Show archive completion summary including:
@@ -130,7 +140,7 @@ Archive a completed change in the experimental workflow.
    - Schema that was used
    - Archive location
    - Whether specs were synced (if applicable)
-   - Branch status (returned to main)
+   - Branch status (returned to main / stayed on opsx/<name>)
    - Note about any warnings (incomplete artifacts/tasks)
 
 **Output On Success**
@@ -142,6 +152,7 @@ Archive a completed change in the experimental workflow.
 **Schema:** <schema-name>
 **Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
 **Specs:** ✓ Synced to main specs (or "No delta specs" or "Sync skipped")
+**Branch:** returned to main | stayed on opsx/<name>
 
 All artifacts complete. All tasks complete.
 ```

--- a/openspec/changes/fix-opsx-archive-guards/.openspec.yaml
+++ b/openspec/changes/fix-opsx-archive-guards/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: unbound-force
+created: 2026-07-31

--- a/openspec/changes/fix-opsx-archive-guards/design.md
+++ b/openspec/changes/fix-opsx-archive-guards/design.md
@@ -1,0 +1,98 @@
+## Context
+
+The `/opsx-archive` workflow has two entry points — the command
+file (`.opencode/commands/opsx-archive.md`) and the skill file
+(`.opencode/skills/openspec-archive-change/SKILL.md`). Both
+have two structural gaps identified in issue #356:
+
+1. The "Return to main branch" step performs `git checkout main`
+   without user confirmation
+2. In the "Perform the archive" step, the `mv` command block
+   appears as a visually separate, unconditional code fence
+   after the target-exists check, making the conditional
+   relationship ambiguous
+
+These gaps follow the same class of issue found in issue #346
+(review-pr confirmation gate bypass). The fix applies the
+established hardening pattern: mandatory `AskUserQuestion`
+gates before state-changing operations, and explicit guard
+structure for conditional commands.
+
+## Goals / Non-Goals
+
+### Goals
+- Add an `AskUserQuestion` confirmation gate before
+  `git checkout main` in both the command file and skill file
+- Make the conditional relationship between the target-exists
+  check and the `mv` command explicit in both files
+- Maintain consistency with the guard patterns used in
+  `/opsx-propose` (dirty tree check, branch check)
+
+### Non-Goals
+- Adding new archive functionality
+- Modifying other commands (those have separate issues)
+- Adding programmatic tests for command files (these are
+  agent instruction files, not executable code)
+- Changing the archive directory structure or naming
+- Adding a dirty-tree check before the branch switch (the
+  SKILL.md already has a "Commit and push all changes" step;
+  the command file does not, but adding one is a separate
+  concern from the confirmation gate)
+
+## Decisions
+
+### D1: AskUserQuestion with two options for branch switch
+
+The confirmation gate will use `AskUserQuestion` with two
+explicit options: "Return to main" and "Stay on branch".
+This matches the pattern proposed in issue #356 and gives
+the user a clear choice rather than a yes/no prompt.
+
+**Rationale**: Binary yes/no prompts are ambiguous in context.
+Named options make the action explicit and reduce
+misinterpretation risk.
+
+### D2: Clarify conditional nesting, not restructure
+
+The target-exists check already precedes the `mv` command block
+in both files. The issue is that the `mv` code fence appears as
+a standalone instruction after the check text, and an agent
+could interpret it as unconditional. The fix adds explicit
+conditional language before the code fence (e.g., "If the
+target does not exist, execute:") to make the guard relationship
+unambiguous. The step will not be split into sub-steps.
+
+**Rationale**: The ordering is correct; only the association
+between the guard and the command is ambiguous. Adding explicit
+conditional language is a minimal change that makes the intent
+clear without restructuring.
+
+### D3: No changes to the guardrails section
+
+The existing guardrails at the end of `opsx-archive.md` are
+adequate. The new confirmation gate is a procedural step, not
+a guardrail principle.
+
+**Rationale**: Guardrails describe invariants. The branch
+switch confirmation is a specific procedural gate within
+the step sequence.
+
+## Risks / Trade-offs
+
+### Risk: Agent may treat options as decorative
+
+The `AskUserQuestion` gate depends on the agent correctly
+pausing execution and waiting for user input. Issue #346
+showed that agents can skip gates under compressed context.
+
+**Mitigation**: The fix in issue #346 added session-resume
+guard language to `/review-pr`. This change uses the same
+`AskUserQuestion` tool pattern, which has clearer tool-call
+semantics than inline text gates.
+
+### Trade-off: Additional user friction
+
+Adding a confirmation prompt adds one interaction to the
+archive flow. This is acceptable because branch switches
+are infrequent (once per archive) and the cost of an
+unintended switch is higher than the cost of a prompt.

--- a/openspec/changes/fix-opsx-archive-guards/proposal.md
+++ b/openspec/changes/fix-opsx-archive-guards/proposal.md
@@ -1,0 +1,122 @@
+## Why
+
+The `/opsx-archive` command (`.opencode/commands/opsx-archive.md`)
+and its corresponding skill file
+(`.opencode/skills/openspec-archive-change/SKILL.md`) have two
+structural safety gaps identified in issue #356, traced from the
+parent audit in issue #346:
+
+1. **Unguarded branch switch**: The "Return to main branch" step
+   executes `git checkout main` without an `AskUserQuestion` gate.
+   Branch switches change working directory state and should
+   require explicit user confirmation — consistent with the
+   pattern established in `/opsx-propose` and the fix applied to
+   `/review-pr` after issue #346. This gap exists in both the
+   command file (Step 6) and the skill file (Step 7).
+
+2. **Ambiguous target-exists guard**: In the "Perform the archive"
+   step, the target-exists check text and the `mv` command block
+   are in the correct order (check first, then command), but the
+   `mv` code fence appears as a visually separate, unconditional
+   instruction. An agent could interpret the code fence as
+   "always execute" rather than as the "If no" branch of the
+   preceding check. The conditional relationship between the
+   guard and the command needs to be made explicit. This
+   structural ambiguity exists in both files.
+
+These gaps were discovered during the root cause analysis of
+issue #346 (review-pr confirmation gate bypass). Applying the
+same hardening patterns across all commands prevents recurrence.
+
+## What Changes
+
+Targeted edits to two files:
+- `.opencode/commands/opsx-archive.md` (command file)
+- `.opencode/skills/openspec-archive-change/SKILL.md` (skill file)
+
+In both files:
+
+- **Gap A**: Add an `AskUserQuestion` confirmation gate before
+  `git checkout main`, with options to return to main or stay
+  on the current branch.
+- **Gap B**: Make the conditional relationship between the
+  target-exists check and the `mv` command explicit, so agents
+  treat the `mv` as guarded by the check rather than as an
+  unconditional instruction.
+
+## Capabilities
+
+### New Capabilities
+- None
+
+### Modified Capabilities
+- `opsx-archive`: Adds user confirmation before branch switch;
+  clarifies conditional relationship in target-exists guard
+
+### Removed Capabilities
+- None
+
+## Impact
+
+- **Files**:
+  - `.opencode/commands/opsx-archive.md` (command file)
+  - `.opencode/skills/openspec-archive-change/SKILL.md` (skill file)
+- **Scaffold**: No scaffold asset exists for either file under
+  `internal/scaffold/assets/`, so no scaffold sync is required
+- **Behavioral**: Agents running `/opsx-archive` (via either
+  entry point) will now pause for user confirmation before
+  switching to main, and will see the `mv` command explicitly
+  guarded by the target-exists check
+- **Risk**: Low — the changes add a confirmation gate and clarify
+  existing logic; no new functionality introduced
+- **Upstream**: Consistent with the hardening pattern from
+  issue #346 applied to `/review-pr`
+
+## Constitution Alignment
+
+Assessed against the Unbound Force org constitution.
+
+### I. Autonomous Collaboration
+
+**Assessment**: N/A
+
+This change modifies agent command instructions, not inter-hero
+artifact communication. No artifact formats or exchange protocols
+are affected.
+
+### II. Composability First
+
+**Assessment**: N/A
+
+This change is internal to the meta repository's command
+definitions. No hero dependencies or standalone functionality
+are affected.
+
+### III. Observable Quality
+
+**Assessment**: N/A
+
+No machine-parseable outputs or provenance metadata are
+affected. The change modifies agent behavioral instructions
+only.
+
+### IV. Testability
+
+**Assessment**: PASS
+
+The change targets Markdown instruction files, not executable
+code. Testability is achieved through manual verification of
+procedural correctness (task 4.1), which is the appropriate
+verification mechanism for agent instruction files.
+
+### V. Security by Default
+
+**Assessment**: PASS
+
+This change directly improves security posture by adding
+a mandatory confirmation gate before a state-changing
+operation (branch switch) and clarifying guard structure
+to prevent ambiguous interpretation of file-moving
+operations. Both gaps represent input-validation-adjacent
+concerns where agent instructions should enforce explicit
+user consent before irreversible actions.

--- a/openspec/changes/fix-opsx-archive-guards/specs/opsx-archive/spec.md
+++ b/openspec/changes/fix-opsx-archive-guards/specs/opsx-archive/spec.md
@@ -1,0 +1,88 @@
+## ADDED Requirements
+
+### Requirement: Branch switch confirmation gate
+
+The `/opsx-archive` workflow MUST present an `AskUserQuestion`
+confirmation gate before executing `git checkout main`. This
+requirement applies to both entry points:
+- `.opencode/commands/opsx-archive.md` (Step 6)
+- `.opencode/skills/openspec-archive-change/SKILL.md` (Step 7)
+
+The gate MUST use the `AskUserQuestion tool` with options
+`["Return to main", "Stay on branch"]`.
+
+If the user selects "Stay on branch", the workflow MUST skip
+the `git checkout main` step and proceed directly to the
+summary display. The summary MUST note that the user remained
+on the `opsx/<name>` branch.
+
+#### Scenario: User confirms return to main
+
+- **GIVEN** the archive move has completed successfully
+- **WHEN** the agent presents the branch switch confirmation
+- **AND** the user selects "Return to main"
+- **THEN** the agent MUST execute `git checkout main`
+- **AND** the summary MUST show "Branch: returned to main"
+
+#### Scenario: User chooses to stay on branch
+
+- **GIVEN** the archive move has completed successfully
+- **WHEN** the agent presents the branch switch confirmation
+- **AND** the user selects "Stay on branch"
+- **THEN** the agent MUST NOT execute `git checkout main`
+- **AND** the summary MUST show "Branch: stayed on
+  opsx/<name>"
+
+## MODIFIED Requirements
+
+### Requirement: Target-exists guard clarity
+
+In the "Perform the archive" step, the `mv` command block
+MUST be explicitly marked as conditional on the target-exists
+check. The target-exists check text and the `mv` command are
+already in the correct order (check first, command second),
+but the `mv` code fence appears as a visually separate block
+that could be interpreted as an unconditional instruction.
+
+The corrected structure MUST make the conditional relationship
+explicit by adding guard language before the `mv` code fence
+(e.g., "If the target does not exist, execute:") so agents
+treat the command as guarded rather than unconditional.
+
+This requirement applies to both entry points:
+- `.opencode/commands/opsx-archive.md` (Step 5)
+- `.opencode/skills/openspec-archive-change/SKILL.md` (Step 6)
+
+Previously: The `mv` code fence appeared as a standalone
+instruction after the target-exists check text, with no
+explicit conditional language linking the two. An agent
+could interpret the code fence as "always execute" rather
+than as the "If no" branch of the preceding check.
+
+#### Scenario: Target archive does not exist
+
+- **GIVEN** the archive directory exists at
+  `openspec/changes/archive/`
+- **AND** no directory exists at
+  `openspec/changes/archive/YYYY-MM-DD-<name>`
+- **WHEN** the agent reaches the "Perform the archive" step
+- **THEN** the agent MUST first verify the target does
+  not exist
+- **AND** the `mv` command MUST appear under explicit
+  conditional language indicating it runs only when the
+  target does not exist
+- **AND** then execute the `mv` command
+
+#### Scenario: Target archive already exists
+
+- **GIVEN** a directory already exists at
+  `openspec/changes/archive/YYYY-MM-DD-<name>`
+- **WHEN** the agent reaches the "Perform the archive" step
+- **THEN** the agent MUST detect the existing target
+  before attempting any `mv` operation
+- **AND** MUST fail with an error suggesting alternatives
+- **AND** the `mv` command MUST NOT be executed
+
+## REMOVED Requirements
+
+No requirements are removed by this change.

--- a/openspec/changes/fix-opsx-archive-guards/tasks.md
+++ b/openspec/changes/fix-opsx-archive-guards/tasks.md
@@ -1,0 +1,79 @@
+<!--
+  [P] marks tasks eligible for parallel execution.
+  Add [P] when a task: (a) touches different files from
+  other [P] tasks in the group, (b) has no dependency
+  on prior tasks in the group, (c) can safely execute
+  without ordering constraints.
+  Do NOT add [P] when tasks modify the same file --
+  parallel workers will cause merge conflicts.
+  Tasks without [P] run sequentially first, then [P]
+  tasks run in parallel.
+-->
+
+## 1. Fix target-exists guard clarity (Gap B)
+
+- [x] 1.1 In `.opencode/commands/opsx-archive.md` Step 5
+  ("Perform the archive"), add explicit conditional language
+  before the `mv` command code fence to make it clear that
+  the command runs only when the target does not exist. The
+  target-exists check (starting with "Check if target already
+  exists") already precedes the `mv` block; the fix is to add
+  guard text such as "If the target does not exist, execute:"
+  before the `mv` code fence so agents treat it as conditional
+  rather than unconditional.
+- [x] 1.2 [P] In `.opencode/skills/openspec-archive-change/SKILL.md`
+  Step 6 ("Perform the archive"), apply the same fix: add
+  explicit conditional language before the `mv` command code
+  fence to link it to the target-exists check.
+
+## 2. Add branch switch confirmation gate (Gap A)
+
+- [x] 2.1 In `.opencode/commands/opsx-archive.md` Step 6
+  ("Return to main branch"), add an `AskUserQuestion`
+  confirmation gate before `git checkout main`. The gate
+  MUST use the `AskUserQuestion tool` with options
+  `["Return to main", "Stay on branch"]`. If the user
+  selects "Stay on branch", skip the `git checkout main`
+  and note in the summary that the user remained on the
+  `opsx/<name>` branch.
+- [x] 2.2 [P] In `.opencode/skills/openspec-archive-change/SKILL.md`
+  Step 7 ("Return to main branch"), add an `AskUserQuestion`
+  confirmation gate before `git checkout main` with the same
+  two options and conditional behavior. Note: the SKILL.md
+  Step 7 has a commit/push sub-step before the checkout — the
+  gate goes after the commit/push and before `git checkout
+  main`.
+
+## 3. Update summary output templates
+
+- [x] 3.1 In `.opencode/commands/opsx-archive.md`, update
+  the summary display step (Step 7) and all three standalone
+  output template blocks ("Output On Success", "Output On
+  Success (No Delta Specs)", "Output On Success With
+  Warnings") to include a conditional `**Branch:**` line.
+  Show `**Branch:** returned to main` or `**Branch:** stayed
+  on opsx/<name>` depending on the user's choice in the
+  confirmation gate. The current templates do not have a
+  branch status field — this line needs to be added, not
+  replaced.
+- [x] 3.2 [P] In `.opencode/skills/openspec-archive-change/SKILL.md`,
+  update the summary display step (Step 8) and the output
+  template block to include the same conditional
+  `**Branch:**` line.
+
+## 4. Verification
+
+- [x] 4.1 Read the updated `.opencode/commands/opsx-archive.md`
+  and verify: (a) the `mv` command in Step 5 has explicit
+  conditional language linking it to the target-exists check,
+  (b) Step 6 contains the `AskUserQuestion` gate with the
+  exact options "Return to main" and "Stay on branch",
+  (c) the "Stay on branch" path skips `git checkout main`
+  and updates the summary, (d) the summary templates reflect
+  conditional branch status, (e) no constitution principles
+  are violated (per proposal.md assessment).
+- [x] 4.2 [P] Read the updated
+  `.opencode/skills/openspec-archive-change/SKILL.md` and
+  verify the same criteria as 4.1 applied to the skill file.
+<!-- spec-review: passed -->
+<!-- code-review: passed -->


### PR DESCRIPTION
## Summary

Fixes two structural safety gaps in the `/opsx-archive` workflow identified in #356 (traced from parent audit #346):

**Gap A — Unguarded branch switch**: The "Return to main branch" step executed `git checkout main` without user confirmation. Now presents an `AskUserQuestion` gate with "Return to main" / "Stay on branch" options before any branch switch.

**Gap B — Ambiguous target-exists guard**: The `mv` command code fence appeared as a standalone instruction after the target-exists check, making the conditional relationship ambiguous. Now includes explicit guard text ("Execute the following only if the target does not already exist:") before the `mv` code fence.

Both fixes applied to both entry points: the command file (`.opencode/commands/opsx-archive.md`) and the parallel skill file (`.opencode/skills/openspec-archive-change/SKILL.md`).

Fixes #356

## How to Test

1. Read `.opencode/commands/opsx-archive.md` Step 5 (line 74) — confirm conditional guard text before `mv`
2. Read `.opencode/commands/opsx-archive.md` Step 6 (lines 82-97) — confirm `AskUserQuestion` gate with two options
3. Read `.opencode/commands/opsx-archive.md` output templates (lines 122, 136, 150) — confirm `**Branch:**` line in all three
4. Read `.opencode/skills/openspec-archive-change/SKILL.md` Step 6 (line 104) — confirm conditional guard text
5. Read `.opencode/skills/openspec-archive-change/SKILL.md` Step 7 (lines 118-134) — confirm gate after commit/push block
6. Run `go test -race -count=1 ./...` — all packages pass (Markdown-only change)

## How to Demo

Run `/opsx-archive` on a completed change. At Step 6, observe the new confirmation gate asking whether to return to main or stay on the branch. Select "Stay on branch" and verify the summary shows "stayed on opsx/<name>".

## Key Files Changed

- `.opencode/commands/opsx-archive.md` — Gap A (branch switch gate) + Gap B (mv guard clarity) + summary template updates
- `.opencode/skills/openspec-archive-change/SKILL.md` — Same fixes applied to parallel skill entry point
- `openspec/changes/fix-opsx-archive-guards/` — Spec artifacts (proposal, design, delta spec, tasks)

_This PR was generated by /finale (AI-assisted)._
