### PR TITLE
fix(openspec-propose): enforce dirty-tree guard with AskUserQuestion tool call

### DIFF
--- a/.opencode/commands/opsx-propose.md
+++ b/.opencode/commands/opsx-propose.md
@@ -43,18 +43,38 @@ When ready to implement, run /unleash (autonomous) or /opsx-apply (sequential)
 
    a. **Dirty working tree check**: Run `git status --short`.
       If there are uncommitted changes (staged, unstaged,
-      or untracked files that appear related to work):
-      - **STOP** and ask the user for confirmation before
-        switching branches. Show what uncommitted changes
-        exist and warn that switching branches with a
-        dirty working tree may cause changes to be
-        applied to the wrong branch.
-      - If the user confirms, proceed. If not, abort.
-      - Exception: if the user explicitly requested a
-        new change in the same message (e.g.,
-        `/opsx-propose fix-typos`), this still requires
-        confirmation -- never silently switch branches
-        with uncommitted work.
+      or untracked files that appear related to work),
+      switching branches may cause those changes to appear
+      on the wrong branch. The agent MUST confirm with the
+      user before proceeding — never silently switch
+      branches with uncommitted work, even if the user
+      explicitly requested a new change in the same message
+      (e.g., `/opsx-propose fix-typos`).
+
+      When `git status --short` output is non-empty, invoke
+      the **AskUserQuestion tool** with:
+      - **Question**: Include the full `git status --short`
+        output, the target branch name (`opsx/<name>`), and
+        a warning that switching branches with uncommitted
+        changes may cause changes to appear on the wrong
+        branch.
+      - **Options**: `["Stash changes and continue",
+        "Abort — keep changes as-is"]`
+
+      The agent MUST NOT run `git checkout -b` until the
+      user responds.
+
+      - If the user selects **"Abort — keep changes as-is"**:
+        stop the workflow and report that the operation was
+        aborted due to uncommitted changes.
+      - If the user selects **"Stash changes and continue"**:
+        run `git stash`. If `git stash` exits with a
+        non-zero exit code, abort and report the stash
+        failure. After a successful stash, re-run
+        `git status --short` — if the output is still
+        non-empty, abort and report the remaining
+        uncommitted changes. Only proceed to branch
+        creation when the working tree is confirmed clean.
 
    b. **Branch check**: Check the current branch:
       - If already on `opsx/<name>` (exact match): skip

--- a/.opencode/skills/openspec-propose/SKILL.md
+++ b/.opencode/skills/openspec-propose/SKILL.md
@@ -50,18 +50,41 @@ When ready to implement, run /unleash (autonomous) or /opsx-apply (sequential)
 
    a. **Dirty working tree check**: Run `git status --short`.
       If there are uncommitted changes (staged, unstaged,
-      or untracked files that appear related to work):
-      - **STOP** and ask the user for confirmation before
-        switching branches. Show what uncommitted changes
-        exist and warn that switching branches with a
-        dirty working tree may cause changes to be
-        applied to the wrong branch.
-      - If the user confirms, proceed. If not, abort.
-      - Exception: if the user explicitly requested a
-        new change in the same message (e.g.,
-        `/opsx:propose fix-typos`), this still requires
-        confirmation -- never silently switch branches
-        with uncommitted work.
+      or untracked files that appear related to work),
+      switching branches may cause those changes to appear
+      on the wrong branch. The agent MUST confirm with the
+      user before proceeding — never silently switch
+      branches with uncommitted work, even if the user
+      explicitly requested a new change in the same message
+      (e.g., `/opsx:propose fix-typos`).
+
+      **When `git status --short` output is non-empty, the
+      agent MUST invoke the AskUserQuestion tool** with:
+      - **Question**: Include the full `git status --short`
+        output, the target branch name (`opsx/<name>`), and
+        a warning that switching branches with uncommitted
+        changes may cause changes to appear on the wrong
+        branch.
+      - **Options** (exactly two):
+        1. "Stash changes and continue"
+        2. "Abort — keep changes as-is"
+
+      The agent MUST NOT run `git checkout -b` until the
+      user responds.
+
+      - If the user selects **"Abort — keep changes as-is"**:
+        stop the workflow and report that the propose was
+        aborted due to uncommitted changes.
+      - If the user selects **"Stash changes and continue"**:
+        1. Run `git stash`.
+        2. If `git stash` exits with a non-zero exit code,
+           abort and report the stash failure.
+        3. Run `git status --short` again to verify the
+           working tree is clean.
+        4. If the output is still non-empty, abort and
+           report the remaining uncommitted changes.
+        5. Only when the working tree is confirmed clean,
+           proceed to branch creation.
 
    b. **Branch check**: Check the current branch:
       - If already on `opsx/<name>` (exact match): skip

--- a/openspec/changes/fix-dirty-tree-guard/.openspec.yaml
+++ b/openspec/changes/fix-dirty-tree-guard/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: unbound-force
+created: 2026-07-31

--- a/openspec/changes/fix-dirty-tree-guard/design.md
+++ b/openspec/changes/fix-dirty-tree-guard/design.md
@@ -1,0 +1,125 @@
+## Context
+
+The `openspec-propose` skill and its companion `opsx-propose` command
+both include a dirty-tree guard before `git checkout -b`. The guard
+describes checking `git status --short` and asking the user before
+switching branches with uncommitted changes. However, the enforcement
+is prose-only — no AskUserQuestion tool call is specified.
+
+This is a T1 (prose-only gate) + T3 (no session-resume guard) weakness.
+Under context compression, the prose reasoning can be dropped,
+causing silent branch switches with uncommitted work.
+
+## Goals / Non-Goals
+
+### Goals
+- Replace prose-only dirty-tree guard with explicit AskUserQuestion
+  tool-call enforcement in both files
+- Provide concrete options ("Stash changes and continue" /
+  "Abort — keep changes as-is") so the guard is unambiguous
+- Ensure the guard survives context compression by being expressed
+  as a tool-call instruction, not reasoning prose
+
+### Non-Goals
+- Adding automated stashing logic (the agent already knows how to
+  `git stash`; the guard's job is to get confirmation, not automate
+  the recovery)
+- Fixing the same prose-only guard in other files (see Known
+  Remaining Instances below) — those are tracked separately
+- Changing the branch-check logic (part b of the guard)
+- Adding session-resume guards (T3 weakness is lower priority and
+  would require a broader pattern across all skills; tracked in
+  parent audit issue #346)
+
+## Decisions
+
+### D1: AskUserQuestion with two fixed options
+
+The guard will use AskUserQuestion with exactly two options:
+1. "Stash changes and continue"
+2. "Abort — keep changes as-is"
+
+**Rationale**: These match the issue's specification (#350). A third
+option like "Continue without stashing" would risk data loss and is
+intentionally excluded. The tool-call format ensures the guard cannot
+be optimized away during compression.
+
+### D2: Identical fix in both files
+
+Both `.opencode/skills/openspec-propose/SKILL.md` and
+`.opencode/commands/opsx-propose.md` receive the same fix. The
+dirty-tree guard sections are nearly identical across the two files.
+
+**Rationale**: The skill and command files are independent entry points
+to the same workflow. Both must be hardened.
+
+### D3: Preserve existing prose, augment with tool call
+
+The existing prose describing the dirty-tree check is retained. The
+AskUserQuestion call is added immediately after the detection step,
+before any `git checkout -b`. This avoids rewriting the entire section.
+
+**Rationale**: The prose provides useful context for the agent (what
+to check, why it matters). The tool call provides enforcement. Both
+are needed.
+
+### D4: Guard placement — after detection, before checkout
+
+The AskUserQuestion call is placed between the "detect dirty tree"
+step and the "execute git checkout -b" step. The agent MUST NOT
+proceed to checkout until the user responds.
+
+**Rationale**: This mirrors the issue's recommended fix location
+("around line 54" in the skill file).
+
+## Risks / Trade-offs
+
+### Risk: Dual-file maintenance burden
+Both files must stay in sync. If one is updated without the other,
+the guard diverges.
+
+**Mitigation**: The proposal notes this explicitly. The two files are
+rarely edited independently, and the change is small enough that
+divergence risk is low.
+
+### Risk: AskUserQuestion not available in all runtimes
+Some agent runtimes may not support AskUserQuestion.
+
+**Mitigation**: The instructions already assume AskUserQuestion
+availability (it's used in step 1 of the same skill for "what do you
+want to build?"). This is not a new dependency.
+
+### Trade-off: No automated stash
+The user must manually decide. This adds friction on the happy path
+when users intentionally have dirty trees.
+
+**Accepted**: The friction is intentional. Silent branch switches are
+more dangerous than a confirmation prompt.
+
+## Known Remaining Instances
+
+The same T1 (prose-only dirty-tree guard) vulnerability exists in at
+least five additional files. These are intentionally out of scope for
+this change (scoped to the two files from issues #350 and #353) but
+are documented here to prevent a false sense of complete closure:
+
+| File | Guard Location |
+|------|---------------|
+| `.opencode/skills/openspec-archive-change/SKILL.md` | ~line 73 |
+| `.opencode/skills/speckit-workflow/SKILL.md` | ~line 123 |
+| `.opencode/commands/speckit.specify.md` | ~line 42 |
+| `.opencode/commands/cobalt-crush.md` | ~line 102 |
+| `.opencode/commands/speckit.implement.md` | ~line 141 |
+
+A follow-up issue should be filed to harden all remaining instances
+with the same AskUserQuestion pattern established by this change.
+
+## Coverage Strategy
+
+This change modifies Markdown instruction files (agent skill and
+command files), not Go source code. Automated unit/integration/e2e
+tests are not applicable. Verification is through structural
+inspection of the modified files (tasks 2.1 and 2.2), confirming
+that the AskUserQuestion tool-call instruction is present and
+correctly placed. This satisfies Constitution Principle IV's intent
+for content-only changes.

--- a/openspec/changes/fix-dirty-tree-guard/proposal.md
+++ b/openspec/changes/fix-dirty-tree-guard/proposal.md
@@ -1,0 +1,88 @@
+## Why
+
+The `openspec-propose` skill (`SKILL.md`) and its companion command
+(`opsx-propose.md`) both describe a dirty-tree guard before
+`git checkout -b` — but the guard exists only in prose. No explicit
+`AskUserQuestion` tool call is specified to enforce user confirmation.
+
+Under context compression (long sessions, large tool outputs), the
+prose-only guard reasoning can be omitted by the agent, causing it to
+silently switch branches despite uncommitted changes. This is a
+T1 (prose-only gate) + T3 (no session-resume guard) weakness pattern
+identified in the parent audit (issue #346).
+
+Fixes: #350, #353
+
+## What Changes
+
+Replace the prose-only dirty-tree guard in both files with an explicit
+`AskUserQuestion` tool call that forces the agent to obtain user
+confirmation before proceeding with `git checkout -b` when uncommitted
+changes are detected.
+
+## Capabilities
+
+### New Capabilities
+- None (this is a hardening fix, not a new feature)
+
+### Modified Capabilities
+- `dirty-tree-guard`: Upgraded from prose-only description to explicit
+  AskUserQuestion enforcement with concrete options
+  ("Stash changes and continue" / "Abort — keep changes as-is")
+
+### Removed Capabilities
+- None
+
+## Impact
+
+- **Files affected**:
+  - `.opencode/skills/openspec-propose/SKILL.md` (lines 51-64)
+  - `.opencode/commands/opsx-propose.md` (lines 44-57)
+- **Behavioral change**: Agents following these instructions will now
+  be required to invoke the AskUserQuestion tool (not just reason about
+  asking) when uncommitted changes are detected. This makes the guard
+  resilient to context compression.
+- **Risk**: Low. The change is additive — it strengthens an existing
+  guard without altering the happy path (clean working tree).
+
+## Constitution Alignment
+
+Assessed against the Unbound Force org constitution.
+
+### I. Autonomous Collaboration
+
+**Assessment**: N/A
+
+This change modifies agent instruction artifacts (skill and command
+files), not inter-hero communication or artifact exchange formats.
+
+### II. Composability First
+
+**Assessment**: N/A
+
+No dependencies are introduced or modified. The skill and command
+remain independently usable.
+
+### III. Observable Quality
+
+**Assessment**: N/A
+
+No machine-parseable output or provenance metadata is affected.
+
+### IV. Testability
+
+**Assessment**: PASS
+
+The fix is verifiable: an agent following the updated instructions
+MUST invoke the AskUserQuestion tool (an observable side effect) when
+`git status --short` produces output. This is testable by reviewing
+agent behavior in a dirty-tree scenario.
+
+### V. Security by Default
+
+**Assessment**: PASS
+
+This change directly improves security posture by closing a gate
+bypass vulnerability. The prose-only guard allowed silent branch
+switches with uncommitted work — a data integrity risk. The explicit
+tool-call enforcement ensures the gate cannot be optimized away.

--- a/openspec/changes/fix-dirty-tree-guard/specs/dirty-tree-guard-enforcement.md
+++ b/openspec/changes/fix-dirty-tree-guard/specs/dirty-tree-guard-enforcement.md
@@ -1,0 +1,93 @@
+## ADDED Requirements
+
+### Requirement: FR-001 — Explicit AskUserQuestion on dirty tree detection
+
+When `git status --short` produces any non-empty output (staged,
+unstaged, or untracked files), the agent MUST invoke the
+AskUserQuestion tool before proceeding to `git checkout -b`.
+
+The AskUserQuestion prompt MUST include:
+- The full output of `git status --short`
+- The target branch name (`opsx/<name>`)
+- A warning that switching branches with uncommitted changes may
+  cause changes to appear on the wrong branch
+
+The AskUserQuestion MUST offer exactly two options:
+
+1. "Stash changes and continue"
+2. "Abort — keep changes as-is"
+
+The agent MUST NOT execute `git checkout -b` until the user has
+responded. If the user selects "Abort", the agent MUST stop the
+workflow and report that the change was not created.
+
+If the user selects "Stash changes and continue", the agent MUST
+run `git stash` before proceeding to `git checkout -b`. After
+`git stash`, the agent MUST verify that `git status --short`
+returns empty output before proceeding. If output is still
+non-empty, the agent MUST abort and report the remaining
+uncommitted changes.
+
+If `git stash` returns a non-zero exit code, the agent MUST NOT
+proceed to `git checkout -b`. The agent MUST report the stash
+failure and abort the workflow.
+
+#### Scenario: Dirty tree detected — user confirms stash
+
+- **GIVEN** the working tree has uncommitted changes
+- **WHEN** the agent runs `git status --short` and output is non-empty
+- **THEN** the agent MUST invoke AskUserQuestion with options
+  "Stash changes and continue" and "Abort — keep changes as-is"
+- **AND** if the user selects "Stash changes and continue"
+- **THEN** the agent MUST run `git stash` and proceed to
+  `git checkout -b opsx/<name>`
+
+#### Scenario: Dirty tree detected — user aborts
+
+- **GIVEN** the working tree has uncommitted changes
+- **WHEN** the agent runs `git status --short` and output is non-empty
+- **THEN** the agent MUST invoke AskUserQuestion with options
+  "Stash changes and continue" and "Abort — keep changes as-is"
+- **AND** if the user selects "Abort — keep changes as-is"
+- **THEN** the agent MUST NOT execute `git checkout -b`
+- **AND** the agent MUST report that the operation was aborted
+
+#### Scenario: Stash fails after user confirms
+
+- **GIVEN** the working tree has uncommitted changes
+- **WHEN** the user selects "Stash changes and continue"
+- **AND** `git stash` returns a non-zero exit code
+- **THEN** the agent MUST NOT execute `git checkout -b`
+- **AND** the agent MUST report the stash failure to the user
+
+#### Scenario: Partial stash — uncommitted changes remain
+
+- **GIVEN** the working tree has uncommitted changes
+- **WHEN** the user selects "Stash changes and continue"
+- **AND** `git stash` succeeds (exit code 0)
+- **BUT** `git status --short` still produces non-empty output
+- **THEN** the agent MUST NOT execute `git checkout -b`
+- **AND** the agent MUST report the remaining uncommitted changes
+
+#### Scenario: Clean working tree — no prompt
+
+- **GIVEN** the working tree has no uncommitted changes
+- **WHEN** the agent runs `git status --short` and output is empty
+- **THEN** the agent MUST proceed directly to branch creation
+  without invoking AskUserQuestion for dirty-tree confirmation
+
+## MODIFIED Requirements
+
+### Requirement: FR-002 — Dirty tree guard applies to both files
+
+The dirty-tree guard with AskUserQuestion enforcement MUST be
+present in both:
+- `.opencode/skills/openspec-propose/SKILL.md`
+- `.opencode/commands/opsx-propose.md`
+
+Previously: The guard was described in prose only, without specifying
+AskUserQuestion as the enforcement mechanism.
+
+## REMOVED Requirements
+
+None.

--- a/openspec/changes/fix-dirty-tree-guard/tasks.md
+++ b/openspec/changes/fix-dirty-tree-guard/tasks.md
@@ -1,0 +1,25 @@
+<!--
+  [P] marks tasks eligible for parallel execution.
+  Add [P] when a task: (a) touches different files from
+  other [P] tasks in the group, (b) has no dependency
+  on prior tasks in the group, (c) can safely execute
+  without ordering constraints.
+  Do NOT add [P] when tasks modify the same file —
+  parallel workers will cause merge conflicts.
+  Tasks without [P] run sequentially first, then [P]
+  tasks run in parallel.
+-->
+
+## 1. Add AskUserQuestion enforcement to dirty-tree guard
+
+- [x] 1.1 [P] Update `.opencode/skills/openspec-propose/SKILL.md` — in the "Dirty working tree check" subsection under step 3 ("Create and checkout a branch"), augment the prose-only dirty-tree guard with an explicit AskUserQuestion tool call. After `git status --short` detects any non-empty output, add instruction to invoke AskUserQuestion showing the `git status` output, target branch name, and a warning. Options: "Stash changes and continue" / "Abort — keep changes as-is". Agent MUST NOT proceed to `git checkout -b` until user responds. If user selects "Abort", stop workflow. If user selects "Stash", run `git stash`, verify `git status --short` is empty, then proceed. If `git stash` fails (non-zero exit), abort and report.
+
+- [x] 1.2 [P] Update `.opencode/commands/opsx-propose.md` — apply the identical fix to the companion command file's "Dirty working tree check" subsection under step 3. Same AskUserQuestion enforcement, same options, same stash failure handling, same behavior as task 1.1.
+
+## 2. Verification
+
+- [x] 2.1 Verify both files contain an explicit AskUserQuestion tool-call instruction in the dirty-tree guard section with options "Stash changes and continue" / "Abort — keep changes as-is". Verify the tool-call instruction appears after the `git status --short` detection step and before any `git checkout -b` instruction. Confirm no prose-only guard exists as the sole enforcement mechanism without an accompanying AskUserQuestion tool-call instruction (existing prose context per D3 is retained alongside the tool call).
+
+- [x] 2.2 Verify constitution alignment — confirm the changes do not introduce runtime coupling (Principle I), mandatory dependencies (Principle II), or untestable components (Principle IV). Confirm the fix strengthens Security by Default (Principle V) by closing a gate bypass.
+<!-- spec-review: passed -->
+<!-- code-review: passed -->


### PR DESCRIPTION
## Summary

Closes the T1 (prose-only gate) vulnerability in the `openspec-propose` skill and
`opsx-propose` command identified in issues #350 and #353.

Both files had a dirty-tree guard before `git checkout -b` that described "asking the
user for confirmation" in prose only. Under context compression (long sessions, large
tool outputs), this prose reasoning could be dropped by the agent, causing silent branch
switches with uncommitted work — a data integrity risk.

The fix replaces the prose-only guard with an explicit `AskUserQuestion` tool-call
instruction that cannot be optimized away. The guard now requires:
- Showing the user the `git status` output, target branch, and a warning
- Two options: "Stash changes and continue" / "Abort — keep changes as-is"
- Stash failure handling (non-zero exit → abort)
- Post-stash verification (git status must be empty after stash)

Fixes #350, #353

## How to Test

1. Start an `/opsx-propose` session with a dirty working tree (uncommitted changes).
   Verify the agent invokes AskUserQuestion with two options instead of silently
   switching branches.
2. Select "Abort" — verify the workflow stops without switching branches.
3. Select "Stash" — verify `git stash` runs and the tree is verified clean before checkout.
4. Open both files and verify the AskUserQuestion instruction appears in section 3a
   ("Dirty working tree check"), after `git status --short` and before `git checkout -b`.

## How to Demo

Open `.opencode/skills/openspec-propose/SKILL.md` and navigate to the "Dirty working
tree check" subsection. The prose-only "ask the user" language has been replaced with
an explicit AskUserQuestion tool-call block specifying options, stash handling, and
verification. The same change is mirrored in `.opencode/commands/opsx-propose.md`.

## Key Files Changed

**Implementation:**
- `.opencode/skills/openspec-propose/SKILL.md` (+23 lines) — AskUserQuestion enforcement added to dirty-tree guard
- `.opencode/commands/opsx-propose.md` (+20 lines) — identical fix in companion command

**OpenSpec artifacts:**
- `openspec/changes/fix-dirty-tree-guard/proposal.md` — change proposal with constitution alignment
- `openspec/changes/fix-dirty-tree-guard/design.md` — technical design with known remaining instances
- `openspec/changes/fix-dirty-tree-guard/specs/dirty-tree-guard-enforcement.md` — delta spec (FR-001, FR-002)
- `openspec/changes/fix-dirty-tree-guard/tasks.md` — implementation checklist (all tasks complete)

_This PR was generated by /finale (AI-assisted)._
