### PR TITLE
fix(speckit): move STOP HERE gates to preamble in remaining 5 commands

### DIFF
--- a/.opencode/commands/speckit.analyze.md
+++ b/.opencode/commands/speckit.analyze.md
@@ -13,6 +13,13 @@ You **MUST** consider the user input before proceeding (if not empty).
 
 ## Goal
 
+**STOP HERE. Do NOT proceed to implementation.**
+
+Your job is done. Report the results and prompt the
+user. The user will invoke a separate command
+(/uf.unleash, /uf.cobalt-crush, or /opsx-apply) when they
+are ready to implement.
+
 Identify inconsistencies, duplications, ambiguities, and underspecified items across the three core artifacts (`spec.md`, `plan.md`, `tasks.md`) before implementation. This command MUST run only after `/speckit.tasks` has successfully produced a complete `tasks.md`.
 
 ## Operating Constraints
@@ -162,13 +169,6 @@ At end of report, output a concise Next Actions block:
 ### 8. Offer Remediation
 
 Ask the user: "Would you like me to suggest concrete remediation edits for the top N issues?" (Do NOT apply them automatically.)
-
-**STOP HERE. Do NOT proceed to implementation.**
-
-Your job is done. Report the results and prompt the
-user. The user will invoke a separate command
-(/uf.unleash, /uf.cobalt-crush, or /opsx-apply) when they
-are ready to implement.
 
 ## Operating Principles
 

--- a/.opencode/commands/speckit.checklist.md
+++ b/.opencode/commands/speckit.checklist.md
@@ -34,6 +34,13 @@ You **MUST** consider the user input before proceeding (if not empty).
 
 ## Execution Steps
 
+**STOP HERE. Do NOT proceed to implementation.**
+
+Your job is done. Report the results and prompt the
+user. The user will invoke a separate command
+(/uf.unleash, /uf.cobalt-crush, or /opsx-apply) when they
+are ready to implement.
+
 1. **Setup**: Run `.specify/scripts/bash/check-prerequisites.sh --json` from repo root and parse JSON for FEATURE_DIR and AVAILABLE_DOCS list.
    - All file paths must be absolute.
    - For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
@@ -219,13 +226,6 @@ You **MUST** consider the user input before proceeding (if not empty).
 - Easy identification and navigation in the `checklists/` folder
 
 To avoid clutter, use descriptive types and clean up obsolete checklists when done.
-
-**STOP HERE. Do NOT proceed to implementation.**
-
-Your job is done. Report the results and prompt the
-user. The user will invoke a separate command
-(/uf.unleash, /uf.cobalt-crush, or /opsx-apply) when they
-are ready to implement.
 
 ## Example Checklist Types & Sample Items
 

--- a/.opencode/commands/speckit.clarify.md
+++ b/.opencode/commands/speckit.clarify.md
@@ -17,6 +17,13 @@ You **MUST** consider the user input before proceeding (if not empty).
 
 ## Outline
 
+**STOP HERE. Do NOT proceed to implementation.**
+
+Your job is done. Report the results and prompt the
+user. The user will invoke a separate command
+(/uf.unleash, /uf.cobalt-crush, or /opsx-apply) when they
+are ready to implement.
+
 Goal: Detect and reduce ambiguity or missing decision points in the active feature specification and record the clarifications directly in the spec file.
 
 Note: This clarification workflow is expected to run (and be completed) BEFORE invoking `/speckit.plan`. If the user explicitly states they are skipping clarification (e.g., exploratory spike), you may proceed, but must warn that downstream rework risk increases.
@@ -181,13 +188,6 @@ Execution steps:
    - Coverage summary table listing each taxonomy category with Status: Resolved (was Partial/Missing and addressed), Deferred (exceeds question quota or better suited for planning), Clear (already sufficient), Outstanding (still Partial/Missing but low impact).
    - If any Outstanding or Deferred remain, recommend whether to proceed to `/speckit.plan` or run `/speckit.clarify` again later post-plan.
    - Suggested next command.
-
-**STOP HERE. Do NOT proceed to implementation.**
-
-Your job is done. Report the results and prompt the
-user. The user will invoke a separate command
-(/uf.unleash, /uf.cobalt-crush, or /opsx-apply) when they
-are ready to implement.
 
 Behavior rules:
 

--- a/.opencode/commands/speckit.specify.md
+++ b/.opencode/commands/speckit.specify.md
@@ -21,6 +21,13 @@ You **MUST** consider the user input before proceeding (if not empty).
 
 ## Outline
 
+**STOP HERE. Do NOT proceed to implementation.**
+
+Your job is done. Report the results and prompt the
+user. The user will invoke a separate command
+(/uf.unleash, /uf.cobalt-crush, or /opsx-apply) when they
+are ready to implement.
+
 The text the user typed after `/speckit.specify` in the triggering message **is** the feature description. Assume you always have it available in this conversation even if `$ARGUMENTS` appears literally below. Do not ask the user to repeat it unless they provided an empty command.
 
 Given that feature description, do this:
@@ -232,13 +239,6 @@ Given that feature description, do this:
    d. **Update Checklist**: After each validation iteration, update the checklist file with current pass/fail status
 
 9. Report completion with branch name, spec file path, checklist results, and readiness for the next phase (`/speckit.clarify` or `/speckit.plan`).
-
-**STOP HERE. Do NOT proceed to implementation.**
-
-Your job is done. Report the results and prompt the
-user. The user will invoke a separate command
-(/uf.unleash, /uf.cobalt-crush, or /opsx-apply) when they
-are ready to implement.
 
 **NOTE:** The script creates and checks out the new branch and initializes the spec file before writing.
 

--- a/.opencode/commands/speckit.testreview.md
+++ b/.opencode/commands/speckit.testreview.md
@@ -13,6 +13,13 @@ You **MUST** consider the user input before proceeding (if not empty).
 
 ## Goal
 
+**STOP HERE. Do NOT proceed to implementation.**
+
+Your job is done. Report the results and prompt the
+user. The user will invoke a separate command
+(/uf.unleash, /uf.cobalt-crush, or /opsx-apply) when they
+are ready to implement.
+
 Assess the testability of feature specification artifacts (`spec.md`, `plan.md`, `tasks.md`) through a dedicated testing lens. This command identifies vague acceptance criteria, missing coverage strategy, undefined contract surfaces, and infeasible fixture requirements — issues that cause rework if discovered only during implementation. This command MUST run only after `/speckit.tasks` has successfully produced a complete `tasks.md`.
 
 ## Operating Constraints
@@ -115,13 +122,6 @@ At end of report, output a concise Next Actions block:
 ### 6. Offer Remediation
 
 Ask the user: "Would you like me to suggest concrete remediation edits for the top N issues?" (Do NOT apply them automatically.)
-
-**STOP HERE. Do NOT proceed to implementation.**
-
-Your job is done. Report the results and prompt the
-user. The user will invoke a separate command
-(/uf.unleash, /uf.cobalt-crush, or /opsx-apply) when they
-are ready to implement.
 
 ## Operating Principles
 

--- a/openspec/changes/speckit-stop-gate-preamble/.openspec.yaml
+++ b/openspec/changes/speckit-stop-gate-preamble/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: unbound-force
+created: 2026-08-01

--- a/openspec/changes/speckit-stop-gate-preamble/design.md
+++ b/openspec/changes/speckit-stop-gate-preamble/design.md
@@ -1,0 +1,82 @@
+## Context
+
+Five speckit command files have the STOP HERE gate positioned
+after the workflow steps it governs. This was identified in the
+root cause analysis (#346) and partially fixed by #363 for
+`speckit.tasks.md` and `speckit.plan.md`. The remaining 5 files
+need the same treatment.
+
+The established pattern (from #363) places the STOP HERE block
+as a bolded preamble immediately after the first major section
+heading (`## Outline`), before any workflow steps.
+
+## Goals / Non-Goals
+
+### Goals
+- Move the STOP HERE block to preamble position in all 5
+  remaining speckit command files
+- Follow the exact pattern established by PR #363
+- Ensure agents encounter the STOP constraint before reading
+  any workflow steps
+
+### Non-Goals
+- Changing the STOP HERE wording or behavior
+- Adding new headings or restructuring the command files beyond
+  the gate relocation
+- Fixing non-speckit command files (those use a different
+  pattern and are tracked separately)
+
+## Decisions
+
+### D1: Insert position relative to first major heading
+
+The STOP HERE block is inserted immediately after the first
+major `## ` heading that precedes the workflow steps. The
+specific heading varies by file:
+
+| File | Heading | Line |
+|------|---------|------|
+| `speckit.specify.md` | `## Outline` | 22 |
+| `speckit.clarify.md` | `## Outline` | 18 |
+| `speckit.analyze.md` | `## Goal` | 14 |
+| `speckit.checklist.md` | `## Execution Steps` | 35 |
+| `speckit.testreview.md` | `## Goal` | 14 |
+
+For files with `## Outline`, the STOP block goes on the line
+after the heading (matching the `tasks.md` / `plan.md` pattern
+exactly).
+
+For files without `## Outline` (analyze, checklist, testreview),
+the STOP block goes after the first `## ` heading that begins
+the substantive content section. This is the earliest position
+the agent will read before encountering workflow steps.
+
+### D2: Block content is identical across all files
+
+The STOP HERE block uses the same wording established in #363:
+
+```
+**STOP HERE. Do NOT proceed to implementation.**
+
+Your job is done. Report the results and prompt the
+user. The user will invoke a separate command
+(/uf.unleash, /uf.cobalt-crush, or /opsx-apply) when they
+are ready to implement.
+```
+
+### D3: Remove the original STOP block at the end of each file
+
+After inserting the preamble STOP block, the original STOP
+block at the end of the file MUST be removed to avoid
+duplication and confusion.
+
+## Risks / Trade-offs
+
+- **Risk**: The heading name varies across files (`## Outline`
+  vs `## Goal` vs `## Checklist Purpose`). The agent
+  implementing this must identify the correct insertion point
+  per file rather than applying a uniform search-and-replace.
+  Mitigated by explicit line numbers in the task list.
+- **Trade-off**: We are not standardizing all files to use
+  `## Outline` as the heading name. This avoids scope creep
+  and keeps the change minimal.

--- a/openspec/changes/speckit-stop-gate-preamble/proposal.md
+++ b/openspec/changes/speckit-stop-gate-preamble/proposal.md
@@ -1,0 +1,90 @@
+## Why
+
+The STOP HERE gate in 5 speckit command files is positioned
+after the workflow steps it governs. This means the agent
+reads and executes all workflow steps before encountering the
+instruction to stop. The gate must appear before the steps
+to prevent phase boundary violations (speckit commands produce
+artifacts, not implementation).
+
+Issue #363 fixed `speckit.tasks.md` and `speckit.plan.md` by
+moving the STOP HERE block to a bolded preamble immediately
+after the `## Outline` heading. This change applies the same
+fix to the remaining 5 commands.
+
+Fixes: https://github.com/unbound-force/unbound-force/issues/386
+
+## What Changes
+
+Move the STOP HERE block from the end of each file to a
+preamble position immediately after the first major heading
+(e.g., `## Outline`, `## Goal`, or equivalent) in these 5
+speckit command files:
+
+- `.opencode/commands/speckit.specify.md`
+- `.opencode/commands/speckit.clarify.md`
+- `.opencode/commands/speckit.analyze.md`
+- `.opencode/commands/speckit.checklist.md`
+- `.opencode/commands/speckit.testreview.md`
+
+## Capabilities
+
+### New Capabilities
+- None
+
+### Modified Capabilities
+- `speckit.specify`: STOP gate moved to preamble position
+- `speckit.clarify`: STOP gate moved to preamble position
+- `speckit.analyze`: STOP gate moved to preamble position
+- `speckit.checklist`: STOP gate moved to preamble position
+- `speckit.testreview`: STOP gate moved to preamble position
+
+### Removed Capabilities
+- None
+
+## Impact
+
+- **5 command files**: Content reordering only (no new text,
+  no logic changes). The STOP HERE block moves from after
+  the last workflow step to immediately after the first
+  major section heading.
+- **Agent behavior**: Agents will encounter the STOP
+  constraint before reading workflow steps, reducing the
+  risk of phase boundary violations.
+- **No code changes**: This is a documentation/command-file-only
+  change. No Go source, tests, or CI workflows are affected.
+
+## Constitution Alignment
+
+Assessed against the Unbound Force org constitution.
+
+### I. Autonomous Collaboration
+
+**Assessment**: N/A
+
+This change modifies agent command files (workflow
+instructions) and does not affect artifact-based
+communication or inter-hero interfaces.
+
+### II. Composability First
+
+**Assessment**: N/A
+
+No new dependencies are introduced. The change is
+internal to this meta repository's command files.
+
+### III. Observable Quality
+
+**Assessment**: N/A
+
+No machine-parseable outputs or provenance metadata
+are affected. The command files are agent instructions,
+not data artifacts.
+
+### IV. Testability
+
+**Assessment**: N/A
+
+The change involves moving a text block within Markdown
+files. No testable components are introduced or modified.
+Verification is by manual inspection of file structure.

--- a/openspec/changes/speckit-stop-gate-preamble/specs/stop-gate-placement.md
+++ b/openspec/changes/speckit-stop-gate-preamble/specs/stop-gate-placement.md
@@ -1,0 +1,62 @@
+## ADDED Requirements
+
+None.
+
+## MODIFIED Requirements
+
+### Requirement: STOP gate position in speckit commands
+
+Each speckit command file MUST position its STOP HERE
+block as a bolded preamble immediately after the first
+major `## ` heading, before any workflow steps.
+
+Previously: The STOP HERE block was positioned after
+the final workflow step in 5 of 7 speckit command files.
+
+#### Scenario: Agent reads speckit.specify.md
+
+- **GIVEN** the agent loads `speckit.specify.md`
+- **WHEN** it reads past the `## Outline` heading
+- **THEN** it MUST encounter the STOP HERE block before
+  any numbered workflow step
+
+#### Scenario: Agent reads speckit.clarify.md
+
+- **GIVEN** the agent loads `speckit.clarify.md`
+- **WHEN** it reads past the `## Outline` heading
+- **THEN** it MUST encounter the STOP HERE block before
+  any numbered workflow step
+
+#### Scenario: Agent reads speckit.analyze.md
+
+- **GIVEN** the agent loads `speckit.analyze.md`
+- **WHEN** it reads past the `## Goal` heading
+- **THEN** it MUST encounter the STOP HERE block before
+  any numbered workflow step
+
+#### Scenario: Agent reads speckit.checklist.md
+
+- **GIVEN** the agent loads `speckit.checklist.md`
+- **WHEN** it reads past the `## Execution Steps`
+  heading
+- **THEN** it MUST encounter the STOP HERE block before
+  any numbered workflow step
+
+#### Scenario: Agent reads speckit.testreview.md
+
+- **GIVEN** the agent loads `speckit.testreview.md`
+- **WHEN** it reads past the `## Goal` heading
+- **THEN** it MUST encounter the STOP HERE block before
+  any numbered workflow step
+
+#### Scenario: No duplicate STOP blocks
+
+- **GIVEN** any speckit command file
+- **WHEN** the STOP HERE block is moved to preamble
+  position
+- **THEN** the file MUST contain exactly one STOP HERE
+  block (the original at the end MUST be removed)
+
+## REMOVED Requirements
+
+None.

--- a/openspec/changes/speckit-stop-gate-preamble/tasks.md
+++ b/openspec/changes/speckit-stop-gate-preamble/tasks.md
@@ -1,0 +1,59 @@
+<!--
+  [P] marks tasks eligible for parallel execution.
+  Add [P] when a task: (a) touches different files from
+  other [P] tasks in the group, (b) has no dependency
+  on prior tasks in the group, (c) can safely execute
+  without ordering constraints.
+  Do NOT add [P] when tasks modify the same file —
+  parallel workers will cause merge conflicts.
+  Tasks without [P] run sequentially first, then [P]
+  tasks run in parallel.
+-->
+
+## 1. Move STOP HERE blocks to preamble position
+
+Each task below modifies a single file. The operation
+for each file is identical:
+
+1. Insert the STOP HERE block (6 lines) immediately
+   after the first major heading following the User
+   Input section (with a blank line before and after).
+2. Remove the original STOP HERE block from its current
+   position at the end of the file (including
+   surrounding blank lines).
+3. Verify exactly one STOP HERE block remains.
+
+The STOP HERE block content (identical for all files):
+
+```
+**STOP HERE. Do NOT proceed to implementation.**
+
+Your job is done. Report the results and prompt the
+user. The user will invoke a separate command
+(/uf.unleash, /uf.cobalt-crush, or /opsx-apply) when they
+are ready to implement.
+```
+
+Reference pattern: `.opencode/commands/speckit.tasks.md`
+lines 25-30 and `.opencode/commands/speckit.plan.md`
+lines 24-29.
+
+- [x] 1.1 [P] **speckit.specify.md**: Insert STOP block after `## Outline` (line 22), before the paragraph at line 24. Remove original STOP block at line 236. File: `.opencode/commands/speckit.specify.md`
+
+- [x] 1.2 [P] **speckit.clarify.md**: Insert STOP block after `## Outline` (line 18), before the Goal paragraph at line 20. Remove original STOP block at line 185. File: `.opencode/commands/speckit.clarify.md`
+
+- [x] 1.3 [P] **speckit.analyze.md**: Insert STOP block after `## Goal` (line 14), before the goal description at line 16. Remove original STOP block at line 166. File: `.opencode/commands/speckit.analyze.md`
+
+- [x] 1.4 [P] **speckit.checklist.md**: Insert STOP block after `## Execution Steps` heading (line 35), before step 1 at line 37. Remove original STOP block at line 223. File: `.opencode/commands/speckit.checklist.md`
+
+- [x] 1.5 [P] **speckit.testreview.md**: Insert STOP block after `## Goal` (line 14), before the goal description at line 16. Remove original STOP block at line 119. File: `.opencode/commands/speckit.testreview.md`
+
+## 2. Verification
+
+- [x] 2.1 Verify each of the 5 files contains exactly one `**STOP HERE` block. Run: `rg -c "STOP HERE" .opencode/commands/speckit.{specify,clarify,analyze,checklist,testreview}.md` — each file should show count 1.
+
+- [x] 2.2 Verify the STOP block appears before the first numbered step in each file. For each file, confirm the STOP block line number is less than the first `1.` or `### 1.` line number.
+
+- [x] 2.3 Verify the 2 already-fixed files (`speckit.tasks.md`, `speckit.plan.md`) are untouched. Run: `git diff .opencode/commands/speckit.tasks.md .opencode/commands/speckit.plan.md` — should produce no output.
+<!-- spec-review: passed -->
+<!-- code-review: passed -->


### PR DESCRIPTION
## Summary

Moves the STOP HERE gate block from the end of 5 speckit
command files to preamble position (immediately after the
first major heading, before any workflow steps). This
ensures agents encounter the "do not implement" constraint
before reading workflow instructions, preventing phase
boundary violations.

This applies the same fix from PR #363 (which fixed
`speckit.tasks.md` and `speckit.plan.md`) to the remaining
5 commands. Parent audit: #346.

Fixes #386

## How to Test

1. Verify each file has exactly one STOP block positioned
   before workflow steps:

   ```bash
   rg -c "STOP HERE" .opencode/commands/speckit.{specify,clarify,analyze,checklist,testreview}.md
   # Expected: each file shows 1
   ```

2. Verify STOP block appears before first numbered step:

   ```bash
   for f in speckit.specify.md speckit.clarify.md speckit.analyze.md speckit.checklist.md speckit.testreview.md; do
     rg -n "STOP HERE" ".opencode/commands/$f"
   done
   # Expected: all at line < 40
   ```

3. Verify already-fixed files are untouched:

   ```bash
   git diff main -- .opencode/commands/speckit.tasks.md .opencode/commands/speckit.plan.md
   # Expected: no output
   ```

## How to Demo

Open any of the 5 modified command files and confirm the
STOP HERE block appears near the top (after the first
major heading), not at the bottom of the file. Compare
with `speckit.tasks.md` (lines 25-30) for the reference
pattern.

## Key Files Changed

**Command files (STOP gate relocated):**
- `.opencode/commands/speckit.specify.md` -- line 236 -> 24
- `.opencode/commands/speckit.clarify.md` -- line 185 -> 20
- `.opencode/commands/speckit.analyze.md` -- line 166 -> 16
- `.opencode/commands/speckit.checklist.md` -- line 223 -> 37
- `.opencode/commands/speckit.testreview.md` -- line 119 -> 16

**OpenSpec change artifacts (new):**
- `openspec/changes/speckit-stop-gate-preamble/` -- proposal,
  design, specs, and tasks for this change

_This PR was generated by /uf.finale (AI-assisted)._
