### PR TITLE
fix(finale): replace prose secrets check gate with AskUserQuestion tool call

### DIFF
--- a/.opencode/commands/uf.finale.md
+++ b/.opencode/commands/uf.finale.md
@@ -77,8 +77,15 @@ Run `git status --short` to inspect the working tree.
   > Proceed with staging all files? These files will be
   > included in the commit."
 
-  Ask for confirmation. If the user declines, stop and
-  let them handle it manually.
+  Use the **AskUserQuestion tool** with options
+  `["Yes -- stage all files and continue", "No -- stop here"]`.
+
+  - If the user selects **"Yes -- stage all files and
+    continue"**: proceed to `git add .`.
+  - If the user selects **"No -- stop here"**: **STOP**.
+    Do not run `git add .`. Do not proceed to Step 3 or
+    any subsequent steps. Report that the user declined
+    and let them handle the secret files manually.
 
 - **Stage all changes**: `git add .`
 

--- a/internal/scaffold/assets/opencode/commands/uf.finale.md
+++ b/internal/scaffold/assets/opencode/commands/uf.finale.md
@@ -77,8 +77,15 @@ Run `git status --short` to inspect the working tree.
   > Proceed with staging all files? These files will be
   > included in the commit."
 
-  Ask for confirmation. If the user declines, stop and
-  let them handle it manually.
+  Use the **AskUserQuestion tool** with options
+  `["Yes -- stage all files and continue", "No -- stop here"]`.
+
+  - If the user selects **"Yes -- stage all files and
+    continue"**: proceed to `git add .`.
+  - If the user selects **"No -- stop here"**: **STOP**.
+    Do not run `git add .`. Do not proceed to Step 3 or
+    any subsequent steps. Report that the user declined
+    and let them handle the secret files manually.
 
 - **Stage all changes**: `git add .`
 

--- a/openspec/changes/finale-secrets-askuser-gate/.openspec.yaml
+++ b/openspec/changes/finale-secrets-askuser-gate/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: unbound-force
+created: 2026-07-31

--- a/openspec/changes/finale-secrets-askuser-gate/design.md
+++ b/openspec/changes/finale-secrets-askuser-gate/design.md
@@ -1,0 +1,96 @@
+## Context
+
+The `/uf.finale` command (Step 2) scans for potential secret
+files before staging changes with `git add .`. When secret
+files are detected, the command instructs the agent to "ask for
+confirmation" using prose text. This is a T3 weakness: the
+confirmation is not enforced by a tool call, so agents under
+context compression may skip it and stage secrets.
+
+The sibling push gate (Step 4, line 175) was already fixed in
+PR #405 by replacing prose with an explicit AskUserQuestion
+tool call. This design applies the identical pattern to the
+secrets check gate.
+
+## Goals / Non-Goals
+
+### Goals
+
+- Replace the prose confirmation at lines 80-81 with an
+  explicit AskUserQuestion tool call that blocks execution
+- Match the established pattern from the push gate (line 175)
+- Keep both file copies in sync (command file and scaffold
+  asset)
+
+### Non-Goals
+
+- Changing the secret file detection logic or patterns
+- Adding new secret file patterns to the scan list
+- Modifying any other confirmation gates in `/uf.finale`
+- Changing the push gate (already fixed)
+- Modifying Go source code or tests beyond drift detection
+
+## Decisions
+
+### D1: Use binary AskUserQuestion options
+
+The AskUserQuestion tool call will present exactly two options:
+
+1. "Yes -- stage all files and continue"
+2. "No -- stop here"
+
+**Rationale**: This matches the push gate pattern at line 175
+which uses two options (`"Push to remote"` /
+`"Abort -- keep commits local"`). Binary options eliminate
+ambiguity and prevent agents from interpreting a third option
+as permission to proceed.
+
+### D2: Add explicit STOP instruction on decline
+
+When the user selects "No", the command MUST include an
+explicit `STOP. Do not run git add .` instruction.
+
+**Rationale**: The push gate fix (line 182) uses the same
+pattern: `report error and **STOP**. Do not proceed to
+Step 5 or any subsequent steps.` Explicit stop instructions
+prevent agents from treating the decline as a soft suggestion.
+
+### D3: Both files updated identically
+
+The command file (`.opencode/commands/uf.finale.md`) and the
+scaffold asset (`internal/scaffold/assets/opencode/commands/
+uf.finale.md`) MUST receive identical changes.
+
+**Rationale**: These files share the same hash (`A26164A968`)
+and existing drift detection tests verify they stay in sync.
+Updating only one would break the drift test.
+
+### D4: Preserve the warning message block
+
+The existing warning message (lines 71-78) is well-structured
+and informative. It MUST be preserved as-is. Only the
+confirmation mechanism (lines 80-81) changes.
+
+## Risks / Trade-offs
+
+### Risk: Line number drift
+
+The issue references line 80 based on the current file state.
+If another PR merges before this change, line numbers may
+shift.
+
+**Mitigation**: The implementation task will use content
+matching (the specific prose text "Ask for confirmation")
+rather than line numbers to locate the edit target.
+
+### Trade-off: No automated enforcement
+
+This change relies on the agent's instruction-following
+behavior. A truly hardened gate would require runtime
+enforcement (e.g., a pre-commit hook that blocks `.env`
+files). However, that is out of scope for this change and
+would require a separate spec.
+
+**Accepted**: The AskUserQuestion tool call is the strongest
+gate available within the slash command instruction layer,
+and matches the pattern already approved for the push gate.

--- a/openspec/changes/finale-secrets-askuser-gate/proposal.md
+++ b/openspec/changes/finale-secrets-askuser-gate/proposal.md
@@ -1,0 +1,109 @@
+## Why
+
+The `/uf.finale` command's secrets check gate (Step 2, lines 63-83)
+relies on prose instructions to ask for user confirmation before
+staging potentially sensitive files. The confirmation is expressed
+as plain text:
+
+> "Ask for confirmation. If the user declines, stop and let them
+> handle it manually."
+
+This is a T3 weakness (inline text confirmation, not enforced by
+a tool call). Under context compression or fast-path reasoning,
+an agent can treat this prose as informational and proceed to
+`git add .` without explicit user confirmation, potentially
+staging files that contain secrets (`.env`, `*.key`, `*.pem`,
+`credentials.json`).
+
+The sibling push gate (Step 4) was already fixed in PR #405
+with an explicit AskUserQuestion tool call at line 175. This
+change applies the same pattern to the secrets check gate.
+
+Fixes: https://github.com/unbound-force/unbound-force/issues/347
+
+## What Changes
+
+Replace the prose confirmation at lines 80-81 of
+`.opencode/commands/uf.finale.md` (and its scaffold copy in
+`internal/scaffold/assets/opencode/commands/uf.finale.md`) with
+an explicit AskUserQuestion tool call that blocks execution
+until the user responds.
+
+## Capabilities
+
+### New Capabilities
+
+- None
+
+### Modified Capabilities
+
+- `secrets-check-gate`: The secrets file warning in Step 2 of
+  `/uf.finale` now uses an explicit AskUserQuestion tool call
+  with binary options instead of prose instructions. This
+  ensures agents cannot skip the confirmation under context
+  compression.
+
+### Removed Capabilities
+
+- None
+
+## Impact
+
+- **Files**: `.opencode/commands/uf.finale.md` and
+  `internal/scaffold/assets/opencode/commands/uf.finale.md`
+  (both must stay in sync)
+- **Behavior**: Agents executing `/uf.finale` will now be
+  structurally required to pause for user confirmation when
+  potential secret files are detected, matching the pattern
+  already established by the push gate at line 175.
+- **Risk**: Low. This is a narrowly-scoped change to an
+  instruction file. No Go source code, tests, or CI
+  configuration is affected.
+
+## Constitution Alignment
+
+Assessed against the Unbound Force org constitution.
+
+### I. Autonomous Collaboration
+
+**Assessment**: N/A
+
+This change modifies agent instruction prose within a slash
+command file. It does not affect artifact-based communication
+between heroes or inter-hero collaboration patterns.
+
+### II. Composability First
+
+**Assessment**: N/A
+
+This change is internal to the `/uf.finale` command. It does
+not introduce dependencies between heroes or affect standalone
+functionality.
+
+### III. Observable Quality
+
+**Assessment**: N/A
+
+This change does not affect machine-parseable output or
+provenance metadata. The AskUserQuestion tool call produces
+user-visible interaction, not data artifacts.
+
+### IV. Testability
+
+**Assessment**: PASS
+
+The fix is structurally verifiable: a drift detection test can
+confirm the scaffold copy matches the command file, and the
+presence of the AskUserQuestion pattern can be validated by
+grep-based assertions. The existing scaffold drift tests
+already cover this file pair.
+
+### V. Security by Default
+
+**Assessment**: PASS
+
+This change directly strengthens security by converting a
+prose-only confirmation gate into a tool-enforced gate,
+preventing agents from accidentally staging secret files.
+This addresses the T3 weakness class identified in the
+parent audit (issue #346).

--- a/openspec/changes/finale-secrets-askuser-gate/specs/secrets-gate.md
+++ b/openspec/changes/finale-secrets-askuser-gate/specs/secrets-gate.md
@@ -1,0 +1,76 @@
+## ADDED Requirements
+
+### Requirement: FR-001 Secrets gate AskUserQuestion call
+
+When `/uf.finale` Step 2 detects potential secret files in
+the working tree, the agent MUST invoke the AskUserQuestion
+tool with exactly two options before proceeding to
+`git add .`.
+
+Options:
+1. "Yes -- stage all files and continue"
+2. "No -- stop here"
+
+The agent MUST NOT run `git add .` until the user responds.
+
+#### Scenario: Secret file detected and user approves
+
+- **GIVEN** the working tree contains a file matching secret
+  patterns (e.g., `.env.local`, `credentials.json`)
+- **WHEN** `/uf.finale` reaches Step 2 secrets check
+- **THEN** the agent MUST display the warning message listing
+  the detected files AND invoke the AskUserQuestion tool
+  with the two options above
+- **AND** when the user selects "Yes -- stage all files and
+  continue", the agent proceeds to `git add .`
+
+#### Scenario: Secret file detected and user declines
+
+- **GIVEN** the working tree contains a file matching secret
+  patterns
+- **WHEN** `/uf.finale` reaches Step 2 secrets check AND the
+  user selects "No -- stop here"
+- **THEN** the agent MUST stop execution immediately
+- **AND** the agent MUST NOT run `git add .`
+- **AND** the agent MUST NOT proceed to Step 3 or any
+  subsequent steps
+
+#### Scenario: No secret files detected
+
+- **GIVEN** the working tree contains only non-secret files
+- **WHEN** `/uf.finale` reaches Step 2 secrets check
+- **THEN** the agent SHALL proceed directly to `git add .`
+  without invoking AskUserQuestion
+
+### Requirement: FR-002 Scaffold file sync
+
+The scaffold asset copy at `internal/scaffold/assets/opencode/
+commands/uf.finale.md` MUST receive identical changes to the
+command file at `.opencode/commands/uf.finale.md`.
+
+#### Scenario: Both files updated identically
+
+- **GIVEN** the change modifies `.opencode/commands/
+  uf.finale.md`
+- **WHEN** the change is applied
+- **THEN** `internal/scaffold/assets/opencode/commands/
+  uf.finale.md` MUST contain identical content
+- **AND** existing drift detection tests MUST pass
+
+## MODIFIED Requirements
+
+### Requirement: Secrets check confirmation mechanism
+
+The secrets check confirmation in Step 2 of `/uf.finale`
+MUST use an explicit AskUserQuestion tool call instead of
+prose instructions.
+
+Previously: "Ask for confirmation. If the user declines,
+stop and let them handle it manually."
+
+New: An AskUserQuestion tool call with explicit options and
+a STOP instruction on decline.
+
+## REMOVED Requirements
+
+None.

--- a/openspec/changes/finale-secrets-askuser-gate/tasks.md
+++ b/openspec/changes/finale-secrets-askuser-gate/tasks.md
@@ -1,0 +1,67 @@
+<!--
+  [P] marks tasks eligible for parallel execution.
+  Add [P] when a task: (a) touches different files from
+  other [P] tasks in the group, (b) has no dependency
+  on prior tasks in the group, (c) can safely execute
+  without ordering constraints.
+  Do NOT add [P] when tasks modify the same file --
+  parallel workers will cause merge conflicts.
+  Tasks without [P] run sequentially first, then [P]
+  tasks run in parallel.
+-->
+
+## 1. Replace prose confirmation with AskUserQuestion
+
+- [x] 1.1 In `.opencode/commands/uf.finale.md`, locate the
+  secrets check confirmation at lines 80-81 (the text
+  "Ask for confirmation. If the user declines, stop and
+  let them handle it manually.") and replace it with an
+  explicit AskUserQuestion tool call block:
+
+  ```
+  Use the **AskUserQuestion tool** with options
+  `["Yes -- stage all files and continue", "No -- stop here"]`.
+
+  - If the user selects **"Yes -- stage all files and
+    continue"**: proceed to `git add .`.
+  - If the user selects **"No -- stop here"**: **STOP**.
+    Do not run `git add .`. Do not proceed to Step 3 or
+    any subsequent steps. Report that the user declined
+    and let them handle the secret files manually.
+  ```
+
+  The existing warning message block (lines 71-78) MUST
+  be preserved unchanged. Only the confirmation mechanism
+  (lines 80-81) is replaced.
+
+- [x] 1.2 In `internal/scaffold/assets/opencode/commands/
+  uf.finale.md`, apply the identical edit to keep the
+  scaffold copy in sync.
+
+  **Note**: Tasks 1.1 and 1.2 are NOT marked [P] because
+  they modify files that share identical content and the
+  edit must be verified as identical. Sequential execution
+  ensures consistency.
+
+## 2. Verification
+
+- [x] 2.1 Run `make test` to verify existing drift
+  detection tests pass (scaffold asset matches command
+  file).
+
+- [x] 2.2 Verify the AskUserQuestion pattern in the
+  modified file matches the established push gate pattern
+  at line 175 (same file). Confirm both gates use:
+  (a) explicit AskUserQuestion tool call,
+  (b) exactly two options,
+  (c) explicit STOP instruction on decline.
+
+- [x] 2.3 Verify constitution alignment: confirm the
+  change does not introduce runtime coupling (Principle I),
+  mandatory dependencies (Principle II), or untestable
+  components (Principle IV). The change strengthens
+  Principle V (Security by Default) by enforcing the
+  secrets confirmation gate.
+
+<!-- spec-review: passed -->
+<!-- code-review: passed -->


### PR DESCRIPTION
## Summary

Replaces the prose-only secrets confirmation gate in `/uf.finale`
Step 2 with an explicit `AskUserQuestion` tool call. Under context
compression, the prose instruction ("Ask for confirmation") could
be skipped, allowing the agent to stage files containing secrets
without user confirmation.

The new gate presents structured options:
`["Yes -- stage all files and continue", "No -- stop here"]`

If the user selects "No", the agent stops immediately without
running `git add .`.

Fixes #347

## How to Test

1. Open `.opencode/commands/uf.finale.md` and navigate to the
   secrets check section (around line 80)
2. Verify `AskUserQuestion tool` is explicitly referenced
3. Verify both option strings appear verbatim
4. Verify the "No" path includes STOP and does not proceed
5. Verify the scaffold copy matches:
   `diff .opencode/commands/uf.finale.md internal/scaffold/assets/opencode/commands/uf.finale.md`

## Key Files Changed

- `.opencode/commands/uf.finale.md` — Replaced prose gate with
  AskUserQuestion tool call (+11/-4 lines)
- `internal/scaffold/assets/opencode/commands/uf.finale.md` —
  Scaffold copy in sync
- `openspec/changes/finale-secrets-askuser-gate/` — OpenSpec
  artifacts (proposal, design, specs, tasks)

_This PR was generated by /uf.finale (AI-assisted)._
