### PR TITLE
fix(speckit): move STOP HERE gates before workflow steps

### DIFF
--- a/.opencode/commands/speckit.plan.md
+++ b/.opencode/commands/speckit.plan.md
@@ -21,6 +21,13 @@ You **MUST** consider the user input before proceeding (if not empty).
 
 ## Outline
 
+**STOP HERE. Do NOT proceed to implementation.**
+
+Your job is done. Report the results and prompt the
+user. The user will invoke a separate command
+(/unleash, /cobalt-crush, or /opsx-apply) when they
+are ready to implement.
+
 1. **Setup**: Run `.specify/scripts/bash/setup-plan.sh --json` from repo root and parse JSON for FEATURE_SPEC, IMPL_PLAN, SPECS_DIR, BRANCH. For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
 
 2. **Load context**: Read FEATURE_SPEC and `.specify/memory/constitution.md`. Load IMPL_PLAN template (already copied).
@@ -35,13 +42,6 @@ You **MUST** consider the user input before proceeding (if not empty).
    - Re-evaluate Constitution Check post-design
 
 4. **Stop and report**: Command ends after Phase 2 planning. Report branch, IMPL_PLAN path, and generated artifacts.
-
-**STOP HERE. Do NOT proceed to implementation.**
-
-Your job is done. Report the results and prompt the
-user. The user will invoke a separate command
-(/unleash, /cobalt-crush, or /opsx-apply) when they
-are ready to implement.
 
 ## Phases
 

--- a/.opencode/commands/speckit.tasks.md
+++ b/.opencode/commands/speckit.tasks.md
@@ -22,6 +22,13 @@ You **MUST** consider the user input before proceeding (if not empty).
 
 ## Outline
 
+**STOP HERE. Do NOT proceed to implementation.**
+
+Your job is done. Report the results and prompt the
+user. The user will invoke a separate command
+(/unleash, /cobalt-crush, or /opsx-apply) when they
+are ready to implement.
+
 1. **Setup**: Run `.specify/scripts/bash/check-prerequisites.sh --json` from repo root and parse FEATURE_DIR and AVAILABLE_DOCS list. All paths must be absolute. For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
 
 2. **Dewey Discovery** (optional): Before generating
@@ -66,13 +73,6 @@ You **MUST** consider the user input before proceeding (if not empty).
    - Dependencies section showing story completion order
    - Parallel execution examples per story
    - Implementation strategy section (MVP first, incremental delivery)
-
-**STOP HERE. Do NOT proceed to implementation.**
-
-Your job is done. Report the results and prompt the
-user. The user will invoke a separate command
-(/unleash, /cobalt-crush, or /opsx-apply) when they
-are ready to implement.
 
 6. **Report**: Output path to generated tasks.md and summary:
    - Total task count

--- a/.opencode/commands/uf-init.md
+++ b/.opencode/commands/uf-init.md
@@ -794,9 +794,11 @@ user. The user will invoke a separate command
 when they are ready to implement.
 ```
 
-**Where**: After the main workflow instructions, before
-the `## Guardrails` section. If no `## Guardrails`
-section exists, insert at the end of the file.
+**Where**: Immediately after the `## Outline` heading
+(or equivalent section heading), before the first
+numbered workflow step. If no `## Outline` heading
+exists, insert before the first numbered step in the
+file.
 
 ### Step 11: Scaffold Comment Deduplication
 

--- a/internal/scaffold/assets/opencode/commands/uf-init.md
+++ b/internal/scaffold/assets/opencode/commands/uf-init.md
@@ -794,9 +794,11 @@ user. The user will invoke a separate command
 when they are ready to implement.
 ```
 
-**Where**: After the main workflow instructions, before
-the `## Guardrails` section. If no `## Guardrails`
-section exists, insert at the end of the file.
+**Where**: Immediately after the `## Outline` heading
+(or equivalent section heading), before the first
+numbered workflow step. If no `## Outline` heading
+exists, insert before the first numbered step in the
+file.
 
 ### Step 11: Scaffold Comment Deduplication
 

--- a/openspec/changes/fix-speckit-stop-gates/.openspec.yaml
+++ b/openspec/changes/fix-speckit-stop-gates/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: unbound-force
+created: 2026-07-31

--- a/openspec/changes/fix-speckit-stop-gates/design.md
+++ b/openspec/changes/fix-speckit-stop-gates/design.md
@@ -1,0 +1,102 @@
+## Context
+
+The STOP HERE phase-boundary gates in `speckit.tasks.md` and
+`speckit.plan.md` currently appear AFTER the workflow steps
+they govern. This is a T2 structural weakness: a CRITICAL rule
+placed where an LLM with compressed context may never process
+it before executing the workflow.
+
+The proposal (proposal.md) identifies three files requiring
+changes and confirms constitution alignment (all principles
+N/A except Testability: PASS).
+
+## Goals / Non-Goals
+
+### Goals
+
+- Move STOP HERE blocks to preamble position (before Step 1)
+  in `speckit.tasks.md` and `speckit.plan.md`
+- Update `uf-init.md` Step 10 placement instruction to direct
+  future scaffolding to the correct position
+- Preserve the exact STOP HERE block content (wording unchanged)
+- Ensure no duplicate STOP HERE blocks remain after the move
+
+### Non-Goals
+
+- Fixing the same T2 pattern in other files (`opsx-propose.md`,
+  `cobalt-crush.md`) -- those are tracked by separate issues
+  (#353, #355)
+- Changing the STOP HERE block wording or format
+- Adding new phase-boundary gates to files that lack them
+- Modifying the Guardrails sections in any affected file
+
+## Decisions
+
+### D1: Preamble position for STOP HERE blocks
+
+The STOP HERE block MUST be placed immediately after the
+`## Outline` heading (or equivalent section heading) and
+before the first numbered workflow step. This ensures the
+LLM processes the stop instruction before beginning any
+workflow execution.
+
+**Rationale**: The `## Outline` heading provides structural
+context for what follows. Placing the STOP HERE block between
+the heading and the first step ensures it is read as a
+pre-condition, not a post-condition. This mirrors how a
+"pre-flight check" works -- constraints are loaded before
+execution begins.
+
+### D2: Remove-then-insert approach
+
+Each file will have its existing STOP HERE block (and
+accompanying explanation lines) removed from its current
+position, then inserted at the preamble position. This
+avoids duplication.
+
+**Rationale**: A move operation (delete old + insert new)
+is clearer than trying to reorder blocks in place. It also
+makes the diff readable: one deletion hunk and one insertion
+hunk per file.
+
+### D3: uf-init.md placement instruction update
+
+The Step 10 "Where" instruction in `uf-init.md` currently
+reads:
+
+> After the main workflow instructions, before the
+> `## Guardrails` section.
+
+This will be changed to:
+
+> Immediately after the `## Outline` heading (or equivalent
+> section heading), before the first numbered workflow step.
+> If no `## Outline` heading exists, insert before the first
+> numbered step in the file.
+
+**Rationale**: The uf-init scaffold command creates STOP HERE
+blocks in new files. If the placement instruction remains
+incorrect, every future `uf init` run will perpetuate the
+T2 weakness.
+
+## Risks / Trade-offs
+
+### Risk: Existing files scaffolded by uf-init
+
+Files that were scaffolded before this fix will retain the
+old placement until either manually fixed or re-scaffolded.
+The `uf-init` deduplication logic (Step 11) will not move
+an existing STOP HERE block -- it only checks for presence.
+
+**Mitigation**: The two files being fixed in this change
+(`speckit.tasks.md`, `speckit.plan.md`) are the only files
+identified by issue #363. Other files with the same pattern
+are tracked by separate issues.
+
+### Trade-off: Preamble placement vs. bold banner
+
+An alternative approach would be to add a bold banner at the
+very top of each file (before any frontmatter). This was
+rejected because frontmatter YAML must come first in the
+file, and a banner above the outline heading would be
+visually intrusive.

--- a/openspec/changes/fix-speckit-stop-gates/proposal.md
+++ b/openspec/changes/fix-speckit-stop-gates/proposal.md
@@ -1,0 +1,113 @@
+## Why
+
+The "STOP HERE. Do NOT proceed to implementation." phase-boundary
+gates in `speckit.tasks.md` and `speckit.plan.md` are positioned
+AFTER the workflow steps they are meant to govern. This is a T2
+weakness (CRITICAL/MANDATORY rule placed after the workflow it
+governs) identified in the root cause analysis from issue #346.
+
+A phase-boundary rule intended to prevent premature progression
+to the next phase is only effective if the LLM encounters it
+BEFORE executing the workflow that produces the artifacts. When
+the STOP HERE block appears after the workflow steps, an LLM
+with compressed context may execute the workflow and proceed
+past the gate without ever processing the stop instruction.
+
+Related issues confirm this is a recurring structural pattern:
+- Issue #353: Same T2 pattern in `opsx-propose.md`
+- Issue #355: Same T2 pattern in `cobalt-crush.md`
+
+Additionally, the `uf-init.md` scaffold instruction (Step 10)
+currently directs placement "after the main workflow
+instructions, before the `## Guardrails` section" -- this
+instruction itself perpetuates the T2 weakness and must also
+be corrected to direct placement BEFORE the workflow steps.
+
+## What Changes
+
+Move the STOP HERE gate block to a position BEFORE the workflow
+steps in both `speckit.tasks.md` and `speckit.plan.md`. Update
+the `uf-init.md` Step 10 placement instruction so that future
+scaffolding operations place STOP HERE blocks correctly.
+
+## Capabilities
+
+### New Capabilities
+
+- None. This is a correctness fix, not a feature addition.
+
+### Modified Capabilities
+
+- `speckit.tasks`: STOP HERE gate moved to preamble position
+  (after Outline heading, before Step 1)
+- `speckit.plan`: STOP HERE gate moved to preamble position
+  (after Outline heading, before Step 1)
+- `uf-init` Step 10: Placement instruction updated from
+  "after the main workflow instructions" to "immediately
+  after the Outline heading, before the first numbered step"
+
+### Removed Capabilities
+
+- None.
+
+## Impact
+
+- **Files affected**: 3 files
+  - `.opencode/commands/speckit.tasks.md`
+  - `.opencode/commands/speckit.plan.md`
+  - `.opencode/commands/uf-init.md`
+- **Behavioral change**: LLMs processing these commands will
+  encounter the STOP HERE instruction before executing any
+  workflow steps, preventing premature phase progression.
+- **No code changes**: This change affects only Markdown
+  command files (agent instructions), not Go source code.
+- **No CI impact**: No build, test, or lint changes needed.
+- **Scaffold impact**: Future `uf init` runs will place
+  STOP HERE blocks in the correct position for newly
+  scaffolded files.
+
+## Constitution Alignment
+
+Assessed against the Unbound Force org constitution.
+
+### I. Autonomous Collaboration
+
+**Assessment**: N/A
+
+This change modifies agent instruction files, not artifact
+formats or inter-hero communication. No impact on
+artifact-based collaboration.
+
+### II. Composability First
+
+**Assessment**: N/A
+
+No hero dependencies are introduced or modified. The change
+is internal to command instruction files within this
+meta-repository.
+
+### III. Observable Quality
+
+**Assessment**: N/A
+
+No machine-parseable output or provenance metadata is
+affected. The change corrects instruction ordering in
+Markdown files.
+
+### IV. Testability
+
+**Assessment**: PASS
+
+The fix is verifiable by inspection: after the change,
+the STOP HERE block must appear before the first numbered
+workflow step in each affected file. The `uf-init.md`
+placement instruction can be verified by reading its
+updated text. No external services or shared state are
+required for verification.
+
+### V. Security by Default
+
+**Assessment**: N/A
+
+No dependencies, inputs, permissions, or supply chain
+elements are affected.

--- a/openspec/changes/fix-speckit-stop-gates/specs/stop-gate-placement.md
+++ b/openspec/changes/fix-speckit-stop-gates/specs/stop-gate-placement.md
@@ -1,0 +1,94 @@
+## ADDED Requirements
+
+_None._
+
+## MODIFIED Requirements
+
+### Requirement: STOP HERE gate position in speckit.tasks.md
+
+The STOP HERE phase-boundary block in `speckit.tasks.md`
+MUST appear immediately after the `## Outline` heading and
+before the first numbered workflow step (Step 1).
+
+Previously: The STOP HERE block appeared at line 70, after
+Step 5 (the final workflow step) and before Step 6 (Report).
+
+#### Scenario: LLM processes speckit.tasks command
+
+- **GIVEN** an LLM is executing the `speckit.tasks` command
+- **WHEN** it reads the `## Outline` section
+- **THEN** it MUST encounter the STOP HERE block before any
+  numbered workflow step
+
+#### Scenario: STOP HERE block content preserved
+
+- **GIVEN** the STOP HERE block is moved to preamble position
+  in `speckit.tasks.md`
+- **WHEN** the block content is compared to the canonical
+  format from `uf-init.md`
+- **THEN** the wording MUST be identical to the canonical
+  STOP HERE block
+
+### Requirement: STOP HERE gate position in speckit.plan.md
+
+The STOP HERE phase-boundary block in `speckit.plan.md`
+MUST appear immediately after the `## Outline` heading and
+before the first numbered workflow step (Step 1).
+
+Previously: The STOP HERE block appeared at line 39, after
+Step 4 (the final workflow step) and before the `## Phases`
+section.
+
+#### Scenario: LLM processes speckit.plan command
+
+- **GIVEN** an LLM is executing the `speckit.plan` command
+- **WHEN** it reads the `## Outline` section
+- **THEN** it MUST encounter the STOP HERE block before any
+  numbered workflow step
+
+#### Scenario: STOP HERE block content preserved
+
+- **GIVEN** the STOP HERE block is moved to preamble position
+  in `speckit.plan.md`
+- **WHEN** the block content is compared to the canonical
+  format from `uf-init.md`
+- **THEN** the wording MUST be identical to the canonical
+  STOP HERE block
+
+### Requirement: uf-init STOP HERE placement instruction
+
+The `uf-init.md` Step 10 placement instruction MUST direct
+insertion of STOP HERE blocks immediately after the
+`## Outline` heading (or equivalent section heading) and
+before the first numbered workflow step.
+
+Previously: The instruction directed placement "After the
+main workflow instructions, before the `## Guardrails`
+section."
+
+#### Scenario: Future uf-init scaffolding
+
+- **GIVEN** an operator runs `uf init` on a new project
+- **WHEN** Step 10 injects STOP HERE blocks into spec-phase
+  speckit command files
+- **THEN** each STOP HERE block MUST be placed immediately
+  after the `## Outline` heading and before the first
+  numbered step
+
+### Requirement: No duplicate STOP HERE blocks
+
+After the move operation, each affected file MUST contain
+exactly one STOP HERE block. No duplicate blocks SHALL
+remain at the old position.
+
+#### Scenario: Duplicate detection after move
+
+- **GIVEN** the STOP HERE block has been moved in
+  `speckit.tasks.md` or `speckit.plan.md`
+- **WHEN** the file is searched for "STOP HERE"
+  (case-sensitive)
+- **THEN** exactly one match MUST be found
+
+## REMOVED Requirements
+
+_None._

--- a/openspec/changes/fix-speckit-stop-gates/tasks.md
+++ b/openspec/changes/fix-speckit-stop-gates/tasks.md
@@ -1,0 +1,32 @@
+<!--
+  [P] marks tasks eligible for parallel execution.
+  Add [P] when a task: (a) touches different files from
+  other [P] tasks in the group, (b) has no dependency
+  on prior tasks in the group, (c) can safely execute
+  without ordering constraints.
+  Do NOT add [P] when tasks modify the same file --
+  parallel workers will cause merge conflicts.
+  Tasks without [P] run sequentially first, then [P]
+  tasks run in parallel.
+-->
+
+## 1. Move STOP HERE blocks to preamble position
+
+Each file requires removing the STOP HERE block from its
+current position and inserting it immediately after the
+`## Outline` heading, before the first numbered step.
+The block content MUST be preserved exactly.
+
+Fixes: https://github.com/unbound-force/unbound-force/issues/363
+
+- [x] 1.1 [P] Move STOP HERE block in `.opencode/commands/speckit.tasks.md`: Remove the STOP HERE block (lines 70-75) from after Step 5, and insert it immediately after the `## Outline` heading (after line 23), before Step 1. Verify exactly one "STOP HERE" match remains in the file.
+
+- [x] 1.2 [P] Move STOP HERE block in `.opencode/commands/speckit.plan.md`: Remove the STOP HERE block (lines 39-44) from after Step 4, and insert it immediately after the `## Outline` heading (after line 22), before Step 1. Verify exactly one "STOP HERE" match remains in the file.
+
+- [x] 1.3 [P] Update STOP HERE placement instruction in `.opencode/commands/uf-init.md`: In Step 10, change the "Where" instruction (lines 797-799) from "After the main workflow instructions, before the `## Guardrails` section" to "Immediately after the `## Outline` heading (or equivalent section heading), before the first numbered workflow step. If no `## Outline` heading exists, insert before the first numbered step in the file."
+
+## 2. Verification
+
+- [x] 2.1 Verify each affected file contains exactly one STOP HERE block, positioned before the first numbered workflow step. Confirm no content was lost during the move (the block wording and the Guardrails section remain intact and unchanged in each file).
+<!-- spec-review: passed -->
+<!-- code-review: passed -->


### PR DESCRIPTION
## Summary

Fixes the T2 structural weakness (CRITICAL rule placed after the workflow it governs) in `speckit.tasks.md` and `speckit.plan.md`. The "STOP HERE. Do NOT proceed to implementation." phase-boundary blocks were positioned after the workflow steps, allowing LLMs with compressed context to execute the full workflow before encountering the stop instruction.

The fix moves each STOP HERE block to immediately after the `## Outline` heading and before Step 1, so LLMs encounter the stop instruction as a pre-condition. The `uf-init.md` Step 10 scaffold instruction is also updated to prevent the T2 pattern from being re-introduced by future scaffold runs.

Fixes #363

## How to Test

1. Open `.opencode/commands/speckit.tasks.md` and verify the STOP HERE block appears at line 25 (after `## Outline`, before Step 1)
2. Open `.opencode/commands/speckit.plan.md` and verify the STOP HERE block appears at line 24 (after `## Outline`, before Step 1)
3. Open `.opencode/commands/uf-init.md` and verify Step 10's "Where" instruction reads "Immediately after the `## Outline` heading"
4. Run `make check` to confirm all tests pass (including scaffold drift detection for uf-init.md)
5. Verify each file has exactly one "STOP HERE" occurrence: `grep -c "STOP HERE" .opencode/commands/speckit.tasks.md .opencode/commands/speckit.plan.md`

## How to Demo

Trivial instruction-ordering fix -- no demo required. The fix is verifiable by reading the diff: one deletion hunk (old position) and one insertion hunk (new position) per file, with identical block content.

## Key Files Changed

```
.opencode/commands/
  speckit.tasks.md                    STOP HERE moved from line 70 to line 25
  speckit.plan.md                     STOP HERE moved from line 39 to line 24
  uf-init.md                          Step 10 placement instruction updated

internal/scaffold/assets/opencode/commands/
  uf-init.md                          Embedded asset synced with source

openspec/changes/fix-speckit-stop-gates/
  .openspec.yaml                      Change metadata
  proposal.md                         Change proposal + constitution alignment
  design.md                           Technical design decisions
  specs/stop-gate-placement.md        Delta specs with Given/When/Then scenarios
  tasks.md                            Implementation task checklist (all complete)
```

_This PR was generated by /finale (AI-assisted)._
