### PR TITLE
fix: move branch safety rules to pre-conditions in speckit-workflow skill

### DIFF
--- a/openspec/changes/branch-safety-placement/.openspec.yaml
+++ b/openspec/changes/branch-safety-placement/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: unbound-force
+created: 2026-07-31

--- a/openspec/changes/branch-safety-placement/design.md
+++ b/openspec/changes/branch-safety-placement/design.md
@@ -1,0 +1,72 @@
+## Context
+
+The `speckit-workflow/SKILL.md` file contains a "Branch Safety" section
+(lines 114-129) with CRITICAL rules about dirty working tree handling.
+These rules appear after the full workflow (lines 18-113), meaning an
+agent can execute branch-affecting actions before encountering the
+safety constraints.
+
+This is classified as a T2 weakness: a CRITICAL/MANDATORY rule placed
+after the workflow it governs. The fix follows the same pattern as
+sibling issues #355 and #359.
+
+## Goals / Non-Goals
+
+### Goals
+- Move branch safety rules before any workflow step that could trigger
+  a branch switch
+- Create a "Pre-conditions" section as the first actionable section
+  after the introductory text
+- Preserve all existing branch safety rule content verbatim
+- Maintain consistency with the fix pattern used in sibling issues
+
+### Non-Goals
+- Rewriting or expanding the branch safety rules themselves
+- Modifying other sections of the skill file
+- Addressing other potential T2 weaknesses in this file
+- Changing the behavior or semantics of any rules
+
+## Decisions
+
+**D1: Place pre-conditions before "Reading tasks.md" (line 30)**
+
+The "When This Skill Applies" section (lines 18-28) is a detection
+check, not a workflow step. The first actionable workflow section is
+"Reading tasks.md" (line 30). The pre-conditions section MUST appear
+between "When This Skill Applies" and "Reading tasks.md" so agents
+encounter it before any workflow action.
+
+**D2: Use "Pre-conditions" as the section heading**
+
+Consistent with the issue description and the pattern established
+in sibling fixes. The heading clearly signals that these are
+constraints to check before proceeding.
+
+**D3: Remove the original "Branch Safety" section entirely**
+
+The content moves wholesale to "Pre-conditions". Leaving a stub or
+cross-reference at the old location would create maintenance burden
+and a risk of drift. Delete the old section completely.
+
+**D4: Preserve content verbatim**
+
+The branch safety rules are well-written and correct. Only the
+position changes. The content within the new "Pre-conditions"
+section MUST match the original "Branch Safety" content with no
+semantic modifications, though minor formatting adjustments (e.g.,
+adjusting the heading level, adding a CRITICAL label) are acceptable.
+
+## Risks / Trade-offs
+
+**R1: Agents with cached/stale skill versions**
+
+Agents that have already loaded the old version of the skill in an
+active session will not benefit from this change until their next
+session. This is inherent to all skill file changes and not specific
+to this fix. Risk: LOW.
+
+**R2: Merge conflicts with sibling fixes**
+
+If issues #355 or #359 are being worked on concurrently and share
+any common file, there could be merge conflicts. Since each issue
+targets a different file, this risk is NONE.

--- a/openspec/changes/branch-safety-placement/proposal.md
+++ b/openspec/changes/branch-safety-placement/proposal.md
@@ -1,0 +1,86 @@
+## Why
+
+The "Branch Safety" section of `speckit-workflow/SKILL.md` (lines 114-129)
+contains CRITICAL rules about never switching branches with a dirty working
+tree. These rules are placed at the END of the file, after the full workflow
+steps (lines 18-113). An agent executing the workflow sequentially can reach
+branch-related actions (Phase Checkpoints, worker spawning) before ever
+encountering these constraints.
+
+This is a T2 weakness (CRITICAL/MANDATORY rule placed after the workflow it
+governs), identified as part of the parent audit in issue #346. The same
+pattern was found in `cobalt-crush.md` (issue #355) and
+`openspec-apply-change/SKILL.md` (issue #359).
+
+Fixes: #361
+
+## What Changes
+
+Move the branch safety content from its current position (after
+"Phase Checkpoints") to a new "Pre-conditions" section placed before
+"Reading tasks.md", ensuring agents encounter the CRITICAL constraint
+before any workflow step that could trigger a branch switch.
+
+## Capabilities
+
+### New Capabilities
+- None
+
+### Modified Capabilities
+- `speckit-workflow skill`: Branch safety rules relocated to pre-conditions
+  section, ensuring agents process them before any workflow step
+
+### Removed Capabilities
+- None
+
+## Impact
+
+- **File affected**: `.opencode/skills/speckit-workflow/SKILL.md`
+- **Behavioral change**: Agents using this skill will encounter branch safety
+  rules earlier in the file, reducing risk of dirty-tree branch switches
+- **No functional change**: The rules themselves are unchanged; only their
+  position in the document changes
+- **Pattern alignment**: Consistent with fixes applied to sibling issues
+  #355 (cobalt-crush) and #359 (openspec-apply-change)
+
+## Constitution Alignment
+
+Assessed against the Unbound Force org constitution.
+
+### I. Autonomous Collaboration
+
+**Assessment**: N/A
+
+This change restructures an agent skill file. It does not affect
+artifact-based communication or inter-hero interfaces.
+
+### II. Composability First
+
+**Assessment**: N/A
+
+This change modifies internal skill documentation ordering. It does
+not affect standalone functionality or hero dependencies.
+
+### III. Observable Quality
+
+**Assessment**: N/A
+
+This change does not affect machine-parseable output or provenance
+metadata. The skill file is agent instruction content, not output.
+
+### IV. Testability
+
+**Assessment**: N/A
+
+This change restructures documentation. The branch safety rules
+themselves are unchanged. Drift detection tests (if any) that verify
+embedded assets will continue to pass since the content is preserved.
+
+### V. Security by Default
+
+**Assessment**: PASS
+
+Moving CRITICAL safety rules to a pre-conditions section reduces the
+risk of agents bypassing branch safety checks due to document ordering.
+This strengthens the security posture of the workflow by ensuring
+constraints are processed before actions.

--- a/openspec/changes/branch-safety-placement/specs/skill-structure.md
+++ b/openspec/changes/branch-safety-placement/specs/skill-structure.md
@@ -1,0 +1,54 @@
+## ADDED Requirements
+
+### Requirement: Pre-conditions section placement
+
+The `speckit-workflow/SKILL.md` file MUST contain a "Pre-conditions"
+section placed after "When This Skill Applies" and before "Reading
+tasks.md". This section MUST contain all CRITICAL safety rules that
+govern the workflow.
+
+#### Scenario: Agent processes skill file sequentially
+
+- **GIVEN** an agent loads `speckit-workflow/SKILL.md`
+- **WHEN** it processes sections in document order
+- **THEN** it MUST encounter the "Pre-conditions" section (containing
+  branch safety rules) before any workflow step that could trigger a
+  branch switch
+
+#### Scenario: Branch safety content completeness
+
+- **GIVEN** the "Pre-conditions" section exists in the skill file
+- **WHEN** an agent reads the pre-conditions
+- **THEN** it MUST find all of the following rules:
+  - All work MUST be committed and pushed before any branch switch
+  - After completing all phases, commit and push before PR creation
+  - Before creating a new feature branch, check `git status --short`
+  - Never silently switch branches with a dirty working tree
+
+## MODIFIED Requirements
+
+### Requirement: Branch safety rule location
+
+Branch safety rules MUST appear in the "Pre-conditions" section of
+the skill file, not in a trailing "Branch Safety" section after the
+workflow steps.
+
+Previously: Branch safety rules were in a "Branch Safety" section
+at lines 114-129, after the full workflow (lines 18-113).
+
+#### Scenario: No trailing branch safety section
+
+- **GIVEN** the skill file has been updated per this change
+- **WHEN** an agent or reviewer scans for a "Branch Safety" heading
+  after the workflow sections
+- **THEN** no such section SHALL exist; the content MUST reside
+  solely in "Pre-conditions"
+
+## REMOVED Requirements
+
+### Requirement: Standalone "Branch Safety" section
+
+The standalone "Branch Safety" section (previously at lines 114-129)
+is removed. Its content is relocated to the "Pre-conditions" section.
+Reason: T2 weakness — CRITICAL rules placed after the workflow they
+govern.

--- a/openspec/changes/branch-safety-placement/tasks.md
+++ b/openspec/changes/branch-safety-placement/tasks.md
@@ -1,0 +1,25 @@
+<!--
+  [P] marks tasks eligible for parallel execution.
+  Add [P] when a task: (a) touches different files from
+  other [P] tasks in the group, (b) has no dependency
+  on prior tasks in the group, (c) can safely execute
+  without ordering constraints.
+  Do NOT add [P] when tasks modify the same file —
+  parallel workers will cause merge conflicts.
+  Tasks without [P] run sequentially first, then [P]
+  tasks run in parallel.
+-->
+
+## 1. Restructure skill file
+
+- [x] 1.1 Add "Pre-conditions" section after "When This Skill Applies" (line 29) and before "Reading tasks.md" (line 30) in `.opencode/skills/speckit-workflow/SKILL.md`. Insert a `## Pre-conditions` heading followed by the CRITICAL branch safety content (currently at lines 116-128). Include the `**CRITICAL**:` label and all four bullet points verbatim.
+- [x] 1.2 Remove the original "Branch Safety" section (lines 114-129) from `.opencode/skills/speckit-workflow/SKILL.md`, including the `## Branch Safety` heading and the blank line before it.
+
+## 2. Verification
+
+- [x] 2.1 Verify the "Pre-conditions" section appears before "Reading tasks.md" in the updated file
+- [x] 2.2 Verify no "Branch Safety" heading exists after the workflow sections
+- [x] 2.3 Verify all four original branch safety rules are present in the "Pre-conditions" section
+- [x] 2.4 Run `make check` to confirm no build, lint, or test regressions
+<!-- spec-review: passed -->
+<!-- code-review: passed -->


### PR DESCRIPTION
## Summary

Move CRITICAL branch safety rules from the end of `speckit-workflow/SKILL.md`
(after the full workflow at lines 114-129) to a new "Pre-conditions" section
placed before "Reading tasks.md". This fixes a T2 weakness (CRITICAL/MANDATORY
rule placed after the workflow it governs) identified in the parent audit (#346).

The same pattern was fixed in sibling issues #355 (cobalt-crush) and #359
(openspec-apply-change).

Fixes #361

## How to Test

1. Open `.opencode/skills/speckit-workflow/SKILL.md` and verify:
   - "Pre-conditions" section appears before "Reading tasks.md"
   - No "Branch Safety" heading exists after the workflow sections
   - All four original branch safety rules are present verbatim
2. Verify scaffold asset sync:
   ```bash
   diff .opencode/skills/speckit-workflow/SKILL.md \
     internal/scaffold/assets/opencode/skills/speckit-workflow/SKILL.md
   ```
   Should produce no output (files are identical).
3. Run `make check` -- all tests pass.

## How to Demo

Open the skill file and observe that the "Pre-conditions" section (line 30)
now appears immediately after "When This Skill Applies" and before "Reading
tasks.md", ensuring agents encounter branch safety constraints before any
workflow step.

## Key Files Changed

**Agent skills:**
- `.opencode/skills/speckit-workflow/SKILL.md` -- moved "Branch Safety" content to "Pre-conditions" section

**Scaffold assets:**
- `internal/scaffold/assets/opencode/skills/speckit-workflow/SKILL.md` -- synced embedded copy

**OpenSpec artifacts (new):**
- `openspec/changes/branch-safety-placement/proposal.md` -- change proposal with constitution alignment
- `openspec/changes/branch-safety-placement/design.md` -- technical design decisions
- `openspec/changes/branch-safety-placement/specs/skill-structure.md` -- delta spec with Given/When/Then scenarios
- `openspec/changes/branch-safety-placement/tasks.md` -- implementation task checklist

_This PR was generated by /finale (AI-assisted)._
