### PR TITLE
fix(commands): add compression guards to /uf.address-feedback

### DIFF
--- a/.opencode/commands/uf.address-feedback.md
+++ b/.opencode/commands/uf.address-feedback.md
@@ -10,11 +10,48 @@ You are a token-efficient feedback analyst. The user will provide a PR number or
 
 The command follows four sequential phases (Ingest → Assess → Triage → Execute). Phases are not independently invocable — run all four in sequence every invocation.
 
+> **SESSION-RESUME GUARD**: If this session has been resumed
+> from compressed context, or if you cannot locate the
+> execution checklist in the current conversation, you MUST:
+> 1. Re-read this full command template
+> 2. Check `.uf/feedback/pr-<PR_NUMBER>/state.json` for
+>    cached assessment state
+> 3. Locate the execution checklist in your prior output
+>    and verify which phases are marked `[x]`
+> 4. Do NOT infer phase completion or triage decisions from
+>    compressed context summaries — only `state.json` and the
+>    execution checklist are authoritative
+> 5. Resume from the first incomplete phase
+
 ## Arguments
 
 - **PR number** (optional): The pull request number to address feedback for (e.g., `42`). If omitted, auto-detect the open PR for the current branch.
 
 **Argument parsing** (before any tool calls): Check the user's message for a PR number argument. If present, set `PR_NUMBER` to that value immediately. All subsequent steps use `<PR_NUMBER>` — no auto-detection commands are needed or permitted.
+
+---
+
+## Execution Checklist
+
+At the start of execution, render this checklist in your
+output. Update it in-place using the **Edit tool** as each
+phase and sub-step completes. This checklist survives
+context compression and serves as the authoritative record
+of progress.
+
+```
+- [ ] Phase 1: Ingest -- _N_ items fetched
+- [ ] Phase 2: Assess -- _N_ items classified
+- [ ] Phase 3: Triage -- _N_/_M_ items decided: _n_A _n_M _n_R _n_K
+- [ ] Phase 4.1: Code changes -- _N_ files modified
+- [ ] Phase 4.2: Commits -- _N_ commits created
+- [ ] Phase 4.3: Review-council -- iteration _N_, PASS/FAIL
+- [ ] Phase 4.4: Push -- done
+- [ ] Phase 4.5: Reply comments -- _N_/_M_ posted
+```
+
+Replace `_N_`, `_M_`, etc. with actual counts as you
+progress. Mark each line `[x]` when the phase completes.
 
 ---
 
@@ -123,6 +160,9 @@ On crash-recovery re-entry: items marked as fully executed (`comment-posted`) in
 
 If no items remain after filtering: report "No unresolved feedback to address" and **STOP**.
 
+> **CHECKPOINT**: Update the execution checklist above
+> before proceeding to Phase 2.
+
 ---
 
 ## Phase 2: Assess
@@ -207,6 +247,9 @@ Write assessment results to `.uf/feedback/pr-<PR_NUMBER>/state.json`:
 
 **Permissions**: files `600`, directories `700`.
 
+> **CHECKPOINT**: Update the execution checklist above
+> before proceeding to Phase 3.
+
 ---
 
 ## Phase 3: Triage
@@ -275,6 +318,10 @@ List each item with its decision. Use the
 proceed with execution", "Revise -- change decisions"]`
 before execution proceeds.
 
+> **CHECKPOINT**: Update the execution checklist above
+> before proceeding to Phase 4. Verify all items have
+> decisions recorded.
+
 ---
 
 ## Phase 4: Execute
@@ -323,6 +370,9 @@ attribution").
 
 The `<scope>` is the package or directory of the changed files. The description summarizes the logical group of fixes.
 
+> **CHECKPOINT**: Update the execution checklist:
+> Phase 4.2 commit count.
+
 ### 4.3 Review-Council Gate
 
 After all code changes are committed locally, run `/uf.review-council` on the cumulative changes.
@@ -330,6 +380,13 @@ After all code changes are committed locally, run `/uf.review-council` on the cu
 - **If passes**: continue to push
 - **If fails**: enter fix loop (same behavior as `/uf.unleash`). Fix findings and re-run council.
 - **If fix loop exhausts iterations**: **STOP** and report persistent findings. Do NOT push until council passes.
+
+After each council run, update the execution checklist:
+`[ ] Phase 4.3: Review-council -- iteration N, PASS/FAIL`
+Mark `[x]` only when the council passes.
+
+> **CHECKPOINT**: Update the execution checklist:
+> Phase 4.3 iteration and result.
 
 ### 4.4 Push Changes
 
@@ -354,12 +411,25 @@ git push origin <branch>
 **If push fails** (network error, branch protection rejection): preserve local commits and report which commits are stranded. Provide guidance:
 > "Push failed. Local commits preserved. Retry with `git push origin <branch>` after resolving the issue."
 
+> **CHECKPOINT**: Update the execution checklist:
+> Phase 4.4 push status.
+
 ### 4.5 Post Reply Comments
 
 After push succeeds (or if there are no code changes),
 post reply comments to the PR. Before posting, use the
 **AskUserQuestion tool** with options `["Yes -- post
 reply comments", "No -- skip posting"]`.
+
+**Checklist gate**: Before presenting comments for posting,
+verify the execution checklist shows:
+1. Phase 3 is marked `[x]` with all items decided
+2. Phase 4.1 through 4.4 are marked `[x]`
+
+If the checklist is missing, incomplete, or shows Phase 3
+as not complete, you MUST re-read this command template and
+rebuild state from `state.json` and the git log. Do NOT
+post comments without verified checklist state.
 
 For each item, compose the reply:
 
@@ -395,6 +465,9 @@ rm -f "$REPLY_FILE"
 > "Posted 3 of 6 reply comments. Items 4-6 pending. Re-run `/uf.address-feedback <PR_NUMBER>` to retry."
 
 Record progress in `.uf/feedback/pr-<PR_NUMBER>/state.json` for idempotent retry.
+
+> **CHECKPOINT**: Update the execution checklist:
+> Phase 4.5 comment posting count.
 
 ### 4.6 Resolve Threads
 

--- a/internal/scaffold/assets/opencode/commands/uf.address-feedback.md
+++ b/internal/scaffold/assets/opencode/commands/uf.address-feedback.md
@@ -10,11 +10,48 @@ You are a token-efficient feedback analyst. The user will provide a PR number or
 
 The command follows four sequential phases (Ingest → Assess → Triage → Execute). Phases are not independently invocable — run all four in sequence every invocation.
 
+> **SESSION-RESUME GUARD**: If this session has been resumed
+> from compressed context, or if you cannot locate the
+> execution checklist in the current conversation, you MUST:
+> 1. Re-read this full command template
+> 2. Check `.uf/feedback/pr-<PR_NUMBER>/state.json` for
+>    cached assessment state
+> 3. Locate the execution checklist in your prior output
+>    and verify which phases are marked `[x]`
+> 4. Do NOT infer phase completion or triage decisions from
+>    compressed context summaries — only `state.json` and the
+>    execution checklist are authoritative
+> 5. Resume from the first incomplete phase
+
 ## Arguments
 
 - **PR number** (optional): The pull request number to address feedback for (e.g., `42`). If omitted, auto-detect the open PR for the current branch.
 
 **Argument parsing** (before any tool calls): Check the user's message for a PR number argument. If present, set `PR_NUMBER` to that value immediately. All subsequent steps use `<PR_NUMBER>` — no auto-detection commands are needed or permitted.
+
+---
+
+## Execution Checklist
+
+At the start of execution, render this checklist in your
+output. Update it in-place using the **Edit tool** as each
+phase and sub-step completes. This checklist survives
+context compression and serves as the authoritative record
+of progress.
+
+```
+- [ ] Phase 1: Ingest -- _N_ items fetched
+- [ ] Phase 2: Assess -- _N_ items classified
+- [ ] Phase 3: Triage -- _N_/_M_ items decided: _n_A _n_M _n_R _n_K
+- [ ] Phase 4.1: Code changes -- _N_ files modified
+- [ ] Phase 4.2: Commits -- _N_ commits created
+- [ ] Phase 4.3: Review-council -- iteration _N_, PASS/FAIL
+- [ ] Phase 4.4: Push -- done
+- [ ] Phase 4.5: Reply comments -- _N_/_M_ posted
+```
+
+Replace `_N_`, `_M_`, etc. with actual counts as you
+progress. Mark each line `[x]` when the phase completes.
 
 ---
 
@@ -123,6 +160,9 @@ On crash-recovery re-entry: items marked as fully executed (`comment-posted`) in
 
 If no items remain after filtering: report "No unresolved feedback to address" and **STOP**.
 
+> **CHECKPOINT**: Update the execution checklist above
+> before proceeding to Phase 2.
+
 ---
 
 ## Phase 2: Assess
@@ -207,6 +247,9 @@ Write assessment results to `.uf/feedback/pr-<PR_NUMBER>/state.json`:
 
 **Permissions**: files `600`, directories `700`.
 
+> **CHECKPOINT**: Update the execution checklist above
+> before proceeding to Phase 3.
+
 ---
 
 ## Phase 3: Triage
@@ -275,6 +318,10 @@ List each item with its decision. Use the
 proceed with execution", "Revise -- change decisions"]`
 before execution proceeds.
 
+> **CHECKPOINT**: Update the execution checklist above
+> before proceeding to Phase 4. Verify all items have
+> decisions recorded.
+
 ---
 
 ## Phase 4: Execute
@@ -323,6 +370,9 @@ attribution").
 
 The `<scope>` is the package or directory of the changed files. The description summarizes the logical group of fixes.
 
+> **CHECKPOINT**: Update the execution checklist:
+> Phase 4.2 commit count.
+
 ### 4.3 Review-Council Gate
 
 After all code changes are committed locally, run `/uf.review-council` on the cumulative changes.
@@ -330,6 +380,13 @@ After all code changes are committed locally, run `/uf.review-council` on the cu
 - **If passes**: continue to push
 - **If fails**: enter fix loop (same behavior as `/uf.unleash`). Fix findings and re-run council.
 - **If fix loop exhausts iterations**: **STOP** and report persistent findings. Do NOT push until council passes.
+
+After each council run, update the execution checklist:
+`[ ] Phase 4.3: Review-council -- iteration N, PASS/FAIL`
+Mark `[x]` only when the council passes.
+
+> **CHECKPOINT**: Update the execution checklist:
+> Phase 4.3 iteration and result.
 
 ### 4.4 Push Changes
 
@@ -354,12 +411,25 @@ git push origin <branch>
 **If push fails** (network error, branch protection rejection): preserve local commits and report which commits are stranded. Provide guidance:
 > "Push failed. Local commits preserved. Retry with `git push origin <branch>` after resolving the issue."
 
+> **CHECKPOINT**: Update the execution checklist:
+> Phase 4.4 push status.
+
 ### 4.5 Post Reply Comments
 
 After push succeeds (or if there are no code changes),
 post reply comments to the PR. Before posting, use the
 **AskUserQuestion tool** with options `["Yes -- post
 reply comments", "No -- skip posting"]`.
+
+**Checklist gate**: Before presenting comments for posting,
+verify the execution checklist shows:
+1. Phase 3 is marked `[x]` with all items decided
+2. Phase 4.1 through 4.4 are marked `[x]`
+
+If the checklist is missing, incomplete, or shows Phase 3
+as not complete, you MUST re-read this command template and
+rebuild state from `state.json` and the git log. Do NOT
+post comments without verified checklist state.
 
 For each item, compose the reply:
 
@@ -395,6 +465,9 @@ rm -f "$REPLY_FILE"
 > "Posted 3 of 6 reply comments. Items 4-6 pending. Re-run `/uf.address-feedback <PR_NUMBER>` to retry."
 
 Record progress in `.uf/feedback/pr-<PR_NUMBER>/state.json` for idempotent retry.
+
+> **CHECKPOINT**: Update the execution checklist:
+> Phase 4.5 comment posting count.
 
 ### 4.6 Resolve Threads
 

--- a/openspec/changes/address-feedback-compression-guards/.openspec.yaml
+++ b/openspec/changes/address-feedback-compression-guards/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: unbound-force
+created: 2026-08-01

--- a/openspec/changes/address-feedback-compression-guards/design.md
+++ b/openspec/changes/address-feedback-compression-guards/design.md
@@ -1,0 +1,133 @@
+## Context
+
+The `/uf.address-feedback` command (496 lines) runs a four-phase
+sequential workflow: Ingest, Assess, Triage, Execute. The workflow
+spans many tool calls, making it vulnerable to OpenCode's context
+compression firing between phases.
+
+The existing crash-recovery cache (`state.json`) persists assessment
+results after Phase 2 but does not persist Phase 3 triage decisions.
+Phase 3 decisions are accumulated in-context via interactive
+AskUserQuestion calls and consumed as a batch in Phase 4. This
+in-context-only state is the primary vulnerability.
+
+Issue #373 proposed the same three-part remediation for
+`/uf.review-pr`. The review-pr command currently has a
+session-resume guard at its Step 11 posting gate (line 846) but
+does not yet have the execution checklist or checkpoint reminders.
+This change applies the full pattern to address-feedback first.
+
+## Goals / Non-Goals
+
+### Goals
+- Protect Phase 3 triage decisions from compression loss by
+  making them observable in a persistent checklist
+- Prevent Phase 4.5 posting gate bypass when compressed context
+  is treated as prior authorization
+- Prevent Phase 4.3 review-council state loss (iteration count,
+  pass/fail constraint) during compression
+- Follow the same remediation pattern proposed in #373 for
+  consistency across commands
+
+### Non-Goals
+- Persisting triage decisions to `state.json` (cache format
+  change is a larger scope change tracked separately)
+- Restructuring the command as a parent/subagent split (the
+  alternative approach from #373, deferred)
+- Applying the same guards to `/uf.review-pr` (separate issue
+  #373, separate change)
+- Preventing compression from firing (that is an OpenCode
+  platform concern, not a command-level fix)
+
+## Decisions
+
+### D1: Three-part guard structure
+
+Apply the three mechanisms proposed in #381:
+
+1. **Session-resume guard** (blockquote, top of file) -- instructs
+   the agent to re-read the full template on resume, and to treat
+   only `state.json` as authoritative for item state. Compressed
+   context summaries MUST NOT be used to infer phase completion or
+   triage decisions.
+
+2. **Execution checklist** (markdown checklist, placed after the
+   preamble before Phase 1) -- a live checklist the agent updates
+   in-place using the Edit tool. Includes:
+   - Phase completion markers (`[ ] Phase 1: Ingest`)
+   - Running triage decision counts in Phase 3 line
+     (e.g., `[x] Phase 3: Triage -- 4/6: 2A 1M 1R`)
+   - Review-council iteration count in Phase 4.3 line
+   - Comment posting count in Phase 4.5 line
+
+3. **Step-level checkpoint reminders** (one-liner at end of each
+   phase section) -- reminds the agent to update the checklist
+   before proceeding. Pattern:
+   `> CHECKPOINT: Update the execution checklist before
+   > proceeding to Phase N+1.`
+
+**Rationale**: This is the lightest-weight approach that makes
+critical state observable and recoverable without changing the
+workflow structure or cache format. The checklist acts as a
+secondary persistence mechanism that the agent can read back
+after compression.
+
+### D2: Checklist lives in the command output, not the file
+
+The checklist is rendered as agent output at the start of
+execution, not embedded statically in the command template. The
+agent writes it to its output and then uses the Edit tool to
+update it in-place as phases complete. This keeps the checklist
+co-located with the execution context.
+
+**Rationale**: The command template is a static instruction file.
+Dynamic state (which items were triaged, what decisions were made)
+belongs in the agent's output where the Edit tool can modify it.
+
+### D3: Phase 4.5 posting gate references checklist
+
+The existing posting gate (AskUserQuestion confirmation before
+posting reply comments) is hardened with an additional instruction:
+the agent MUST verify that the checklist shows Phase 3 as complete
+with all items decided AND Phase 4.1-4.4 as complete before
+presenting comments for posting. If the checklist is missing or
+incomplete, the agent MUST re-read the template and rebuild state
+from `state.json` and the git log.
+
+**Rationale**: Same pattern as #346/#373 for the review-pr APPROVE
+gate. The checklist provides a verifiable pre-condition that cannot
+be fabricated from compressed context.
+
+### D4: Scaffold copy must be updated in lockstep
+
+Both `.opencode/commands/uf.address-feedback.md` and
+`internal/scaffold/assets/opencode/commands/uf.address-feedback.md`
+MUST be identical. Existing drift detection tests enforce this.
+
+**Rationale**: The scaffold copy is what `uf init` writes to new
+projects. If only the command file is updated, new projects would
+not get the compression guards.
+
+## Risks / Trade-offs
+
+### R1: Template size increase (~30-40 lines)
+The command grows from 496 to ~530-540 lines. This slightly
+increases the initial context consumption but is a net positive:
+the guards prevent the much larger cost of re-running Phase 3
+from scratch after compression.
+
+### R2: Edit tool reliability
+The checklist update mechanism depends on the agent correctly
+using the Edit tool to modify its own output. If the agent fails
+to update the checklist, the guards degrade gracefully -- the
+session-resume guard and checkpoint reminders still provide
+defense-in-depth.
+
+### R3: Does not protect against all compression scenarios
+If compression fires mid-Phase-3 (between individual triage
+decisions), the checklist will show partial progress but the
+specific per-item decisions already made may still be lost from
+context. The checklist's running count (e.g., "3/6 decided")
+tells the agent where to resume but not what the prior decisions
+were. Full protection would require persisting decisions to
+`state.json` (out of scope -- see Non-Goals).

--- a/openspec/changes/address-feedback-compression-guards/proposal.md
+++ b/openspec/changes/address-feedback-compression-guards/proposal.md
@@ -1,0 +1,124 @@
+## Why
+
+When OpenCode's context compression fires during an `/uf.address-feedback`
+session, the four-phase sequential workflow (Ingest, Assess, Triage,
+Execute) spans enough tool calls that the compression system can activate
+between phases. The summary preserves fetched data (PR metadata, comment
+list) but discards:
+
+1. **Phase 3 triage decisions** -- interactive Accept/Modify/Reject/Ask
+   decisions accumulated in-context are lost before Phase 4 can execute
+   them, causing the agent to re-triage or apply wrong/missing changes.
+2. **Phase 4.5 posting gate** -- the mandatory AskUserQuestion
+   confirmation before posting reply comments may be bypassed if
+   compressed context is treated as prior authorization.
+3. **Phase 4.3 review-council iteration state** -- the fix loop count
+   and "do not push until council passes" constraint are lost, risking
+   pushes of unreviewed code.
+
+The root cause is the same as #373 (`/uf.review-pr`): the command
+template is injected as conversation content, making it subject to
+compression heuristics. The cache (`state.json`) persists assessment
+results (Phase 2) but not Phase 3 triage decisions, leaving them
+fully vulnerable to mid-session compression.
+
+Fixes: #381
+Related: #373 (same root cause for `/uf.review-pr`), #346 (APPROVE
+gate bypass pattern)
+
+## What Changes
+
+Add three compression-resilience mechanisms to
+`.opencode/commands/uf.address-feedback.md` (and its scaffold copy),
+following the same pattern established for `/uf.review-pr`:
+
+1. **Session-resume guard** at the top of the file instructing the
+   agent to re-read the template on resume and treat only the cache
+   (`state.json`) as authoritative for item state.
+2. **Execution checklist** that the agent updates in-place using the
+   Edit tool as each phase and sub-step completes, including running
+   triage decision counts.
+3. **Step-level checkpoint reminders** at the end of each phase and
+   major sub-step, reminding the agent to mark the checklist before
+   proceeding.
+4. **Phase 4.5 posting gate hardening** referencing the checklist to
+   prevent bypassed confirmation.
+
+## Capabilities
+
+### New Capabilities
+- `compression-resilient-triage`: Triage decisions survive context
+  compression through checklist persistence and session-resume guards
+- `checkpoint-reminders`: Per-phase checkpoint reminders ensure the
+  agent tracks progress through the execution checklist
+
+### Modified Capabilities
+- `phase-4.5-posting-gate`: Hardened to reference the execution
+  checklist, preventing bypass via compressed context
+- `phase-4.3-council-gate`: Checklist tracks iteration count to
+  prevent premature push after compression
+
+### Removed Capabilities
+- (none)
+
+## Impact
+
+- **Files modified**: `.opencode/commands/uf.address-feedback.md`,
+  `internal/scaffold/assets/opencode/commands/uf.address-feedback.md`
+- **Behavioral change**: The command template grows by ~30-40 lines
+  to accommodate guards, checklist, and checkpoint reminders. No
+  functional change to the four-phase workflow itself.
+- **Drift detection**: Existing scaffold drift tests will verify
+  both copies stay in sync.
+- **Backward compatibility**: Fully backward compatible. The guards
+  are advisory instructions to the agent -- they add resilience
+  without changing the happy-path workflow.
+
+## Constitution Alignment
+
+Assessed against the Unbound Force org constitution.
+
+### I. Autonomous Collaboration
+
+**Assessment**: N/A
+
+This change modifies a slash command template (agent instructions),
+not inter-hero artifact formats or communication patterns. The
+feedback-triage artifact schema and cache format are unchanged.
+
+### II. Composability First
+
+**Assessment**: N/A
+
+The change is internal to the address-feedback command. No new
+dependencies are introduced. The command remains independently
+usable without other heroes.
+
+### III. Observable Quality
+
+**Assessment**: PASS
+
+The execution checklist makes the agent's progress through the
+workflow observable. Triage decision counts in the checklist
+(e.g., "Phase 3: 4/6 items decided: 2 ACCEPT, 1 MODIFY, 1 REJECT")
+provide machine-inspectable state that survives compression.
+
+### IV. Testability
+
+**Assessment**: PASS
+
+The changes are to a markdown command template. Testability is
+maintained through scaffold drift detection tests that verify
+the command file and its scaffold copy stay in sync. The guards
+themselves are agent behavioral instructions that are validated
+through manual invocation.
+
+### V. Security by Default
+
+**Assessment**: N/A
+
+This change does not introduce new inputs, external dependencies,
+privilege decisions, or security-sensitive operations. The
+modifications are to agent behavioral instructions within a
+markdown command template. No supply chain, input validation,
+or least privilege concerns apply.

--- a/openspec/changes/address-feedback-compression-guards/specs/compression-guards.md
+++ b/openspec/changes/address-feedback-compression-guards/specs/compression-guards.md
@@ -1,0 +1,160 @@
+## ADDED Requirements
+
+### Requirement: Session-resume guard (FR-001)
+
+The `/uf.address-feedback` command template MUST include a
+session-resume guard at the top of the file (after frontmatter,
+before Phase 1). The guard MUST instruct the agent to:
+
+1. Re-read the full command template on session resume
+2. NOT infer phase completion or triage decisions from
+   compressed context summaries
+3. Treat only `state.json` as authoritative for item state
+
+#### Scenario: Agent resumes after compression fires
+
+- **GIVEN** the agent is executing `/uf.address-feedback` and
+  context compression has fired, producing a summary of
+  prior phases
+- **WHEN** the agent reads the compressed summary and
+  continues execution
+- **THEN** the agent MUST re-read the command template,
+  reconstruct state from `state.json` and the execution
+  checklist, and NOT rely on the compressed summary for
+  phase completion status or triage decisions
+
+### Requirement: Execution checklist (FR-002)
+
+The command template MUST define an execution checklist
+that the agent renders at the start of execution and
+updates in-place using the Edit tool as phases complete.
+
+The checklist MUST include:
+
+- `[ ] Phase 1: Ingest -- N items fetched`
+- `[ ] Phase 2: Assess -- N items classified`
+- `[ ] Phase 3: Triage -- N/M items decided: nA nM nR nK`
+- `[ ] Phase 4.1: Code changes -- N files modified`
+- `[ ] Phase 4.2: Commits -- N commits created`
+- `[ ] Phase 4.3: Review-council -- iteration N, PASS/FAIL`
+- `[ ] Phase 4.4: Push -- committed`
+- `[ ] Phase 4.5: Reply comments -- N/M posted`
+
+Where `nA`=Accept, `nM`=Modify, `nR`=Reject, `nK`=Ask counts.
+
+#### Scenario: Agent tracks triage progress
+
+- **GIVEN** the agent is in Phase 3 and has triaged 3 of 6
+  items (2 Accept, 1 Reject)
+- **WHEN** the agent completes the triage of item 3
+- **THEN** the agent MUST update the checklist to read
+  `[ ] Phase 3: Triage -- 3/6 items decided: 2A 0M 1R 0K`
+  using the Edit tool
+
+#### Scenario: Agent completes Phase 3
+
+- **GIVEN** the agent has triaged all 6 items
+  (3 Accept, 1 Modify, 1 Reject, 1 Ask)
+- **WHEN** the user confirms the triage summary
+- **THEN** the agent MUST update the checklist to read
+  `[x] Phase 3: Triage -- 6/6 items decided: 3A 1M 1R 1K`
+
+### Requirement: Step-level checkpoint reminders (FR-003)
+
+Each phase section in the command template MUST end with a
+checkpoint reminder instructing the agent to update the
+execution checklist before proceeding to the next phase.
+
+The reminder MUST use the format:
+```
+> CHECKPOINT: Update the execution checklist above
+> before proceeding to Phase N+1.
+```
+
+#### Scenario: Phase 1 completion
+
+- **GIVEN** the agent has completed Phase 1 (Ingest) and
+  identified 6 feedback items
+- **WHEN** the agent reaches the Phase 1 checkpoint
+- **THEN** the agent MUST update the checklist to read
+  `[x] Phase 1: Ingest -- 6 items fetched` before
+  proceeding to Phase 2
+
+#### Scenario: Phase 2 completion
+
+- **GIVEN** the agent has completed Phase 2 (Assess) and
+  classified all 6 items
+- **WHEN** the agent reaches the Phase 2 checkpoint
+- **THEN** the agent MUST update the checklist to read
+  `[x] Phase 2: Assess -- 6 items classified` before
+  proceeding to Phase 3
+
+## MODIFIED Requirements
+
+### Requirement: Phase 4.5 posting gate hardening (FR-004)
+
+Previously: Phase 4.5 required AskUserQuestion confirmation
+before posting reply comments.
+
+The posting gate MUST additionally require verification that
+the execution checklist shows:
+1. Phase 3 is marked `[x]` with all items decided
+2. Phase 4.1 through 4.4 are marked `[x]`
+
+If the checklist is missing, incomplete, or shows Phase 3 as
+not complete, the agent MUST NOT present comments for posting.
+Instead, the agent MUST re-read the template and rebuild state
+from `state.json` and the git log.
+
+#### Scenario: Posting gate with complete checklist
+
+- **GIVEN** the execution checklist shows all phases through
+  4.4 as complete
+- **WHEN** the agent reaches Phase 4.5
+- **THEN** the agent MUST present prepared reply comments to
+  the user via AskUserQuestion for confirmation before posting
+
+#### Scenario: Posting gate with incomplete checklist
+
+- **GIVEN** the execution checklist shows Phase 3 as
+  incomplete or the checklist is missing
+- **WHEN** the agent reaches Phase 4.5
+- **THEN** the agent MUST NOT present comments for posting
+  and MUST re-read the command template and rebuild state
+
+### Requirement: Phase 4.3 council gate state tracking (FR-005)
+
+Previously: Phase 4.3 tracked review-council pass/fail and
+iteration count in-context only.
+
+The execution checklist MUST track the review-council
+iteration count and pass/fail status. The "do not push until
+council passes" constraint MUST be verifiable from the
+checklist, not just from in-context memory.
+
+#### Scenario: Council gate after compression
+
+- **GIVEN** the agent has run `/uf.review-council` twice
+  (iteration 1 failed, iteration 2 passed) and compression
+  fires
+- **WHEN** the agent resumes and checks the checklist
+- **THEN** the checklist MUST show
+  `[x] Phase 4.3: Review-council -- iteration 2, PASS`
+  confirming that the agent may proceed to push
+
+### Requirement: Scaffold copy sync (FR-006)
+
+The scaffold copy at
+`internal/scaffold/assets/opencode/commands/uf.address-feedback.md`
+MUST be updated to match the command file at
+`.opencode/commands/uf.address-feedback.md` exactly.
+
+#### Scenario: Drift detection passes
+
+- **GIVEN** both copies of the command file exist
+- **WHEN** the drift detection test runs
+- **THEN** both files MUST be byte-identical
+
+## REMOVED Requirements
+
+(none)

--- a/openspec/changes/address-feedback-compression-guards/tasks.md
+++ b/openspec/changes/address-feedback-compression-guards/tasks.md
@@ -1,0 +1,96 @@
+<!--
+  [P] marks tasks eligible for parallel execution.
+  Add [P] when a task: (a) touches different files from
+  other [P] tasks in the group, (b) has no dependency
+  on prior tasks in the group, (c) can safely execute
+  without ordering constraints.
+  Do NOT add [P] when tasks modify the same file --
+  parallel workers will cause merge conflicts.
+  Tasks without [P] run sequentially first, then [P]
+  tasks run in parallel.
+
+  Both tasks in group 1 modify the same file
+  (uf.address-feedback.md), so neither is [P].
+  Group 2 copies the result of group 1 to the scaffold.
+  Group 3 runs verification.
+-->
+
+## 1. Add compression guards to command template
+
+Target: `.opencode/commands/uf.address-feedback.md`
+
+- [x] 1.1 Add session-resume guard blockquote after
+  frontmatter (before Phase 1). The guard MUST instruct
+  the agent to: (a) re-read the full command template on
+  resume, (b) NOT infer phase completion or triage
+  decisions from compressed context, (c) treat only
+  `state.json` as authoritative for item state. Reference
+  the pattern at `.opencode/commands/uf.review-pr.md`
+  line 846 but place it at the top of the file for
+  earlier visibility. (FR-001)
+
+- [x] 1.2 Add execution checklist section after the
+  session-resume guard and before Phase 1. The checklist
+  template MUST include all phases and sub-steps defined
+  in FR-002. Include an instruction paragraph telling the
+  agent to render this checklist at execution start and
+  update it in-place using the Edit tool. (FR-002)
+
+- [x] 1.3 Add checkpoint reminder at the end of Phase 1
+  (after section 1.6, before the `---` separator).
+  Format: blockquote with "CHECKPOINT: Update the
+  execution checklist above before proceeding to
+  Phase 2." (FR-003)
+
+- [x] 1.4 Add checkpoint reminder at the end of Phase 2
+  (after section 2.6, before the `---` separator).
+  Format: blockquote with "CHECKPOINT: Update the
+  execution checklist above before proceeding to
+  Phase 3." (FR-003)
+
+- [x] 1.5 Add checkpoint reminder at the end of Phase 3
+  (after section 3.4, before the `---` separator).
+  Format: blockquote with "CHECKPOINT: Update the
+  execution checklist above before proceeding to
+  Phase 4." (FR-003)
+
+- [x] 1.6 Harden Phase 4.5 posting gate. Add instruction
+  requiring the agent to verify that the execution
+  checklist shows Phase 3 as `[x]` with all items decided
+  AND Phase 4.1-4.4 as `[x]` before presenting comments
+  for posting. If the checklist is missing or incomplete,
+  the agent MUST re-read the template and rebuild state.
+  (FR-004)
+
+- [x] 1.7 Add checklist tracking to Phase 4.3
+  review-council section. The agent MUST update the
+  checklist with iteration count and PASS/FAIL after each
+  council run. (FR-005)
+
+- [x] 1.8 Add checkpoint reminders at the end of Phase 4
+  sub-steps 4.2, 4.3, 4.4, and 4.5. (FR-003)
+
+## 2. Sync scaffold copy
+
+Target: `internal/scaffold/assets/opencode/commands/uf.address-feedback.md`
+
+- [x] 2.1 Copy the updated command file to the scaffold
+  assets directory, replacing the existing file. Both
+  copies MUST be byte-identical. (FR-006)
+
+## 3. Verification
+
+- [x] 3.1 Run scaffold drift detection tests to verify
+  both copies are in sync:
+  `go test -race -count=1 ./internal/scaffold/...`
+
+- [x] 3.2 Run full lint and test suite:
+  `make check`
+
+- [x] 3.3 Verify constitution alignment: confirm the
+  change does not introduce runtime coupling (Principle I),
+  mandatory dependencies (Principle II), or non-observable
+  state (Principle III). The execution checklist satisfies
+  Principle III by making workflow state observable.
+<!-- spec-review: passed -->
+<!-- code-review: passed -->


### PR DESCRIPTION
## Summary

Add compression-resilience guards to the `/uf.address-feedback`
command template to prevent Phase 3 triage decisions and Phase 4
gate state from being lost when OpenCode's context compression
fires mid-session.

Three mechanisms are added following the pattern proposed in #373:

1. **Session-resume guard** -- blockquote at top of file instructing
   the agent to re-read the template on resume and treat only
   `state.json` as authoritative
2. **Execution checklist** -- live checklist the agent renders and
   updates via Edit tool, tracking phase completion with running
   triage decision counts
3. **Checkpoint reminders** -- blockquote reminders at each phase
   boundary; Phase 4.5 posting gate hardened with checklist
   verification

Fixes #381

## How to Test

1. Verify the command file has the three guard mechanisms:
   ```bash
   grep -n "SESSION-RESUME GUARD\|Execution Checklist\|CHECKPOINT\|Checklist gate" \
     .opencode/commands/uf.address-feedback.md
   ```
   Expected: 10 matches (1 guard, 1 checklist, 7 checkpoints, 1 gate)

2. Verify scaffold sync:
   ```bash
   diff .opencode/commands/uf.address-feedback.md \
     internal/scaffold/assets/opencode/commands/uf.address-feedback.md
   ```
   Expected: no output (byte-identical)

3. Run drift detection tests:
   ```bash
   go test -race -count=1 ./internal/scaffold/...
   ```

## How to Demo

1. Open `.opencode/commands/uf.address-feedback.md`
2. Observe the session-resume guard at lines 13-24
3. Observe the execution checklist template at lines 34-55
4. Search for "CHECKPOINT" to see phase boundary reminders
5. Search for "Checklist gate" at Phase 4.5 to see the hardened posting gate

## Key Files Changed

- `.opencode/commands/uf.address-feedback.md` -- added 73 lines: session-resume guard, execution checklist, 7 checkpoint reminders, posting gate hardening, council gate tracking
- `internal/scaffold/assets/opencode/commands/uf.address-feedback.md` -- byte-identical scaffold copy
- `openspec/changes/address-feedback-compression-guards/` -- proposal, design, specs (FR-001 to FR-006), and tasks artifacts

_This PR was generated by /uf.finale (AI-assisted)._
