### PR TITLE
fix: add compression resilience to /uf.unleash pipeline

### DIFF
--- a/.opencode/commands/uf.unleash.md
+++ b/.opencode/commands/uf.unleash.md
@@ -29,6 +29,36 @@ off on re-run.
 
 ## Instructions
 
+> **SESSION-RESUME GUARD**: If you are resuming this
+> command after context compression or a session restart,
+> STOP and re-read this entire template before continuing.
+> Do NOT infer which steps are complete from compressed
+> context summaries. Only filesystem markers are
+> authoritative for resumability:
+> - Task checkboxes (`[x]` vs `[ ]`) in `tasks.md`
+> - `<!-- spec-review: passed -->` in `tasks.md`
+> - `<!-- code-review: passed -->` in `tasks.md`
+>
+> Maintain the execution checklist below using the Edit
+> tool. Update it in-place as each step, phase, or
+> iteration completes. This is your live state record.
+
+**Execution Checklist** -- update in-place with Edit tool:
+
+```
+- [ ] Step 0: Startup Cleanup
+- [ ] Step 1: Branch Safety Gate
+- [ ] Step 2: Resumability Detection
+- [ ] Step 3: Clarify (Step 1)
+- [ ] Step 4: Plan (Step 2)
+- [ ] Step 5: Tasks (Step 3)
+- [ ] Step 6: Spec Review (Step 4) -- iteration: 0/3
+- [ ] Step 7: Implement (Step 5) -- phase: 0/N, batch: 0/N, workers: 0/N
+- [ ] Step 8: Code Review (Step 6) -- iteration: 0/3
+- [ ] Step 9: Retrospective (Step 7)
+- [ ] Step 10: Demo (Step 8)
+```
+
 ### 0. Startup Cleanup
 
 Before any pipeline logic, clean up stale worktrees from
@@ -43,6 +73,9 @@ previous interrupted runs:
 
 If `swarm_worktree_list` is not available (Replicator
 not installed), skip this step silently.
+
+> CHECKPOINT: Mark Step 0 complete in the execution
+> checklist before proceeding.
 
 ### 1. Branch Safety Gate
 
@@ -95,10 +128,16 @@ git rev-parse --abbrev-ref HEAD
   > (`opsx/*`). Run `/speckit.specify` or
   > `/opsx-propose` to create one."
 
+> CHECKPOINT: Mark Step 1 complete in the execution
+> checklist before proceeding.
+
 ### 2. Resumability Detection
 
 Probe filesystem state to determine which steps are
-already complete. Check in order:
+already complete. Check in order. **Important**:
+compressed context summaries are NOT valid resumability
+indicators -- only the filesystem markers listed below
+are authoritative.
 
 **If `WORKFLOW_TIER = openspec`**: checks 1-3 are always
 "done" — these artifacts were created by `/opsx-propose`.
@@ -151,6 +190,9 @@ from the first incomplete step.
 If ALL steps are complete (all tasks done, tests pass):
 skip directly to step 7 (retrospective) since it is
 idempotent.
+
+> CHECKPOINT: Mark Step 2 complete in the execution
+> checklist before proceeding.
 
 ### 3. Step 1 -- Clarify
 
@@ -227,6 +269,9 @@ needed" and proceed to step 2.
   Run `/uf.unleash` to continue from the plan step.
   ```
 
+> CHECKPOINT: Mark Step 3 complete in the execution
+> checklist before proceeding.
+
 ### 4. Step 2 -- Plan
 
 **If `WORKFLOW_TIER = openspec`**: skip this step.
@@ -248,6 +293,9 @@ Generate the implementation plan by delegating to the
    > "Plan generation failed -- plan.md was not created.
    > Check the agent output for errors."
 
+> CHECKPOINT: Mark Step 4 complete in the execution
+> checklist before proceeding.
+
 ### 5. Step 3 -- Tasks
 
 **If `WORKFLOW_TIER = openspec`**: skip this step.
@@ -267,6 +315,9 @@ Generate the task list by delegating to the
 4. If `tasks.md` was NOT created: **STOP** with error:
    > "Task generation failed -- tasks.md was not created.
    > Check the agent output for errors."
+
+> CHECKPOINT: Mark Step 5 complete in the execution
+> checklist before proceeding.
 
 ### 6. Step 4 -- Spec Review
 
@@ -302,6 +353,9 @@ analysis + quality validation) in a single pass.
   policy). After fixes, re-run the review. If all
   APPROVE after fixes, write the marker and proceed.
 
+  > CHECKPOINT: Update execution checklist -- spec
+  > review iteration N/3.
+
 - If HIGH or CRITICAL findings remain after auto-fixing
   LOW/MEDIUM: **EXIT** with the findings:
 
@@ -321,6 +375,9 @@ analysis + quality validation) in a single pass.
   ### Then resume
   Run `/uf.unleash` to continue from spec review.
   ```
+
+> CHECKPOINT: Mark Step 6 complete in the execution
+> checklist before proceeding.
 
 ### 7. Step 5 -- Implement
 
@@ -373,6 +430,9 @@ logic used by `/uf.review-council` and `/uf.review-pr`.
         worktree path.
 
    d. Wait for all workers in the batch to complete.
+
+      > CHECKPOINT: Update execution checklist --
+      > batch N/M complete, workers done/total.
 
    e. **If any worker fails**: stop spawning new workers
       (do not start the next batch). Wait for any
@@ -451,6 +511,10 @@ logic used by `/uf.review-council` and `/uf.review-pr`.
    are complete (both sequential and parallel), run the
    pre-flight skill in `hard-gate` mode to execute all
    detected CI and local tool commands.
+
+   > CHECKPOINT: Update execution checklist -- Phase
+   > N/M complete.
+
    - If all pass: proceed to the next phase.
    - If any fail: **EXIT** with the failure details:
 
@@ -468,6 +532,9 @@ logic used by `/uf.review-council` and `/uf.review-pr`.
      ### Then resume
      Run `/uf.unleash` to continue from the next phase.
      ```
+
+> CHECKPOINT: Mark Step 7 complete in the execution
+> checklist before proceeding.
 
 ### 8. Step 6 -- Code Review
 
@@ -508,6 +575,9 @@ quality data.
   b. Re-run the review council in code review mode.
   c. If all APPROVE: proceed to step 7.
 
+  > CHECKPOINT: Update execution checklist -- code
+  > review iteration N/3.
+
 - If 3 iterations are exhausted with remaining findings:
   **EXIT** with the persistent issues:
 
@@ -533,6 +603,9 @@ quality data.
   ### Then resume
   Run `/uf.unleash` to continue from code review.
   ```
+
+> CHECKPOINT: Mark Step 8 complete in the execution
+> checklist before proceeding.
 
 ### 9. Step 7 -- Retrospective
 
@@ -569,6 +642,9 @@ memory.
 
    Display the learnings in the output so they are not
    lost.
+
+> CHECKPOINT: Mark Step 9 complete in the execution
+> checklist before proceeding.
 
 ### 10. Step 8 -- Demo
 
@@ -633,6 +709,9 @@ Format the output as:
 - Run `/uf.finale` to create PR and watch CI
 - Run `/speckit.clarify` to refine and iterate
 ```
+
+> CHECKPOINT: Mark Step 10 complete in the execution
+> checklist. Pipeline complete.
 
 ## Guardrails
 

--- a/internal/scaffold/assets/opencode/commands/uf.unleash.md
+++ b/internal/scaffold/assets/opencode/commands/uf.unleash.md
@@ -29,6 +29,36 @@ off on re-run.
 
 ## Instructions
 
+> **SESSION-RESUME GUARD**: If you are resuming this
+> command after context compression or a session restart,
+> STOP and re-read this entire template before continuing.
+> Do NOT infer which steps are complete from compressed
+> context summaries. Only filesystem markers are
+> authoritative for resumability:
+> - Task checkboxes (`[x]` vs `[ ]`) in `tasks.md`
+> - `<!-- spec-review: passed -->` in `tasks.md`
+> - `<!-- code-review: passed -->` in `tasks.md`
+>
+> Maintain the execution checklist below using the Edit
+> tool. Update it in-place as each step, phase, or
+> iteration completes. This is your live state record.
+
+**Execution Checklist** -- update in-place with Edit tool:
+
+```
+- [ ] Step 0: Startup Cleanup
+- [ ] Step 1: Branch Safety Gate
+- [ ] Step 2: Resumability Detection
+- [ ] Step 3: Clarify (Step 1)
+- [ ] Step 4: Plan (Step 2)
+- [ ] Step 5: Tasks (Step 3)
+- [ ] Step 6: Spec Review (Step 4) -- iteration: 0/3
+- [ ] Step 7: Implement (Step 5) -- phase: 0/N, batch: 0/N, workers: 0/N
+- [ ] Step 8: Code Review (Step 6) -- iteration: 0/3
+- [ ] Step 9: Retrospective (Step 7)
+- [ ] Step 10: Demo (Step 8)
+```
+
 ### 0. Startup Cleanup
 
 Before any pipeline logic, clean up stale worktrees from
@@ -43,6 +73,9 @@ previous interrupted runs:
 
 If `swarm_worktree_list` is not available (Replicator
 not installed), skip this step silently.
+
+> CHECKPOINT: Mark Step 0 complete in the execution
+> checklist before proceeding.
 
 ### 1. Branch Safety Gate
 
@@ -95,10 +128,16 @@ git rev-parse --abbrev-ref HEAD
   > (`opsx/*`). Run `/speckit.specify` or
   > `/opsx-propose` to create one."
 
+> CHECKPOINT: Mark Step 1 complete in the execution
+> checklist before proceeding.
+
 ### 2. Resumability Detection
 
 Probe filesystem state to determine which steps are
-already complete. Check in order:
+already complete. Check in order. **Important**:
+compressed context summaries are NOT valid resumability
+indicators -- only the filesystem markers listed below
+are authoritative.
 
 **If `WORKFLOW_TIER = openspec`**: checks 1-3 are always
 "done" — these artifacts were created by `/opsx-propose`.
@@ -151,6 +190,9 @@ from the first incomplete step.
 If ALL steps are complete (all tasks done, tests pass):
 skip directly to step 7 (retrospective) since it is
 idempotent.
+
+> CHECKPOINT: Mark Step 2 complete in the execution
+> checklist before proceeding.
 
 ### 3. Step 1 -- Clarify
 
@@ -227,6 +269,9 @@ needed" and proceed to step 2.
   Run `/uf.unleash` to continue from the plan step.
   ```
 
+> CHECKPOINT: Mark Step 3 complete in the execution
+> checklist before proceeding.
+
 ### 4. Step 2 -- Plan
 
 **If `WORKFLOW_TIER = openspec`**: skip this step.
@@ -248,6 +293,9 @@ Generate the implementation plan by delegating to the
    > "Plan generation failed -- plan.md was not created.
    > Check the agent output for errors."
 
+> CHECKPOINT: Mark Step 4 complete in the execution
+> checklist before proceeding.
+
 ### 5. Step 3 -- Tasks
 
 **If `WORKFLOW_TIER = openspec`**: skip this step.
@@ -267,6 +315,9 @@ Generate the task list by delegating to the
 4. If `tasks.md` was NOT created: **STOP** with error:
    > "Task generation failed -- tasks.md was not created.
    > Check the agent output for errors."
+
+> CHECKPOINT: Mark Step 5 complete in the execution
+> checklist before proceeding.
 
 ### 6. Step 4 -- Spec Review
 
@@ -302,6 +353,9 @@ analysis + quality validation) in a single pass.
   policy). After fixes, re-run the review. If all
   APPROVE after fixes, write the marker and proceed.
 
+  > CHECKPOINT: Update execution checklist -- spec
+  > review iteration N/3.
+
 - If HIGH or CRITICAL findings remain after auto-fixing
   LOW/MEDIUM: **EXIT** with the findings:
 
@@ -321,6 +375,9 @@ analysis + quality validation) in a single pass.
   ### Then resume
   Run `/uf.unleash` to continue from spec review.
   ```
+
+> CHECKPOINT: Mark Step 6 complete in the execution
+> checklist before proceeding.
 
 ### 7. Step 5 -- Implement
 
@@ -373,6 +430,9 @@ logic used by `/uf.review-council` and `/uf.review-pr`.
         worktree path.
 
    d. Wait for all workers in the batch to complete.
+
+      > CHECKPOINT: Update execution checklist --
+      > batch N/M complete, workers done/total.
 
    e. **If any worker fails**: stop spawning new workers
       (do not start the next batch). Wait for any
@@ -451,6 +511,10 @@ logic used by `/uf.review-council` and `/uf.review-pr`.
    are complete (both sequential and parallel), run the
    pre-flight skill in `hard-gate` mode to execute all
    detected CI and local tool commands.
+
+   > CHECKPOINT: Update execution checklist -- Phase
+   > N/M complete.
+
    - If all pass: proceed to the next phase.
    - If any fail: **EXIT** with the failure details:
 
@@ -468,6 +532,9 @@ logic used by `/uf.review-council` and `/uf.review-pr`.
      ### Then resume
      Run `/uf.unleash` to continue from the next phase.
      ```
+
+> CHECKPOINT: Mark Step 7 complete in the execution
+> checklist before proceeding.
 
 ### 8. Step 6 -- Code Review
 
@@ -508,6 +575,9 @@ quality data.
   b. Re-run the review council in code review mode.
   c. If all APPROVE: proceed to step 7.
 
+  > CHECKPOINT: Update execution checklist -- code
+  > review iteration N/3.
+
 - If 3 iterations are exhausted with remaining findings:
   **EXIT** with the persistent issues:
 
@@ -533,6 +603,9 @@ quality data.
   ### Then resume
   Run `/uf.unleash` to continue from code review.
   ```
+
+> CHECKPOINT: Mark Step 8 complete in the execution
+> checklist before proceeding.
 
 ### 9. Step 7 -- Retrospective
 
@@ -569,6 +642,9 @@ memory.
 
    Display the learnings in the output so they are not
    lost.
+
+> CHECKPOINT: Mark Step 9 complete in the execution
+> checklist before proceeding.
 
 ### 10. Step 8 -- Demo
 
@@ -633,6 +709,9 @@ Format the output as:
 - Run `/uf.finale` to create PR and watch CI
 - Run `/speckit.clarify` to refine and iterate
 ```
+
+> CHECKPOINT: Mark Step 10 complete in the execution
+> checklist. Pipeline complete.
 
 ## Guardrails
 

--- a/openspec/changes/unleash-compression-resilience/.openspec.yaml
+++ b/openspec/changes/unleash-compression-resilience/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: unbound-force
+created: 2026-08-01

--- a/openspec/changes/unleash-compression-resilience/design.md
+++ b/openspec/changes/unleash-compression-resilience/design.md
@@ -1,0 +1,156 @@
+## Context
+
+The `/uf.unleash` command template (661 lines) is injected as
+conversation content in OpenCode. When context compression is
+enabled, the compression system can discard procedural instructions
+between pipeline steps, causing the agent to lose awareness of its
+current execution state, phase boundaries, fix loop iteration counts,
+and parallel worker batch progress (issue #380).
+
+Issue #373 describes the same root cause for `/uf.review-pr` and
+proposes a three-part remediation pattern. This design applies that
+same pattern to `/uf.unleash`, adapted for its 8-step pipeline
+structure with phases, parallel workers, and fix loops.
+
+## Goals / Non-Goals
+
+### Goals
+- Survive context compression events without losing pipeline state
+- Maintain awareness of current step, phase, and iteration count
+  after compression fires
+- Ensure the agent re-reads the template on resume rather than
+  inferring procedure from compressed summaries
+- Keep filesystem markers (checkboxes, HTML comment markers) as the
+  authoritative resumability source
+- Apply a consistent pattern with the `/uf.review-pr` fix (#373)
+
+### Non-Goals
+- Restructuring `/uf.unleash` into parent/subagent split (that is the
+  approach proposed for `/uf.review-pr` but is a separate effort)
+- Reducing the template size to avoid triggering compression (the
+  template must remain comprehensive for the pipeline to function)
+- Modifying OpenCode's compression behavior itself
+- Changing any pipeline logic, step ordering, or exit conditions
+
+## Decisions
+
+### D1: Three-part remediation pattern
+
+Apply the same three-part pattern proposed in issue #373:
+
+1. **Session-resume guard** (blockquote at top of Instructions)
+2. **Execution checklist** (inline state updated via Edit tool)
+3. **Step-level checkpoint reminders** (one-liner at each boundary)
+
+**Rationale**: Consistency with the `/uf.review-pr` fix means the
+pattern is recognizable across commands. The agent learns one
+resilience pattern and applies it uniformly.
+
+### D2: Execution checklist placement
+
+Place the execution checklist immediately after the session-resume
+guard blockquote, before Step 0 (Startup Cleanup). The checklist
+tracks:
+
+- Current step (0-8) with step name
+- Current phase within Step 5 (e.g., Phase 2/3)
+- Fix loop iteration for Steps 4 and 6 (e.g., iteration 1/3)
+- Parallel worker batch progress (e.g., batch 1/2, 3/4 workers done)
+
+**Rationale**: Placing the checklist early in the template means it
+survives even aggressive compression that preserves only the first
+portion of the content. The Edit tool instruction ensures the agent
+actively maintains state rather than passively relying on context.
+
+### D3: Checkpoint reminder format
+
+Each step's final paragraph includes a one-line checkpoint reminder:
+
+```
+> CHECKPOINT: Mark Step N complete in the execution checklist
+> before proceeding.
+```
+
+Phase boundaries within Step 5 include:
+
+```
+> CHECKPOINT: Update execution checklist -- Phase N/M complete.
+```
+
+Fix loop iterations in Steps 4 and 6 include:
+
+```
+> CHECKPOINT: Update execution checklist -- iteration N/3.
+```
+
+**Rationale**: Short, formulaic reminders are less likely to be
+compressed away than longer prose. The `>` blockquote format
+visually distinguishes checkpoints from regular instructions.
+
+### D4: Filesystem markers remain authoritative
+
+The session-resume guard explicitly states that only filesystem
+markers are authoritative for resumability:
+
+- Task checkboxes (`[x]` vs `[ ]`) in `tasks.md`
+- HTML comment markers (`<!-- spec-review: passed -->`,
+  `<!-- code-review: passed -->`)
+
+The execution checklist is a conversation-level aid, not a
+replacement for filesystem state. On re-run, the agent MUST
+re-probe filesystem markers per Step 2 (Resumability Detection)
+regardless of what the execution checklist says.
+
+**Rationale**: Filesystem markers persist across sessions. The
+execution checklist exists only within a single conversation and
+is designed to survive intra-session compression, not inter-session
+continuity.
+
+### D5: Both canonical and scaffold copies updated
+
+Both files must be updated in sync:
+- `.opencode/commands/uf.unleash.md` (canonical)
+- `internal/scaffold/assets/opencode/commands/uf.unleash.md` (scaffold)
+
+Existing drift detection tests verify these match.
+
+**Rationale**: The scaffold copy is what `uf init` deploys to new
+projects. Drift between canonical and scaffold is caught by existing
+tests, but both must be updated in the same PR to avoid test failures.
+
+## Risks / Trade-offs
+
+### R1: Template size increase
+
+Adding the guard, checklist, and checkpoint reminders will increase
+the template from ~661 lines to ~700-720 lines. This slightly
+increases the probability of compression firing, but the added
+content is specifically designed to survive compression.
+
+**Mitigation**: The additions are concise. The checklist is a compact
+table. Checkpoint reminders are single lines.
+
+### R2: Agent compliance with Edit tool instructions
+
+The execution checklist relies on the agent actually using the Edit
+tool to update it. If the agent ignores the instruction, the checklist
+becomes stale and provides no value.
+
+**Mitigation**: The session-resume guard prominently instructs the
+agent to maintain the checklist. Checkpoint reminders at each step
+boundary reinforce this. The pattern is already proposed for
+`/uf.review-pr`, so agents will encounter it consistently.
+
+### R3: No structural guarantee
+
+This is a behavioral mitigation (instructing the agent differently),
+not a structural one (like the parent/subagent split proposed in
+#373). Compression behavior is ultimately controlled by OpenCode,
+and sufficiently aggressive compression could still discard the
+guard and checklist.
+
+**Mitigation**: The guard is placed at the very top of the
+Instructions section. The checklist follows immediately. Both are
+formatted as blockquotes, which compression systems may treat
+differently from regular prose. The structural fix (parent/subagent
+split) is a separate, complementary effort.

--- a/openspec/changes/unleash-compression-resilience/proposal.md
+++ b/openspec/changes/unleash-compression-resilience/proposal.md
@@ -1,0 +1,129 @@
+## Why
+
+When OpenCode's context compression is enabled during a `/uf.unleash`
+session, the 661-line command template is injected as conversation
+content and becomes subject to compression heuristics. The 8-step
+autonomous pipeline (clarify, plan, tasks, spec review, implement,
+code review, retrospective, demo) spans many tool calls and subagent
+delegations. Compression can fire between steps, discarding procedural
+instructions while preserving only data summaries.
+
+This causes four failure modes (GitHub issue #380):
+
+1. **Resumability detection misread** -- the agent loses awareness of
+   which step it is currently executing, potentially misinterpreting
+   intermediate state as complete and skipping partially-done steps.
+2. **Phase checkpoint hard-gate skipped** -- the agent loses awareness
+   that a pre-flight checkpoint is required before proceeding to the
+   next phase, advancing without verifying build and tests pass.
+3. **Parallel worker batch state lost** -- the agent loses track of
+   which workers in a batch have completed, potentially double-executing
+   tasks or incorrectly reporting batches as complete.
+4. **Fix loop iteration count lost** -- the agent loses the iteration
+   counter for spec review and code review fix loops, potentially
+   exceeding the 3-iteration limit or skipping remaining iterations.
+
+The root cause is the same as issue #373 (`/uf.review-pr`): the command
+template is injected as conversation content, making it subject to the
+same compression heuristics as tool output and intermediate results.
+
+## What Changes
+
+Add compression resilience to the `/uf.unleash` command template using
+the same three-part remediation pattern proposed for `/uf.review-pr`
+in issue #373:
+
+1. **Session-resume guard** -- a blockquote at the top of the file
+   instructing the agent to re-read the template on resume and rely
+   only on filesystem markers (checkboxes, HTML comment markers) for
+   resumability, never compressed context summaries.
+
+2. **Execution checklist with Edit tool instruction** -- a live
+   checklist the agent updates in-place using the Edit tool as each
+   step completes. Includes iteration count and current phase as inline
+   state (e.g., `Step 5: Implement -- Phase 2/3, iteration 1/3`).
+
+3. **Step-level checkpoint reminders** -- one-line checkpoint at the
+   end of each step and phase boundary reminding the agent to mark the
+   checklist before proceeding.
+
+## Capabilities
+
+### New Capabilities
+- `compression-resilient-state`: Pipeline execution state survives
+  context compression events via in-conversation checklist that the
+  agent maintains with Edit tool operations
+- `session-resume-guard`: Explicit instructions preventing the agent
+  from inferring step completion from compressed summaries
+
+### Modified Capabilities
+- `resumability-detection`: Enhanced with explicit guard against
+  treating compressed context as authoritative state source
+- `phase-checkpoints`: Each phase boundary now includes a checkpoint
+  reminder to update the execution checklist
+- `fix-loop-tracking`: Iteration counters for spec review and code
+  review loops are maintained in the execution checklist
+
+### Removed Capabilities
+- None
+
+## Impact
+
+- **Files**: `.opencode/commands/uf.unleash.md` and its scaffold copy
+  at `internal/scaffold/assets/opencode/commands/uf.unleash.md`
+- **Behavior**: No change to pipeline logic or step ordering. The
+  additions are purely defensive -- they add state tracking and
+  checkpoint reminders that are harmless when compression is disabled
+  and essential when compression is enabled.
+- **Testing**: Existing drift detection tests verify the scaffold copy
+  matches the canonical source. No new test functions needed since the
+  change is to a Markdown command template, not Go source code.
+
+## Constitution Alignment
+
+Assessed against the Unbound Force org constitution (v1.2.0).
+
+### I. Autonomous Collaboration
+
+**Assessment**: PASS
+
+This change strengthens artifact-based collaboration. The execution
+checklist is itself an artifact -- an in-conversation state record
+that the agent maintains via Edit tool operations. The filesystem
+markers (`<!-- spec-review: passed -->`, `<!-- code-review: passed -->`,
+task checkboxes) remain the authoritative resumability state, and the
+session-resume guard explicitly reinforces this artifact-first pattern.
+
+### II. Composability First
+
+**Assessment**: N/A
+
+This change modifies only the `/uf.unleash` command template. It does
+not introduce dependencies between heroes or affect standalone
+hero functionality.
+
+### III. Observable Quality
+
+**Assessment**: PASS
+
+The execution checklist makes pipeline progress observable within the
+conversation. Step completion, phase counts, and iteration numbers
+are tracked explicitly rather than inferred from compressed context.
+
+### IV. Testability
+
+**Assessment**: PASS
+
+The change is to a Markdown command template. Existing drift detection
+tests in the scaffold package verify that the scaffold copy matches
+the canonical source. The template modifications are testable by
+verifying the guard text, checklist, and checkpoint reminders exist
+in the file.
+
+### V. Security by Default
+
+**Assessment**: N/A
+
+This change does not affect supply chain integrity, input validation,
+or privilege boundaries. It modifies only conversational instructions
+within a command template.

--- a/openspec/changes/unleash-compression-resilience/specs/compression-resilience.md
+++ b/openspec/changes/unleash-compression-resilience/specs/compression-resilience.md
@@ -1,0 +1,140 @@
+## ADDED Requirements
+
+### Requirement: Session-Resume Guard (FR-001)
+
+The `/uf.unleash` command template MUST include a session-resume
+guard blockquote at the beginning of the Instructions section,
+before Step 0 (Startup Cleanup). The guard MUST instruct the agent
+to:
+
+1. Re-read the full template on session resume
+2. NOT infer step completion from compressed context summaries
+3. Treat only filesystem markers as authoritative for resumability
+4. Maintain the execution checklist using the Edit tool
+
+#### Scenario: Compression fires mid-pipeline
+- **GIVEN** the agent is executing Step 5 (Implement) Phase 2
+- **WHEN** context compression fires and discards procedural
+  instructions from earlier in the conversation
+- **THEN** the session-resume guard remains visible in the
+  compressed context and the agent re-reads the template to
+  recover step-by-step instructions
+
+#### Scenario: Agent resumes after re-run
+- **GIVEN** the agent is re-invoked with `/uf.unleash` after a
+  previous session was interrupted
+- **WHEN** the agent reads the session-resume guard
+- **THEN** the agent probes filesystem markers per Step 2
+  (Resumability Detection) and does NOT rely on any prior
+  conversation state
+
+### Requirement: Execution Checklist (FR-002)
+
+The `/uf.unleash` command template MUST include an execution
+checklist immediately after the session-resume guard. The checklist
+MUST track:
+
+- Current pipeline step (0-8) with step name
+- Current phase within Step 5 (Phase N/M)
+- Fix loop iteration count for Step 4 and Step 6 (iteration N/3)
+- Parallel worker batch progress for Step 5 (batch N/M,
+  workers completed/total)
+
+The agent MUST update the checklist in-place using the Edit tool
+as each step, phase, or iteration completes.
+
+#### Scenario: Agent updates checklist after completing Step 4
+- **GIVEN** the agent has completed Step 4 (Spec Review)
+  with all reviewers approving
+- **WHEN** the agent prepares to proceed to Step 5 (Implement)
+- **THEN** the agent uses the Edit tool to mark Step 4 as
+  complete in the execution checklist before proceeding
+
+#### Scenario: Agent tracks fix loop iteration
+- **GIVEN** the agent is in Step 6 (Code Review) and findings
+  were returned on the first iteration
+- **WHEN** the agent begins the second fix-and-review iteration
+- **THEN** the agent uses the Edit tool to update the checklist
+  to show "iteration 2/3" for Step 6
+
+#### Scenario: Agent tracks parallel worker batch
+- **GIVEN** Step 5 has 6 parallel tasks, batched as 4 + 2
+- **WHEN** the first batch of 4 workers completes
+- **THEN** the agent uses the Edit tool to update the checklist
+  to show "batch 2/2, 0/2 workers done" before spawning the
+  second batch
+
+### Requirement: Step-Level Checkpoint Reminders (FR-003)
+
+Each step in the `/uf.unleash` command template MUST end with a
+checkpoint reminder instructing the agent to update the execution
+checklist. The reminders MUST use blockquote format:
+
+- Step boundaries: `> CHECKPOINT: Mark Step N complete in the
+  execution checklist before proceeding.`
+- Phase boundaries (Step 5): `> CHECKPOINT: Update execution
+  checklist -- Phase N/M complete.`
+- Fix loop iterations (Steps 4, 6): `> CHECKPOINT: Update
+  execution checklist -- iteration N/3.`
+
+#### Scenario: Agent completes Step 3 (Tasks)
+- **GIVEN** the agent has generated tasks.md in the feature
+  directory
+- **WHEN** the agent reaches the end of Step 3 instructions
+- **THEN** the agent encounters the checkpoint reminder and
+  updates the execution checklist to mark Step 3 complete
+
+#### Scenario: Agent completes a phase in Step 5
+- **GIVEN** the agent has completed all tasks in Phase 2 of 3
+  and the pre-flight hard-gate has passed
+- **WHEN** the agent reaches the phase checkpoint reminder
+- **THEN** the agent updates the execution checklist to show
+  "Phase 2/3 complete" before proceeding to Phase 3
+
+### Requirement: Filesystem Markers Remain Authoritative (FR-004)
+
+The execution checklist MUST NOT replace filesystem markers as the
+authoritative source for resumability detection. On re-run, the
+agent MUST re-probe filesystem markers per Step 2 regardless of
+execution checklist state.
+
+Authoritative filesystem markers:
+- Task checkboxes (`[x]` vs `[ ]`) in `tasks.md`
+- `<!-- spec-review: passed -->` HTML comment in `tasks.md`
+- `<!-- code-review: passed -->` HTML comment in `tasks.md`
+
+#### Scenario: Checklist disagrees with filesystem
+- **GIVEN** the execution checklist shows Step 5 as complete
+  but `tasks.md` contains unchecked `[ ]` task checkboxes
+- **WHEN** the agent runs Step 2 (Resumability Detection)
+- **THEN** the agent treats Step 5 as incomplete based on
+  filesystem markers, ignoring the execution checklist
+
+### Requirement: Scaffold Copy Sync (FR-005)
+
+The scaffold copy at
+`internal/scaffold/assets/opencode/commands/uf.unleash.md`
+MUST be updated to match the canonical copy at
+`.opencode/commands/uf.unleash.md`. Existing drift detection
+tests MUST continue to pass.
+
+#### Scenario: Drift detection after update
+- **GIVEN** both files have been updated with identical content
+- **WHEN** drift detection tests run
+- **THEN** all tests pass, confirming the files are in sync
+
+## MODIFIED Requirements
+
+### Requirement: Step 2 Resumability Detection
+
+Step 2 MUST explicitly state that only filesystem markers are
+authoritative for resumability. Previously, this was implicit.
+The modification adds a sentence clarifying that compressed
+context summaries are NOT valid resumability indicators.
+
+Previously: Step 2 listed filesystem markers to check but did
+not explicitly warn against using compressed context.
+
+## REMOVED Requirements
+
+None.

--- a/openspec/changes/unleash-compression-resilience/tasks.md
+++ b/openspec/changes/unleash-compression-resilience/tasks.md
@@ -1,0 +1,106 @@
+<!--
+  [P] marks tasks eligible for parallel execution.
+  Add [P] when a task: (a) touches different files from
+  other [P] tasks in the group, (b) has no dependency
+  on prior tasks in the group, (c) can safely execute
+  without ordering constraints.
+  Do NOT add [P] when tasks modify the same file --
+  parallel workers will cause merge conflicts.
+  Tasks without [P] run sequentially first, then [P]
+  tasks run in parallel.
+-->
+
+## 1. Add Compression Resilience to Canonical Template
+
+All tasks in this group modify the same file
+(`.opencode/commands/uf.unleash.md`), so they MUST run
+sequentially. No `[P]` markers.
+
+- [ ] 1.1 Add session-resume guard blockquote at the beginning of
+  the Instructions section (after `## Instructions`, before
+  `### 0. Startup Cleanup`). The guard MUST instruct the agent
+  to: (a) re-read the full template on resume, (b) not infer
+  step completion from compressed context summaries, (c) treat
+  only filesystem markers as authoritative for resumability,
+  (d) maintain the execution checklist using the Edit tool.
+  File: `.opencode/commands/uf.unleash.md`
+
+- [ ] 1.2 Add execution checklist immediately after the
+  session-resume guard. The checklist MUST track: current step
+  (0-8) with name, current phase in Step 5 (Phase N/M), fix
+  loop iteration for Steps 4 and 6 (iteration N/3), and
+  parallel worker batch progress (batch N/M, workers done/total).
+  Include an instruction for the agent to update the checklist
+  in-place using the Edit tool as each milestone completes.
+  File: `.opencode/commands/uf.unleash.md`
+
+- [ ] 1.3 Add checkpoint reminder at the end of Step 0 (Startup
+  Cleanup) in blockquote format:
+  `> CHECKPOINT: Mark Step 0 complete in the execution checklist
+  before proceeding.`
+  File: `.opencode/commands/uf.unleash.md`
+
+- [ ] 1.4 Add checkpoint reminder at the end of Step 1 (Branch
+  Safety Gate).
+  File: `.opencode/commands/uf.unleash.md`
+
+- [ ] 1.5 Add checkpoint reminder at the end of Step 2
+  (Resumability Detection). Also add an explicit note that
+  compressed context summaries are NOT valid resumability
+  indicators -- only filesystem markers are authoritative.
+  File: `.opencode/commands/uf.unleash.md`
+
+- [ ] 1.6 Add checkpoint reminder at the end of Step 3 (Clarify).
+  File: `.opencode/commands/uf.unleash.md`
+
+- [ ] 1.7 Add checkpoint reminder at the end of Step 4 (Plan).
+  File: `.opencode/commands/uf.unleash.md`
+
+- [ ] 1.8 Add checkpoint reminder at the end of Step 5 (Tasks).
+  File: `.opencode/commands/uf.unleash.md`
+
+- [ ] 1.9 Add checkpoint reminders to Step 6 (Spec Review):
+  one at each fix loop iteration boundary (`> CHECKPOINT:
+  Update execution checklist -- iteration N/3.`) and one at the
+  end of the step.
+  File: `.opencode/commands/uf.unleash.md`
+
+- [ ] 1.10 Add checkpoint reminders to Step 7 (Implement): one at
+  each phase boundary (`> CHECKPOINT: Update execution checklist
+  -- Phase N/M complete.`) and one for parallel worker batch
+  completion. Also add a checkpoint at the end of the step.
+  File: `.opencode/commands/uf.unleash.md`
+
+- [ ] 1.11 Add checkpoint reminders to Step 8 (Code Review):
+  one at each fix loop iteration boundary and one at the end of
+  the step.
+  File: `.opencode/commands/uf.unleash.md`
+
+- [ ] 1.12 Add checkpoint reminder at the end of Step 9
+  (Retrospective).
+  File: `.opencode/commands/uf.unleash.md`
+
+- [ ] 1.13 Add checkpoint reminder at the end of Step 10 (Demo).
+  File: `.opencode/commands/uf.unleash.md`
+
+## 2. Sync Scaffold Copy
+
+- [ ] 2.1 Copy the updated canonical template to the scaffold
+  location. The scaffold copy MUST be identical to the canonical
+  copy.
+  File: `internal/scaffold/assets/opencode/commands/uf.unleash.md`
+  Source: `.opencode/commands/uf.unleash.md`
+
+## 3. Verify
+
+- [ ] 3.1 Run drift detection tests to confirm canonical and
+  scaffold copies are in sync:
+  `go test -race -count=1 ./internal/scaffold/...`
+
+- [ ] 3.2 Run full test suite to verify no regressions:
+  `go test -race -count=1 ./...`
+
+- [ ] 3.3 Verify constitution alignment: confirm that the changes
+  are purely additive (no pipeline logic changes), maintain
+  artifact-based resumability (Principle I), and do not introduce
+  new dependencies (Principle II).


### PR DESCRIPTION
## Summary

Adds compression resilience to the `/uf.unleash` command template
to prevent pipeline state loss when OpenCode's context compression
fires mid-session.

When compression is enabled, the 661-line command template can be
compressed between pipeline steps, causing the agent to lose
awareness of its current step, phase boundaries, fix loop iteration
counts, and parallel worker batch progress (issue #380).

This applies the same three-part remediation pattern proposed for
`/uf.review-pr` in issue #373:

1. **Session-resume guard** -- blockquote at the top of Instructions
   telling the agent to re-read the template on resume and rely only
   on filesystem markers for resumability
2. **Execution checklist** -- live state record maintained via Edit
   tool tracking step, phase, iteration, and batch progress
3. **Checkpoint reminders** -- 15 one-line reminders at step, phase,
   and iteration boundaries

No pipeline logic or step ordering is changed. The additions are
purely defensive -- harmless when compression is disabled, essential
when enabled.

Fixes #380

## How to Test

1. Verify drift detection passes:
   ```bash
   go test -race -count=1 ./internal/scaffold/...
   ```

2. Verify full test suite passes:
   ```bash
   go test -race -count=1 ./...
   ```

3. Verify the guard is present at the top of Instructions:
   ```bash
   grep -n "SESSION-RESUME GUARD" .opencode/commands/uf.unleash.md
   ```

4. Verify all 15 checkpoints are present:
   ```bash
   grep -c "CHECKPOINT" .opencode/commands/uf.unleash.md
   # Expected: 15
   ```

5. Verify canonical and scaffold copies are identical:
   ```bash
   diff .opencode/commands/uf.unleash.md \
     internal/scaffold/assets/opencode/commands/uf.unleash.md
   # Expected: no output
   ```

## How to Demo

1. Open `.opencode/commands/uf.unleash.md` and observe the
   session-resume guard blockquote at line 32
2. Observe the execution checklist at line 46 with all 11 steps
3. Scroll through the file and observe checkpoint reminders after
   each step section (blockquote format starting with `> CHECKPOINT:`)
4. Note the explicit compressed-context warning added to Step 2
   (Resumability Detection)

## Key Files Changed

**Command templates:**
- `.opencode/commands/uf.unleash.md` -- canonical template (+81 lines)
- `internal/scaffold/assets/opencode/commands/uf.unleash.md` -- scaffold copy (synced)

**OpenSpec change artifacts:**
- `openspec/changes/unleash-compression-resilience/proposal.md` -- change proposal
- `openspec/changes/unleash-compression-resilience/design.md` -- technical design
- `openspec/changes/unleash-compression-resilience/specs/compression-resilience.md` -- delta specs (FR-001 through FR-005)
- `openspec/changes/unleash-compression-resilience/tasks.md` -- implementation tasks

_This PR was generated by /uf.finale (AI-assisted)._
