### PR TITLE
fix(speckit-workflow): replace prose-only dirty-tree check with explicit AskUserQuestion gate

### DIFF
--- a/.opencode/skills/speckit-workflow/SKILL.md
+++ b/.opencode/skills/speckit-workflow/SKILL.md
@@ -37,8 +37,33 @@ current feature branch before any branch switch occurs.
   `main`.
 - Before creating a new feature branch (via `/speckit.specify`),
   check `git status --short` for uncommitted changes. If
-  uncommitted changes exist, **STOP** and ask the user for
-  confirmation before switching branches.
+  uncommitted changes exist, use the **AskUserQuestion tool**
+  to confirm before proceeding. Include the `git status --short`
+  output in the question so the user can see which files are
+  uncommitted:
+
+  > "Uncommitted changes detected. Switching branches with
+  > a dirty working tree may cause changes to be applied
+  > to the wrong branch or lost."
+
+  Use options:
+  `["Stash changes and continue",
+  "Abort -- keep changes as-is"]`
+
+  - If the user selects **"Stash changes and continue"**:
+    run `git stash`. If `git stash` returns a non-zero exit
+    code, **STOP** the workflow, report the stash failure to
+    the user, and do NOT proceed to branch creation. If
+    `git stash` succeeds, re-run `git status --short` to
+    verify the working tree is clean. If the working tree is
+    still not clean, **STOP** and report the remaining
+    uncommitted changes. Only when the working tree is
+    confirmed clean, proceed to branch creation. Upon
+    workflow completion, inform the user that their changes
+    are stashed and can be restored with `git stash pop`.
+  - If the user selects **"Abort -- keep changes as-is"**:
+    **STOP** the workflow immediately without creating a
+    branch or modifying the working tree.
 - Never silently switch branches with a dirty working tree.
   Uncommitted changes may follow to the wrong branch or be
   lost entirely.

--- a/internal/scaffold/assets/opencode/skills/speckit-workflow/SKILL.md
+++ b/internal/scaffold/assets/opencode/skills/speckit-workflow/SKILL.md
@@ -37,8 +37,33 @@ current feature branch before any branch switch occurs.
   `main`.
 - Before creating a new feature branch (via `/speckit.specify`),
   check `git status --short` for uncommitted changes. If
-  uncommitted changes exist, **STOP** and ask the user for
-  confirmation before switching branches.
+  uncommitted changes exist, use the **AskUserQuestion tool**
+  to confirm before proceeding. Include the `git status --short`
+  output in the question so the user can see which files are
+  uncommitted:
+
+  > "Uncommitted changes detected. Switching branches with
+  > a dirty working tree may cause changes to be applied
+  > to the wrong branch or lost."
+
+  Use options:
+  `["Stash changes and continue",
+  "Abort -- keep changes as-is"]`
+
+  - If the user selects **"Stash changes and continue"**:
+    run `git stash`. If `git stash` returns a non-zero exit
+    code, **STOP** the workflow, report the stash failure to
+    the user, and do NOT proceed to branch creation. If
+    `git stash` succeeds, re-run `git status --short` to
+    verify the working tree is clean. If the working tree is
+    still not clean, **STOP** and report the remaining
+    uncommitted changes. Only when the working tree is
+    confirmed clean, proceed to branch creation. Upon
+    workflow completion, inform the user that their changes
+    are stashed and can be restored with `git stash pop`.
+  - If the user selects **"Abort -- keep changes as-is"**:
+    **STOP** the workflow immediately without creating a
+    branch or modifying the working tree.
 - Never silently switch branches with a dirty working tree.
   Uncommitted changes may follow to the wrong branch or be
   lost entirely.

--- a/openspec/changes/speckit-workflow-dirty-tree-hardening/.openspec.yaml
+++ b/openspec/changes/speckit-workflow-dirty-tree-hardening/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: unbound-force
+created: 2026-08-01

--- a/openspec/changes/speckit-workflow-dirty-tree-hardening/design.md
+++ b/openspec/changes/speckit-workflow-dirty-tree-hardening/design.md
@@ -1,0 +1,85 @@
+## Context
+
+The `speckit-workflow/SKILL.md` Pre-conditions section (lines
+38-44) instructs agents to check for uncommitted changes before
+branch creation, but uses only prose: "STOP and ask the user
+for confirmation." Under context compression, agents may skip
+this check entirely, creating branches with dirty working trees.
+
+Three sibling files have already been hardened with explicit
+`AskUserQuestion` tool calls:
+- `speckit.specify.md` (PR #396)
+- `openspec-propose/SKILL.md` (PR #406)
+- `opsx-propose.md` (PR #406)
+
+The hardened pattern is well-established and proven.
+
+## Goals / Non-Goals
+
+### Goals
+- Replace prose-only dirty-tree check with explicit
+  `AskUserQuestion` tool call including stash/abort options
+- Match the exact pattern used in sibling files for
+  consistency
+- Keep source file and scaffold copy in sync
+
+### Non-Goals
+- Refactoring other sections of `speckit-workflow/SKILL.md`
+- Adding new guardrails beyond the dirty-tree check
+- Modifying any Go source code or tests
+
+## Decisions
+
+### D1: Reuse the sibling hardening pattern exactly
+
+**Decision**: Apply the same `AskUserQuestion` pattern used in
+`speckit.specify.md` (PR #396) — two options ("Stash changes
+and continue", "Abort -- keep changes as-is"), stash failure
+handling, and post-stash verification.
+
+**Rationale**: Consistency across all branch-creation guardrails
+reduces cognitive load for both agents and human reviewers.
+The pattern is proven across three files without issues.
+
+### D2: Replace in-place rather than append
+
+**Decision**: Replace lines 38-44 (the prose block) with the
+hardened block, rather than appending a new section.
+
+**Rationale**: The existing prose covers the same logical
+requirement. Replacing it avoids duplication and conflicting
+instructions within the same section.
+
+### D3: Update scaffold copy simultaneously
+
+**Decision**: Apply identical changes to both
+`.opencode/skills/speckit-workflow/SKILL.md` and
+`internal/scaffold/assets/opencode/skills/speckit-workflow/SKILL.md`.
+
+**Rationale**: The scaffold drift-detection tests verify these
+files match. Updating only one would break the build. Both
+files must contain identical content.
+
+## Risks / Trade-offs
+
+### Low risk: Line number drift
+
+The issue body documents updated line numbers (39-40) from PRs
+#392 and #398. The implementation task must re-read the file to
+locate the exact prose block rather than relying on hardcoded
+line numbers.
+
+**Mitigation**: Tasks specify matching by content pattern
+("STOP and ask the user for confirmation") rather than line
+numbers.
+
+### Minimal risk: Context window increase
+
+The hardened block is longer than the prose it replaces (~25
+lines vs ~7 lines). This marginally increases the skill's
+token footprint.
+
+**Accepted trade-off**: The security improvement (preventing
+silent branch creation with dirty trees) justifies the
+additional tokens. The increase is small relative to the full
+skill file.

--- a/openspec/changes/speckit-workflow-dirty-tree-hardening/proposal.md
+++ b/openspec/changes/speckit-workflow-dirty-tree-hardening/proposal.md
@@ -1,0 +1,99 @@
+## Why
+
+The `speckit-workflow/SKILL.md` dirty-tree check (lines 38-44)
+uses prose-only instructions: "STOP and ask the user for
+confirmation before switching branches." Under context
+compression or token pressure, agents can skip the check and
+create a branch despite uncommitted changes — causing work to
+appear on the wrong branch or be lost entirely.
+
+This is the same T1+T3 vulnerability pattern identified in
+audit issue #346. Sibling files (`speckit.specify.md`,
+`openspec-propose/SKILL.md`, `opsx-propose.md`) have already
+been hardened with explicit `AskUserQuestion` tool calls via
+PRs #396 and #406. The `speckit-workflow/SKILL.md` is the
+remaining file that still uses the prose-only pattern.
+
+Fixes: https://github.com/unbound-force/unbound-force/issues/395
+
+## What Changes
+
+Replace the prose-only dirty-tree check in
+`.opencode/skills/speckit-workflow/SKILL.md` (Pre-conditions
+section, lines 38-44) with an explicit `AskUserQuestion` tool
+call pattern that matches the hardened sibling files.
+
+The same change is applied to the scaffold copy at
+`internal/scaffold/assets/opencode/skills/speckit-workflow/SKILL.md`
+to keep both files in sync.
+
+## Capabilities
+
+### New Capabilities
+- None
+
+### Modified Capabilities
+- `speckit-workflow dirty-tree guard`: Replaces prose-only
+  "STOP and ask" instruction with explicit `AskUserQuestion`
+  tool call, stash/abort options, stash failure handling, and
+  post-workflow stash restore reminder.
+
+### Removed Capabilities
+- None
+
+## Impact
+
+- **Files modified**: 2 (source skill + scaffold copy)
+  - `.opencode/skills/speckit-workflow/SKILL.md`
+  - `internal/scaffold/assets/opencode/skills/speckit-workflow/SKILL.md`
+- **Behavioral change**: Agents using the speckit-workflow
+  skill will now be forced through a structured decision gate
+  before branch creation with a dirty working tree, instead of
+  relying on prose that may be skipped under context pressure.
+- **Risk**: Low — the pattern is proven in three sibling files.
+  No Go code changes. No CI changes. No schema changes.
+
+## Constitution Alignment
+
+Assessed against the Unbound Force org constitution.
+
+### I. Autonomous Collaboration
+
+**Assessment**: N/A
+
+This change modifies agent skill instructions, not inter-hero
+artifact communication. No artifact formats or hero interfaces
+are affected.
+
+### II. Composability First
+
+**Assessment**: N/A
+
+This change hardens an existing guardrail within a single skill
+file. No hero dependencies are introduced or modified.
+
+### III. Observable Quality
+
+**Assessment**: N/A
+
+No machine-parseable output or provenance metadata is affected.
+The change is purely to agent instruction text.
+
+### IV. Testability
+
+**Assessment**: PASS
+
+The scaffold copy at `internal/scaffold/assets/` has an existing
+drift-detection test that verifies it matches the source file.
+Both copies are updated in sync, so existing tests continue to
+pass.
+
+### V. Security by Default
+
+**Assessment**: PASS
+
+This change directly improves security posture by hardening a
+guardrail against context-compression bypass. The explicit
+`AskUserQuestion` gate ensures agents cannot silently skip the
+dirty-tree check — a form of input validation for workflow
+state.

--- a/openspec/changes/speckit-workflow-dirty-tree-hardening/specs/dirty-tree-guard.md
+++ b/openspec/changes/speckit-workflow-dirty-tree-hardening/specs/dirty-tree-guard.md
@@ -1,0 +1,95 @@
+## ADDED Requirements
+
+### Requirement: Explicit AskUserQuestion gate for dirty-tree detection
+
+When the speckit-workflow skill detects uncommitted changes
+before branch creation, the agent MUST invoke the
+`AskUserQuestion` tool with exactly two options:
+1. "Stash changes and continue"
+2. "Abort -- keep changes as-is"
+
+The agent MUST include the `git status --short` output in the
+question text so the user can see which files are affected.
+
+The agent MUST NOT proceed to branch creation until the user
+responds.
+
+#### Scenario: Agent detects uncommitted changes before branch switch
+
+- **GIVEN** the agent is executing the speckit-workflow skill
+  and needs to create or switch to a feature branch
+- **AND** `git status --short` returns non-empty output
+- **WHEN** the agent reaches the dirty-tree check
+- **THEN** the agent MUST invoke the `AskUserQuestion` tool
+  with the two options listed above and the `git status` output
+- **AND** the agent MUST NOT run `git checkout -b` until the
+  user responds
+
+#### Scenario: User selects "Stash changes and continue"
+
+- **GIVEN** the agent has presented the dirty-tree
+  `AskUserQuestion` gate
+- **WHEN** the user selects "Stash changes and continue"
+- **THEN** the agent MUST run `git stash`
+- **AND** if `git stash` exits with a non-zero exit code, the
+  agent MUST abort the workflow and report the stash failure
+- **AND** if `git stash` succeeds, the agent MUST re-run
+  `git status --short` to verify the working tree is clean
+- **AND** if the working tree is still not clean after stash,
+  the agent MUST abort and report the remaining changes
+- **AND** only when the working tree is confirmed clean SHALL
+  the agent proceed to branch creation
+
+#### Scenario: User selects "Abort -- keep changes as-is"
+
+- **GIVEN** the agent has presented the dirty-tree
+  `AskUserQuestion` gate
+- **WHEN** the user selects "Abort -- keep changes as-is"
+- **THEN** the agent MUST stop the workflow immediately
+- **AND** the agent MUST NOT create a branch or modify the
+  working tree
+- **AND** the agent MUST report that the operation was aborted
+  due to uncommitted changes
+
+### Requirement: Post-stash user notification
+
+When the agent successfully stashes changes and completes the
+workflow, the agent SHOULD inform the user that their changes
+are stashed and can be restored with `git stash pop`.
+
+#### Scenario: Workflow completes after stash
+
+- **GIVEN** the agent stashed changes at the start of the
+  workflow
+- **WHEN** the workflow completes successfully
+- **THEN** the agent SHOULD remind the user that their changes
+  are stashed and can be restored with `git stash pop`
+
+### Requirement: Scaffold copy synchronization
+
+The scaffold copy at
+`internal/scaffold/assets/opencode/skills/speckit-workflow/SKILL.md`
+MUST contain identical content to the source file at
+`.opencode/skills/speckit-workflow/SKILL.md`.
+
+#### Scenario: Source and scaffold diverge
+
+- **GIVEN** the source SKILL.md has been updated
+- **WHEN** the scaffold copy is not updated with the same
+  content
+- **THEN** the existing drift-detection tests MUST fail
+
+## MODIFIED Requirements
+
+### Requirement: Pre-conditions dirty-tree check
+
+The Pre-conditions section MUST use explicit `AskUserQuestion`
+tool calls with structured options instead of prose-only
+instructions.
+
+Previously: "If uncommitted changes exist, **STOP** and ask
+the user for confirmation before switching branches."
+
+## REMOVED Requirements
+
+None.

--- a/openspec/changes/speckit-workflow-dirty-tree-hardening/tasks.md
+++ b/openspec/changes/speckit-workflow-dirty-tree-hardening/tasks.md
@@ -1,0 +1,42 @@
+<!--
+  [P] marks tasks eligible for parallel execution.
+  Add [P] when a task: (a) touches different files from
+  other [P] tasks in the group, (b) has no dependency
+  on prior tasks in the group, (c) can safely execute
+  without ordering constraints.
+  Do NOT add [P] when tasks modify the same file —
+  parallel workers will cause merge conflicts.
+  Tasks without [P] run sequentially first, then [P]
+  tasks run in parallel.
+-->
+
+## 1. Harden dirty-tree check
+
+- [x] 1.1 [P] Replace the prose-only dirty-tree check in
+  `.opencode/skills/speckit-workflow/SKILL.md` Pre-conditions
+  section (lines 38-44) with an explicit `AskUserQuestion`
+  block. Match the pattern from `speckit.specify.md` lines
+  42-67: include `git status --short` output in the question,
+  offer "Stash changes and continue" and "Abort -- keep
+  changes as-is" options, handle stash failure (abort on
+  non-zero exit), re-verify clean tree after stash, and add
+  post-workflow stash restore reminder.
+- [x] 1.2 [P] Apply the identical replacement to the scaffold
+  copy at
+  `internal/scaffold/assets/opencode/skills/speckit-workflow/SKILL.md`.
+  The content MUST be identical to the source file after both
+  edits.
+
+## 2. Verification
+
+- [x] 2.1 Run `make check` to verify lint, tests, and build
+  pass. The scaffold drift-detection tests confirm source and
+  scaffold copies match.
+- [x] 2.2 Verify constitution alignment: confirm no
+  Autonomous Collaboration, Composability, Observable Quality,
+  Testability, or Security by Default principles are violated.
+  This change hardens a security guardrail (Principle V) and
+  preserves testability (Principle IV) via existing
+  drift-detection tests.
+<!-- spec-review: passed -->
+<!-- code-review: passed -->


### PR DESCRIPTION
## Summary

Replace the prose-only dirty-tree check in
`speckit-workflow/SKILL.md` Pre-conditions section with an
explicit `AskUserQuestion` tool call pattern. The prose-only
"STOP and ask the user for confirmation" instruction can be
skipped by agents under context compression (T1+T3
vulnerability from audit #346). The fix applies the same
hardening pattern proven in 3 sibling files via PRs #396 and
#406.

Fixes #395

## How to Test

1. Open `.opencode/skills/speckit-workflow/SKILL.md` and verify
   the Pre-conditions section (lines 38-69) contains the full
   `AskUserQuestion` pattern with stash/abort options
2. Run `diff .opencode/skills/speckit-workflow/SKILL.md internal/scaffold/assets/opencode/skills/speckit-workflow/SKILL.md`
   — should produce no output (files identical)
3. Run `go test -race -count=1 ./internal/scaffold/...` —
   drift-detection tests should pass

## How to Demo

Trivial security hardening fix — no demo required. The
change replaces 2 lines of prose with a 25-line explicit
tool call block in agent instruction text.

## Key Files Changed

- `.opencode/skills/speckit-workflow/SKILL.md` — hardened
  dirty-tree check with explicit AskUserQuestion gate
- `internal/scaffold/assets/opencode/skills/speckit-workflow/SKILL.md`
  — identical scaffold copy (kept in sync)
- `openspec/changes/speckit-workflow-dirty-tree-hardening/` —
  OpenSpec change artifacts (proposal, design, spec, tasks)

## Known Issues

The following findings from the review council were
acknowledged but not resolved:

- **LOW**: Pre-existing dash inconsistency across sibling
  files (`--` vs `—` in "Abort" option text). Does not
  affect functionality.

_This PR was generated by /uf.finale (AI-assisted)._
