### PR TITLE
fix(openspec-explore): enforce branch-switching gate with AskUserQuestion

### DIFF
--- a/.opencode/skills/openspec-explore/SKILL.md
+++ b/.opencode/skills/openspec-explore/SKILL.md
@@ -327,7 +327,46 @@ But this summary is optional. Sometimes the thinking IS the value.
 - **Don't rush** - Discovery is thinking time, not task time
 - **Don't force structure** - Let patterns emerge naturally
 - **Don't auto-capture** - Offer to save insights, don't just do it
-- **Don't switch branches without confirmation** - If exploration leads to creating a proposal (which requires a new `opsx/` branch), check for uncommitted changes first and ask the user before switching. Never silently leave uncommitted work behind.
+- **Branch Creation Gate** - If exploration leads to creating
+  a proposal (which requires a new `opsx/` branch) or directly
+  creating a branch via `git checkout -b`, the agent MUST
+  execute this confirmation gate before any branch operation:
+
+  1. **Check current branch state**:
+     a. If already on the target `opsx/<name>` branch: skip
+        branch creation, proceed without the gate.
+     b. If on a different `opsx/*` branch: **STOP** with error:
+        "Already on branch `opsx/<other>` -- finish or archive
+        that change first."
+     c. If on `main` or any non-opsx branch: proceed to step 2.
+
+  2. **Check for uncommitted changes**: Run `git status --short`.
+     If uncommitted changes exist, show what changes exist and
+     warn the user that switching branches with a dirty working
+     tree may cause changes to be applied to the wrong branch.
+
+  3. **Get explicit confirmation**: Use the **AskUserQuestion
+     tool** with the proposed branch name included in the prompt
+     text (e.g., "Create branch `opsx/<name>` and start a
+     proposal?") and options:
+     - "Create branch and proceed"
+     - "Stay in explore mode"
+
+  4. **Act on the response**: Only execute branch creation or
+     invoke `/opsx-propose` if the user selects "Create branch
+     and proceed." If the user selects "Stay in explore mode,"
+     remain in explore mode without creating a branch.
+
+  The agent MUST NOT create a branch, switch branches, or invoke
+  `/opsx-propose` without completing this gate. This applies to
+  both direct `git checkout -b` and transitions via
+  `/opsx-propose`.
+
+  Note: The `/opsx-propose` skill has its own independent branch
+  guard (Step 3). Both gates apply independently -- the explore
+  gate fires before the transition, and the propose gate fires
+  within `/opsx-propose`.
+
 - **Do visualize** - A good diagram is worth many paragraphs
 - **Do explore the codebase** - Ground discussions in reality
 - **Do question assumptions** - Including the user's and your own

--- a/openspec/changes/enforce-explore-branch-gate/.openspec.yaml
+++ b/openspec/changes/enforce-explore-branch-gate/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: unbound-force
+created: 2026-07-31

--- a/openspec/changes/enforce-explore-branch-gate/design.md
+++ b/openspec/changes/enforce-explore-branch-gate/design.md
@@ -1,0 +1,90 @@
+## Context
+
+The `openspec-explore/SKILL.md` Guardrails section (line 330) contains an
+advisory statement: "Don't switch branches without confirmation." This is
+prose-only guidance that agents can and do skip, especially when session
+context is compressed or resumed. Issue #346 established that advisory
+prose is insufficient for confirmation gates -- agents need explicit tool
+call instructions to enforce them.
+
+The `openspec-propose/SKILL.md` already contains a robust branch guard
+pattern (Step 3) with dirty working tree checks, branch state checks,
+and explicit user confirmation. This is the reference implementation for
+how branch guards should work in OpenSpec skills.
+
+## Goals / Non-Goals
+
+### Goals
+- Replace the advisory guardrail in `openspec-explore/SKILL.md` with an
+  explicit, enforceable confirmation gate
+- Require `AskUserQuestion` tool call before any branch creation or
+  transition to `/opsx-propose` from explore mode
+- Present the proposed branch name and options to the user before acting
+- Align the pattern with the existing branch guard in `openspec-propose`
+
+### Non-Goals
+- Modifying the `openspec-propose` skill (it already has proper guards)
+- Adding runtime enforcement (this is skill instruction enforcement, not
+  Go code enforcement)
+- Changing explore mode's core behavior or stance
+
+## Decisions
+
+### D1: Replace advisory bullet with structured gate section
+
+The single advisory bullet at line 330 will be replaced with a dedicated
+subsection under Guardrails that provides explicit, step-by-step
+instructions for the confirmation gate. This mirrors how `openspec-propose`
+structures its branch guard (Step 3).
+
+**Rationale**: A structured section with numbered steps and explicit tool
+call references is harder for agents to skip than a single dash-prefixed
+advisory sentence. The parent audit (issue #346) established this pattern.
+
+### D2: Use AskUserQuestion with binary options
+
+The gate will require an `AskUserQuestion` call with two options:
+1. "Create branch and proceed"
+2. "Stay in explore mode"
+
+**Rationale**: Binary options are clear and unambiguous. The user either
+consents to branch creation or stays in explore mode. This matches the
+issue #362 specification exactly.
+
+### D3: Include dirty working tree check
+
+The gate will include a dirty working tree check (via `git status --short`)
+before presenting the confirmation prompt. If uncommitted changes exist,
+the confirmation must warn about them.
+
+**Rationale**: This aligns with the existing pattern in `openspec-propose`
+and prevents the secondary risk of silently leaving uncommitted work behind
+when switching branches.
+
+### D4: Keep the gate within Guardrails section
+
+The confirmation gate stays in the Guardrails section rather than being
+moved to a separate "Branch Guard" section. The Guardrails section is where
+agents look for behavioral constraints.
+
+**Rationale**: Moving it elsewhere risks it being overlooked. Guardrails is
+the natural home for "you MUST do this before X" instructions.
+
+## Risks / Trade-offs
+
+### Risk: Gate adds friction to natural explore-to-propose flow
+When exploration naturally crystallizes into a proposal, the confirmation
+gate adds a mandatory pause. This is intentional -- the gate exists
+precisely to prevent silent transitions. The user can confirm immediately
+if they agree.
+
+### Risk: Agents may still skip the gate under context compression
+This is a known limitation of all instruction-based enforcement. The
+structured format with explicit tool call references and numbered steps
+is the strongest mitigation available at the skill instruction level.
+Further hardening would require runtime enforcement (out of scope).
+
+### Trade-off: Verbose guardrail vs. concise list
+The replacement text is significantly longer than the single advisory
+bullet it replaces. This is acceptable because the expanded text provides
+the specificity agents need to consistently execute the gate.

--- a/openspec/changes/enforce-explore-branch-gate/proposal.md
+++ b/openspec/changes/enforce-explore-branch-gate/proposal.md
@@ -1,0 +1,82 @@
+## Why
+
+The `openspec-explore/SKILL.md` contains a guardrail at line 330 that says
+"Don't switch branches without confirmation." This is advisory prose only --
+there is no enforced `AskUserQuestion` tool call before branch creation. When
+exploration naturally leads to recommending `/opsx-propose`, an agent in
+explore mode can transition to branch creation without explicit user consent.
+
+This was identified in issue #362 as part of the parent audit (issue #346)
+that discovered confirmation gates expressed as prose are routinely bypassed
+by agents, especially under compressed/resumed session context.
+
+The fix converts the advisory guardrail into an enforced gate by requiring
+an explicit `AskUserQuestion` tool call with confirmation options before any
+branch creation or switching occurs from explore mode.
+
+## What Changes
+
+### Modified Capabilities
+- `openspec-explore skill`: The branch-switching guardrail is replaced with
+  an explicit, enforceable confirmation gate that requires `AskUserQuestion`
+  before any `git checkout -b` or `/opsx-propose` transition from explore
+  mode.
+
+### New Capabilities
+- None
+
+### Removed Capabilities
+- None
+
+## Impact
+
+- **File**: `.opencode/skills/openspec-explore/SKILL.md` (single file change)
+- **Behavior**: Agents in explore mode will be required to present the
+  proposed branch name to the user and use `AskUserQuestion` with explicit
+  options before creating a branch or transitioning to proposal mode.
+- **Risk**: Low. This is a skill file text change only -- no Go code, no
+  CLI changes, no schema changes.
+
+## Constitution Alignment
+
+Assessed against the Unbound Force org constitution.
+
+### I. Autonomous Collaboration
+
+**Assessment**: N/A
+
+This change modifies agent skill instructions, not inter-hero artifact
+communication or runtime coupling. No impact on artifact-based collaboration.
+
+### II. Composability First
+
+**Assessment**: N/A
+
+This change is internal to the openspec-explore skill. It does not affect
+hero installability, extension points, or standalone functionality.
+
+### III. Observable Quality
+
+**Assessment**: PASS
+
+The enforcement claim ("enforced gate" vs. "advisory guardrail") is
+verifiable via structural text analysis of the SKILL.md file -- the
+presence of `AskUserQuestion` in numbered steps within the Guardrails
+section constitutes reproducible evidence of enforcement.
+
+### IV. Testability
+
+**Assessment**: PASS
+
+The enforced gate is structurally verifiable: reviewers can confirm the
+`AskUserQuestion` requirement is present as explicit instructions rather
+than advisory prose. The gate's presence is a textual property of the
+skill file, not a runtime behavior requiring integration tests.
+
+### V. Security by Default
+
+**Assessment**: PASS
+
+This change strengthens security posture by preventing unauthorized branch
+switching. It enforces least-privilege: the agent must not take irreversible
+actions (branch creation) without explicit user authorization.

--- a/openspec/changes/enforce-explore-branch-gate/specs/branch-gate.md
+++ b/openspec/changes/enforce-explore-branch-gate/specs/branch-gate.md
@@ -1,0 +1,120 @@
+## ADDED Requirements
+
+### FR-001: Explore-to-branch confirmation gate
+
+When an agent in explore mode proposes creating a branch (either directly
+via `git checkout -b` or by transitioning to `/opsx-propose`), the agent
+MUST:
+
+1. Check the current branch state:
+   a. If already on the target `opsx/<name>` branch: skip branch
+      creation, proceed without the gate.
+   b. If on a different `opsx/*` branch: STOP with error:
+      "Already on branch `opsx/<other>` -- finish or archive that
+      change first."
+   c. If on `main` or any non-opsx branch: proceed to step 2.
+2. Present the proposed branch name and change name to the user.
+   The branch name MUST be included in the `AskUserQuestion` prompt
+   text so the user sees it alongside the confirmation options.
+3. Check for uncommitted changes via `git status --short`. If
+   uncommitted changes exist, the confirmation MUST show what
+   changes exist and warn the user that switching branches with
+   a dirty working tree may cause changes to be applied to the
+   wrong branch.
+4. Use the **AskUserQuestion tool** with options:
+   - "Create branch and proceed"
+   - "Stay in explore mode"
+5. Only execute branch creation if the user selects "Create branch
+   and proceed."
+
+The agent MUST NOT create a branch, switch branches, or invoke
+`/opsx-propose` without completing this confirmation gate.
+
+Note: The `/opsx-propose` skill has its own independent branch guard
+(Step 3). Both gates apply independently -- the explore gate fires
+before the transition, and the propose gate fires within `/opsx-propose`.
+The explore gate does NOT subsume the propose gate.
+
+### Known Limitations
+
+Instruction-based enforcement is not runtime-enforced. Agents may skip
+the gate under context compression or session resumption. The structured
+format with explicit tool call references and numbered steps is the
+strongest mitigation available at the skill instruction level.
+
+#### Scenario: Clean explore-to-propose transition
+
+- **GIVEN** an agent is in explore mode on the `main` branch with no
+  uncommitted changes
+- **WHEN** the user says "Ready to start? Create a proposal."
+- **THEN** the agent MUST include the proposed branch name (e.g.,
+  `opsx/<change-name>`) in the **AskUserQuestion** prompt text and
+  present options "Create branch and proceed" and "Stay in explore
+  mode" before creating the branch
+
+#### Scenario: Dirty working tree during transition
+
+- **GIVEN** an agent is in explore mode with uncommitted changes in
+  the working tree
+- **WHEN** exploration leads to proposing a new branch
+- **THEN** the agent MUST show what uncommitted changes exist, warn
+  the user that switching branches may cause changes to be applied
+  to the wrong branch, AND present the **AskUserQuestion**
+  confirmation before any branch operation
+
+#### Scenario: User declines branch creation
+
+- **GIVEN** an agent is in explore mode and has presented the
+  **AskUserQuestion** confirmation
+- **WHEN** the user selects "Stay in explore mode"
+- **THEN** the agent MUST remain in explore mode without creating
+  a branch, switching branches, or invoking `/opsx-propose`
+
+#### Scenario: Agent attempts direct branch creation
+
+- **GIVEN** an agent is in explore mode
+- **WHEN** the agent determines it should create a branch via
+  `git checkout -b` directly (bypassing `/opsx-propose`)
+- **THEN** the agent MUST still execute the full confirmation gate
+  including **AskUserQuestion** before running the git command
+
+#### Scenario: Explore-to-propose transition via /opsx-propose
+
+- **GIVEN** an agent is in explore mode
+- **WHEN** the agent recommends transitioning to `/opsx-propose`
+- **THEN** the agent MUST execute the confirmation gate before
+  invoking `/opsx-propose`
+- **AND** the `/opsx-propose` skill's own branch guard applies
+  independently after the transition
+
+#### Scenario: Agent already on a different opsx branch
+
+- **GIVEN** an agent is in explore mode on branch `opsx/<other>`
+- **WHEN** the agent proposes creating a new branch
+- **THEN** the agent MUST stop with an error instructing the user
+  to finish or archive the current change first
+
+#### Scenario: Agent already on the target opsx branch
+
+- **GIVEN** an agent is in explore mode on branch `opsx/<name>`
+- **WHEN** exploration leads to proposing a change with the same
+  name (target branch is `opsx/<name>`)
+- **THEN** the agent MUST skip branch creation (branch already
+  exists) and proceed without the confirmation gate
+
+## MODIFIED Requirements
+
+### FR-002: Explore mode guardrail on branch switching (modified)
+
+Previously: "Don't switch branches without confirmation - If exploration
+leads to creating a proposal (which requires a new `opsx/` branch),
+check for uncommitted changes first and ask the user before switching.
+Never silently leave uncommitted work behind."
+
+The advisory guardrail is replaced by the explicit confirmation gate
+defined in FR-001 above. The requirement changes from SHOULD (advisory)
+to MUST (enforced via **AskUserQuestion** tool call).
+
+## REMOVED Requirements
+
+None.

--- a/openspec/changes/enforce-explore-branch-gate/tasks.md
+++ b/openspec/changes/enforce-explore-branch-gate/tasks.md
@@ -1,0 +1,62 @@
+<!--
+  [P] marks tasks eligible for parallel execution.
+  Add [P] when a task: (a) touches different files from
+  other [P] tasks in the group, (b) has no dependency
+  on prior tasks in the group, (c) can safely execute
+  without ordering constraints.
+  Do NOT add [P] when tasks modify the same file --
+  parallel workers will cause merge conflicts.
+  Tasks without [P] run sequentially first, then [P]
+  tasks run in parallel.
+-->
+
+## 1. Replace advisory guardrail with enforced gate
+
+- [x] 1.1 In `.opencode/skills/openspec-explore/SKILL.md`, replace the
+  advisory bullet at line 330 ("Don't switch branches without
+  confirmation...") with a structured confirmation gate subsection.
+  The replacement MUST include:
+  - A "Branch Creation Gate" heading or equivalent within Guardrails
+  - Branch state check (already on target branch: skip; on different
+    `opsx/*` branch: stop with error; on `main`/non-opsx: proceed)
+  - Explicit instruction to include the proposed branch name in the
+    **AskUserQuestion** prompt text
+  - Instruction to run `git status --short` and warn about uncommitted
+    changes if any exist, showing what changes exist
+  - An **AskUserQuestion** call with options "Create branch and proceed"
+    and "Stay in explore mode"
+  - Explicit statement that branch creation MUST NOT proceed without
+    user confirmation
+  - Clear statement that this applies to both direct `git checkout -b`
+    and transitions via `/opsx-propose`
+  - Note that the `/opsx-propose` skill's own branch guard applies
+    independently after the transition
+
+  **Checkpoint**: Read the modified SKILL.md Guardrails section
+  end-to-end. Verify the advisory bullet has been replaced with a
+  structured gate subsection containing numbered steps.
+
+## 2. Verification
+
+- [x] 2.1 Verify the updated SKILL.md contains the literal string
+  `AskUserQuestion` within a numbered step in the Guardrails section
+  (not a dash-prefixed advisory bullet). PASS if `AskUserQuestion`
+  appears in a numbered step; FAIL if it only appears in advisory prose.
+- [x] 2.2 Verify the gate covers both code paths: the text MUST
+  mention both `git checkout -b` and `/opsx-propose` (or equivalent
+  references). PASS if both strings appear in the gate section.
+- [x] 2.3 Verify dirty working tree check is included: the text MUST
+  include `git status --short` or equivalent dirty-tree check
+  instruction. PASS if the command reference is present.
+- [x] 2.4 Verify branch state checks are included: the text MUST handle
+  three branch states (already on target branch, on different `opsx/*`
+  branch, on `main`/non-opsx). PASS if all three cases are addressed.
+- [x] 2.5 Verify the gate structure mirrors `openspec-propose/SKILL.md`
+  Step 3 pattern (dirty tree check, branch state check, confirmation).
+  PASS if the structural elements align.
+- [x] 2.6 Verify constitution alignment: confirm the implemented gate
+  text aligns with the constitution assessments in proposal.md
+  (Principle IV: structurally verifiable; Principle V: explicit
+  authorization before irreversible action).
+<!-- spec-review: passed -->
+<!-- code-review: passed -->


### PR DESCRIPTION
## Summary

Replaces the advisory-only branch-switching guardrail in
`openspec-explore/SKILL.md` (line 330) with an explicit,
enforced confirmation gate requiring an `AskUserQuestion` tool
call before any branch creation from explore mode.

This was identified in issue #362 as part of the parent audit
(#346) that discovered confirmation gates expressed as advisory
prose are routinely bypassed by agents, especially under
compressed/resumed session context.

Fixes #362

## How to Test

1. Read `.opencode/skills/openspec-explore/SKILL.md` Guardrails
   section (lines 330-368)
2. Verify `AskUserQuestion` appears in numbered step 3 (not
   advisory prose)
3. Verify both `git checkout -b` and `/opsx-propose` are
   mentioned in the gate
4. Verify `git status --short` dirty tree check is present
5. Verify all three branch states are handled (already on
   target, different opsx/*, main/non-opsx)
6. Verify the dual-gate independence note is present

## How to Demo

Enter explore mode via `/opsx-explore`, then suggest creating
a proposal. The agent should now present an `AskUserQuestion`
prompt with the branch name and options "Create branch and
proceed" / "Stay in explore mode" before any branch operation.

## Key Files Changed

- `.opencode/skills/openspec-explore/SKILL.md` -- Replaced
  advisory bullet at line 330 with structured 4-step
  confirmation gate
- `openspec/changes/enforce-explore-branch-gate/` -- OpenSpec
  change artifacts (proposal, design, specs, tasks)

_This PR was generated by /finale (AI-assisted)._
