### PR TITLE
fix(gaze-test-generator): replace advisory compile check with concrete pre-write gate

### DIFF
--- a/.opencode/agents/gaze-test-generator.md
+++ b/.opencode/agents/gaze-test-generator.md
@@ -34,7 +34,7 @@ function, the caller provides:
 
 1. **Source code** — the function's implementation (read from file)
 2. **Fix strategy** — one of: `add_tests`, `add_assertions`,
-   `decompose_and_test`, `decompose`
+   `decompose_and_test`, `decompose`, `verify`
 3. **Contract coverage data** (from `gaze quality --format=json`):
    - `Gaps []SideEffect` — contractual effects not asserted
    - `GapHints []string` — Go code snippets for each gap (parallel)
@@ -58,12 +58,14 @@ function, the caller provides:
 **When**: Function has `fix_strategy: add_tests` (0% line coverage).
 
 Generate a complete test function that:
+
 - Calls the target function with realistic inputs
 - Asserts on each `Gap` using the corresponding `GapHint` as a template
 - Handles `DiscardedReturns` by capturing and asserting the return value
 - Uses table-driven tests if the function has multiple meaningful input variations
 
 **Template**:
+
 ```go
 func TestFunctionName_Description(t *testing.T) {
     // Setup
@@ -92,6 +94,7 @@ assertions near the existing call site for the target function.
 
 **b) Restructure for mapper visibility**: For each `UnmappedAssertion`
 with reason `helper_param` or `inline_call`:
+
 - Read the helper function to understand the wrapping
 - Restructure so the assertion is directly on the target function's
   return value, not through the helper
@@ -146,6 +149,33 @@ for tests to help).
 Report: "Skipped FunctionName — fix strategy is `decompose`
 (complexity N). Reduce complexity first, then generate tests."
 
+### 6. `verify` — Measure Coverage Improvement
+
+**When**: After generating tests via any of the above actions, or
+when explicitly requested to verify coverage impact.
+
+Steps:
+
+1. Record the baseline contract coverage from the input quality data
+   (the `ContractCoverage.Percentage` field from the quality JSON).
+2. After test generation, run:
+
+   ```bash
+   gaze quality --format=json <package>
+   ```
+
+3. Parse the JSON output and extract the new contract coverage
+   percentage for the target function.
+4. Compare before/after and report the delta:
+   - Improvement: "Contract coverage: 25% → 67% (+42%)"
+   - No change: "Contract coverage unchanged at 25% — review
+     generated assertions for mapping to the function's side effects"
+   - No baseline: "Contract coverage: 67% (no prior baseline)"
+
+The verify action does NOT modify any files — it is a read-only
+measurement step. Use it after `add_tests`, `add_assertions`, or
+`add_docs` to confirm the generated code actually improved coverage.
+
 ---
 
 ## Convention Detection
@@ -170,6 +200,7 @@ files to detect and match conventions:
    naming (`testXxx`, `newTestXxx`, `setupXxx`).
 
 If no existing tests exist, use these defaults:
+
 - `package foo_test` for exported, `package foo` for unexported
 - `TestXxx_Description` naming
 - `t.Fatalf` for fatal errors, `t.Errorf` for non-fatal
@@ -183,22 +214,26 @@ Generated tests MUST satisfy these criteria (derived from the
 reviewer-testing agent rubric):
 
 ### Assertion Depth
+
 - Assert specific expected values, not just "no error"
 - Check return values, struct fields, slice contents — not just
   length or nil/non-nil
 - Validate error messages when error behavior is part of the contract
 
 ### Test Isolation
+
 - No shared mutable state between test cases
 - No external network or filesystem access outside the repo
 - No timing-dependent assertions
 
 ### Contract Focus
+
 - Assert on contractual side effects (returns, mutations, I/O)
 - Do NOT assert on incidental effects (internal state, log output)
 - Each assertion should map to a specific `Gap` from the quality data
 
 ### Convention Compliance
+
 - Use only `testing` package — no testify, gomega, or external libs
 - Use `t.Errorf` / `t.Fatalf` directly
 - Compatible with `-race -count=1`
@@ -217,7 +252,11 @@ For each target function, output:
 3. **File target**: Which `*_test.go` file to write to
 4. **Verification**: Whether the code compiles and tests pass
 
-After generating all code, run:
+After generating all code, run a final integrity check across all
+modified packages. Individual files have already been verified by
+the pre-write compile gate (see Important Constraints). This final
+check is a full-package verification:
+
 ```bash
 go build ./path/to/package/...
 go test -race -count=1 -run "TestGeneratedFunctionName" ./path/to/package/...
@@ -237,6 +276,14 @@ added, compilation status, test pass/fail.
   guess at the function signature
 - ALWAYS read existing tests before adding assertions — do not
   duplicate existing coverage
-- ALWAYS verify generated code compiles before reporting success
+- Before any Write or Edit tool call that modifies a Go source
+  or test file, MUST run compile verification:
+  1. Run via bash: `go build ./path/to/package/...` (scoped to
+     the target package being modified)
+  2. If the command exits with non-zero code, MUST NOT proceed
+     with the Write or Edit call. Report the compilation error
+     and continue to the next target.
+  3. Only proceed with the Write or Edit call after a successful
+     (exit code 0) compile check.
 - When adding to an existing file, preserve all existing content —
   append only, never delete or modify existing tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,16 @@ Each entry follows the format: `- <change-name>: <summary>`.
   (Spec: openspec/changes/improve-finale-pr-description/)
 
 ### Fixed
+- `gaze-test-generator` agent: replaced advisory compile
+  verification prose ("ALWAYS verify generated code compiles")
+  with a concrete pre-write compile gate protocol. The agent
+  now MUST run `go build` before any Write or Edit tool call
+  and halt if compilation fails. Resolves T3 weakness where
+  the advisory check could be skipped under context compression.
+  Also resolves existing drift between the active copy (242
+  lines) and the canonical scaffold copy (278 lines).
+  (Spec: openspec/changes/fix-gaze-test-generator-compile-gate/,
+  Fixes: unbound-force/gaze#204)
 - `uf init --force` no longer hangs on Dewey re-indexing.
   Dewey indexing now runs with `--no-embeddings` for a fast
   metadata-only pass. Run `dewey index` separately to

--- a/openspec/changes/fix-gaze-test-generator-compile-gate/.openspec.yaml
+++ b/openspec/changes/fix-gaze-test-generator-compile-gate/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: unbound-force
+created: 2026-07-31

--- a/openspec/changes/fix-gaze-test-generator-compile-gate/design.md
+++ b/openspec/changes/fix-gaze-test-generator-compile-gate/design.md
@@ -1,0 +1,142 @@
+## Context
+
+The `gaze-test-generator` agent generates Go test code, GoDoc
+improvements, and assertion restructurings based on gaze quality
+analysis data. It writes generated code to disk using the Write
+and Edit tools. The agent's "Important Constraints" section
+(line 240/276) says "ALWAYS verify generated code compiles before
+reporting success" but provides no concrete protocol for how or
+when to verify.
+
+The parent audit (issue #346) identified that advisory prose
+gates are systematically bypassed under context compression.
+The fix pattern established in that audit is to replace advisory
+text with concrete tool call sequences and explicit halt
+conditions.
+
+The agent file exists in three locations that must stay in sync:
+- `internal/scaffold/.opencode/agents/gaze-test-generator.md`
+  (canonical scaffold -- 278 lines)
+- `.opencode/agents/gaze-test-generator.md` (active runtime
+  copy -- 242 lines, currently drifted from scaffold)
+- `cmd/unbound-force/.opencode/agents/gaze-test-generator.md`
+  (embedded copy -- 278 lines, matches scaffold)
+
+The active copy is an older version missing the `verify` action
+section and some formatting differences. This change resolves
+that drift as part of the sync step. The existing drift
+detection tests (`internal/scaffold/scaffold_test.go`) do NOT
+cover the gaze-test-generator agent file -- it is listed in
+`knownNonEmbeddedFiles` as local-only tooling.
+
+## Goals / Non-Goals
+
+### Goals
+- Replace advisory compile verification prose with a concrete
+  pre-write gate protocol
+- Specify the exact bash command, failure handling, and halt
+  condition
+- Maintain consistency across all three copies of the agent file
+- Follow the T3 remediation pattern from issue #346
+
+### Non-Goals
+- Modifying the gaze-fix command (`/gaze fix`) -- it already has
+  its own verification step in Step 4
+- Adding compile gates to other agents -- that is separate work
+  tracked in the parent audit
+- Changing the agent's tool permissions or mode
+- Introducing the pre-flight skill dependency -- the compile
+  check is simple enough to inline as `go build`
+
+## Decisions
+
+### D1: Inline compile gate, not pre-flight skill delegation
+
+The pre-flight skill is designed for CI-aware, multi-tool
+execution with coverage matrices and baseline classification.
+The gaze-test-generator needs a single `go build` check before
+each write. Delegating to pre-flight would add unnecessary
+complexity and make the agent harder to reason about.
+
+Decision: Inline the compile check as a concrete 3-step protocol
+in the agent's "Important Constraints" section.
+
+### D2: Gate placement -- before Write, not after all generation
+
+The issue specifies "before any Write tool call." This is the
+correct placement because:
+- Writing non-compiling code to disk is the harmful action
+- A post-generation check allows broken files to persist
+- Per-write gating catches each file individually
+
+Decision: The gate fires before each Write/Edit tool call, not
+as a batch check after all generation.
+
+### D3: Compile scope -- package-level, not full repo
+
+Running `go build ./...` (full repo) after each generated test
+file is expensive and may surface pre-existing errors unrelated
+to the generated code. Running `go build ./path/to/package/...`
+scopes the check to the package being modified.
+
+Decision: Use `go build ./path/to/package/...` scoped to the
+target package. This matches the existing pattern in the Output
+Format section (line 222/258).
+
+### D4: Resolve drift and sync all three copies
+
+The scaffold copy (`internal/scaffold/`) is the canonical source.
+The active copy (`.opencode/agents/`) has drifted -- it is 36
+lines shorter, missing the `verify` action section added in a
+later scaffold update. The embedded copy (`cmd/unbound-force/`)
+matches the scaffold. No automated drift detection test covers
+these files.
+
+Decision: Apply the compile gate changes to the scaffold copy
+first. Then sync the active and embedded copies to match the
+scaffold. This resolves the existing drift as a side effect.
+Verification uses explicit `diff` commands rather than relying
+on the scaffold drift detection tests (which exclude this file).
+
+## Risks / Trade-offs
+
+### Risk: False negatives from pre-existing build errors
+
+If the target project already has compilation errors, the gate
+will block all writes even though the generated code is correct.
+
+Mitigation: The gate instruction specifies to report the error
+context, allowing the user to identify pre-existing vs generated
+errors. This is acceptable -- writing into a non-compiling
+codebase is itself a risky action.
+
+### Risk: Agent may still skip the gate under extreme compression
+
+No amount of prose can guarantee LLM compliance. However, the
+concrete 3-step protocol with an explicit "MUST NOT" halt
+condition is significantly more resistant to fast-path skipping
+than advisory prose.
+
+### Trade-off: Per-write compilation adds latency
+
+Running `go build` before each write adds variable latency:
+~1-3 seconds per file with a warm build cache, potentially
+10-30+ seconds on a cold cache or for large dependency trees.
+For batch operations processing 10+ functions, this adds
+meaningful overhead. The Go build cache mitigates repeated
+builds of the same package. No per-package deduplication is
+specified -- each write triggers its own check, which is
+correct because the prior write may have introduced new errors.
+This is acceptable because correctness outweighs speed for
+code generation.
+
+### Note: Overlap with /gaze fix verification
+
+The `/gaze fix` command (`.opencode/commands/gaze-fix.md`,
+Step 4) already has its own post-generation compile and test
+verification. When `/gaze fix` invokes the gaze-test-generator
+agent, generated code will be verified twice: once by the
+agent's pre-write gate and once by `/gaze fix`'s Step 4. This
+is intentional defense-in-depth -- the pre-write gate catches
+errors before they reach disk; the batch check provides a
+final integrity verification across all modified packages.

--- a/openspec/changes/fix-gaze-test-generator-compile-gate/proposal.md
+++ b/openspec/changes/fix-gaze-test-generator-compile-gate/proposal.md
@@ -1,0 +1,113 @@
+## Why
+
+The `gaze-test-generator` agent (`.opencode/agents/gaze-test-generator.md`)
+contains a compile verification rule at line 240/276: "ALWAYS verify
+generated code compiles before reporting success." This is advisory
+prose only -- there is no concrete tool call sequence specified, no
+gate enforcement, and no instruction to halt before writing if
+compilation fails.
+
+This is a T3 weakness (required verification step is inline text
+only, not enforced as a concrete tool call). Under context
+compression or fast-path reasoning, an agent can skip compilation
+checking entirely and write test files that do not compile.
+
+The parent audit (unbound-force/unbound-force#346) identified this
+pattern across multiple agent files. The gaze-test-generator is the
+most impactful instance because it generates code that is written
+to disk via the Write tool -- writing non-compiling tests is worse
+than skipping the check for a read-only report.
+
+Fixes: unbound-force/gaze#204
+
+## What Changes
+
+Harden the `gaze-test-generator` agent to enforce compile
+verification as a concrete, mandatory gate before any Write tool
+call. The advisory prose "ALWAYS verify generated code compiles"
+is replaced with an explicit pre-write protocol specifying exact
+tool calls and halt conditions.
+
+## Capabilities
+
+### New Capabilities
+- `compile-gate`: Mandatory compile verification gate before any
+  Write tool call in the gaze-test-generator agent. Specifies the
+  exact bash command, failure behavior, and halt condition.
+
+### Modified Capabilities
+- `gaze-test-generator`: The "Important Constraints" and "Output
+  Format" sections are updated to include the concrete compile-gate
+  protocol instead of advisory prose.
+
+### Removed Capabilities
+- None
+
+## Impact
+
+- **Files**: `internal/scaffold/.opencode/agents/gaze-test-generator.md`
+  (canonical scaffold copy -- primary modification target),
+  `.opencode/agents/gaze-test-generator.md` (active runtime copy),
+  `cmd/unbound-force/.opencode/agents/gaze-test-generator.md`
+  (embedded copy)
+- **Existing drift**: The active copy (242 lines) is an older
+  version of the scaffold copy (278 lines). It is missing the
+  `verify` action section and has a different scaffolded-by
+  marker. This change resolves the drift by syncing the active
+  copy to match the scaffold copy after applying the compile
+  gate modifications.
+- **Behavior**: The agent will now be instructed to run `go build`
+  before writing files and to halt (not write) if compilation
+  fails. This may cause the agent to report more errors instead
+  of silently writing broken tests.
+- **Drift detection**: The existing drift detection tests in
+  `internal/scaffold/` do not cover the gaze-test-generator
+  agent file (it is listed in `knownNonEmbeddedFiles`). A manual
+  diff verification step is included in the tasks.
+
+## Constitution Alignment
+
+Assessed against the Unbound Force org constitution (v1.2.0).
+
+### I. Autonomous Collaboration
+
+**Assessment**: N/A
+
+This change modifies an agent's internal instruction set. It does
+not affect artifact-based communication between heroes or
+inter-hero protocols. The gaze-test-generator continues to consume
+gaze quality JSON artifacts and produce test files independently.
+
+### II. Composability First
+
+**Assessment**: PASS
+
+The compile-gate uses `go build ./...`, which is universally
+available in any Go project. No new dependencies are introduced.
+The gaze-test-generator remains independently usable on any Go
+project.
+
+### III. Observable Quality
+
+**Assessment**: PASS
+
+The compile-gate adds a concrete verification step that produces
+observable, machine-parseable output (go build exit code and error
+output). This strengthens quality observability -- compilation
+status was previously unverified advisory text.
+
+### IV. Testability
+
+**Assessment**: PASS
+
+The change enforces verification of observable side effects (does
+the generated code compile?) before writing. This directly aligns
+with the testability principle's requirement that "test contracts
+MUST verify observable side effects."
+
+### V. Security by Default
+
+**Assessment**: N/A
+
+This change does not introduce dependencies, modify file
+permissions, handle external inputs, or alter privilege boundaries.

--- a/openspec/changes/fix-gaze-test-generator-compile-gate/specs/compile-gate.md
+++ b/openspec/changes/fix-gaze-test-generator-compile-gate/specs/compile-gate.md
@@ -1,0 +1,145 @@
+## ADDED Requirements
+
+### Requirement: FR-001 Pre-Write Compile Gate
+
+The gaze-test-generator agent MUST run a compile verification
+check before any Write or Edit tool call that modifies a Go
+source file or test file. The check MUST use the bash tool to
+execute `go build ./path/to/package/...` scoped to the target
+package. If the compile check exits with a non-zero exit code,
+the agent MUST NOT proceed with the Write or Edit tool call.
+The agent MUST report the compilation error and halt file
+writing for that target.
+
+#### Scenario: Successful compile before write
+
+- **GIVEN** the agent has generated a test function for
+  package `internal/foo`
+- **WHEN** the agent runs `go build ./internal/foo/...` and
+  the command exits with code 0
+- **THEN** the agent proceeds with the Write tool call to
+  create or append to the test file
+
+#### Scenario: Failed compile before write
+
+- **GIVEN** the agent has generated a test function for
+  package `internal/foo`
+- **WHEN** the agent runs `go build ./internal/foo/...` and
+  the command exits with a non-zero code
+- **THEN** the agent MUST NOT execute the Write tool call
+- **AND** the agent reports the compilation error output
+- **AND** the agent continues processing remaining target
+  functions (does not abort the entire batch)
+
+#### Scenario: Compile gate for doc improvements (Edit tool)
+
+- **GIVEN** the agent has generated a GoDoc improvement for
+  a function in package `internal/bar`
+- **WHEN** the agent runs `go build ./internal/bar/...` after
+  composing the doc comment change and the command exits with
+  code 0
+- **THEN** the agent proceeds with the Edit tool call to
+  modify the source file
+
+#### Scenario: Failed compile before Edit tool call
+
+- **GIVEN** the agent has composed a GoDoc improvement for
+  a function in package `internal/bar`
+- **WHEN** the agent runs `go build ./internal/bar/...` and
+  the command exits with a non-zero code
+- **THEN** the agent MUST NOT execute the Edit tool call
+- **AND** the original file content is preserved unchanged
+- **AND** the agent reports the compilation error output
+- **AND** the agent continues processing remaining target
+  functions
+
+#### Scenario: Toolchain failure vs compilation error
+
+- **GIVEN** the agent attempts to run `go build` but the Go
+  toolchain is not available (e.g., `go` not in PATH, wrong
+  Go version, module download failure)
+- **WHEN** the bash command returns a non-zero exit code
+- **THEN** the agent MUST NOT proceed with the Write or Edit
+  call (same gate behavior as a compilation error)
+- **AND** the agent reports the environmental error clearly,
+  distinguishing it from a code compilation error where
+  possible
+
+### Requirement: FR-002 Compile Gate Protocol Specification
+
+The compile gate MUST be specified as a numbered protocol in
+the agent's "Important Constraints" section, not as advisory
+prose. The protocol MUST include:
+1. The exact bash command to run
+2. The exit code check
+3. The explicit halt condition (MUST NOT write)
+
+This ensures the gate is not skippable under context
+compression, following the T3 remediation pattern from
+issue #346.
+
+#### Scenario: Protocol is structurally verifiable
+
+- **GIVEN** the agent file at
+  `internal/scaffold/.opencode/agents/gaze-test-generator.md`
+- **WHEN** the Important Constraints section is inspected
+- **THEN** it contains a numbered list with at least 3 steps
+- **AND** the list uses RFC 2119 "MUST NOT" language for the
+  halt condition
+- **AND** the list includes a concrete `go build` command
+
+## MODIFIED Requirements
+
+### Requirement: FR-003 Output Format Verification Order
+
+Previously: "After generating all code, run: `go build`..."
+
+The Output Format section's post-generation compile check
+SHOULD remain as a final batch verification, but the pre-write
+gate (FR-001) MUST take precedence. The Output Format section
+MUST note that individual files have already passed compilation
+via the pre-write gate, and the final batch check serves as a
+full-repo integrity verification.
+
+#### Scenario: Batch verification after individual gates
+
+- **GIVEN** the agent has written 3 test files, each passing
+  the pre-write compile gate individually
+- **WHEN** the agent reaches the Output Format verification step
+- **THEN** the agent runs `go build ./...` as a final integrity
+  check across all modified packages
+- **AND** reports the aggregate compilation status
+
+### Requirement: FR-004 Important Constraints Section Update
+
+Previously: "ALWAYS verify generated code compiles before
+reporting success"
+
+The bullet point reading "ALWAYS verify generated code compiles
+before reporting success" (line 240 in the active copy, line 276
+in the scaffold/embedded copies) MUST be replaced with the
+concrete compile gate protocol (FR-002). The replacement text
+MUST use MUST NOT language for the halt condition, not ALWAYS
+advisory language.
+
+**Coverage strategy**: This change modifies agent Markdown files
+only -- no new Go source code is introduced. Verification is
+structural: the agent file contains the numbered protocol with
+MUST NOT language, and all three copies are byte-identical
+(excluding the scaffolded-by marker). Drift detection uses
+explicit `diff` commands (the scaffold drift detection tests do
+not cover this file).
+
+#### Scenario: Constraint replacement
+
+- **GIVEN** the current text reads "ALWAYS verify generated
+  code compiles before reporting success"
+- **WHEN** the change is applied
+- **THEN** the text is replaced with a numbered pre-write
+  protocol specifying the bash command, exit code check, and
+  MUST NOT halt condition
+
+## REMOVED Requirements
+
+None -- no existing requirements are removed. The advisory
+prose is replaced with a stronger, concrete version.

--- a/openspec/changes/fix-gaze-test-generator-compile-gate/tasks.md
+++ b/openspec/changes/fix-gaze-test-generator-compile-gate/tasks.md
@@ -1,0 +1,105 @@
+<!--
+  [P] marks tasks eligible for parallel execution.
+  Add [P] when a task: (a) touches different files from
+  other [P] tasks in the group, (b) has no dependency
+  on prior tasks in the group, (c) can safely execute
+  without ordering constraints.
+  Do NOT add [P] when tasks modify the same file --
+  parallel workers will cause merge conflicts.
+  Tasks without [P] run sequentially first, then [P]
+  tasks run in parallel.
+-->
+
+## 1. Update canonical scaffold agent file
+
+- [x] 1.1 Replace advisory compile prose in Important Constraints
+  - File: `internal/scaffold/.opencode/agents/gaze-test-generator.md`
+  - Replace the bullet reading "ALWAYS verify generated code
+    compiles before reporting success" (line 276) with the
+    concrete pre-write compile gate protocol:
+    ```
+    - Before any Write or Edit tool call that modifies a Go
+      source or test file, MUST run compile verification:
+      1. Run via bash: `go build ./path/to/package/...`
+         (scoped to the target package)
+      2. If the command exits with non-zero code, MUST NOT
+         proceed with the Write or Edit call. Report the
+         compilation error and continue to the next target.
+      3. Only proceed with the Write or Edit call after a
+         successful (exit code 0) compile check.
+    ```
+
+- [x] 1.2 Update Output Format section to reference pre-write gate
+  - File: `internal/scaffold/.opencode/agents/gaze-test-generator.md`
+  - In the Output Format section (around line 255, after the
+    `go build` command), add a note that individual files have
+    already been verified by the pre-write compile gate, and
+    this final check is a full-package integrity verification.
+
+## 2. Sync copies from canonical scaffold
+
+- [x] 2.1 [P] Sync active runtime copy from scaffold
+  - Source: `internal/scaffold/.opencode/agents/gaze-test-generator.md`
+  - Target: `.opencode/agents/gaze-test-generator.md`
+  - The active copy is currently 242 lines (an older version
+    missing the `verify` action section). Copy the full
+    updated scaffold content, then restore the active copy's
+    scaffolded-by marker on line 16:
+    `<!-- scaffolded by gaze v1.4.6 -->`
+  - This resolves the existing drift between the active and
+    scaffold copies.
+
+- [x] 2.2 [P] Sync embedded CLI copy from scaffold
+  - Source: `internal/scaffold/.opencode/agents/gaze-test-generator.md`
+  - Target: `cmd/unbound-force/.opencode/agents/gaze-test-generator.md`
+  - The embedded copy MUST be byte-identical to the scaffold
+    copy (both use `<!-- scaffolded by gaze dev -->`).
+
+## 3. Verification
+
+- [x] 3.1 Verify copy consistency with explicit diff
+  - The scaffold drift detection tests do NOT cover the
+    gaze-test-generator agent file (it is listed in
+    `knownNonEmbeddedFiles`). Verify manually:
+    ```bash
+    diff <(sed '16d' internal/scaffold/.opencode/agents/gaze-test-generator.md) \
+         <(sed '16d' .opencode/agents/gaze-test-generator.md)
+    diff internal/scaffold/.opencode/agents/gaze-test-generator.md \
+         cmd/unbound-force/.opencode/agents/gaze-test-generator.md
+    ```
+  - First diff: scaffold vs active (excluding line 16
+    scaffolded-by marker) must produce no output.
+  - Second diff: scaffold vs embedded must produce no output.
+
+- [x] 3.2 Run full build and test suite
+  - Command: `make check` (or `go build ./... && go test -race -count=1 ./... && golangci-lint run`)
+  - Verify no regressions from the agent file changes.
+
+- [x] 3.3 Verify constitution alignment
+  - Confirm the change aligns with Principle III (Observable
+    Quality) by adding a concrete verification step that
+    produces observable output.
+  - Confirm the change aligns with Principle IV (Testability)
+    by enforcing verification of observable side effects before
+    writing.
+  - No new dependencies introduced (Principle II).
+
+## 4. Documentation Gate
+
+- [x] 4.1 Assess CHANGELOG entry
+  - Add a CHANGELOG.md entry:
+    `fix: harden gaze-test-generator compile verification gate`
+  - This is a behavioral change to the agent (it will now halt
+    instead of writing broken tests), warranting a changelog
+    entry.
+
+- [x] 4.2 Assess documentation issue
+  - This change modifies internal agent behavior (the
+    gaze-test-generator's pre-write verification protocol).
+    It does not change user-facing CLI commands, workflows, or
+    hero capabilities. Exempt from documentation issue
+    requirement per AGENTS.md: "Exempt: internal refactoring,
+    test-only, CI-only, spec artifacts."
+
+<!-- spec-review: passed -->
+<!-- code-review: passed -->


### PR DESCRIPTION
## Summary

The `gaze-test-generator` agent's compile verification was advisory
prose only ("ALWAYS verify generated code compiles before reporting
success"). Under context compression or fast-path reasoning, this
check could be skipped, allowing the agent to write non-compiling
test files to disk.

This PR replaces the advisory text with a concrete 3-step pre-write
compile gate protocol using MUST NOT halt language. The agent now
runs `go build ./path/to/package/...` before any Write or Edit tool
call and halts if compilation fails.

Also resolves existing drift between the active copy (previously 242
lines) and the canonical scaffold copy (278 lines, now 289 with the
compile gate).

Fixes: unbound-force/gaze#204
Parent audit: #346

## How to Test

1. Open `.opencode/agents/gaze-test-generator.md` and verify:
   - Lines 279-287 contain the numbered compile gate protocol
   - The protocol uses `MUST NOT proceed` (not `ALWAYS verify`)
   - Lines 255-258 reference the "pre-write compile gate"
2. Verify build and tests pass:
   ```bash
   go build ./...
   go test -race -count=1 ./...
   ```
3. Verify the old advisory text is gone:
   ```bash
   grep "ALWAYS verify generated code compiles" \
     .opencode/agents/gaze-test-generator.md
   # Should return no results
   ```

## How to Demo

Invoke the `gaze-test-generator` agent (via `/gaze fix`) on a Go
project. The agent should now run `go build` before each Write/Edit
call and report compilation errors instead of writing broken tests.

## Key Files Changed

- `.opencode/agents/gaze-test-generator.md` — Active agent copy:
  advisory compile prose replaced with 3-step compile gate protocol;
  Output Format section updated; existing drift resolved (synced
  from scaffold, gaining the `verify` action section)
- `CHANGELOG.md` — Added fix entry under Unreleased/Fixed
- `openspec/changes/fix-gaze-test-generator-compile-gate/` — Full
  OpenSpec change artifacts (proposal, design, specs with FR-001
  through FR-004, tasks)

_This PR was generated by /finale (AI-assisted)._
