### PR TITLE
fix(speckit): harden dirty-tree check with explicit AskUserQuestion tool call

### DIFF
--- a/.opencode/commands/speckit.specify.md
+++ b/.opencode/commands/speckit.specify.md
@@ -40,12 +40,29 @@ Given that feature description, do this:
 2. **Check for uncommitted work before creating a new branch**:
 
    a. Run `git status --short` to check for uncommitted changes.
-      - **If uncommitted changes exist**: **STOP** and ask the
-        user for confirmation before proceeding. Show the list
-        of uncommitted files and warn that switching branches
-        with a dirty working tree may cause changes to be
-        applied to the wrong branch or lost.
-      - If the user confirms, proceed. If not, abort.
+      - **If uncommitted changes exist**: use the
+        **AskUserQuestion tool** to confirm before proceeding.
+        Include the `git status --short` output in the question
+        so the user can see which files are uncommitted:
+
+        > "Uncommitted changes detected. Switching branches with
+        > a dirty working tree may cause changes to be applied
+        > to the wrong branch or lost."
+
+        Use options:
+        `["Stash changes and continue",
+        "Abort -- keep changes as-is"]`
+
+      - If the user selects **"Stash changes and continue"**:
+        run `git stash`. If `git stash` returns a non-zero exit
+        code, **STOP** the workflow, report the stash failure to
+        the user, and do NOT proceed to branch creation. If
+        `git stash` succeeds, proceed to step 3. Upon workflow
+        completion, inform the user that their changes are
+        stashed and can be restored with `git stash pop`.
+      - If the user selects **"Abort -- keep changes as-is"**:
+        **STOP** the workflow immediately without creating a
+        branch or modifying the working tree.
       - Exception: only skip this check if the user explicitly
         said to create a new spec in the same message.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,14 @@ Each entry follows the format: `- <change-name>: <summary>`.
   lines) and the canonical scaffold copy (278 lines).
   (Spec: openspec/changes/fix-gaze-test-generator-compile-gate/,
   Fixes: unbound-force/gaze#204)
+- `speckit.specify`: Dirty-tree check before branch creation now
+  uses an explicit `AskUserQuestion` tool call with structured
+  options ("Stash changes and continue" / "Abort -- keep changes
+  as-is") instead of prose-only instructions. Includes `git stash`
+  failure handling and stash recovery notification. Hardens against
+  context compression skipping the guard (T1+T3 weakness).
+  (Spec: openspec/changes/fix-speckit-dirty-tree-check/,
+  Fixes: #358)
 - `uf init --force` no longer hangs on Dewey re-indexing.
   Dewey indexing now runs with `--no-embeddings` for a fast
   metadata-only pass. Run `dewey index` separately to

--- a/openspec/changes/fix-speckit-dirty-tree-check/.openspec.yaml
+++ b/openspec/changes/fix-speckit-dirty-tree-check/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: unbound-force
+created: 2026-07-31

--- a/openspec/changes/fix-speckit-dirty-tree-check/design.md
+++ b/openspec/changes/fix-speckit-dirty-tree-check/design.md
@@ -1,0 +1,89 @@
+## Context
+
+The speckit specify command (`speckit.specify.md`) includes a
+dirty-tree check at lines 40-50 that instructs agents to stop and
+ask the user for confirmation when uncommitted changes are detected
+before `git checkout -b`. However, this check is expressed entirely
+in prose with no structured tool call, making it vulnerable to
+context compression (T1+T3 weakness pattern from audit #346).
+
+The proposal (proposal.md) identifies this as a hardening fix with
+PASS alignment on Observable Quality and Security by Default
+principles.
+
+## Goals / Non-Goals
+
+### Goals
+- Replace prose-only dirty-tree guard with an explicit
+  `AskUserQuestion` tool call that presents structured options
+- Match the established pattern already used elsewhere in speckit
+  commands (e.g., step 1 uses `AskUserQuestion` for feature
+  description input)
+- Ensure the guard is resistant to context compression by agents
+
+### Non-Goals
+- Modifying the branch numbering or naming logic (steps 3-4)
+- Fixing sibling issues #350 (openspec-propose SKILL.md) or #353
+  (opsx-propose.md) -- those are tracked separately
+- Fixing `speckit-workflow/SKILL.md` which contains a parallel
+  prose-only dirty-tree guard -- a follow-up issue should be filed
+- No scaffold asset sync is required -- `speckit.specify.md` is a
+  non-embedded file (created by `specify init`, not scaffolded by
+  `uf init`)
+- Adding automated enforcement beyond agent instructions (e.g., no
+  git hooks or CI checks for this pattern)
+- Changing the exception behavior (user explicitly requesting a new
+  spec in the same message)
+
+## Decisions
+
+### D1: Use AskUserQuestion with two structured options
+
+Replace the prose "STOP and ask the user for confirmation" with an
+explicit `AskUserQuestion` tool call. The two options are:
+
+1. **"Stash changes and continue"** -- proceed with branch creation
+2. **"Abort -- keep changes as-is"** -- stop the workflow
+
+This matches the fix described in issue #358 and provides a clear,
+unambiguous decision point that agents cannot skip through
+compression.
+
+**Rationale**: Two options cover the practical choices a user has
+when uncommitted work is detected. "Stash changes" implies the
+agent should run `git stash` before proceeding. "Abort" stops the
+workflow entirely. Adding more options (e.g., "commit first") would
+expand scope beyond the fix.
+
+### D2: Preserve the exception clause
+
+The existing exception ("only skip this check if the user explicitly
+said to create a new spec in the same message") is retained as-is.
+This exception is already a conditional check that agents can
+evaluate before reaching the tool call.
+
+### D3: Show uncommitted file list in the question context
+
+The `AskUserQuestion` call should include the output of
+`git status --short` in its context so the user can make an informed
+decision. This aligns with Observable Quality -- the user sees
+exactly what uncommitted work exists.
+
+## Risks / Trade-offs
+
+### Low Risk: Behavioral change for agents already following the prose
+Agents that were already correctly interpreting the prose instruction
+will now see a structured tool call instead. The behavior is
+functionally identical but the mechanism changes. No user-facing
+impact expected.
+
+### Accepted Trade-off: Stash vs. manual management
+The "Stash changes and continue" option implies `git stash` will be
+run by the agent. If the user has complex uncommitted work, stashing
+may not be the ideal approach. However, this matches the simplicity
+principle -- users who need more control can abort and manage their
+working tree manually. If `git stash` fails (non-zero exit), the
+agent aborts the workflow. Upon successful stash and workflow
+completion, the agent notifies the user that their changes can be
+restored with `git stash pop`. Stash recovery is the user's
+responsibility -- the agent does not auto-restore.

--- a/openspec/changes/fix-speckit-dirty-tree-check/proposal.md
+++ b/openspec/changes/fix-speckit-dirty-tree-check/proposal.md
@@ -1,0 +1,88 @@
+## Why
+
+The dirty-tree check in `speckit.specify.md` (lines 42-50) describes
+a safety gate before `git checkout -b` entirely in prose. It says
+"STOP and ask the user for confirmation" but never specifies an
+`AskUserQuestion` tool call. Under context compression, an agent can
+skip the check entirely and create the branch despite uncommitted
+changes, risking work applied to the wrong branch or lost.
+
+This is a T1+T3 weakness (gate exists in prose but is not enforced by
+a tool call), identified in the parent audit (issue #346). Sibling
+issues #350 and #353 address the same pattern in `openspec-propose`
+and `opsx-propose` respectively.
+
+Fixes #358.
+
+## What Changes
+
+Replace the prose-only dirty-tree guard in `speckit.specify.md` with
+an explicit `AskUserQuestion` tool call that presents the user with
+structured options before proceeding past uncommitted changes.
+
+## Capabilities
+
+### New Capabilities
+- None (this is a hardening fix, not a new feature)
+
+### Modified Capabilities
+- `speckit.specify`: Dirty-tree check before branch creation now uses
+  an explicit `AskUserQuestion` tool call with structured options
+  instead of prose-only instructions
+
+### Removed Capabilities
+- None
+
+## Impact
+
+- **File**: `.opencode/commands/speckit.specify.md` (lines 40-50)
+- **Behavior**: Agents executing the speckit specify command will now
+  encounter a structured tool call when uncommitted changes are
+  detected, making it resistant to context compression skipping
+- **Risk**: Low -- this is a documentation/instruction change only,
+  no Go source code is modified
+- **Related sibling changes**: Issues #350 (openspec-propose SKILL.md)
+  and #353 (opsx-propose.md) address the same pattern in other files
+
+## Constitution Alignment
+
+Assessed against the Unbound Force org constitution.
+
+### I. Autonomous Collaboration
+
+**Assessment**: N/A
+
+This change modifies agent instructions in a command file. It does not
+affect artifact-based communication or inter-hero collaboration.
+
+### II. Composability First
+
+**Assessment**: N/A
+
+This change is internal to the speckit workflow command. It does not
+introduce dependencies or affect standalone functionality.
+
+### III. Observable Quality
+
+**Assessment**: PASS
+
+The change makes the dirty-tree guard observable: instead of relying on
+prose interpretation, the structured tool call creates an auditable
+decision point with explicit user confirmation.
+
+### IV. Testability
+
+**Assessment**: N/A
+
+This is an agent instruction change, not a code change. No new
+components require isolation testing.
+
+### V. Security by Default
+
+**Assessment**: PASS
+
+This change hardens input validation by ensuring user intent is
+explicitly confirmed before a branch-switching operation that could
+affect uncommitted work. It enforces the principle that
+security-sensitive operations require structured validation, not
+prose-level trust.

--- a/openspec/changes/fix-speckit-dirty-tree-check/specs/dirty-tree-guard.md
+++ b/openspec/changes/fix-speckit-dirty-tree-check/specs/dirty-tree-guard.md
@@ -1,0 +1,90 @@
+## ADDED Requirements
+
+### Requirement: Structured dirty-tree confirmation
+
+When `speckit.specify.md` step 2 detects uncommitted changes via
+`git status --short`, the agent MUST use an `AskUserQuestion` tool
+call with structured options before proceeding. The agent MUST NOT
+rely on prose-only instructions to gate branch creation.
+
+The `AskUserQuestion` call MUST present exactly two options:
+1. "Stash changes and continue"
+2. "Abort -- keep changes as-is"
+
+The question context MUST include the output of `git status --short`
+so the user can see which files have uncommitted changes.
+
+#### Scenario: Uncommitted changes detected
+
+- **GIVEN** the user invokes `speckit.specify` and there are
+  uncommitted changes in the working tree
+- **WHEN** the agent runs `git status --short` and finds output
+- **THEN** the agent MUST present an `AskUserQuestion` with two
+  options: "Stash changes and continue" and "Abort -- keep changes
+  as-is", including the git status output in the question context
+
+#### Scenario: User chooses to stash and continue
+
+- **GIVEN** uncommitted changes are detected and the user selects
+  "Stash changes and continue"
+- **WHEN** the agent processes the user's choice
+- **THEN** the agent MUST run `git stash` before proceeding to
+  `git checkout -b` for the new branch. Upon workflow completion,
+  the agent MUST inform the user that their changes are stashed
+  and can be restored with `git stash pop`.
+
+#### Scenario: git stash fails
+
+- **GIVEN** uncommitted changes are detected and the user selects
+  "Stash changes and continue"
+- **WHEN** the agent runs `git stash` and it returns a non-zero
+  exit code
+- **THEN** the agent MUST stop the workflow, report the stash
+  failure to the user, and MUST NOT proceed to branch creation
+
+#### Scenario: User explicitly requests new spec in same message
+
+- **GIVEN** uncommitted changes exist AND the user's triggering
+  message contains a `/speckit.specify <description>` invocation
+  with a feature description
+- **WHEN** the agent evaluates the dirty-tree check
+- **THEN** the agent MAY skip the `AskUserQuestion` and proceed
+  directly to branch creation
+
+#### Scenario: User chooses to abort
+
+- **GIVEN** uncommitted changes are detected and the user selects
+  "Abort -- keep changes as-is"
+- **WHEN** the agent processes the user's choice
+- **THEN** the agent MUST stop the workflow immediately without
+  creating a branch or modifying the working tree
+
+#### Scenario: Clean working tree
+
+- **GIVEN** the user invokes `speckit.specify` and there are no
+  uncommitted changes
+- **WHEN** the agent runs `git status --short` and finds no output
+- **THEN** the agent MUST proceed directly to branch creation
+  without presenting the `AskUserQuestion`
+
+## MODIFIED Requirements
+
+### Requirement: Dirty-tree check before branch creation
+
+Previously: "STOP and ask the user for confirmation before
+proceeding. Show the list of uncommitted files and warn that
+switching branches with a dirty working tree may cause changes to
+be applied to the wrong branch or lost."
+
+Now: The agent MUST use an explicit `AskUserQuestion` tool call
+with structured options as defined in the "Structured dirty-tree
+confirmation" requirement above. Prose-only instructions for this
+gate are insufficient and MUST NOT be used.
+
+The existing exception clause is retained: the agent MAY skip this
+check only if the user explicitly requested a new spec in the same
+message that triggered the command.
+
+## REMOVED Requirements
+
+(None)

--- a/openspec/changes/fix-speckit-dirty-tree-check/tasks.md
+++ b/openspec/changes/fix-speckit-dirty-tree-check/tasks.md
@@ -1,0 +1,58 @@
+<!--
+  [P] marks tasks eligible for parallel execution.
+  Add [P] when a task: (a) touches different files from
+  other [P] tasks in the group, (b) has no dependency
+  on prior tasks in the group, (c) can safely execute
+  without ordering constraints.
+  Do NOT add [P] when tasks modify the same file —
+  parallel workers will cause merge conflicts.
+  Tasks without [P] run sequentially first, then [P]
+  tasks run in parallel.
+-->
+
+## 1. Harden dirty-tree guard in speckit.specify.md
+
+- [x] 1.1 Replace prose-only dirty-tree check (lines 40-50) in
+  `.opencode/commands/speckit.specify.md` with an explicit
+  `AskUserQuestion` tool call. Replace lines 42-50 with:
+  (a) Run `git status --short` to check for uncommitted changes.
+  (b) If output is non-empty, use `AskUserQuestion` with options:
+      - "Stash changes and continue"
+      - "Abort -- keep changes as-is"
+  Include the `git status --short` output in the question context
+  so the user can see which files are uncommitted.
+  (c) If user selects "Stash changes and continue", run `git stash`
+      before proceeding to branch creation. If `git stash` fails
+      (non-zero exit), abort the workflow and report the error.
+      Upon workflow completion, inform the user their changes can
+      be restored with `git stash pop`.
+  (d) If user selects "Abort", stop the workflow immediately.
+  (e) Retain the existing exception: skip this check only if the
+      user explicitly requested a new spec in the same message.
+  File: `.opencode/commands/speckit.specify.md`
+
+## 2. Verification
+
+- [x] 2.1 Verify the modified text in `speckit.specify.md` contains
+  an explicit `AskUserQuestion` tool call (not just prose) and that
+  the two options match the spec: "Stash changes and continue" and
+  "Abort -- keep changes as-is"
+- [x] 2.2 [P] Verify constitution alignment: confirm the change
+  aligns with Observable Quality (structured decision point) and
+  Security by Default (explicit user confirmation for
+  security-sensitive operation). No code changes, so Testability
+  and Composability are N/A.
+- [x] 2.3 [P] Verify the exception clause is preserved: the agent
+  MAY skip the check only if the user explicitly requested a new
+  spec in the same message
+- [x] 2.4 [P] Check `speckit-workflow/SKILL.md` for a parallel
+  prose-only dirty-tree guard. If present, file a follow-up issue
+  to harden it with the same `AskUserQuestion` pattern (Filed: #395)
+
+## 3. Documentation
+
+- [x] 3.1 Add CHANGELOG.md entry under Unreleased/Fixed:
+  "fix(speckit): harden dirty-tree check with explicit
+  AskUserQuestion tool call (#358)"
+<!-- spec-review: passed -->
+<!-- code-review: passed -->


### PR DESCRIPTION
## Summary

Replaces the prose-only dirty-tree guard in `speckit.specify.md` (step 2) with an explicit `AskUserQuestion` tool call. The previous prose instruction ("STOP and ask the user for confirmation") was vulnerable to context compression — agents could skip the check entirely and create a branch despite uncommitted changes, risking work applied to the wrong branch or lost.

The hardened guard now presents two structured options:
- **"Stash changes and continue"** — runs `git stash`, with failure handling (non-zero exit → abort) and recovery notification at workflow completion (`git stash pop`)
- **"Abort -- keep changes as-is"** — stops the workflow immediately

This is a T1+T3 weakness fix from audit #346. Sibling issues #350 and #353 address the same pattern in other files.

Fixes #358

## How to Test

1. Open `.opencode/commands/speckit.specify.md` and verify lines 40-67
2. Confirm `AskUserQuestion tool` is explicitly referenced (line 44)
3. Confirm the two option strings appear verbatim (lines 53-54)
4. Confirm `git stash` failure handling (lines 57-59): non-zero exit → STOP
5. Confirm stash recovery notification (lines 61-62): `git stash pop`
6. Confirm exception clause preserved (lines 66-67)
7. Run `make check` — all tests pass (no Go code changed)

## How to Demo

This is an agent instruction hardening fix (Markdown only). To observe the behavioral change, invoke `/speckit.specify` with uncommitted changes in the working tree — the agent should now present a structured `AskUserQuestion` instead of relying on prose interpretation.

## Key Files Changed

| File | Change | Description |
|------|--------|-------------|
| `.opencode/commands/speckit.specify.md` | +29/-6 | Core fix: prose → AskUserQuestion |
| `CHANGELOG.md` | +8 | New Fixed entry |
| `openspec/changes/fix-speckit-dirty-tree-check/.openspec.yaml` | +2 | Change metadata |
| `openspec/changes/fix-speckit-dirty-tree-check/proposal.md` | +88 | What & why, constitution alignment |
| `openspec/changes/fix-speckit-dirty-tree-check/design.md` | +89 | Decisions D1-D3, risks/trade-offs |
| `openspec/changes/fix-speckit-dirty-tree-check/specs/dirty-tree-guard.md` | +90 | Delta spec, 6 Given/When/Then scenarios |
| `openspec/changes/fix-speckit-dirty-tree-check/tasks.md` | +58 | Implementation tasks (all complete) |

_This PR was generated by /finale (AI-assisted)._
