### PR TITLE
fix(skill): elevate branch-safety rule to pre-condition in openspec-apply-change

### DIFF
--- a/.opencode/skills/openspec-apply-change/SKILL.md
+++ b/.opencode/skills/openspec-apply-change/SKILL.md
@@ -15,6 +15,8 @@ Implement tasks from an OpenSpec change.
 
 **Steps**
 
+**Pre-condition**: Before any step, verify: NEVER switch branches or suggest archiving with uncommitted changes. Run `git status --short` if branch state is uncertain.
+
 1. **Select the change**
 
    If a name is provided, use it. Otherwise:

--- a/openspec/changes/fix-apply-change-branch-guard/.openspec.yaml
+++ b/openspec/changes/fix-apply-change-branch-guard/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: unbound-force
+created: 2026-07-31

--- a/openspec/changes/fix-apply-change-branch-guard/design.md
+++ b/openspec/changes/fix-apply-change-branch-guard/design.md
@@ -1,0 +1,83 @@
+## Context
+
+The `openspec-apply-change` skill file places a CRITICAL branch-
+safety rule ("NEVER switch branches or suggest archiving with
+uncommitted changes") at line 212, inside the Guardrails section
+at the end of a 219-line file. Agents processing the file
+sequentially encounter Step 8's completion flow (which suggests
+archiving) at lines 139-149 before reaching the constraint that
+prohibits it with uncommitted changes.
+
+This is a documented T2 weakness pattern: a MANDATORY rule placed
+after the workflow it governs.
+
+The proposal's constitution alignment confirmed this change is N/A
+for all principles -- it modifies agent instructions only, with no
+impact on artifact formats, composability, or testability.
+
+## Goals / Non-Goals
+
+### Goals
+- Ensure agents encounter the branch-safety constraint BEFORE any
+  workflow step that could trigger a violation
+- Add a pre-condition block immediately after the "Steps" heading
+  and before Step 1
+- Retain the existing guardrail text for completeness (belt and
+  suspenders)
+
+### Non-Goals
+- Rewriting or restructuring the entire SKILL.md file
+- Addressing the same T2 pattern in other skill files (#355, #361)
+- Adding runtime enforcement or tooling changes
+- Modifying any Go source code
+
+## Decisions
+
+### D1: Pre-condition block placement
+
+Insert a `**Pre-condition**` block between the `**Steps**` heading
+(line 16) and Step 1 (line 18). This ensures the constraint is the
+first thing an agent reads when entering the workflow.
+
+**Rationale**: The issue specifies this exact placement. A pre-
+condition is semantically correct -- it describes something that
+MUST be verified before any step executes, not a step itself.
+
+### D2: Keep existing Guardrails entry
+
+The existing guardrail at line 212 remains unchanged. Having the
+rule in both places (pre-condition and guardrails) provides
+defense-in-depth: agents that skip to the guardrails section
+still encounter it.
+
+**Rationale**: Removing the guardrail entry would weaken coverage
+for agents that process guardrails first (e.g., during planning
+or review rather than execution).
+
+### D3: Pre-condition text includes actionable verification
+
+The pre-condition text includes the `git status --short` command
+as the verification mechanism, matching the issue's suggested fix.
+
+**Rationale**: A constraint without a verification method is
+unenforceable. Including the command makes the rule actionable.
+
+## Risks / Trade-offs
+
+### Risk: Duplication of the rule in two locations
+
+The same rule appears in both the pre-condition and guardrails.
+Future edits might update one but not the other.
+
+**Mitigation**: The pre-condition is short (2 lines) and
+references the same concept. The guardrails entry is also brief.
+Drift risk is low for such a focused rule.
+
+### Trade-off: Minimal change vs. full restructure
+
+A more thorough fix would audit the entire file for other T2
+patterns. This change scopes narrowly to the reported issue.
+
+**Accepted**: The sibling issues (#355, #361) track the same
+pattern in other files. Each fix is intentionally scoped to
+one file per issue.

--- a/openspec/changes/fix-apply-change-branch-guard/proposal.md
+++ b/openspec/changes/fix-apply-change-branch-guard/proposal.md
@@ -1,0 +1,90 @@
+## Why
+
+The `openspec-apply-change/SKILL.md` contains a CRITICAL/MANDATORY
+rule at line 212 -- "NEVER switch branches or suggest archiving with
+uncommitted changes" -- buried in the Guardrails section at the end
+of a 219-line file. An agent executing the workflow sequentially
+reaches and acts on branch-switching suggestions (e.g., Step 8's
+completion flow at lines 139-149) before encountering this
+constraint.
+
+This is a T2 weakness: a CRITICAL rule placed after the workflow
+it governs. The fix is to elevate it to a pre-condition block
+before Step 1, ensuring agents encounter the constraint before
+any workflow step that might violate it.
+
+Fixes: https://github.com/unbound-force/unbound-force/issues/359
+
+Related sibling issues with the same T2 pattern:
+- #355 (cobalt-crush.md)
+- #361 (speckit-workflow/SKILL.md)
+
+## What Changes
+
+Elevate the branch-safety guardrail from the end-of-file Guardrails
+section to a **Pre-condition** block placed immediately after the
+"Steps" heading and before Step 1. The rule remains in Guardrails
+as well (for completeness), but the pre-condition ensures agents
+process it before any workflow step.
+
+## Capabilities
+
+### New Capabilities
+- None
+
+### Modified Capabilities
+- `openspec-apply-change skill`: Branch-safety rule promoted to
+  pre-condition position, ensuring agents encounter it before
+  executing any workflow step
+
+### Removed Capabilities
+- None
+
+## Impact
+
+- **File**: `.opencode/skills/openspec-apply-change/SKILL.md`
+- **Behavioral**: Agents will encounter the "NEVER switch branches
+  with uncommitted changes" rule before Step 1, reducing the risk
+  of branch-switching violations during implementation workflows
+- **No runtime code changes**: This is a skill file (agent
+  instruction) modification only
+
+## Constitution Alignment
+
+Assessed against the Unbound Force org constitution.
+
+### I. Autonomous Collaboration
+
+**Assessment**: N/A
+
+This change modifies agent instructions, not artifact formats
+or inter-hero communication. No impact on autonomous collaboration.
+
+### II. Composability First
+
+**Assessment**: N/A
+
+No dependencies are introduced or modified. The skill file remains
+standalone and independently usable.
+
+### III. Observable Quality
+
+**Assessment**: N/A
+
+No machine-parseable output or provenance metadata is affected.
+This is an agent instruction ordering fix.
+
+### IV. Testability
+
+**Assessment**: N/A
+
+No testable components are added or modified. The change is to
+a Markdown skill file that guides agent behavior.
+
+### V. Security by Default
+
+**Assessment**: N/A
+
+No security-sensitive operations, supply chain changes, input
+validation, or dependency modifications are introduced. This is
+an agent instruction ordering fix.

--- a/openspec/changes/fix-apply-change-branch-guard/specs/branch-safety-precondition.md
+++ b/openspec/changes/fix-apply-change-branch-guard/specs/branch-safety-precondition.md
@@ -1,0 +1,47 @@
+## ADDED Requirements
+
+### Requirement: Branch-safety pre-condition
+
+The `openspec-apply-change` skill MUST include a pre-condition
+block immediately after the "Steps" heading and before Step 1
+that states:
+
+> **Pre-condition**: Before any step, verify: NEVER switch
+> branches or suggest archiving with uncommitted changes. Run
+> `git status --short` if branch state is uncertain.
+
+This pre-condition MUST be encountered by agents before any
+workflow step executes.
+
+#### Scenario: Agent processes skill file sequentially
+
+- **GIVEN** an agent loads `openspec-apply-change/SKILL.md`
+- **WHEN** the agent begins processing the "Steps" section
+- **THEN** the agent encounters the branch-safety pre-condition
+  BEFORE reading Step 1 ("Select the change")
+
+#### Scenario: Agent has uncommitted changes and reaches
+completion
+
+- **GIVEN** an agent is executing the apply-change workflow
+- **AND** there are uncommitted changes in the working tree
+- **WHEN** the agent reaches Step 8 (completion)
+- **THEN** the agent MUST NOT suggest switching branches or
+  archiving because the pre-condition was processed before
+  Step 1
+
+## MODIFIED Requirements
+
+### Requirement: Guardrails section branch-safety rule
+
+The existing guardrail "NEVER switch branches or suggest
+archiving with uncommitted changes" at the end of the file
+SHALL remain unchanged.
+
+Previously: This was the only location of the branch-safety
+constraint. Now it serves as a secondary reinforcement of the
+pre-condition.
+
+## REMOVED Requirements
+
+None.

--- a/openspec/changes/fix-apply-change-branch-guard/tasks.md
+++ b/openspec/changes/fix-apply-change-branch-guard/tasks.md
@@ -1,0 +1,22 @@
+<!--
+  [P] marks tasks eligible for parallel execution.
+  Add [P] when a task: (a) touches different files from
+  other [P] tasks in the group, (b) has no dependency
+  on prior tasks in the group, (c) can safely execute
+  without ordering constraints.
+  Do NOT add [P] when tasks modify the same file --
+  parallel workers will cause merge conflicts.
+  Tasks without [P] run sequentially first, then [P]
+  tasks run in parallel.
+-->
+
+## 1. Add pre-condition block to SKILL.md
+
+- [x] 1.1 Insert a `**Pre-condition**` block in `.opencode/skills/openspec-apply-change/SKILL.md` immediately after the `**Steps**` heading (line 16) and before Step 1 (line 18). The block text MUST be: `**Pre-condition**: Before any step, verify: NEVER switch branches or suggest archiving with uncommitted changes. Run `git status --short` if branch state is uncertain.`
+
+## 2. Verify
+
+- [x] 2.1 Verify the pre-condition block appears before Step 1 in the file and the existing guardrail at line 212 remains unchanged
+- [x] 2.2 Verify constitution alignment: confirm the change is N/A for all four org principles (no artifact formats, composability, observable quality, or testability impact)
+<!-- spec-review: passed -->
+<!-- code-review: passed -->


### PR DESCRIPTION
## Summary

Fixes #359

The `openspec-apply-change` skill file contained a CRITICAL branch-safety
rule ("NEVER switch branches or suggest archiving with uncommitted changes")
buried in the Guardrails section at line 212 of a 219-line file. This is a
T2 weakness: agents processing the file sequentially encounter Step 8's
archiving suggestions before reaching the constraint.

This PR elevates the rule to a **Pre-condition** block immediately after
the "Steps" heading and before Step 1, ensuring agents encounter it before
any workflow step. The existing guardrail is preserved for defense-in-depth.

## How to Test

1. Open `.opencode/skills/openspec-apply-change/SKILL.md`
2. Verify line 18 contains the pre-condition block
3. Verify the pre-condition appears BEFORE Step 1 ("Select the change")
4. Verify line 214 still contains the original guardrail (unchanged)

## How to Demo

Open the SKILL.md file and observe that the branch-safety constraint now
appears as a Pre-condition between the "Steps" heading and Step 1, rather
than only in the Guardrails section at the end of the file.

## Key Files Changed

- `.opencode/skills/openspec-apply-change/SKILL.md` -- Added Pre-condition block (2 lines inserted)
- `openspec/changes/fix-apply-change-branch-guard/proposal.md` -- Change proposal with constitution alignment
- `openspec/changes/fix-apply-change-branch-guard/design.md` -- Technical design decisions
- `openspec/changes/fix-apply-change-branch-guard/specs/branch-safety-precondition.md` -- Delta spec with Given/When/Then scenarios
- `openspec/changes/fix-apply-change-branch-guard/tasks.md` -- Implementation tasks (all complete)

_This PR was generated by /finale (AI-assisted)._
