### PR TITLE
fix(speckit.clarify): require AskUserQuestion tool calls for sequential questioning

### DIFF
--- a/.opencode/commands/speckit.clarify.md
+++ b/.opencode/commands/speckit.clarify.md
@@ -98,6 +98,17 @@ Execution steps:
     - If more than 5 categories remain unresolved, select the top 5 by (Impact * Uncertainty) heuristic.
 
 4. Sequential questioning loop (interactive):
+
+    ---
+    **MANDATORY GATE — AskUserQuestion Required**
+
+    Each question MUST be delivered as a single
+    **AskUserQuestion tool call**. Do NOT present the next
+    question until the previous AskUserQuestion response has
+    been received. Do NOT batch questions together.
+
+    ---
+
     - Present EXACTLY ONE question at a time.
     - For multiple‑choice questions:
        - **Analyze all options** and determine the **most suitable option** based on:
@@ -117,14 +128,16 @@ Execution steps:
        | Short | Provide a different short answer (<=5 words) (Include only if free-form alternative is appropriate) |
 
        - After the table, add: `You can reply with the option letter (e.g., "A"), accept the recommendation by saying "yes" or "recommended", or provide your own short answer.`
+       - Deliver the question using the **AskUserQuestion tool** with options matching the table rows. List the recommended option first with "(Recommended)" appended to its label. Enable custom text for free-form alternatives.
     - For short‑answer style (no meaningful discrete options):
        - Provide your **suggested answer** based on best practices and context.
        - Format as: `**Suggested:** <your proposed answer> - <brief reasoning>`
        - Then output: `Format: Short answer (<=5 words). You can accept the suggestion by saying "yes" or "suggested", or provide your own answer.`
-    - After the user answers:
-       - If the user replies with "yes", "recommended", or "suggested", use your previously stated recommendation/suggestion as the answer.
+       - Deliver the question using the **AskUserQuestion tool** in open-ended mode (no preset options). Include the suggested answer in the question text.
+    - After the AskUserQuestion tool returns a response:
+       - When the AskUserQuestion tool returns "yes", "recommended", or "suggested", use your previously stated recommendation/suggestion as the answer.
        - Otherwise, validate the answer maps to one option or fits the <=5 word constraint.
-       - If ambiguous, ask for a quick disambiguation (count still belongs to same question; do not advance).
+       - If ambiguous, ask for a quick disambiguation via a follow-up **AskUserQuestion tool call** (count still belongs to same question; do not advance).
        - Once satisfactory, record it in working memory (do not yet write to disk) and move to the next queued question.
     - Stop asking further questions when:
        - All critical ambiguities resolved early (remaining queued items become unnecessary), OR

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,12 @@ Each entry follows the format: `- <change-name>: <summary>`.
   label retains supplementary close-semantics confirmation.
   (Spec: openspec/changes/review-council-label-gates/,
   Fixes: #352)
+- `/speckit.clarify`: added mandatory AskUserQuestion tool
+  call gate to sequential questioning loop (step 4);
+  prevents question batching and answer assumption under
+  context compression
+  (Spec: openspec/changes/speckit-clarify-askuser-gate/,
+  Fixes: #364)
 - `/review-council` Code Review Mode: added optional
   Step 7 (GitHub Review Posting) for posting consolidated
   multi-persona council findings as a GitHub PR review;

--- a/openspec/changes/speckit-clarify-askuser-gate/.openspec.yaml
+++ b/openspec/changes/speckit-clarify-askuser-gate/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: unbound-force
+created: 2026-07-31

--- a/openspec/changes/speckit-clarify-askuser-gate/design.md
+++ b/openspec/changes/speckit-clarify-askuser-gate/design.md
@@ -1,0 +1,96 @@
+## Context
+
+The `speckit.clarify` command contains a sequential questioning loop
+(step 4, lines 100-134) that instructs agents to present "EXACTLY ONE
+question at a time" and wait for user responses. This instruction is
+prose-only — no `AskUserQuestion` tool call is specified. Under
+context compression, the prose constraint is not reliably enforced,
+allowing agents to batch questions or assume answers.
+
+This is the same T3 weakness pattern identified in the parent audit
+(issue #346) where the review-pr confirmation gate was bypassed when
+session context was compressed. Other commands in the codebase
+(review-pr, review-council, address-feedback, triage-issue) already
+use explicit `AskUserQuestion` tool call language to enforce
+interaction gates.
+
+## Goals / Non-Goals
+
+### Goals
+- Enforce one-at-a-time questioning via mandatory AskUserQuestion
+  tool calls
+- Prevent question batching under context compression
+- Prevent agents from advancing to the next question without
+  receiving a tool response
+- Follow the established pattern used by other commands
+  (review-pr, review-council, address-feedback)
+
+### Non-Goals
+- Changing the questioning taxonomy or prioritization logic
+- Modifying the spec integration behavior (step 5)
+- Adding session-resume guards (the clarify command does not have
+  the same irreversible side-effect risk as review-pr's GitHub
+  review posting)
+- Modifying the recommendation/suggestion presentation format
+
+## Decisions
+
+### D1: Use AskUserQuestion for both question formats
+
+The clarify command has two question formats: multiple-choice
+(2-5 options) and short-answer (<=5 words). Both MUST use the
+AskUserQuestion tool call. For multiple-choice, the options map
+directly to AskUserQuestion's options parameter. For short-answer,
+the tool call uses open-ended mode (no preset options).
+
+**Rationale**: Consistency. Both formats require user interaction
+and both are vulnerable to the same context compression bypass.
+
+### D2: Add gate language at the structural level, not inline
+
+The AskUserQuestion requirement is added as a structural
+constraint at the beginning of step 4, not scattered inline
+within the formatting instructions. A prominent gate marker
+(similar to review-pr's approach) makes the constraint harder
+to skip during fast-path reasoning.
+
+**Rationale**: The issue root cause is that inline prose
+constraints get lost during context compression. A prominent,
+structurally distinct gate is more resilient.
+
+### D3: Preserve existing formatting instructions
+
+The multiple-choice table format, recommendation presentation,
+and short-answer format instructions remain unchanged. Only the
+delivery mechanism is constrained — the content of each question
+stays the same.
+
+**Rationale**: The formatting instructions are well-designed and
+serve clarity. The fix is about enforcement, not content.
+
+### D4: No scaffold copies needed
+
+Unlike `speckit.testreview.md`, the `speckit.clarify.md` file
+exists only in `.opencode/commands/`. There are no copies in
+`cmd/unbound-force/.opencode/command/` or
+`internal/scaffold/.opencode/command/` that need synchronized
+updates.
+
+**Rationale**: Verified by filesystem search. Only one file
+requires modification.
+
+## Risks / Trade-offs
+
+### Low risk: Over-constraining agent flexibility
+
+Adding mandatory tool calls slightly reduces an agent's ability
+to optimize question presentation. However, the one-at-a-time
+requirement was already the intended behavior — this change
+merely enforces it structurally.
+
+### Mitigated: Pattern drift across commands
+
+Multiple commands now use AskUserQuestion gates. If the tool API
+changes, all commands need updating. This is an acceptable
+coupling — all commands already depend on the same tool, and the
+usage pattern is consistent.

--- a/openspec/changes/speckit-clarify-askuser-gate/proposal.md
+++ b/openspec/changes/speckit-clarify-askuser-gate/proposal.md
@@ -1,0 +1,97 @@
+## Why
+
+The `speckit.clarify` command (lines 100-134) describes a sequential
+questioning loop entirely in prose: "Present EXACTLY ONE question at a
+time", "wait for user to respond". No `AskUserQuestion` tool call is
+specified. Under context compression the one-at-a-time requirement is
+not enforced — an agent can present multiple questions or skip
+straight to processing assumed answers.
+
+This is a T3 weakness (confirmation gate / interaction requirement is
+inline text only, not enforced by a tool call). The parent audit
+(issue #346) identified this pattern as the root cause of the
+review-pr confirmation gate bypass.
+
+Fixes: https://github.com/unbound-force/unbound-force/issues/364
+
+## What Changes
+
+Add explicit `AskUserQuestion` tool call requirements to the
+sequential questioning loop in `.opencode/commands/speckit.clarify.md`
+(step 4, lines 100-134). The prose-only one-at-a-time instruction is
+replaced with mandatory tool call language that survives context
+compression.
+
+## Capabilities
+
+### New Capabilities
+- None
+
+### Modified Capabilities
+- `speckit.clarify sequential questioning`: Each clarification
+  question MUST be delivered via AskUserQuestion tool call, with
+  explicit prohibition on batching or advancing without a tool
+  response
+
+### Removed Capabilities
+- None
+
+## Impact
+
+- **File**: `.opencode/commands/speckit.clarify.md` (step 4,
+  lines ~100-134)
+- **Behavioral**: Agents running `/speckit.clarify` will be
+  constrained to use the AskUserQuestion tool for each question,
+  preventing question batching or answer assumption under context
+  compression
+- **No scaffold copies**: Unlike `speckit.testreview.md`, the
+  `speckit.clarify.md` file does not have copies in
+  `cmd/unbound-force/.opencode/command/` or
+  `internal/scaffold/.opencode/command/`, so only one file
+  requires modification
+- **Backward compatible**: No change to the questioning taxonomy,
+  prioritization logic, or spec integration behavior
+
+## Constitution Alignment
+
+Assessed against the Unbound Force org constitution.
+
+### I. Autonomous Collaboration
+
+**Assessment**: N/A
+
+This change modifies an interactive agent command that inherently
+requires synchronous user interaction (clarification questions).
+It does not affect artifact-based inter-hero communication.
+
+### II. Composability First
+
+**Assessment**: PASS
+
+The change is contained within a single command file. No new
+dependencies are introduced. The speckit.clarify command remains
+independently usable.
+
+### III. Observable Quality
+
+**Assessment**: N/A
+
+This change does not affect machine-parseable output formats or
+provenance metadata. The clarification results are still recorded
+in the spec file with the same format.
+
+### IV. Testability
+
+**Assessment**: PASS
+
+The fix makes the questioning gate structurally enforceable via
+tool calls rather than relying on prose interpretation. The
+presence of AskUserQuestion tool calls in the command output is
+a verifiable observable side effect.
+
+### V. Security by Default
+
+**Assessment**: N/A
+
+No security-sensitive operations, dependencies, or input
+validation paths are affected by this change.

--- a/openspec/changes/speckit-clarify-askuser-gate/specs/askuser-gate/spec.md
+++ b/openspec/changes/speckit-clarify-askuser-gate/specs/askuser-gate/spec.md
@@ -1,0 +1,90 @@
+## ADDED Requirements
+
+### Requirement: AskUserQuestion gate for clarification questions
+
+FR-001: Each clarification question in the sequential questioning
+loop (step 4) MUST be delivered as a single **AskUserQuestion tool
+call**. The agent MUST NOT present the next question until the
+previous AskUserQuestion response has been received. The agent
+MUST NOT batch multiple questions into a single tool call or
+message.
+
+#### Scenario: Multiple-choice question delivery
+
+- **GIVEN** the agent has a multiple-choice clarification question
+  with 2-5 options
+- **WHEN** the agent presents the question to the user
+- **THEN** the agent MUST use the **AskUserQuestion tool** with
+  the options rendered as choices, the recommended option listed
+  first with "(Recommended)" appended to its label, and a custom
+  text option enabled for short free-form answers
+
+#### Scenario: Short-answer question delivery
+
+- **GIVEN** the agent has a short-answer clarification question
+  with no meaningful discrete options
+- **WHEN** the agent presents the question to the user
+- **THEN** the agent MUST use the **AskUserQuestion tool** in
+  open-ended mode (no preset options), with the suggested answer
+  included in the question text
+
+#### Scenario: Context compression resilience
+
+- **GIVEN** the agent is operating under context compression
+  (resumed session, truncated history)
+- **WHEN** the agent reaches the sequential questioning loop
+- **THEN** the AskUserQuestion tool call requirement MUST still
+  be enforced — the tool call is a structural gate, not a
+  prose suggestion that can be optimized away
+
+### Requirement: No advancement without tool response
+
+FR-002: The agent MUST NOT advance to the next queued question,
+record an answer in working memory, or proceed to spec
+integration (step 5) until the AskUserQuestion tool has returned
+a response for the current question.
+
+#### Scenario: Premature advancement prevention
+
+- **GIVEN** the agent has presented a question via AskUserQuestion
+- **WHEN** the AskUserQuestion tool has not yet returned a
+  response
+- **THEN** the agent MUST NOT present the next question, record
+  an assumed answer, or begin spec integration for the current
+  question
+
+### Requirement: Gate marker visibility
+
+FR-003: The AskUserQuestion requirement SHOULD be presented as a
+visually prominent gate marker (bold text, horizontal rule, or
+similar structural separator) to resist fast-path reasoning
+that skips inline constraints.
+
+#### Scenario: Gate marker presence
+
+- **GIVEN** an agent reads the speckit.clarify command file
+- **WHEN** the agent reaches step 4 (sequential questioning loop)
+- **THEN** the AskUserQuestion gate requirement SHOULD be the
+  first instruction encountered, before any formatting details
+
+## MODIFIED Requirements
+
+### Requirement: Sequential questioning loop (step 4)
+
+The existing prose instruction "Present EXACTLY ONE question at a
+time" is replaced with explicit AskUserQuestion tool call
+language. The content and format of questions (multiple-choice
+tables, recommendation presentation, short-answer format) remain
+unchanged.
+
+Previously: "Present EXACTLY ONE question at a time." (prose
+only, no tool specified)
+
+Now: "Each question MUST be delivered as a single AskUserQuestion
+tool call. Do NOT present the next question until the previous
+AskUserQuestion response has been received. Do NOT batch
+questions together."
+
+## REMOVED Requirements
+
+(None -- no existing requirements are removed by this change.)

--- a/openspec/changes/speckit-clarify-askuser-gate/tasks.md
+++ b/openspec/changes/speckit-clarify-askuser-gate/tasks.md
@@ -1,0 +1,85 @@
+<!--
+  [P] marks tasks eligible for parallel execution.
+  Add [P] when a task: (a) touches different files from
+  other [P] tasks in the group, (b) has no dependency
+  on prior tasks in the group, (c) can safely execute
+  without ordering constraints.
+  Do NOT add [P] when tasks modify the same file —
+  parallel workers will cause merge conflicts.
+  Tasks without [P] run sequentially first, then [P]
+  tasks run in parallel.
+-->
+
+## 1. Add AskUserQuestion gate to step 4
+
+All tasks in this group modify the same file
+(`.opencode/commands/speckit.clarify.md`), so none are
+parallel-eligible.
+
+- [x] 1.1 Add a prominent gate marker at the start of step 4
+  (line 100) with horizontal rule and bold header:
+  `**MANDATORY GATE — AskUserQuestion Required**`. Insert
+  the following constraint text immediately after the step 4
+  heading and before the existing "Present EXACTLY ONE question"
+  line:
+  ```
+  Each question MUST be delivered as a single
+  **AskUserQuestion tool call**. Do NOT present the next
+  question until the previous AskUserQuestion response has
+  been received. Do NOT batch questions together.
+  ```
+
+- [x] 1.2 Update the multiple-choice question format (lines
+  102-119) to specify AskUserQuestion tool usage. After the
+  existing Markdown table format instructions, add:
+  ```
+  Deliver the question using the **AskUserQuestion tool**
+  with options matching the table rows. List the
+  recommended option first with "(Recommended)" appended
+  to its label. Enable custom text for free-form
+  alternatives.
+  ```
+
+- [x] 1.3 Update the short-answer question format (lines
+  120-123) to specify AskUserQuestion tool usage. After the
+  existing format instructions, add:
+  ```
+  Deliver the question using the **AskUserQuestion tool**
+  in open-ended mode (no preset options). Include the
+  suggested answer in the question text.
+  ```
+
+- [x] 1.4 Update the "After the user answers" section (lines
+  124-128) to reference the AskUserQuestion tool response
+  rather than generic "user replies". Replace "If the user
+  replies" with "When the AskUserQuestion tool returns a
+  response" to reinforce tool-mediated interaction. Preserve
+  all existing response handling logic (recommendation
+  acceptance, option validation, disambiguation).
+
+## 2. Verification
+
+- [x] 2.1 Verify the modified speckit.clarify.md is valid
+  Markdown and all existing step numbers, heading hierarchy,
+  and cross-references remain intact
+
+- [x] 2.2 Verify constitution alignment: confirm no
+  constitution principles are violated by the change
+  (Testability PASS — tool call is a verifiable gate;
+  Composability PASS — no new dependencies introduced)
+
+- [x] 2.3 Verify no scaffold copies exist that need
+  synchronized updates (confirm speckit.clarify.md is only
+  in `.opencode/commands/`, not in
+  `cmd/unbound-force/.opencode/command/` or
+  `internal/scaffold/.opencode/command/`)
+
+- [x] 2.4 Verify AskUserQuestion pattern consistency: confirm
+  the new AskUserQuestion language uses the same phrasing
+  pattern as existing commands (bold formatting
+  `**AskUserQuestion tool**`, verb pattern "Use the" /
+  "Deliver ... using the", options/open-ended mode
+  terminology). Cross-reference against review-pr.md,
+  address-feedback.md, and triage-issue.md for consistency
+<!-- spec-review: passed -->
+<!-- code-review: passed -->


### PR DESCRIPTION
## Summary

Adds mandatory `AskUserQuestion` tool call enforcement to the
`/speckit.clarify` command's sequential questioning loop (step 4).
Previously, the one-at-a-time questioning requirement was described
in prose only ("Present EXACTLY ONE question at a time"), which
could be bypassed when agents operate under context compression --
allowing question batching or assumed answers.

This is the same T3 weakness pattern identified in the parent audit
(#346) where the `/review-pr` confirmation gate was bypassed under
compressed session context. The fix follows the established
`AskUserQuestion` enforcement pattern already used by 7+ other
commands (`/review-pr`, `/review-council`, `/address-feedback`,
`/triage-issue`, `/opsx-propose`, `/opsx-apply`, `/opsx-archive`).

Fixes #364

## How to Test

1. Open `.opencode/commands/speckit.clarify.md` and navigate to
   step 4 (line 100)
2. Verify the `MANDATORY GATE — AskUserQuestion Required` marker
   is present between horizontal rules (lines 102-110)
3. Verify multiple-choice questions have an AskUserQuestion
   delivery instruction (line 131)
4. Verify short-answer questions have an AskUserQuestion delivery
   instruction (line 136)
5. Verify response handling references the tool response (line 137:
   "After the AskUserQuestion tool returns a response")
6. Run `make check` — all tests pass, lint clean, build succeeds

## How to Demo

Run `/speckit.clarify` on any feature branch with a spec. Observe
that each clarification question is now delivered via
`AskUserQuestion` tool call rather than inline text, preventing
batching and enforcing one-at-a-time interaction.

## Key Files Changed

- `.opencode/commands/speckit.clarify.md` — Added AskUserQuestion
  gate marker, delivery instructions for both question formats,
  and tool-mediated response handling
- `CHANGELOG.md` — Added unreleased entry for this fix
- `openspec/changes/speckit-clarify-askuser-gate/` — OpenSpec
  artifacts (proposal, design, spec with 3 requirements and
  Given/When/Then scenarios, tasks with review markers)

_This PR was generated by /finale (AI-assisted)._
