### PR TITLE
fix(finale): replace prose secrets gate with AskUserQuestion tool call

### DIFF
--- a/.opencode/commands/finale.md
+++ b/.opencode/commands/finale.md
@@ -77,8 +77,11 @@ Run `git status --short` to inspect the working tree.
   > Proceed with staging all files? These files will be
   > included in the commit."
 
-  Ask for confirmation. If the user declines, stop and
-  let them handle it manually.
+  Use the **AskUserQuestion tool** with options:
+    ["Yes -- stage all files including flagged ones",
+     "No -- stop and let me handle it manually"]
+
+  If the user selects "No", STOP. Do not run `git add .`.
 
 - **Stage all changes**: `git add .`
 

--- a/internal/scaffold/assets/opencode/commands/finale.md
+++ b/internal/scaffold/assets/opencode/commands/finale.md
@@ -77,8 +77,11 @@ Run `git status --short` to inspect the working tree.
   > Proceed with staging all files? These files will be
   > included in the commit."
 
-  Ask for confirmation. If the user declines, stop and
-  let them handle it manually.
+  Use the **AskUserQuestion tool** with options:
+    ["Yes -- stage all files including flagged ones",
+     "No -- stop and let me handle it manually"]
+
+  If the user selects "No", STOP. Do not run `git add .`.
 
 - **Stage all changes**: `git add .`
 

--- a/openspec/changes/finale-secrets-askuser-gate/.openspec.yaml
+++ b/openspec/changes/finale-secrets-askuser-gate/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: unbound-force
+created: 2026-07-31

--- a/openspec/changes/finale-secrets-askuser-gate/design.md
+++ b/openspec/changes/finale-secrets-askuser-gate/design.md
@@ -1,0 +1,101 @@
+## Context
+
+The `/finale` command (`.opencode/commands/finale.md`)
+handles branch finalization: staging, committing, pushing,
+and PR creation. Step 2 includes a secrets check that scans
+for files matching common secret patterns (.env, *.key,
+*.pem, credentials.json) before running `git add .`.
+
+The current confirmation gate at lines 79-81 is prose-only:
+"Ask for confirmation. If the user declines, stop and let
+them handle it manually." This is a T3 weakness -- the same
+pattern fixed in `/review-pr`, `/address-feedback`, and
+`/triage-issue` by the `askuser-tool-confirmations` change.
+
+The proposal's constitution alignment confirmed this change
+is N/A for Principles I-III and PASS for Principles IV-V.
+
+## Goals / Non-Goals
+
+### Goals
+- Replace the prose confirmation at lines 79-81 with an
+  explicit AskUserQuestion tool call with structured options
+- Match the established convention from the
+  `askuser-tool-confirmations` change (bold formatting,
+  action-descriptive option labels)
+- Sync the scaffold asset copy to maintain byte-identity
+
+### Non-Goals
+- Scanning for additional secret file patterns beyond what
+  is already defined
+- Modifying other confirmation points in `/finale` (e.g.,
+  commit message approval at line 149)
+- Changing Go source code logic
+- Modifying the AskUserQuestion tool itself
+
+## Decisions
+
+### D1: Use structured selection with action-descriptive labels
+
+Replace the prose "Ask for confirmation" with:
+
+```
+Use the **AskUserQuestion tool** with options:
+  ["Yes -- stage all files including flagged ones",
+   "No -- stop and let me handle it manually"]
+
+If the user selects "No", STOP. Do not run `git add .`.
+```
+
+**Rationale**: Matches the convention established by D2
+in the `askuser-tool-confirmations` design -- option
+labels include action context, not bare yes/no. The
+"including flagged ones" phrasing makes the consequence
+explicit.
+
+### D2: Bold formatting convention preserved
+
+The AskUserQuestion tool is referenced as
+`**AskUserQuestion tool**` (bold, PascalCase), matching
+the convention in `opsx-propose.md`, `opsx-apply.md`,
+`review-pr.md`, `address-feedback.md`, and
+`triage-issue.md`.
+
+**Rationale**: Consistency with established command
+formatting.
+
+### D3: Scaffold asset updated in lockstep
+
+The command file `.opencode/commands/finale.md` has a
+byte-identical copy at
+`internal/scaffold/assets/opencode/commands/finale.md`.
+Both must be updated together. The drift detection test
+(`TestEmbeddedAssets_MatchSource`) enforces this.
+
+**Rationale**: Required by the scaffold pattern. Existing
+test infrastructure validates automatically.
+
+### D4: Minimal diff -- replace only the prose gate
+
+Only lines 79-81 change. The surrounding warning message
+text (lines 70-78), the secrets pattern list (lines 64-68),
+and the `git add .` command (line 83) remain unchanged.
+
+**Rationale**: Smallest possible change reduces risk and
+keeps the review focused.
+
+## Risks / Trade-offs
+
+### R1: No behavioral regression
+
+This change is purely instructional (markdown edits). No
+Go code, API, or schema changes. The scaffold drift test
+provides automated verification. Risk is minimal.
+
+### R2: Single confirmation point
+
+Unlike the `askuser-tool-confirmations` change (15
+interaction points across 3 commands), this change
+addresses exactly 1 interaction point in 1 command. The
+scope is intentionally narrow.
+<!-- scaffolded by uf vdev -->

--- a/openspec/changes/finale-secrets-askuser-gate/proposal.md
+++ b/openspec/changes/finale-secrets-askuser-gate/proposal.md
@@ -1,0 +1,98 @@
+## Why
+
+The `/finale` command's secrets check gate (lines 63-81 in
+`finale.md`) warns users about potential secret files before
+staging, but the confirmation is prose-only: "Ask for
+confirmation. If the user declines, stop and let them handle
+it manually." No `AskUserQuestion` tool call is specified.
+
+Under context compression or fast-path reasoning, an agent
+can treat this prose as informational and proceed to `git
+add .` without explicit user confirmation, potentially
+staging files that contain secrets (.env, credentials.json,
+*.key, *.pem).
+
+This is a T3 weakness (confirmation gate is inline text
+only, not enforced by a tool call) -- the same pattern
+addressed in `/review-pr`, `/address-feedback`, and
+`/triage-issue` by the `askuser-tool-confirmations` change.
+
+Fixes: https://github.com/unbound-force/unbound-force/issues/347
+
+## What Changes
+
+Replace the prose confirmation at lines 79-81 of
+`.opencode/commands/finale.md` with an explicit
+**AskUserQuestion tool** call with structured options.
+Sync the identical change to the scaffold asset copy.
+
+## Capabilities
+
+### New Capabilities
+- None
+
+### Modified Capabilities
+- `/finale` secrets check: Prose confirmation replaced
+  with explicit AskUserQuestion tool call, ensuring the
+  gate cannot be skipped under context compression
+
+### Removed Capabilities
+- None
+
+## Impact
+
+- `.opencode/commands/finale.md` -- secrets check gate
+  section (lines ~63-81)
+- `internal/scaffold/assets/opencode/commands/finale.md`
+  -- byte-identical scaffold copy
+- No Go source code changes
+- No schema, API, or artifact format changes
+
+## Constitution Alignment
+
+Assessed against the Unbound Force org constitution.
+
+### I. Autonomous Collaboration
+
+**Assessment**: N/A
+
+This change modifies agent instruction text only. No
+artifact formats, inter-hero communication, or envelope
+structures are affected.
+
+### II. Composability First
+
+**Assessment**: N/A
+
+No new dependencies introduced. The `/finale` command
+remains independently usable. The AskUserQuestion tool
+is already available in the agent runtime.
+
+### III. Observable Quality
+
+**Assessment**: N/A
+
+No machine-parseable outputs, provenance metadata, or
+scoring thresholds are modified. This is purely an
+instructional text change.
+
+### IV. Testability
+
+**Assessment**: PASS
+
+The scaffold drift test
+(`TestEmbeddedAssets_MatchSource`) validates that command
+files and scaffold assets remain byte-identical. This
+existing test infrastructure covers the change without
+requiring new tests.
+
+### V. Security by Default
+
+**Assessment**: PASS
+
+This change directly improves security posture by
+hardening the secrets confirmation gate from a
+skippable prose instruction to an enforceable tool
+call. It prevents agents from bypassing the user
+confirmation and staging secret files.
+<!-- scaffolded by uf vdev -->

--- a/openspec/changes/finale-secrets-askuser-gate/specs/secrets-confirmation-gate.md
+++ b/openspec/changes/finale-secrets-askuser-gate/specs/secrets-confirmation-gate.md
@@ -1,0 +1,84 @@
+## ADDED Requirements
+
+_None._
+
+## MODIFIED Requirements
+
+### Requirement: Secrets file confirmation gate
+
+The `/finale` command's Step 2 ("Check for Changes to
+Commit") MUST use the **AskUserQuestion tool** with
+structured options when potential secret files are
+detected, instead of prose-only confirmation.
+
+When potential secret files are found, the agent MUST
+present the user with the **AskUserQuestion tool** using
+options:
+- "Yes -- stage all files including flagged ones"
+- "No -- stop and let me handle it manually"
+
+If the user selects "No", the agent MUST NOT run
+`git add .` and MUST stop execution.
+
+Previously: "Ask for confirmation. If the user declines,
+stop and let them handle it manually." (prose-only, no
+tool call specified)
+
+#### Scenario: Secret files detected and user approves
+
+- **GIVEN** the working tree contains `.env.local` and
+  `credentials.json` alongside modified source files
+- **WHEN** `/finale` runs Step 2 and detects these files
+  match secret patterns
+- **THEN** the agent MUST display the warning message
+  listing the flagged files AND present the
+  **AskUserQuestion tool** with options "Yes -- stage
+  all files including flagged ones" and "No -- stop and
+  let me handle it manually"
+- **AND** if the user selects "Yes", the agent MUST
+  proceed to `git add .`
+
+#### Scenario: Secret files detected and user declines
+
+- **GIVEN** the working tree contains `secrets.json`
+  alongside modified source files
+- **WHEN** `/finale` runs Step 2, detects the file, and
+  presents the AskUserQuestion tool
+- **THEN** if the user selects "No -- stop and let me
+  handle it manually", the agent MUST NOT run `git add .`
+- **AND** the agent MUST stop execution and report that
+  the user chose to handle staging manually
+
+#### Scenario: No secret files detected
+
+- **GIVEN** the working tree contains only `.go`, `.md`,
+  and `.yaml` files with no secret-pattern matches
+- **WHEN** `/finale` runs Step 2
+- **THEN** the agent MUST proceed directly to
+  `git add .` without presenting the secrets
+  confirmation prompt
+
+### Requirement: Scaffold asset byte-identity
+
+The file `internal/scaffold/assets/opencode/commands/finale.md`
+MUST be byte-identical to `.opencode/commands/finale.md`
+after all edits.
+
+Previously: This requirement already exists and is
+enforced by `TestEmbeddedAssets_MatchSource`. No change
+to the requirement itself, but the scaffold asset MUST
+be updated to reflect the modified command file.
+
+#### Scenario: Scaffold drift detection
+
+- **GIVEN** `.opencode/commands/finale.md` has been
+  modified with the AskUserQuestion gate
+- **WHEN** `go test ./internal/scaffold/... -count=1`
+  is run
+- **THEN** `TestEmbeddedAssets_MatchSource` MUST pass,
+  confirming the scaffold asset is byte-identical
+
+## REMOVED Requirements
+
+_None._
+<!-- scaffolded by uf vdev -->

--- a/openspec/changes/finale-secrets-askuser-gate/tasks.md
+++ b/openspec/changes/finale-secrets-askuser-gate/tasks.md
@@ -1,0 +1,59 @@
+<!--
+  [P] marks tasks eligible for parallel execution.
+  Add [P] when a task: (a) touches different files from
+  other [P] tasks in the group, (b) has no dependency
+  on prior tasks in the group, (c) can safely execute
+  without ordering constraints.
+  Do NOT add [P] when tasks modify the same file —
+  parallel workers will cause merge conflicts.
+  Tasks without [P] run sequentially first, then [P]
+  tasks run in parallel.
+-->
+
+## 1. Replace prose confirmation with AskUserQuestion gate
+
+All edits target `.opencode/commands/finale.md`.
+No [P] markers -- single file.
+
+- [x] 1.1 Replace lines 79-81 (the prose confirmation
+  "Ask for confirmation. If the user declines, stop and
+  let them handle it manually.") with an explicit
+  AskUserQuestion tool call:
+
+  ```
+  Use the **AskUserQuestion tool** with options:
+    ["Yes -- stage all files including flagged ones",
+     "No -- stop and let me handle it manually"]
+
+  If the user selects "No", STOP. Do not run `git add .`.
+  ```
+
+  Preserve the surrounding warning message (lines 70-78)
+  and the `git add .` line (line 83) unchanged.
+
+**Checkpoint**: Read the modified file. Verify the
+secrets check section (lines ~63-83) references the
+**AskUserQuestion tool** with two options. Verify no
+bare "Ask for confirmation" prose remains.
+
+## 2. Sync scaffold asset
+
+- [x] 2.1 Copy `.opencode/commands/finale.md` to
+  `internal/scaffold/assets/opencode/commands/finale.md`
+  (byte-identical).
+
+**Checkpoint**: Run `go test ./internal/scaffold/... -count=1`.
+`TestEmbeddedAssets_MatchSource` MUST pass.
+
+## 3. Verification
+
+- [x] 3.1 Run `go test -race -count=1 ./...` to verify
+  no test regressions.
+
+- [x] 3.2 Verify constitution alignment: confirm no
+  artifact formats, hero interfaces, or machine-parseable
+  outputs were modified. Only instruction text in
+  markdown files was changed.
+<!-- spec-review: passed -->
+<!-- code-review: passed -->
+<!-- scaffolded by uf vdev -->


### PR DESCRIPTION
## Summary

Replace the prose-only secrets confirmation gate in `/finale` Step 2
with an explicit AskUserQuestion tool call. The previous gate ("Ask
for confirmation") was a T3 weakness that could be bypassed under
context compression, potentially staging files containing secrets
(.env, credentials.json, *.key, *.pem) without user consent.

The fix uses structured options with action-descriptive labels,
matching the convention established by the `askuser-tool-confirmations`
change across `/review-pr`, `/address-feedback`, and `/triage-issue`.

Fixes #347

## How to Test

1. Read `.opencode/commands/finale.md` lines 80-84. Confirm the
   secrets check section uses the `**AskUserQuestion tool**` with
   options `["Yes -- stage all files including flagged ones",
   "No -- stop and let me handle it manually"]`.
2. Verify scaffold byte-identity:
   `diff .opencode/commands/finale.md internal/scaffold/assets/opencode/commands/finale.md`
3. Run `go test -race -count=1 ./internal/scaffold/...` --
   `TestEmbeddedAssets_MatchSource` must pass.
4. Run `go test -race -count=1 ./...` -- all 20 packages must pass.

## How to Demo

Trivial instructional text change -- no interactive demo required.
The user experience is unchanged: `/finale` still warns about
potential secret files and asks for confirmation before staging.
The mechanism changes from prose to an explicit tool call.

## Key Files Changed

- `.opencode/commands/finale.md` -- secrets check gate (lines 80-84)
- `internal/scaffold/assets/opencode/commands/finale.md` -- byte-identical scaffold copy
- `openspec/changes/finale-secrets-askuser-gate/` -- OpenSpec artifacts (proposal, design, spec, tasks)

_This PR was generated by /finale (AI-assisted)._
