### PR TITLE
fix(muti-mind-po): add AskUserQuestion gate before acceptance decision CLI

### DIFF
--- a/.opencode/agents/muti-mind-po.md
+++ b/.opencode/agents/muti-mind-po.md
@@ -66,6 +66,15 @@ When evaluating a Gaze Quality Report against a backlog item's acceptance criter
 - `rationale`: Markdown explanation
 - `criteria_met` / `criteria_failed`
 
+**Interactive Approval**: Before running the `bash` tool to record an acceptance decision using the `go run cmd/mutimind/main.go decide` command, you MUST use the **AskUserQuestion tool** to present:
+- The target backlog item (e.g., `BI-NNN`)
+- The proposed decision (`accept`, `reject`, or `conditional`)
+- The rationale summary
+
+Options: `["Confirm decision", "Abort"]`
+
+Only invoke the Go CLI backend if the user selects "Confirm decision". If the user selects "Abort", report that the acceptance decision was cancelled and do NOT invoke the command.
+
 To generate these artifacts, you MUST use the Go CLI backend to ensure proper schema compliance:
 ```bash
 go run cmd/mutimind/main.go decide --item "BI-NNN" --decision "accept|reject|conditional" --rationale "..." --report-ref "path/to/report.json" --met "Criterion 1" --met "Criterion 2" --failed "Criterion 3"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,16 @@ Each entry follows the format: `- <change-name>: <summary>`.
   (Spec: openspec/changes/council-review-action/,
   Closes: #253)
 
+### Fixed
+- mutimind-acceptance-gate: Added AskUserQuestion
+  confirmation gate before acceptance decision CLI
+  (`go run cmd/mutimind/main.go decide`) in
+  muti-mind-po.md agent. Prevents irreversible
+  governance action from firing without user
+  confirmation.
+  (Spec: openspec/changes/mutimind-acceptance-gate/,
+  Fixes: #351)
+
 ### Changed
 - All 10 uf-owned slash commands renamed to `uf.`
   dot-notation namespace prefix: `/address-feedback`

--- a/openspec/changes/mutimind-acceptance-gate/.openspec.yaml
+++ b/openspec/changes/mutimind-acceptance-gate/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: unbound-force
+created: 2026-07-31

--- a/openspec/changes/mutimind-acceptance-gate/design.md
+++ b/openspec/changes/mutimind-acceptance-gate/design.md
@@ -1,0 +1,51 @@
+## Context
+
+The `muti-mind-po.md` agent file instructs Muti-Mind to invoke `go run cmd/mutimind/main.go decide ...` to record acceptance decisions. This CLI command writes an irreversible governance artifact. Currently, the agent can invoke it without user confirmation. The "Interactive Approval" rule at line 60 only covers the `add` (story generation) command, leaving the `decide` command unprotected.
+
+Sibling fixes for other agents and commands (PRs #391-#408) have established a consistent pattern: an AskUserQuestion gate before any irreversible CLI invocation. This design follows that established pattern.
+
+## Goals / Non-Goals
+
+### Goals
+- Add an AskUserQuestion confirmation gate before the `decide` CLI command in `muti-mind-po.md`
+- Match the confirmation pattern established by the existing "Interactive Approval" rule for story generation
+- Present decision details (backlog item ID, decision type, rationale) for informed user confirmation
+
+### Non-Goals
+- Modifying the Go backend (`cmd/mutimind/main.go`) -- the CLI interface remains unchanged
+- Adding confirmation gates to other Muti-Mind commands (e.g., `generate-artifact`) -- out of scope for this change
+- Changing the acceptance-decision schema or artifact format
+- Adding automated tests for agent instruction behavior
+
+## Decisions
+
+### D1: Inline instruction text, not a separate skill
+
+The confirmation gate will be added as inline instruction text within the "Acceptance Authority" section of `muti-mind-po.md`, following the same pattern as the "Interactive Approval" rule at line 60. A separate skill file is unnecessary for a single confirmation step.
+
+**Rationale**: The existing pattern for story generation confirmation is inline (line 60). Consistency with existing patterns reduces cognitive load and keeps the agent file self-contained (Composability First -- the agent remains independently understandable).
+
+### D2: Present three data points in the confirmation
+
+The AskUserQuestion prompt will include:
+1. Target backlog item ID (e.g., `BI-NNN`)
+2. Proposed decision (`accept`, `reject`, or `conditional`)
+3. Rationale summary
+
+**Rationale**: These are the minimum context needed for an informed confirmation. They map directly to the `--item`, `--decision`, and `--rationale` CLI flags, so the user sees exactly what will be recorded.
+
+### D3: Two-option confirmation ("Confirm decision" / "Abort")
+
+The gate uses a binary choice matching the pattern established by sibling fixes (PRs #391-#408).
+
+**Rationale**: Acceptance decisions are final. There is no "edit and retry" path -- if the user wants to change parameters, they should abort and re-invoke the command with different inputs.
+
+## Risks / Trade-offs
+
+### R1: Additional interaction step
+
+Adding a confirmation gate adds one user interaction per acceptance decision. This is acceptable because acceptance decisions are infrequent (one per backlog item evaluation) and the governance value outweighs the friction.
+
+### R2: Agent instruction compliance
+
+Agent instruction compliance is probabilistic -- the agent may occasionally skip the gate under context pressure. This is a known limitation of instruction-based guardrails and is consistent with how all other confirmation gates in the swarm operate. The Go backend itself does not enforce confirmation; the gate exists at the agent instruction layer.

--- a/openspec/changes/mutimind-acceptance-gate/proposal.md
+++ b/openspec/changes/mutimind-acceptance-gate/proposal.md
@@ -1,0 +1,66 @@
+## Why
+
+The `muti-mind-po.md` agent file contains a `go run cmd/mutimind/main.go decide ...` command block (lines 70-72) that executes acceptance decisions (`accept`/`reject`/`conditional`) without requiring explicit user confirmation. Acceptance decisions are irreversible governance artifacts that affect downstream workflow -- a rejected item cannot be un-rejected without re-running the entire acceptance flow.
+
+The existing "Interactive Approval" rule at line 60 covers story generation (`go run ... add`) but has no parallel for the `decide` command. This is a T1 (irreversible external action without confirmation) and T2 (missing approval gate) weakness identified in the parent audit (issue #346).
+
+All sibling T1/T2/T3 weaknesses in other commands and skills have been fixed by merged PRs #391-#408. This is one of the last remaining open items.
+
+Fixes #351.
+
+## What Changes
+
+Add a mandatory `AskUserQuestion` confirmation gate in the `muti-mind-po.md` agent file immediately before the acceptance decision CLI command block. The gate presents the decision details to the user and requires explicit confirmation before the Go backend is invoked.
+
+## Capabilities
+
+### New Capabilities
+- `acceptance-decision-confirmation`: AskUserQuestion gate before `go run cmd/mutimind/main.go decide` that presents the target backlog item (BI-NNN), proposed decision (accept/reject/conditional), and rationale summary for user confirmation.
+
+### Modified Capabilities
+- `Acceptance Authority` section: Restructured to include the confirmation gate before the CLI invocation, matching the pattern established by the "Interactive Approval" rule for story generation.
+
+### Removed Capabilities
+- None.
+
+## Impact
+
+- **File**: `.opencode/agents/muti-mind-po.md` (lines 62-72, Acceptance Authority section)
+- **Behavior**: The agent will present acceptance decision details and wait for user confirmation before executing the CLI command. If the user selects "Abort", the decision is not recorded.
+- **Downstream**: No impact on the Go backend (`cmd/mutimind/main.go`), schemas, or other agent files. The change is purely in the agent's instruction text.
+- **Testing**: Manual verification that the agent prompts before executing the decide command. No Go code changes, so no unit tests required.
+- **Scaffold**: No scaffold asset exists for `muti-mind-po.md` under `internal/scaffold/assets/`, so no scaffold sync is required.
+
+## Constitution Alignment
+
+Assessed against the Unbound Force org constitution.
+
+### I. Autonomous Collaboration
+
+**Assessment**: N/A
+
+This change modifies agent instructions, not artifact formats or inter-hero communication. The acceptance-decision artifacts produced by the Go backend remain unchanged.
+
+### II. Composability First
+
+**Assessment**: N/A
+
+The Muti-Mind agent remains independently usable. No new dependencies are introduced. The confirmation gate uses the existing AskUserQuestion tool already available to the agent.
+
+### III. Observable Quality
+
+**Assessment**: PASS
+
+The acceptance decision continues to be produced by the Go CLI backend with full schema compliance and provenance metadata. The confirmation gate adds transparency by making the decision visible to the user before execution.
+
+### IV. Testability
+
+**Assessment**: N/A
+
+No new code is introduced. The change is to agent instruction text (Markdown). The Go backend and its tests are unaffected.
+
+### V. Security by Default
+
+**Assessment**: PASS
+
+This change directly improves security posture by preventing an irreversible governance action from firing without explicit user confirmation. It follows the principle of requiring validation before security-sensitive operations (acceptance decisions affect workflow governance).

--- a/openspec/changes/mutimind-acceptance-gate/specs/acceptance-gate.md
+++ b/openspec/changes/mutimind-acceptance-gate/specs/acceptance-gate.md
@@ -1,0 +1,66 @@
+## ADDED Requirements
+
+### Requirement: Acceptance Decision Confirmation Gate
+
+The Muti-Mind agent MUST present an AskUserQuestion
+confirmation prompt before invoking the
+`go run cmd/mutimind/main.go decide` command. The prompt
+MUST include the target backlog item ID, the proposed
+decision (accept/reject/conditional), and the rationale
+summary. The agent MUST NOT invoke the CLI command until
+the user confirms.
+
+Options: `["Confirm decision", "Abort"]`
+
+If the user selects "Abort", the agent MUST NOT invoke
+the decide command and MUST report that the acceptance
+decision was cancelled.
+
+#### Scenario: User confirms acceptance decision
+
+- **GIVEN** the agent has evaluated a backlog item against
+  its acceptance criteria and determined a decision
+- **WHEN** the agent presents the AskUserQuestion prompt
+  with the backlog item ID, decision, and rationale
+- **THEN** if the user selects "Confirm decision", the
+  agent invokes `go run cmd/mutimind/main.go decide`
+  with the determined parameters
+
+#### Scenario: User aborts acceptance decision
+
+- **GIVEN** the agent has evaluated a backlog item and
+  determined a decision
+- **WHEN** the agent presents the AskUserQuestion prompt
+- **THEN** if the user selects "Abort", the agent does
+  not invoke the decide command and reports the
+  cancellation
+
+#### Scenario: Confirmation content accuracy
+
+- **GIVEN** the agent is about to record an acceptance
+  decision for backlog item BI-042 with decision
+  "conditional" and rationale "Coverage meets threshold
+  but edge cases need attention"
+- **WHEN** the AskUserQuestion prompt is presented
+- **THEN** the prompt MUST display "BI-042", "conditional",
+  and the rationale text so the user can verify the
+  parameters before confirmation
+
+## MODIFIED Requirements
+
+### Requirement: Acceptance Authority Section Structure
+
+The "Acceptance Authority" section (lines 62-72) MUST
+include both the existing CLI usage instructions and the
+new confirmation gate. The confirmation gate MUST appear
+before the CLI command block, following the same
+positional pattern as the "Interactive Approval" rule
+(line 60) relative to the story generation command.
+
+Previously: The section contained only the CLI command
+block and output format description with no confirmation
+requirement.
+
+## REMOVED Requirements
+
+None.

--- a/openspec/changes/mutimind-acceptance-gate/tasks.md
+++ b/openspec/changes/mutimind-acceptance-gate/tasks.md
@@ -1,0 +1,23 @@
+<!--
+  [P] marks tasks eligible for parallel execution.
+  Add [P] when a task: (a) touches different files from
+  other [P] tasks in the group, (b) has no dependency
+  on prior tasks in the group, (c) can safely execute
+  without ordering constraints.
+  Do NOT add [P] when tasks modify the same file --
+  parallel workers will cause merge conflicts.
+  Tasks without [P] run sequentially first, then [P]
+  tasks run in parallel.
+-->
+
+## 1. Add confirmation gate to Acceptance Authority section
+
+- [x] 1.1 Add AskUserQuestion instruction text to `.opencode/agents/muti-mind-po.md` immediately before the `go run cmd/mutimind/main.go decide` command block (lines 69-72). The new instruction MUST require the agent to present the backlog item ID, decision type, and rationale summary, with options `["Confirm decision", "Abort"]`. The agent MUST NOT invoke the CLI command unless the user selects "Confirm decision". If the user selects "Abort", the agent MUST report cancellation and stop.
+
+## 2. Verification
+
+- [x] 2.1 Verify the confirmation gate text appears before the CLI command block, follows the pattern of the "Interactive Approval" rule at line 60, and satisfies all three scenarios in `specs/acceptance-gate.md`: user confirms (invoke CLI), user aborts (report cancellation and stop), and content accuracy (displays item ID, decision, rationale)
+- [x] 2.2 Verify no Go source files were modified (this change is agent-instruction-only)
+- [x] 2.3 Verify constitution alignment: the change maintains Composability First (no new dependencies), Observable Quality (artifact format unchanged), and Security by Default (irreversible action now gated)
+<!-- spec-review: passed -->
+<!-- code-review: passed -->


### PR DESCRIPTION
## Summary

Adds a mandatory AskUserQuestion confirmation gate to the Muti-Mind PO agent
before the acceptance decision CLI command (`go run cmd/mutimind/main.go decide`).
The gate prevents an irreversible governance action from firing without explicit
user confirmation -- a T1/T2 weakness identified in the parent audit (#346).

The confirmation prompt presents the target backlog item ID, proposed decision
(accept/reject/conditional), and rationale summary, with binary options
`["Confirm decision", "Abort"]`. The CLI is only invoked on confirmation.

This is one of the last remaining items from the sibling T1/T2/T3 fixes
(PRs #391-#408).

Fixes #351

## How to Test

1. Invoke the Muti-Mind PO agent and request an acceptance decision on a backlog item
2. Verify the agent presents an AskUserQuestion prompt with the backlog item ID,
   decision type, rationale summary, and options ["Confirm decision", "Abort"]
3. Select "Abort" -- verify the agent reports cancellation without invoking the CLI
4. Re-run and select "Confirm decision" -- verify the CLI command executes

## How to Demo

Open the Muti-Mind PO agent and evaluate a backlog item against a Gaze quality
report. When the agent determines a decision, it will now prompt for confirmation
before recording it. Select "Abort" to see the cancellation flow, or "Confirm
decision" to proceed with recording.

## Key Files Changed

| File | Change |
|------|--------|
| `.opencode/agents/muti-mind-po.md` | Added AskUserQuestion confirmation gate (9 lines) before the `decide` CLI command |
| `CHANGELOG.md` | Added fix entry under Unreleased |
| `openspec/changes/mutimind-acceptance-gate/` | OpenSpec change artifacts (proposal, design, spec, tasks) |

## Known Issues

The following findings from the review council were acknowledged but not resolved:

- **LOW**: The existing "Interactive Approval" rule at line 60 (story generation)
  uses less explicit phrasing than the new gate. A follow-up change could uplift
  line 60 to match the more explicit pattern.

_This PR was generated by /uf.finale (AI-assisted)._
