### PR TITLE
fix: harden /uf.review-council against context compression

### DIFF
--- a/.opencode/commands/uf.review-council.md
+++ b/.opencode/commands/uf.review-council.md
@@ -4,6 +4,35 @@ description: Run the reviewer governance council to audit codebase or spec compl
 <!-- scaffolded by uf vdev -->
 # Command: /uf.review-council
 
+> **Session-resume guard**: If this session was resumed
+> from compressed context, re-read this entire template
+> before continuing. Do NOT infer step completion from
+> compressed summaries. Check the EXECUTION CHECKLIST
+> below for actual completion state. If the checklist
+> shows unchecked items, resume from the first unchecked
+> item. When in doubt, re-read — false re-reads are
+> harmless; skipping steps due to stale context causes
+> incomplete reviews or unauthorized actions.
+
+> **EXECUTION CHECKLIST** — Update each item using the
+> Edit tool as you complete it. Mark `[x]` when done.
+>
+> - [ ] Phase 1a: Pre-flight checks
+> - [ ] Phase 1b: Gaze quality analysis
+> - [ ] Phase 1c: Review context discovery
+> - [ ] Step 2: Divisor agent delegation (full branch diff)
+> - [ ] Step 3: Finding consolidation
+> - [ ] Step 4: Fix loop (iteration: _/3)
+> - [ ] Step 5: Iteration limit check
+> - [ ] Step 6: Final report
+> - [ ] Step 7a: PR detection
+> - [ ] Step 7b: Review state fetching
+> - [ ] Step 7c: Pre-posting checks
+> - [ ] Step 7d: Finding aggregation
+> - [ ] Step 7e: Inline comment preparation
+> - [ ] Step 7f: Human confirmation (MANDATORY GATE)
+> - [ ] Step 7g: Post review
+
 ## User Input
 
 ```text
@@ -187,6 +216,8 @@ Review the current codebase for compliance with the Behavioral Constraints in `A
       them for inclusion in the final report (Step 6).
       Proceed to Phase 1b.
 
+   **Checkpoint**: Mark `Phase 1a` complete in the EXECUTION CHECKLIST using the Edit tool before proceeding.
+
    #### Phase 1b -- Gaze Quality Analysis (conditional)
 
    a. Check if `gaze` is available:
@@ -211,6 +242,8 @@ Review the current codebase for compliance with the Behavioral Constraints in `A
        > `go install github.com/unbound-force/gaze/cmd/gaze@latest`)."
 
       Proceed to step 2 without Gaze data.
+
+   **Checkpoint**: Mark `Phase 1b` complete in the EXECUTION CHECKLIST using the Edit tool before proceeding.
 
    #### Phase 1c -- Discover Review Context (mandatory)
 
@@ -258,6 +291,8 @@ Review the current codebase for compliance with the Behavioral Constraints in `A
       consistent with the `pre-flight` skill
       consumption pattern — no inline fallback.
 
+   **Checkpoint**: Mark `Phase 1c` complete in the EXECUTION CHECKLIST using the Edit tool before proceeding.
+
 2. Delegate the review to all **discovered** reviewer agents in parallel using the Task tool. For each discovered agent, use the focus area from the Known Reviewer Roles reference table to provide targeted context. For any discovered agent not in the table, use a generic prompt: "Review the current changes for quality, correctness, and compliance. Return your verdict (APPROVE or REQUEST CHANGES) along with all findings."
 
    **CRITICAL — Review Scope Rule**: The review scope is
@@ -299,6 +334,8 @@ Review the current codebase for compliance with the Behavioral Constraints in `A
 
    For each agent, instruct it to review the full branch diff (all changed files vs `main`) and return its verdict (**APPROVE** or **REQUEST CHANGES**) along with all findings.
 
+   **Checkpoint**: Mark `Step 2` complete in the EXECUTION CHECKLIST using the Edit tool before proceeding.
+
 3. Collect all **REQUEST CHANGES** findings from the
    discovered reviewers. If all discovered reviewers
    return **APPROVE**, report the result and stop.
@@ -321,9 +358,15 @@ Review the current codebase for compliance with the Behavioral Constraints in `A
    Findings with independent root causes MUST remain
    separate even if they affect the same file.
 
+   **Checkpoint**: Mark `Step 3` complete in the EXECUTION CHECKLIST using the Edit tool before proceeding.
+
 4. If there are **REQUEST CHANGES**, address the findings by making the necessary code fixes. Then re-run all discovered reviewers to verify the fixes. Repeat this loop until all discovered reviewers return **APPROVE** or the process has exceeded 3 iterations.
 
+   **Checkpoint**: Update `Step 4` iteration counter in the EXECUTION CHECKLIST (e.g., `iteration: 2/3`) using the Edit tool after each iteration.
+
 5. If 3 iterations are exceeded, ask the user whether to continue or stop.
+
+   **Checkpoint**: Mark `Step 5` complete in the EXECUTION CHECKLIST using the Edit tool before proceeding.
 
 6. Provide a final report to the user:
    - **Discovery summary**: how many reviewer agents were discovered, which were invoked, and which known reviewer roles were absent (informational, non-blocking)
@@ -355,6 +398,8 @@ Review the current codebase for compliance with the Behavioral Constraints in `A
    - What was fixed
    - If stopped early, the current set of outstanding **REQUEST CHANGES**
    - If there were persistent circular **REQUEST CHANGES** (fixes for one reviewer cause failures in another), report those with additional detail so the user can make an informed decision
+
+   **Checkpoint**: Mark `Step 6` complete in the EXECUTION CHECKLIST using the Edit tool before proceeding.
 
 7. **GitHub Review Posting (optional, Code Review Mode only)**
 
@@ -397,6 +442,8 @@ Review the current codebase for compliance with the Behavioral Constraints in `A
       > "No open PR found for this branch — review
       > remains local only."
 
+   **Checkpoint**: Mark `Step 7a` complete in the EXECUTION CHECKLIST using the Edit tool before proceeding.
+
    #### Step 7b -- Review State Fetching
 
    Fetch existing review state to prevent duplicate
@@ -431,6 +478,8 @@ Review the current codebase for compliance with the Behavioral Constraints in `A
    error, skip the sub-step, proceed. All review state
    data is additive context — its absence reduces only
    deduplication accuracy.
+
+   **Checkpoint**: Mark `Step 7b` complete in the EXECUTION CHECKLIST using the Edit tool before proceeding.
 
    #### Step 7c -- Pre-posting Checks
 
@@ -512,6 +561,8 @@ Review the current codebase for compliance with the Behavioral Constraints in `A
    > This APPROVE may not satisfy branch protection if
    > this account is not listed in CODEOWNERS."
 
+   **Checkpoint**: Mark `Step 7c` complete in the EXECUTION CHECKLIST using the Edit tool before proceeding.
+
    #### Step 7d -- Multi-Persona Finding Aggregation
 
    Assemble a single review body from all Divisor persona
@@ -561,6 +612,8 @@ Review the current codebase for compliance with the Behavioral Constraints in `A
    Include: "Full findings available in the terminal
    report."
 
+   **Checkpoint**: Mark `Step 7d` complete in the EXECUTION CHECKLIST using the Edit tool before proceeding.
+
    #### Step 7e -- Inline Comment Preparation
 
    For findings mapped to specific files and line ranges
@@ -600,7 +653,24 @@ Review the current codebase for compliance with the Behavioral Constraints in `A
    Body: <comment text>
    ```
 
+   **Checkpoint**: Mark `Step 7e` complete in the EXECUTION CHECKLIST using the Edit tool before proceeding.
+
    #### Step 7f -- Verdict Mapping and Human Confirmation
+
+   >>> MANDATORY GATE: HUMAN CONFIRMATION REQUIRED <<<
+
+   **Session-resume guard**: If this session was resumed
+   from compressed context, or if you cannot verify that
+   the human explicitly confirmed the review in the
+   current uncompressed conversation history, you MUST
+   re-present the review content (verdict + all comments)
+   and obtain fresh confirmation via the
+   **AskUserQuestion tool** before posting. Do NOT rely
+   on confirmation recorded in compressed context. When
+   in doubt, re-confirm — false re-confirmation is
+   harmless; posting without consent is a violation.
+   Check the EXECUTION CHECKLIST: Step 7f MUST be
+   unchecked before proceeding with confirmation.
 
    Map the council verdict to the GitHub API event type:
 
@@ -642,7 +712,11 @@ Review the current codebase for compliance with the Behavioral Constraints in `A
    human confirmation via the **AskUserQuestion tool**.
    Always show the exact content (verdict type + all
    comments) that will be posted and wait for the user
-   to select a confirming option.
+   to select a confirming option. Mark `Step 7f` as
+   `[x]` in the EXECUTION CHECKLIST only AFTER the
+   human confirms.
+
+   >>> END MANDATORY GATE <<<
 
    #### Step 7g -- Post Review
 
@@ -711,6 +785,8 @@ Review the current codebase for compliance with the Behavioral Constraints in `A
    value for auto-detected PRs without requiring a
    Phase 1c re-run. If any `gh issue view` call fails,
    skip that issue silently.
+
+   **Checkpoint**: Mark `Step 7g` complete in the EXECUTION CHECKLIST using the Edit tool before proceeding.
 
 ---
 

--- a/internal/scaffold/assets/opencode/commands/uf.review-council.md
+++ b/internal/scaffold/assets/opencode/commands/uf.review-council.md
@@ -4,6 +4,35 @@ description: Run the reviewer governance council to audit codebase or spec compl
 <!-- scaffolded by uf vdev -->
 # Command: /uf.review-council
 
+> **Session-resume guard**: If this session was resumed
+> from compressed context, re-read this entire template
+> before continuing. Do NOT infer step completion from
+> compressed summaries. Check the EXECUTION CHECKLIST
+> below for actual completion state. If the checklist
+> shows unchecked items, resume from the first unchecked
+> item. When in doubt, re-read — false re-reads are
+> harmless; skipping steps due to stale context causes
+> incomplete reviews or unauthorized actions.
+
+> **EXECUTION CHECKLIST** — Update each item using the
+> Edit tool as you complete it. Mark `[x]` when done.
+>
+> - [ ] Phase 1a: Pre-flight checks
+> - [ ] Phase 1b: Gaze quality analysis
+> - [ ] Phase 1c: Review context discovery
+> - [ ] Step 2: Divisor agent delegation (full branch diff)
+> - [ ] Step 3: Finding consolidation
+> - [ ] Step 4: Fix loop (iteration: _/3)
+> - [ ] Step 5: Iteration limit check
+> - [ ] Step 6: Final report
+> - [ ] Step 7a: PR detection
+> - [ ] Step 7b: Review state fetching
+> - [ ] Step 7c: Pre-posting checks
+> - [ ] Step 7d: Finding aggregation
+> - [ ] Step 7e: Inline comment preparation
+> - [ ] Step 7f: Human confirmation (MANDATORY GATE)
+> - [ ] Step 7g: Post review
+
 ## User Input
 
 ```text
@@ -187,6 +216,8 @@ Review the current codebase for compliance with the Behavioral Constraints in `A
       them for inclusion in the final report (Step 6).
       Proceed to Phase 1b.
 
+   **Checkpoint**: Mark `Phase 1a` complete in the EXECUTION CHECKLIST using the Edit tool before proceeding.
+
    #### Phase 1b -- Gaze Quality Analysis (conditional)
 
    a. Check if `gaze` is available:
@@ -211,6 +242,8 @@ Review the current codebase for compliance with the Behavioral Constraints in `A
        > `go install github.com/unbound-force/gaze/cmd/gaze@latest`)."
 
       Proceed to step 2 without Gaze data.
+
+   **Checkpoint**: Mark `Phase 1b` complete in the EXECUTION CHECKLIST using the Edit tool before proceeding.
 
    #### Phase 1c -- Discover Review Context (mandatory)
 
@@ -258,6 +291,8 @@ Review the current codebase for compliance with the Behavioral Constraints in `A
       consistent with the `pre-flight` skill
       consumption pattern — no inline fallback.
 
+   **Checkpoint**: Mark `Phase 1c` complete in the EXECUTION CHECKLIST using the Edit tool before proceeding.
+
 2. Delegate the review to all **discovered** reviewer agents in parallel using the Task tool. For each discovered agent, use the focus area from the Known Reviewer Roles reference table to provide targeted context. For any discovered agent not in the table, use a generic prompt: "Review the current changes for quality, correctness, and compliance. Return your verdict (APPROVE or REQUEST CHANGES) along with all findings."
 
    **CRITICAL — Review Scope Rule**: The review scope is
@@ -299,6 +334,8 @@ Review the current codebase for compliance with the Behavioral Constraints in `A
 
    For each agent, instruct it to review the full branch diff (all changed files vs `main`) and return its verdict (**APPROVE** or **REQUEST CHANGES**) along with all findings.
 
+   **Checkpoint**: Mark `Step 2` complete in the EXECUTION CHECKLIST using the Edit tool before proceeding.
+
 3. Collect all **REQUEST CHANGES** findings from the
    discovered reviewers. If all discovered reviewers
    return **APPROVE**, report the result and stop.
@@ -321,9 +358,15 @@ Review the current codebase for compliance with the Behavioral Constraints in `A
    Findings with independent root causes MUST remain
    separate even if they affect the same file.
 
+   **Checkpoint**: Mark `Step 3` complete in the EXECUTION CHECKLIST using the Edit tool before proceeding.
+
 4. If there are **REQUEST CHANGES**, address the findings by making the necessary code fixes. Then re-run all discovered reviewers to verify the fixes. Repeat this loop until all discovered reviewers return **APPROVE** or the process has exceeded 3 iterations.
 
+   **Checkpoint**: Update `Step 4` iteration counter in the EXECUTION CHECKLIST (e.g., `iteration: 2/3`) using the Edit tool after each iteration.
+
 5. If 3 iterations are exceeded, ask the user whether to continue or stop.
+
+   **Checkpoint**: Mark `Step 5` complete in the EXECUTION CHECKLIST using the Edit tool before proceeding.
 
 6. Provide a final report to the user:
    - **Discovery summary**: how many reviewer agents were discovered, which were invoked, and which known reviewer roles were absent (informational, non-blocking)
@@ -355,6 +398,8 @@ Review the current codebase for compliance with the Behavioral Constraints in `A
    - What was fixed
    - If stopped early, the current set of outstanding **REQUEST CHANGES**
    - If there were persistent circular **REQUEST CHANGES** (fixes for one reviewer cause failures in another), report those with additional detail so the user can make an informed decision
+
+   **Checkpoint**: Mark `Step 6` complete in the EXECUTION CHECKLIST using the Edit tool before proceeding.
 
 7. **GitHub Review Posting (optional, Code Review Mode only)**
 
@@ -397,6 +442,8 @@ Review the current codebase for compliance with the Behavioral Constraints in `A
       > "No open PR found for this branch — review
       > remains local only."
 
+   **Checkpoint**: Mark `Step 7a` complete in the EXECUTION CHECKLIST using the Edit tool before proceeding.
+
    #### Step 7b -- Review State Fetching
 
    Fetch existing review state to prevent duplicate
@@ -431,6 +478,8 @@ Review the current codebase for compliance with the Behavioral Constraints in `A
    error, skip the sub-step, proceed. All review state
    data is additive context — its absence reduces only
    deduplication accuracy.
+
+   **Checkpoint**: Mark `Step 7b` complete in the EXECUTION CHECKLIST using the Edit tool before proceeding.
 
    #### Step 7c -- Pre-posting Checks
 
@@ -512,6 +561,8 @@ Review the current codebase for compliance with the Behavioral Constraints in `A
    > This APPROVE may not satisfy branch protection if
    > this account is not listed in CODEOWNERS."
 
+   **Checkpoint**: Mark `Step 7c` complete in the EXECUTION CHECKLIST using the Edit tool before proceeding.
+
    #### Step 7d -- Multi-Persona Finding Aggregation
 
    Assemble a single review body from all Divisor persona
@@ -561,6 +612,8 @@ Review the current codebase for compliance with the Behavioral Constraints in `A
    Include: "Full findings available in the terminal
    report."
 
+   **Checkpoint**: Mark `Step 7d` complete in the EXECUTION CHECKLIST using the Edit tool before proceeding.
+
    #### Step 7e -- Inline Comment Preparation
 
    For findings mapped to specific files and line ranges
@@ -600,7 +653,24 @@ Review the current codebase for compliance with the Behavioral Constraints in `A
    Body: <comment text>
    ```
 
+   **Checkpoint**: Mark `Step 7e` complete in the EXECUTION CHECKLIST using the Edit tool before proceeding.
+
    #### Step 7f -- Verdict Mapping and Human Confirmation
+
+   >>> MANDATORY GATE: HUMAN CONFIRMATION REQUIRED <<<
+
+   **Session-resume guard**: If this session was resumed
+   from compressed context, or if you cannot verify that
+   the human explicitly confirmed the review in the
+   current uncompressed conversation history, you MUST
+   re-present the review content (verdict + all comments)
+   and obtain fresh confirmation via the
+   **AskUserQuestion tool** before posting. Do NOT rely
+   on confirmation recorded in compressed context. When
+   in doubt, re-confirm — false re-confirmation is
+   harmless; posting without consent is a violation.
+   Check the EXECUTION CHECKLIST: Step 7f MUST be
+   unchecked before proceeding with confirmation.
 
    Map the council verdict to the GitHub API event type:
 
@@ -642,7 +712,11 @@ Review the current codebase for compliance with the Behavioral Constraints in `A
    human confirmation via the **AskUserQuestion tool**.
    Always show the exact content (verdict type + all
    comments) that will be posted and wait for the user
-   to select a confirming option.
+   to select a confirming option. Mark `Step 7f` as
+   `[x]` in the EXECUTION CHECKLIST only AFTER the
+   human confirms.
+
+   >>> END MANDATORY GATE <<<
 
    #### Step 7g -- Post Review
 
@@ -711,6 +785,8 @@ Review the current codebase for compliance with the Behavioral Constraints in `A
    value for auto-detected PRs without requiring a
    Phase 1c re-run. If any `gh issue view` call fails,
    skip that issue silently.
+
+   **Checkpoint**: Mark `Step 7g` complete in the EXECUTION CHECKLIST using the Edit tool before proceeding.
 
 ---
 

--- a/openspec/changes/review-council-compression-hardening/.openspec.yaml
+++ b/openspec/changes/review-council-compression-hardening/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: unbound-force
+created: 2026-08-01

--- a/openspec/changes/review-council-compression-hardening/design.md
+++ b/openspec/changes/review-council-compression-hardening/design.md
@@ -1,0 +1,191 @@
+## Context
+
+`/uf.review-council` is an 799-line command template that
+orchestrates a multi-phase review workflow: pre-flight checks
+(Phase 1a-1c), parallel Divisor agent delegation (Step 2),
+finding consolidation (Step 3), fix loop (Steps 4-5), final
+report (Step 6), and optional GitHub review posting (Step 7
+with sub-steps 7a-7g).
+
+When OpenCode's context compression fires, early phases are
+summarized and procedural instructions for later steps are
+lost. This is the same root cause as #373 (`/uf.review-pr`),
+and the same three-part remediation pattern applies.
+
+The existing hardening on `/uf.review-pr` (PR #371) added a
+session-resume guard and MANDATORY GATE markers. Issue #378
+proposes the full three-part pattern for `/uf.review-council`:
+session-resume guard, execution checklist, and step-level
+checkpoint reminders.
+
+## Goals / Non-Goals
+
+### Goals
+- Prevent loss of the full-branch-diff review scope rule
+  after compression
+- Prevent loss of the fix loop iteration counter after
+  compression
+- Prevent bypass of the Step 7f APPROVE confirmation gate
+  after compression
+- Follow the proven pattern from `/uf.review-pr` hardening
+- Keep both copies in sync (`.opencode/commands/` and
+  `internal/scaffold/assets/opencode/commands/`)
+
+### Non-Goals
+- Restructuring the command into parent/subagent
+  architecture (that is PR #413's scope for review-pr,
+  and would be a separate effort for review-council)
+- Changing the review workflow logic (steps, gates,
+  verdicts all remain identical)
+- Adding compression resistance to other commands
+  (each command gets its own change)
+
+## Decisions
+
+### D1: Three-part compression resistance pattern
+
+**Decision**: Apply the same three-part pattern used in
+issue #373's proposed fix:
+
+1. **Session-resume guard** (top of file, after frontmatter)
+2. **Execution checklist** (before Instructions section)
+3. **Step-level checkpoint reminders** (end of each phase/step)
+
+**Rationale**: This is the remediation pattern specified in
+issue #378. The guard provides recovery instructions; the
+checklist provides compression-resistant state tracking (it
+is actively edited content, not passive instructions); the
+checkpoints ensure the agent maintains the checklist.
+
+**Constitution**: Aligns with Observable Quality -- the
+checklist makes workflow execution state explicitly trackable.
+
+### D2: Checklist placement and structure
+
+**Decision**: Place the execution checklist as a blockquote
+section immediately after the session-resume guard, before
+the "Determine Review Mode" section. Structure it as:
+
+```markdown
+> **EXECUTION CHECKLIST** — Update each item using the
+> Edit tool as you complete it. Mark `[x]` when done.
+>
+> - [ ] Phase 1a: Pre-flight checks
+> - [ ] Phase 1b: Gaze quality analysis
+> - [ ] Phase 1c: Review context discovery
+> - [ ] Step 2: Divisor agent delegation (full branch diff)
+> - [ ] Step 3: Finding consolidation
+> - [ ] Step 4: Fix loop (iteration: _/3)
+> - [ ] Step 5: Iteration limit check
+> - [ ] Step 6: Final report
+> - [ ] Step 7a: PR detection
+> - [ ] Step 7b: Review state fetching
+> - [ ] Step 7c: Pre-posting checks
+> - [ ] Step 7d: Finding aggregation
+> - [ ] Step 7e: Inline comment preparation
+> - [ ] Step 7f: Human confirmation (MANDATORY GATE)
+> - [ ] Step 7g: Post review
+```
+
+**Rationale**: Blockquote formatting makes the checklist
+visually distinct. Including the fix loop iteration counter
+directly in the checklist (`iteration: _/3`) makes it
+compression-resistant -- the agent updates the counter
+in-place. The `(MANDATORY GATE)` annotation on 7f provides
+an additional salience signal.
+
+### D3: MANDATORY GATE markers on Step 7f
+
+**Decision**: Wrap the Step 7f confirmation section with
+high-salience ASCII delimiters:
+
+```
+>>> MANDATORY GATE: HUMAN CONFIRMATION REQUIRED <<<
+```
+
+and
+
+```
+>>> END MANDATORY GATE <<<
+```
+
+**Rationale**: Same pattern as PR #371 for `/uf.review-pr`.
+These distinctive ASCII tokens survive compression as
+high-salience markers. They visually delimit the
+confirmation gate and signal to the agent that this
+section requires special attention.
+
+### D4: Session-resume guard placement
+
+**Decision**: Place the session-resume guard as a blockquote
+immediately after the `# Command: /uf.review-council`
+heading and before the `## User Input` section.
+
+```markdown
+> **Session-resume guard**: If this session was resumed
+> from compressed context, re-read this entire template
+> before continuing. Do NOT infer step completion from
+> compressed summaries. Check the EXECUTION CHECKLIST
+> below for actual completion state. If the checklist
+> shows unchecked items, resume from the first unchecked
+> item.
+```
+
+**Rationale**: Placing the guard at the very top maximizes
+the chance it survives compression (first-content bias in
+compression heuristics). Directing the agent to the
+checklist provides a concrete recovery mechanism rather
+than vague re-read instructions.
+
+### D5: Checkpoint reminder format
+
+**Decision**: Add a one-line checkpoint reminder at the end
+of each phase/step in this format:
+
+```markdown
+**Checkpoint**: Mark `Phase 1a` complete in the EXECUTION
+CHECKLIST above using the Edit tool before proceeding.
+```
+
+**Rationale**: Keeps reminders minimal (one line each,
+~60-70 characters) to avoid bloating the template. The
+explicit mention of "Edit tool" reinforces that the
+checklist is a live document. The "before proceeding"
+instruction creates a hard gate between steps.
+
+### D6: Dual-file sync
+
+**Decision**: Apply identical changes to both:
+- `.opencode/commands/uf.review-council.md`
+- `internal/scaffold/assets/opencode/commands/uf.review-council.md`
+
+**Rationale**: The scaffold copy is the canonical source
+distributed by `uf init`. Both files must be byte-identical
+to pass drift detection tests.
+
+## Risks / Trade-offs
+
+### R1: Template size increase
+
+The three-part pattern adds ~50-60 lines to an already
+799-line file. This slightly increases the likelihood of
+compression being triggered in the first place. However,
+the added content is specifically designed to be
+compression-resistant, so the net effect is positive.
+
+### R2: Edit tool reliability
+
+The execution checklist depends on the agent correctly
+using the Edit tool to update checkboxes. If the Edit tool
+fails or the agent skips updates, the checklist becomes
+stale. Mitigation: the checkpoint reminders at each step
+create multiple redundant prompts to update the checklist.
+
+### R3: Not a complete solution
+
+The three-part pattern mitigates compression effects but
+does not eliminate the root cause (template-as-conversation-
+content). The full solution is the parent/subagent
+architecture proposed in #373/#413. This hardening is an
+interim measure that provides meaningful protection at low
+implementation cost.

--- a/openspec/changes/review-council-compression-hardening/proposal.md
+++ b/openspec/changes/review-council-compression-hardening/proposal.md
@@ -1,0 +1,139 @@
+## Why
+
+When OpenCode's context compression is enabled, the
+`/uf.review-council` command template (799 lines) is injected
+as conversation content and becomes subject to compression
+heuristics. Early phases (Phase 1a pre-flight, Phase 1b Gaze,
+Phase 1c review-context) are marked "cleanly closed" and
+compressed into a summary that preserves data but discards
+procedural instructions for subsequent steps.
+
+Three concrete failure modes result (issue #378):
+
+1. **Full-branch-diff review scope rule lost** -- The CRITICAL
+   review scope rule (Step 2) requiring
+   `git diff main...HEAD` is compressed away. Divisor agents
+   default to reviewing only recent or visible changes,
+   producing incomplete reviews.
+
+2. **Fix loop iteration count lost** -- Step 4 runs a fix
+   loop of up to 3 iterations. If compression fires
+   mid-loop, the agent loses the iteration counter and may
+   restart from 1 (exceeding the limit) or skip to Step 6.
+
+3. **Step 7f APPROVE gate bypassed** -- The CRITICAL RULE
+   requiring explicit human confirmation via AskUserQuestion
+   before posting any GitHub review can be lost to
+   compression, allowing the agent to post an APPROVE
+   review without user consent.
+
+The root cause is identical to #373 (`/uf.review-pr`): the
+command template is conversation content subject to
+compression. The same three-part remediation pattern applies.
+
+## What Changes
+
+Apply compression-resistance hardening to
+`.opencode/commands/uf.review-council.md` (and its scaffold
+copy) using the same three-part pattern proven in PR #371
+for `/uf.review-pr`:
+
+1. **Session-resume guard** -- A blockquote at the top of
+   the file instructing the agent to re-read the template
+   on resume and not infer step completion from compressed
+   summaries.
+
+2. **Execution checklist with Edit tool instruction** -- A
+   live checklist the agent updates in-place using the Edit
+   tool as each phase/step completes. The checklist is
+   compression-resistant because it is actively maintained
+   content, not passive instructions.
+
+3. **Step-level checkpoint reminders** -- One-line checkpoint
+   at the end of each phase/step reminding the agent to mark
+   the checklist before proceeding.
+
+4. **Step 7f MANDATORY GATE markers** -- Wrap the Step 7f
+   confirmation gate with high-salience ASCII delimiters
+   (`>>> MANDATORY GATE <<<`) that survive compression as
+   distinctive tokens.
+
+## Capabilities
+
+### New Capabilities
+- `compression-resistant-checklist`: Live execution
+  checklist that the agent maintains via Edit tool,
+  preventing compressed-context state loss
+- `session-resume-guard`: Top-of-file instruction for
+  context recovery after compression events
+- `step-checkpoint-reminders`: Per-step reminders to update
+  the checklist before proceeding
+
+### Modified Capabilities
+- `uf.review-council`: Hardened against context compression
+  with session-resume guard, execution checklist, step
+  checkpoints, and MANDATORY GATE markers
+
+### Removed Capabilities
+- None
+
+## Impact
+
+- **Files**: `.opencode/commands/uf.review-council.md` and
+  `internal/scaffold/assets/opencode/commands/uf.review-council.md`
+  (scaffold copy must stay in sync)
+- **Behavior**: Agents executing `/uf.review-council` will
+  maintain an in-place checklist during execution. No
+  behavioral change to the review workflow itself -- all
+  existing steps, gates, and verdicts remain identical.
+- **Line count**: Estimated +40-60 lines (guard, checklist,
+  checkpoints, gate markers). The file grows from ~799 to
+  ~850-860 lines.
+
+## Constitution Alignment
+
+Assessed against the Unbound Force org constitution.
+
+### I. Autonomous Collaboration
+
+**Assessment**: N/A
+
+This change modifies a command template's internal
+structure. It does not affect artifact-based communication
+between heroes or inter-hero coupling.
+
+### II. Composability First
+
+**Assessment**: PASS
+
+The change is self-contained within the review-council
+command. No new dependencies are introduced. The command
+remains independently usable.
+
+### III. Observable Quality
+
+**Assessment**: PASS
+
+The execution checklist produces a machine-readable
+progress record within the command file itself. Each
+phase completion is explicitly tracked, improving
+observability of the review workflow's execution state.
+
+### IV. Testability
+
+**Assessment**: PASS
+
+The hardening additions are structural markers and
+instructions within a Markdown file. They can be verified
+by grep-based drift detection tests (marker count, guard
+presence, checklist completeness).
+
+### V. Security by Default
+
+**Assessment**: PASS
+
+This change directly hardens the Step 7f APPROVE gate --
+a security-critical confirmation boundary. The MANDATORY
+GATE markers and session-resume guard prevent the agent
+from posting GitHub reviews without explicit human
+consent, even after context compression events.

--- a/openspec/changes/review-council-compression-hardening/specs/compression-hardening.md
+++ b/openspec/changes/review-council-compression-hardening/specs/compression-hardening.md
@@ -1,0 +1,132 @@
+## ADDED Requirements
+
+### FR-001: Session-resume guard
+
+The `/uf.review-council` command template MUST include a
+session-resume guard blockquote immediately after the
+`# Command: /uf.review-council` heading that instructs the
+agent to re-read the template on session resume and check
+the execution checklist for actual completion state.
+
+#### Scenario: Agent resumes from compressed context
+
+- **GIVEN** an agent executing `/uf.review-council` whose
+  session context has been compressed
+- **WHEN** the agent resumes execution after compression
+- **THEN** the session-resume guard MUST direct the agent
+  to re-read the full template and consult the execution
+  checklist for completion state, rather than inferring
+  step completion from compressed summaries
+
+### FR-002: Execution checklist
+
+The `/uf.review-council` command template MUST include an
+execution checklist as a blockquote section listing all
+phases and steps with checkbox markers (`[ ]` / `[x]`).
+The agent MUST update each checkbox using the Edit tool
+as it completes the corresponding phase or step.
+
+#### Scenario: Agent completes Phase 1a
+
+- **GIVEN** an agent executing `/uf.review-council` that
+  has completed Phase 1a pre-flight checks
+- **WHEN** Phase 1a finishes (pass or fail)
+- **THEN** the agent MUST mark the `Phase 1a` checkbox
+  as `[x]` in the execution checklist using the Edit
+  tool before proceeding to Phase 1b
+
+#### Scenario: Fix loop iteration tracking
+
+- **GIVEN** an agent executing the fix loop (Step 4) on
+  iteration 2 of 3
+- **WHEN** the agent completes iteration 2
+- **THEN** the agent MUST update the fix loop entry in
+  the execution checklist to reflect `iteration: 2/3`
+  using the Edit tool
+
+#### Scenario: Context compression during fix loop
+
+- **GIVEN** an agent on iteration 2 of the fix loop whose
+  context is compressed between iterations
+- **WHEN** the agent resumes execution
+- **THEN** the agent MUST read the execution checklist to
+  determine the current iteration count and resume from
+  iteration 3, not restart from iteration 1
+
+### FR-003: Step-level checkpoint reminders
+
+Each phase and step in the `/uf.review-council` command
+template MUST end with a one-line checkpoint reminder
+instructing the agent to mark that item complete in the
+execution checklist using the Edit tool before proceeding.
+
+#### Scenario: Checkpoint at end of Phase 1b
+
+- **GIVEN** an agent that has completed Phase 1b (Gaze
+  quality analysis)
+- **WHEN** the agent reads the checkpoint reminder at the
+  end of Phase 1b
+- **THEN** the agent MUST update the execution checklist
+  to mark Phase 1b as `[x]` before proceeding to
+  Phase 1c
+
+### FR-004: MANDATORY GATE markers on Step 7f
+
+The Step 7f confirmation gate in the `/uf.review-council`
+command template MUST be wrapped with high-salience ASCII
+delimiters:
+
+- Opening: `>>> MANDATORY GATE: HUMAN CONFIRMATION REQUIRED <<<`
+- Closing: `>>> END MANDATORY GATE <<<`
+
+#### Scenario: Compression of Step 7 instructions
+
+- **GIVEN** an agent executing `/uf.review-council` whose
+  Steps 1-6 have been compressed
+- **WHEN** the agent reaches Step 7f
+- **THEN** the MANDATORY GATE markers MUST be present in
+  the uncompressed content, signaling that human
+  confirmation via AskUserQuestion is required before
+  posting any GitHub review
+
+#### Scenario: Session-resume guard reinforces gate
+
+- **GIVEN** an agent that resumed from compressed context
+  and cannot verify prior confirmation
+- **WHEN** the agent reaches the MANDATORY GATE section
+- **THEN** the agent MUST re-present the review content
+  and obtain fresh confirmation via AskUserQuestion,
+  consistent with the session-resume guard instruction
+
+### FR-005: Scaffold copy synchronization
+
+The scaffold copy at
+`internal/scaffold/assets/opencode/commands/uf.review-council.md`
+MUST be updated with identical changes as
+`.opencode/commands/uf.review-council.md`.
+
+#### Scenario: Drift detection
+
+- **GIVEN** both copies of `uf.review-council.md` after
+  this change is applied
+- **WHEN** a drift detection test compares the two files
+- **THEN** the files MUST be byte-identical
+
+## MODIFIED Requirements
+
+### FR-006: Step 7f confirmation gate hardening
+
+The existing Step 7f CRITICAL RULE requiring explicit human
+confirmation via AskUserQuestion MUST additionally reference
+the execution checklist. The agent MUST verify that the
+checklist shows Step 7f as unchecked before proceeding with
+confirmation, and MUST mark it `[x]` only after the human
+confirms.
+
+Previously: Step 7f contained only the CRITICAL RULE text
+and session-resume guard (added by PR #371 for review-pr,
+but not yet present in review-council).
+
+## REMOVED Requirements
+
+None.

--- a/openspec/changes/review-council-compression-hardening/tasks.md
+++ b/openspec/changes/review-council-compression-hardening/tasks.md
@@ -1,0 +1,125 @@
+<!--
+  [P] marks tasks eligible for parallel execution.
+  Add [P] when a task: (a) touches different files from
+  other [P] tasks in the group, (b) has no dependency
+  on prior tasks in the group, (c) can safely execute
+  without ordering constraints.
+  Do NOT add [P] when tasks modify the same file —
+  parallel workers will cause merge conflicts.
+  Tasks without [P] run sequentially first, then [P]
+  tasks run in parallel.
+-->
+
+## 1. Add session-resume guard
+
+- [x] 1.1 Add session-resume guard blockquote to
+  `.opencode/commands/uf.review-council.md` immediately
+  after the `# Command: /uf.review-council` heading
+  (line 5) and before `## User Input` (line 7). The
+  guard MUST instruct the agent to re-read the template
+  on session resume, check the execution checklist for
+  actual completion state, and not infer step completion
+  from compressed summaries. (FR-001)
+
+## 2. Add execution checklist
+
+- [x] 2.1 Add execution checklist blockquote to
+  `.opencode/commands/uf.review-council.md` between
+  the session-resume guard and the `## User Input`
+  section. The checklist MUST list all phases and
+  steps with checkbox markers: Phase 1a, Phase 1b,
+  Phase 1c, Step 2, Step 3, Step 4 (with iteration
+  counter `_/3`), Step 5, Step 6, Step 7a-7g. Step 7f
+  MUST include `(MANDATORY GATE)` annotation. Include
+  an instruction to update each item using the Edit
+  tool. (FR-002)
+
+## 3. Add step-level checkpoint reminders
+
+- [x] 3.1 Add checkpoint reminder at the end of Phase 1a
+  (after the verdict handling, before Phase 1b heading).
+  Format: `**Checkpoint**: Mark Phase 1a complete in
+  the EXECUTION CHECKLIST using the Edit tool before
+  proceeding.` (FR-003)
+
+- [x] 3.2 Add checkpoint reminder at the end of Phase 1b
+  (after the Gaze skip note, before Phase 1c heading).
+  (FR-003)
+
+- [x] 3.3 Add checkpoint reminder at the end of Phase 1c
+  (after the review context recording, before Step 2).
+  (FR-003)
+
+- [x] 3.4 Add checkpoint reminder at the end of Step 2
+  (after the enrichment instructions, before Step 3).
+  (FR-003)
+
+- [x] 3.5 Add checkpoint reminder at the end of Step 3
+  (after the consolidation rules, before Step 4).
+  (FR-003)
+
+- [x] 3.6 Add checkpoint reminder at the end of Step 4
+  with iteration tracking instruction: `**Checkpoint**:
+  Update Step 4 iteration counter in the EXECUTION
+  CHECKLIST (e.g., iteration: 2/3) using the Edit
+  tool.` (FR-003, FR-002)
+
+- [x] 3.7 Add checkpoint reminder at the end of Step 5.
+  (FR-003)
+
+- [x] 3.8 Add checkpoint reminder at the end of Step 6
+  (after the final report structure, before Step 7).
+  (FR-003)
+
+## 4. Add MANDATORY GATE markers to Step 7f
+
+- [x] 4.1 Wrap the Step 7f confirmation section (starting
+  at "Map the council verdict to the GitHub API event
+  type" through the CRITICAL RULE) with:
+  - Opening: `>>> MANDATORY GATE: HUMAN CONFIRMATION REQUIRED <<<`
+  - Closing: `>>> END MANDATORY GATE <<<`
+  Add a session-resume guard within the gate section
+  referencing the execution checklist. (FR-004, FR-006)
+
+## 5. Add checkpoint reminders to Step 7 sub-steps
+
+- [x] 5.1 Add checkpoint reminders at the end of Steps
+  7a, 7b, 7c, 7d, 7e, and 7g. Step 7f checkpoint
+  is handled by the MANDATORY GATE section (Task 4.1).
+  (FR-003)
+
+## 6. Sync scaffold copy
+
+- [x] 6.1 [P] Copy the updated
+  `.opencode/commands/uf.review-council.md` to
+  `internal/scaffold/assets/opencode/commands/uf.review-council.md`
+  to maintain byte-identical copies. (FR-005)
+
+## 7. Verification
+
+- [x] 7.1 Verify session-resume guard appears exactly
+  once in the file, before the `## User Input` section.
+
+- [x] 7.2 Verify execution checklist contains all 15
+  phases/steps with checkbox markers.
+
+- [x] 7.3 Verify `MANDATORY GATE` markers appear exactly
+  twice in the file (opening and closing).
+
+- [x] 7.4 Verify checkpoint reminders appear at each
+  phase/step boundary (count: at least 12 checkpoint
+  lines).
+
+- [x] 7.5 Verify scaffold copy is byte-identical:
+  `diff .opencode/commands/uf.review-council.md internal/scaffold/assets/opencode/commands/uf.review-council.md`
+
+- [x] 7.6 Verify constitution alignment: changes are
+  additive-only (no behavioral changes to review
+  workflow), maintain Observable Quality (checklist
+  state is trackable), and maintain Testability
+  (marker counts are grep-verifiable).
+
+- [x] 7.7 Run `make check` to verify no build/lint/test
+  regressions.
+<!-- spec-review: passed -->
+<!-- code-review: passed -->


### PR DESCRIPTION
## Summary

Fixes #378. When OpenCode's context compression is enabled,
the `/uf.review-council` command template (799 lines) is
compressed and procedural instructions for later steps are
lost. This causes three failure modes:

1. Full-branch-diff review scope rule lost -- Divisor agents
   default to reviewing only recent changes
2. Fix loop iteration counter lost -- agent restarts from
   iteration 1 or skips to final report
3. Step 7f APPROVE gate bypassed -- agent posts GitHub
   reviews without human confirmation

This change applies the same three-part compression
resistance pattern proposed in the issue and proven for
`/uf.review-pr` (PR #371):

- **Session-resume guard** at template top directing the
  agent to re-read on resume and check the checklist
- **15-item execution checklist** with Edit tool instruction
  for compression-resistant state tracking
- **14 step-level checkpoint reminders** at phase/step
  boundaries
- **MANDATORY GATE markers** around Step 7f with a
  section-specific session-resume guard

## How to Test

1. Verify session-resume guard placement:
   ```bash
   grep -n "Session-resume guard" .opencode/commands/uf.review-council.md
   # Expected: line 7 (top-level) and ~line 662 (Step 7f)
   ```

2. Verify execution checklist has 15 items:
   ```bash
   grep -c '> - \[ \]' .opencode/commands/uf.review-council.md
   # Expected: 15
   ```

3. Verify MANDATORY GATE delimiters:
   ```bash
   grep -c '>>>' .opencode/commands/uf.review-council.md
   # Expected: 2
   ```

4. Verify checkpoint reminders:
   ```bash
   grep -c 'Checkpoint' .opencode/commands/uf.review-council.md
   # Expected: 14
   ```

5. Verify scaffold copy is byte-identical:
   ```bash
   diff .opencode/commands/uf.review-council.md \
        internal/scaffold/assets/opencode/commands/uf.review-council.md
   # Expected: no output
   ```

6. Verify build and tests pass:
   ```bash
   go build ./... && go test -race -count=1 ./...
   ```

## How to Demo

Run `/uf.review-council` on any branch with changes. The
agent should maintain the execution checklist during
execution. If the session is compressed and resumed, the
agent should check the checklist for completion state
rather than inferring from compressed summaries.

## Key Files Changed

| File | Change |
|------|--------|
| `.opencode/commands/uf.review-council.md` | +77 lines: session-resume guard, execution checklist, 14 checkpoint reminders, MANDATORY GATE markers |
| `internal/scaffold/assets/opencode/commands/uf.review-council.md` | Synced copy (byte-identical) |
| `openspec/changes/review-council-compression-hardening/proposal.md` | Change proposal with constitution alignment |
| `openspec/changes/review-council-compression-hardening/design.md` | 6 design decisions |
| `openspec/changes/review-council-compression-hardening/specs/compression-hardening.md` | 6 requirements (FR-001 through FR-006) with Given/When/Then |
| `openspec/changes/review-council-compression-hardening/tasks.md` | 18 tasks, all complete |
| `openspec/changes/review-council-compression-hardening/.openspec.yaml` | OpenSpec metadata |

_This PR was generated by /uf.finale (AI-assisted)._
