### PR TITLE
fix(finale): add AskUserQuestion gate before git push

### DIFF
--- a/.opencode/commands/finale.md
+++ b/.opencode/commands/finale.md
@@ -161,9 +161,28 @@ d. Commit with the approved message.
 git rev-parse --abbrev-ref @{upstream} 2>/dev/null
 ```
 
-- If no upstream: `git push -u origin <branch>`
-- If upstream exists: `git push`
-- If push fails: report error and **STOP**.
+Fetch the remote branch state to detect divergence:
+
+```bash
+git fetch origin <branch>
+git status
+```
+
+**If branch has diverged** (the remote has commits not
+in the local branch): warn the user about the divergence
+before presenting the confirmation gate.
+
+Use the **AskUserQuestion tool** with options
+`["Push to remote", "Abort -- keep commits local"]`.
+
+- If the user selects **"Push to remote"**:
+  - If no upstream: `git push -u origin <branch>`
+  - If upstream exists: `git push`
+  - If push fails: report error and **STOP**. Do not
+    proceed to Step 5 or any subsequent steps.
+- If the user selects **"Abort -- keep commits local"**:
+  report that local commits are preserved and **STOP**.
+  Do not proceed to Step 5 or any subsequent steps.
 
 ### 5. Create or Find PR
 

--- a/internal/scaffold/assets/opencode/commands/finale.md
+++ b/internal/scaffold/assets/opencode/commands/finale.md
@@ -161,9 +161,28 @@ d. Commit with the approved message.
 git rev-parse --abbrev-ref @{upstream} 2>/dev/null
 ```
 
-- If no upstream: `git push -u origin <branch>`
-- If upstream exists: `git push`
-- If push fails: report error and **STOP**.
+Fetch the remote branch state to detect divergence:
+
+```bash
+git fetch origin <branch>
+git status
+```
+
+**If branch has diverged** (the remote has commits not
+in the local branch): warn the user about the divergence
+before presenting the confirmation gate.
+
+Use the **AskUserQuestion tool** with options
+`["Push to remote", "Abort -- keep commits local"]`.
+
+- If the user selects **"Push to remote"**:
+  - If no upstream: `git push -u origin <branch>`
+  - If upstream exists: `git push`
+  - If push fails: report error and **STOP**. Do not
+    proceed to Step 5 or any subsequent steps.
+- If the user selects **"Abort -- keep commits local"**:
+  report that local commits are preserved and **STOP**.
+  Do not proceed to Step 5 or any subsequent steps.
 
 ### 5. Create or Find PR
 

--- a/openspec/changes/finale-push-gate/.openspec.yaml
+++ b/openspec/changes/finale-push-gate/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: unbound-force
+created: 2026-07-31

--- a/openspec/changes/finale-push-gate/design.md
+++ b/openspec/changes/finale-push-gate/design.md
@@ -1,0 +1,120 @@
+# Finale Push Gate — Design
+
+## Context
+
+Step 4 of `/finale` (lines 157-166) executes `git push`
+without a human confirmation gate. The
+`askuser-tool-confirmations` change standardized
+AskUserQuestion gates across `/review-pr`,
+`/address-feedback`, and `/triage-issue`, but did not
+cover `/finale`. This leaves a T1 weakness: an
+irreversible external action without mandatory
+confirmation.
+
+The `/address-feedback` command (section 4.4) already
+implements the reference pattern: AskUserQuestion with
+structured action-context options before `git push`.
+
+Per the proposal's constitution alignment, this change
+directly supports Principle V (Security by Default) by
+adding a structural security control before an
+irreversible external action.
+
+## Goals / Non-Goals
+
+### Goals
+- Add AskUserQuestion gate before `git push` in
+  `/finale` Step 4
+- Follow the established pattern from
+  `/address-feedback` section 4.4
+- Update both the command file and its scaffold asset
+  copy to remain byte-identical
+- Option labels include action context (what will
+  happen), not bare yes/no
+
+### Non-Goals
+- Refactoring other parts of `/finale`
+- Adding confirmation gates to other `/finale` steps
+  (PR creation in Step 5 already has interactive
+  elements)
+- Changing the push behavior itself (upstream
+  detection, error handling)
+
+## Decisions
+
+### D1: Gate placement before push, after divergence check
+
+Place the AskUserQuestion gate after the upstream/
+divergence check but before the actual `git push`
+command. This ensures the user sees the branch state
+before confirming.
+
+**Rationale**: The user needs to know what they are
+pushing. Showing the divergence check result before
+asking for confirmation gives the user context to
+make an informed decision. This matches the
+`/address-feedback` pattern where `git fetch` and
+`git status` run before the confirmation gate.
+
+### D2: Structured options with action-context labels
+
+Use AskUserQuestion with options:
+`["Push to remote", "Abort -- keep commits local"]`
+
+**Rationale**: Follows D2 from the
+`askuser-tool-confirmations` design -- option labels
+describe consequences, not bare yes/no. "Abort -- keep
+commits local" tells the user their commits are
+preserved, reducing anxiety about data loss.
+
+### D3: Unconditional gate (always ask)
+
+The gate fires on every push, not only on divergence.
+Unlike `/address-feedback` which only gates on
+divergence, `/finale` gates unconditionally because it
+is the final publishing step in the workflow.
+
+**Rationale**: `/finale` is the terminal workflow
+command. Every push from `/finale` deserves explicit
+confirmation because it represents the transition from
+"local work" to "public submission." The cost of one
+extra confirmation is negligible compared to the risk
+of an accidental push.
+
+### D4: Dual-file update (command + scaffold asset)
+
+Both files must be updated:
+1. `.opencode/commands/finale.md`
+2. `internal/scaffold/assets/opencode/commands/finale.md`
+
+**Rationale**: The scaffold drift detection test
+verifies that embedded assets match their canonical
+sources. Updating only one file would cause test
+failures.
+
+## Risks / Trade-offs
+
+### R1: Extra confirmation step adds friction
+
+**Risk**: Users who run `/finale` expect a streamlined
+flow. Adding a confirmation gate adds one interaction.
+
+**Mitigation**: The gate is a single selection, not
+free-text. The `/address-feedback` change proved this
+pattern is lightweight. The security benefit of
+preventing accidental pushes outweighs the minor
+friction.
+
+### R2: Context compression may lose the gate
+
+**Risk**: Per issue #346, compression can summarize
+away mandatory gates.
+
+**Mitigation**: The gate is placed in a short,
+structurally distinct section (Step 4) that is unlikely
+to be compressed away. The Step 4 section is already
+concise (10 lines). If future work adds
+session-resume guards (as in the `review-pr` change),
+`/finale` would benefit from the same pattern. This
+is out of scope for this change but noted as a future
+consideration.

--- a/openspec/changes/finale-push-gate/proposal.md
+++ b/openspec/changes/finale-push-gate/proposal.md
@@ -1,0 +1,113 @@
+# Finale Push Gate
+
+## Why
+
+Step 4 of `/finale` ("Push to Remote") executes `git push`
+immediately after a divergence check with no AskUserQuestion
+gate before the push command. Pushing to a remote is an
+irreversible external action -- once pushed, code becomes
+public on the remote and is only reversible by additional
+commits.
+
+Per the policy established by issue #346: every irreversible
+external action requires a mandatory AskUserQuestion gate
+immediately before execution. The `/address-feedback` command
+already follows this pattern (section 4.4), having been
+updated by the `askuser-tool-confirmations` change. The
+`/finale` command was not covered by that change.
+
+This is weakness type T1: irreversible external action without
+mandatory AskUserQuestion immediately before it.
+
+Fixes: #348
+
+## What Changes
+
+Add a mandatory AskUserQuestion confirmation gate in Step 4 of
+the `/finale` command, immediately before the `git push`
+execution. The gate uses structured options with
+action-context labels adapted from the `/address-feedback`
+section 4.4 pattern. Unlike `/address-feedback` which gates
+only on divergence, `/finale` gates unconditionally because
+it is the terminal publishing step in the workflow.
+
+Additionally, Step 4 gains a divergence warning (`git fetch`
++ `git status`) before the gate so the user sees the branch
+state before confirming. The current Step 4 only checks
+whether an upstream is set; it does not fetch remote state.
+
+Both the `.opencode/commands/finale.md` command file and its
+scaffold asset copy at
+`internal/scaffold/assets/opencode/commands/finale.md` must
+be updated to remain byte-identical.
+
+## Capabilities
+
+### New Capabilities
+- `finale-push-confirmation`: AskUserQuestion gate before
+  `git push` in `/finale` Step 4, with structured options
+  `["Push to remote", "Abort -- keep commits local"]`.
+
+### Modified Capabilities
+- `/finale` Step 4: Push is no longer automatic; requires
+  explicit human confirmation via AskUserQuestion tool
+  before execution.
+
+### Removed Capabilities
+- None
+
+## Impact
+
+- `.opencode/commands/finale.md` -- Step 4 push section
+  (lines ~157-166)
+- `internal/scaffold/assets/opencode/commands/finale.md` --
+  scaffold copy must mirror the command file exactly
+
+No Go source code, tests, or CI workflows are affected.
+This is a command-file-only change.
+
+## Constitution Alignment
+
+Assessed against the Unbound Force org constitution.
+
+### I. Autonomous Collaboration
+
+**Assessment**: N/A
+
+This change modifies a slash command's interaction flow.
+It does not affect artifact-based communication or
+inter-hero collaboration patterns.
+
+### II. Composability First
+
+**Assessment**: N/A
+
+This change does not introduce dependencies between
+heroes or affect standalone functionality.
+
+### III. Observable Quality
+
+**Assessment**: N/A
+
+This change does not affect machine-parseable output
+or provenance metadata.
+
+### IV. Testability
+
+**Assessment**: N/A
+
+This is a markdown command file change. The scaffold
+drift detection test (`internal/scaffold/`) will verify
+that both copies remain in sync.
+
+### V. Security by Default
+
+**Assessment**: PASS
+
+This change directly strengthens security by adding
+a mandatory human confirmation gate before an
+irreversible external action (git push). It enforces
+the principle that security controls are structural,
+not review-time afterthoughts. The AskUserQuestion
+gate prevents accidental or unauthorized pushes when
+the agent operates under a human's identity.

--- a/openspec/changes/finale-push-gate/specs/finale-push-confirmation.md
+++ b/openspec/changes/finale-push-gate/specs/finale-push-confirmation.md
@@ -1,0 +1,81 @@
+## ADDED Requirements
+
+### Requirement: FR-001 Mandatory push confirmation gate
+
+The `/finale` command MUST present an AskUserQuestion
+gate immediately before executing `git push` in Step 4
+("Push to Remote"). The gate MUST use structured
+options with action-context labels:
+`["Push to remote", "Abort -- keep commits local"]`.
+
+The agent MUST NOT execute `git push` unless the user
+selects "Push to remote".
+
+If the user selects "Abort -- keep commits local", the
+agent MUST stop the push operation, report that local
+commits are preserved, and **STOP** the `/finale` workflow
+(do not proceed to Step 5 or any subsequent steps).
+
+#### Scenario: User confirms push
+
+- **GIVEN** the agent has completed Step 3 (commit)
+  and is in Step 4 (Push to Remote)
+- **WHEN** the agent reaches the push execution point
+- **THEN** the agent MUST present an AskUserQuestion
+  with options `["Push to remote",
+  "Abort -- keep commits local"]`
+- **AND** only execute `git push` if the user selects
+  "Push to remote"
+
+#### Scenario: User aborts push
+
+- **GIVEN** the agent has completed Step 3 and is in
+  Step 4
+- **WHEN** the agent presents the AskUserQuestion gate
+  and the user selects "Abort -- keep commits local"
+- **THEN** the agent MUST NOT execute `git push`
+- **AND** the agent MUST report that local commits are
+  preserved
+- **AND** the agent MUST **STOP** the `/finale` workflow
+  (do not proceed to Step 5 or any subsequent steps)
+
+#### Scenario: Branch divergence detected
+
+- **GIVEN** the agent is in Step 4 and has detected
+  that the local and remote branches have diverged
+- **WHEN** the agent reaches the push execution point
+- **THEN** the agent MUST warn the user about the
+  divergence before presenting the AskUserQuestion
+  gate
+- **AND** the gate options MUST still be
+  `["Push to remote", "Abort -- keep commits local"]`
+
+### Requirement: FR-002 Scaffold asset parity
+
+The scaffold asset copy at
+`internal/scaffold/assets/opencode/commands/finale.md`
+MUST be updated to be byte-identical with the command
+file at `.opencode/commands/finale.md`.
+
+#### Scenario: Drift detection passes
+
+- **GIVEN** both copies of `finale.md` exist
+- **WHEN** the scaffold drift detection test runs
+- **THEN** both files MUST have identical content
+- **AND** the test MUST pass
+
+## MODIFIED Requirements
+
+### Requirement: Step 4 push flow
+
+Previously: Step 4 executed `git push` (or
+`git push -u origin <branch>`) immediately after the
+upstream check with no user confirmation.
+
+Now: Step 4 MUST include an AskUserQuestion gate
+between the upstream/divergence check and the actual
+`git push` execution.
+
+## REMOVED Requirements
+
+None.

--- a/openspec/changes/finale-push-gate/tasks.md
+++ b/openspec/changes/finale-push-gate/tasks.md
@@ -1,0 +1,53 @@
+<!--
+  [P] marks tasks eligible for parallel execution.
+  Add [P] when a task: (a) touches different files from
+  other [P] tasks in the group, (b) has no dependency
+  on prior tasks in the group, (c) can safely execute
+  without ordering constraints.
+  Do NOT add [P] when tasks modify the same file --
+  parallel workers will cause merge conflicts.
+  Tasks without [P] run sequentially first, then [P]
+  tasks run in parallel.
+-->
+
+## 1. Add AskUserQuestion gate to finale Step 4
+
+- [x] 1.1 Update `.opencode/commands/finale.md` Step 4
+  ("Push to Remote", lines 157-166). Replace the
+  current push block with:
+  1. Keep the existing upstream check
+     (`git rev-parse --abbrev-ref @{upstream}`)
+  2. Add a divergence warning: fetch the remote branch
+     state with `git fetch origin <branch>` and
+     `git status` before the gate
+  3. Add AskUserQuestion gate immediately before
+     `git push` with options:
+     `["Push to remote", "Abort -- keep commits local"]`
+  4. Only execute `git push` (or
+     `git push -u origin <branch>`) if the user selects
+     "Push to remote"
+  5. If the user selects "Abort -- keep commits local",
+     report that local commits are preserved and
+     **STOP**
+  6. Keep the existing push failure handling
+
+## 2. Update scaffold asset copy
+
+- [x] 2.1 Copy the updated `.opencode/commands/finale.md`
+  to `internal/scaffold/assets/opencode/commands/finale.md`
+  so both files are byte-identical. This satisfies
+  FR-002 (scaffold asset parity) and ensures the
+  scaffold drift detection test passes.
+
+## 3. Verification
+
+- [x] 3.1 Run `make check` to verify lint, tests,
+  and build all pass. The scaffold drift detection
+  test MUST pass, confirming both copies are
+  byte-identical.
+- [x] 3.2 Verify constitution alignment: confirm the
+  change supports Principle V (Security by Default)
+  by adding a structural security control before an
+  irreversible external action.
+<!-- spec-review: passed -->
+<!-- code-review: passed -->


### PR DESCRIPTION
## Summary

Add a mandatory AskUserQuestion confirmation gate before
`git push` in `/finale` Step 4 ("Push to Remote"). This
closes a T1 security weakness where an irreversible
external action was executed without human confirmation.

The gate presents structured options with action-context
labels: `["Push to remote", "Abort -- keep commits local"]`.
Divergence detection (`git fetch` + `git status`) runs
before the gate so the user has full context before
confirming.

Fixes: #348

## How to Test

1. Run `/finale` on any branch with committed changes
2. At Step 4, verify the agent presents an
   AskUserQuestion with options "Push to remote" and
   "Abort -- keep commits local"
3. Selecting "Push to remote" should proceed with push
4. Selecting "Abort" should stop the workflow and
   report that commits are preserved
5. Verify scaffold parity:
   `diff .opencode/commands/finale.md internal/scaffold/assets/opencode/commands/finale.md`

## How to Demo

Run `/finale` on a feature branch. Observe that Step 4
now pauses for human confirmation before pushing,
whereas previously it pushed immediately.

## Key Files Changed

**Commands:**
- `.opencode/commands/finale.md` — Step 4 push section
  updated with AskUserQuestion gate and divergence
  detection
- `internal/scaffold/assets/opencode/commands/finale.md`
  — byte-identical scaffold asset copy

**OpenSpec artifacts:**
- `openspec/changes/finale-push-gate/proposal.md` —
  change proposal with constitution alignment
- `openspec/changes/finale-push-gate/design.md` —
  design decisions (D1-D4)
- `openspec/changes/finale-push-gate/specs/finale-push-confirmation.md`
  — FR-001, FR-002 with Given/When/Then scenarios
- `openspec/changes/finale-push-gate/tasks.md` —
  task breakdown (all complete)

_This PR was generated by /finale (AI-assisted)._
