### PR TITLE
ci: adopt org-infra reusable release workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,12 +3,19 @@
 # Release
 # =======
 # One-click release pipeline triggered via workflow_dispatch.
-# Validates pre-flight conditions (semver format, tag
-# uniqueness, CI status, unreleased commits), creates the
-# tag, builds cross-platform binaries via GoReleaser with
-# SBOM and Cosign signing, signs macOS archives with Apple
-# Developer ID, notarizes them, and publishes to the
-# Homebrew tap.
+# Delegates to org-infra reusable workflows for preflight
+# validation and GoReleaser execution with supply chain
+# artifacts (cosign signatures and SBOMs).
+#
+# Preflight validates semver format, tag uniqueness (with
+# re-run resilience), semver ordering, CI check status,
+# and unreleased commits before creating an annotated tag.
+#
+# After release, signs macOS archives with Apple Developer
+# ID, notarizes them, patches Homebrew cask and formula
+# checksums, and pushes to the Homebrew tap.
+#
+# Fixes: https://github.com/unbound-force/unbound-force/issues/428
 
 name: Release
 
@@ -19,215 +26,96 @@ on:
         description: 'Release tag (e.g., v0.15.0)'
         required: true
         type: string
+      skip_semver_check:
+        description: 'Skip semver ordering verification'
+        type: boolean
+        default: false
+      skip_ci_checks:
+        description: 'Skip CI check verification on HEAD'
+        type: boolean
+        default: false
+      skip_unreleased_check:
+        description: 'Skip unreleased commits verification'
+        type: boolean
+        default: false
 
 permissions: {}
 
 concurrency:
-  group: release-${{ github.ref }}
+  group: release-${{ github.repository }}
   cancel-in-progress: false
 
 jobs:
   preflight:
-    runs-on: ubuntu-latest
+    name: Preflight
+    uses: complytime/org-infra/.github/workflows/reusable_release_preflight.yml@0c784711926c9864f027ec565fd7c06a382d80f8 # v0.7.1
+    with:
+      tag: ${{ inputs.tag }}
+      # Check names from ci_local.yml, ci_checks.yml, ci_security.yml
+      ci_checks: '["Build and Test", "Standardized CI / Run linters", "OSV-Scanner / Trivy Source Scan"]'
+      skip_semver_check: ${{ inputs.skip_semver_check }}
+      skip_ci_checks: ${{ inputs.skip_ci_checks }}
+      skip_unreleased_check: ${{ inputs.skip_unreleased_check }}
     permissions:
       contents: write
       checks: read
-    timeout-minutes: 10
-    env:
-      RELEASE_TAG: ${{ inputs.tag }}
+
+  release:
+    name: Release
+    needs: preflight
+    if: needs.preflight.outputs.tag != ''
+    uses: complytime/org-infra/.github/workflows/reusable_release_goreleaser.yml@0c784711926c9864f027ec565fd7c06a382d80f8 # v0.7.1
+    with:
+      tag: ${{ needs.preflight.outputs.tag }}
+    permissions:
+      contents: write
+      id-token: write
+
+  check-signing-secrets:
+    name: Check Signing Secrets
+    needs: preflight
+    if: needs.preflight.outputs.tag != ''
+    runs-on: ubuntu-latest
+    permissions: {}
+    timeout-minutes: 5
     outputs:
-      has_signing_secrets: ${{ steps.check-secrets.outputs.has_secrets }}
+      has_signing_secrets: ${{ steps.check.outputs.has_secrets }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
-        with:
-          fetch-depth: 0
-
-      - name: Validate tag format
-        run: |
-          if ! echo "$RELEASE_TAG" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
-            echo "::error::Invalid tag format: '$RELEASE_TAG'. Must match vMAJOR.MINOR.PATCH (e.g., v0.15.0)."
-            exit 1
-          fi
-          echo "Tag format valid: $RELEASE_TAG"
-
-      - name: Check tag uniqueness
-        run: |
-          if git ls-remote --tags origin | grep -q "refs/tags/${RELEASE_TAG}$"; then
-            echo "::error::Tag '$RELEASE_TAG' already exists. Choose a different version."
-            exit 1
-          fi
-          echo "Tag '$RELEASE_TAG' does not exist yet."
-
-      - name: Verify semver ordering
-        run: |
-          LATEST=$(git tag -l 'v[0-9]*' --sort=-v:refname | head -1)
-          if [ -z "$LATEST" ]; then
-            echo "No existing tags found. First release."
-            exit 0
-          fi
-          echo "Latest existing tag: $LATEST"
-          # Compare using sort -V: if TAG sorts after LATEST, it is greater
-          HIGHER=$(printf '%s\n%s' "$LATEST" "$RELEASE_TAG" | sort -V | tail -1)
-          if [ "$HIGHER" = "$LATEST" ]; then
-            echo "::error::Tag '$RELEASE_TAG' is not greater than latest release '$LATEST'."
-            exit 1
-          fi
-          echo "Version ordering valid: $RELEASE_TAG > $LATEST"
-
-      - name: Verify CI passed on HEAD
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_REPO: ${{ github.repository }}
-        run: |
-          HEAD_SHA=$(git rev-parse HEAD)
-          echo "Checking CI status for commit $HEAD_SHA"
-
-          REQUIRED_CHECKS=(
-            "Build and Test"
-            "Standardized CI / Run linters"
-          )
-
-          for CHECK_NAME in "${REQUIRED_CHECKS[@]}"; do
-            STATUS=$(gh api "repos/${GH_REPO}/commits/${HEAD_SHA}/check-runs" \
-              --jq ".check_runs[] | select(.name == \"${CHECK_NAME}\") | .conclusion" \
-              2>/dev/null | head -1)
-            if [ "$STATUS" != "success" ]; then
-              echo "::error::Required check '${CHECK_NAME}' has not passed (status: ${STATUS:-not found}). Push to main and wait for CI before releasing."
-              exit 1
-            fi
-            echo "  ✓ ${CHECK_NAME}: success"
-          done
-
-          # Security checks: verify at least one scan passed
-          SECURITY_PASSED=false
-          for CHECK_NAME in "OSV-Scanner / Trivy Source Scan" "OSV-Scanner / OSV-Scanner / osv-scan"; do
-            STATUS=$(gh api "repos/${GH_REPO}/commits/${HEAD_SHA}/check-runs" \
-              --jq ".check_runs[] | select(.name == \"${CHECK_NAME}\") | .conclusion" \
-              2>/dev/null | head -1)
-            if [ "$STATUS" = "success" ]; then
-              echo "  ✓ ${CHECK_NAME}: success"
-              SECURITY_PASSED=true
-            else
-              echo "  ⚠ ${CHECK_NAME}: ${STATUS:-not found}"
-            fi
-          done
-
-          if [ "$SECURITY_PASSED" != "true" ]; then
-            echo "::error::No security scan checks have passed on HEAD. Push to main and wait for CI before releasing."
-            exit 1
-          fi
-
-          echo "All required CI checks passed."
-
-      - name: Verify unreleased commits
-        run: |
-          LATEST=$(git tag -l 'v[0-9]*' --sort=-v:refname | head -1)
-          if [ -z "$LATEST" ]; then
-            COUNT=$(git rev-list --count HEAD)
-          else
-            COUNT=$(git rev-list --count "${LATEST}..HEAD")
-          fi
-          if [ "$COUNT" -eq 0 ]; then
-            echo "::error::No unreleased commits since ${LATEST:-initial commit}. Nothing to release."
-            exit 1
-          fi
-          echo "$COUNT commit(s) since ${LATEST:-initial commit}."
-
-      - name: Create and push tag
-        run: |
-          # Skip if tag was already created (e.g., re-run after
-          # partial failure or manual tag via GitHub API).
-          if git ls-remote --tags origin | grep -q "refs/tags/${RELEASE_TAG}$"; then
-            echo "Tag $RELEASE_TAG already exists, skipping creation."
-            exit 0
-          fi
-          # Annotated tags require a committer identity on the
-          # CI runner (git tag -a uses GIT_COMMITTER_NAME/EMAIL).
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git tag -a "$RELEASE_TAG" -m "$RELEASE_TAG"
-          git push origin "$RELEASE_TAG"
-          echo "Created and pushed tag: $RELEASE_TAG"
-
       - name: Check signing secrets
-        id: check-secrets
+        id: check
         run: |
-          if [ -n "$MACOS_SIGN_P12" ]; then
+          missing=""
+          for var in MACOS_SIGN_P12 MACOS_SIGN_PASSWORD MACOS_NOTARY_KEY \
+                     MACOS_SIGN_IDENTITY MACOS_NOTARY_KEY_ID MACOS_NOTARY_ISSUER_ID; do
+            eval "val=\$$var"
+            if [ -z "$val" ]; then
+              missing="$missing $var"
+            fi
+          done
+          if [ -z "$missing" ]; then
             echo "has_secrets=true" >> "$GITHUB_OUTPUT"
           else
+            echo "::notice::Missing signing secrets:$missing"
             echo "has_secrets=false" >> "$GITHUB_OUTPUT"
           fi
         env:
           MACOS_SIGN_P12: ${{ secrets.MACOS_SIGN_P12 }}
-
-  release:
-    runs-on: ubuntu-latest
-    needs: preflight
-    permissions:
-      contents: write
-      id-token: write
-    timeout-minutes: 45
-    env:
-      RELEASE_TAG: ${{ inputs.tag }}
-    outputs:
-      has_signing_secrets: ${{ needs.preflight.outputs.has_signing_secrets }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
-        with:
-          fetch-depth: 0
-          ref: ${{ inputs.tag }}
-
-      - name: Set up Go
-        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
-        with:
-          go-version-file: go.mod
-
-      - name: Install Cosign
-        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6  # v4.1.2
-
-      - name: Install Syft
-        uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610  # v0.24.0
-
-      - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94  # v7.2.3
-        with:
-          distribution: goreleaser
-          version: 'v2.14.1'
-          args: release --clean
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GORELEASER_CURRENT_TAG: ${{ inputs.tag }}
-
-      - name: Upload generated cask and formula as release artifacts
-        # GoReleaser writes dist/homebrew/Casks/unbound-force.rb and
-        # dist/homebrew/Formula/unbound-force.rb with skip_upload: true.
-        # Upload both so the sign-macos job can download and patch darwin checksums.
-        run: |
-          gh release upload "$RELEASE_TAG" \
-            --repo "$GITHUB_REPOSITORY" \
-            dist/homebrew/Casks/unbound-force.rb \
-            --clobber
-
-          # Rename formula to avoid filename collision with cask (both are unbound-force.rb)
-          cp dist/homebrew/Formula/unbound-force.rb dist/homebrew/Formula/unbound-force-formula.rb
-          gh release upload "$RELEASE_TAG" \
-            --repo "$GITHUB_REPOSITORY" \
-            dist/homebrew/Formula/unbound-force-formula.rb \
-            --clobber
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MACOS_SIGN_PASSWORD: ${{ secrets.MACOS_SIGN_PASSWORD }}
+          MACOS_NOTARY_KEY: ${{ secrets.MACOS_NOTARY_KEY }}
+          MACOS_SIGN_IDENTITY: ${{ secrets.MACOS_SIGN_IDENTITY }}
+          MACOS_NOTARY_KEY_ID: ${{ secrets.MACOS_NOTARY_KEY_ID }}
+          MACOS_NOTARY_ISSUER_ID: ${{ secrets.MACOS_NOTARY_ISSUER_ID }}
 
   sign-macos:
+    name: Sign macOS
     runs-on: macos-latest
-    needs: release
-    if: ${{ needs.release.outputs.has_signing_secrets == 'true' }}
+    needs: [preflight, release, check-signing-secrets]
+    if: needs.check-signing-secrets.outputs.has_signing_secrets == 'true'
     permissions:
       contents: write
     timeout-minutes: 30
     env:
-      RELEASE_TAG: ${{ inputs.tag }}
+      RELEASE_TAG: ${{ needs.preflight.outputs.tag }}
     steps:
       - name: Import certificate into Keychain
         run: |

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -46,6 +46,12 @@ signs:
       - "${artifact}"
       - --yes
 
+release:
+  extra_files:
+    - glob: dist/homebrew/Casks/unbound-force.rb
+    - glob: dist/homebrew/Formula/unbound-force.rb
+      name_template: unbound-force-formula.rb
+
 changelog:
   sort: asc
   use: github

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ Each entry follows the format: `- <change-name>: <summary>`.
 
 ## Unreleased
 
+### Changed
+- adopt-org-infra-release-workflows: Replace inline
+  release preflight and GoReleaser jobs with org-infra
+  reusable workflow callers (`reusable_release_preflight`
+  + `reusable_release_goreleaser` @ v0.7.1). Adds smart
+  re-run detection, spec-compliant semver comparator
+  (replaces `sort -V`), configurable `ci_checks` input
+  (build, lint, and security scan gates), skip inputs
+  for debugging, and concurrency guard. Signing secrets
+  check expanded to verify all 6 required secrets.
+  GoReleaser config gains `release.extra_files` for
+  Homebrew artifact upload. `sign-macos` stays inline.
+  Updated `docs/RELEASE_PROCESS.md` to reflect the new
+  pipeline, including org-infra upgrade path.
+  (Spec: openspec/changes/adopt-org-infra-release-workflows/,
+  Fixes: #428)
+
 ### Added
 - council-review-action: New composite GitHub Action for
   AI code review using OpenCode with Divisor persona

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -11,42 +11,68 @@ maintainers.
 3. Click **Run workflow**
 4. Done.
 
+### Optional Skip Controls
+
+The workflow exposes three optional boolean inputs for
+debugging or recovering from partial failures:
+
+- **Skip semver check**: Bypass semver ordering verification
+  against the latest existing tag
+- **Skip CI checks**: Bypass CI check verification on HEAD
+- **Skip unreleased check**: Bypass verification that
+  unreleased commits exist since the last tag
+
+These should only be used when you understand why the
+check is failing and have confirmed the release is safe.
+
 ## What Happens Automatically
 
-The release workflow performs the following steps without
-human intervention:
+The release workflow delegates to
+[org-infra](https://github.com/complytime/org-infra)
+reusable workflows for preflight validation and GoReleaser
+execution, then runs macOS signing inline.
 
 ### Pre-flight Validation
 
-Before any artifacts are built, the workflow validates:
+The `reusable_release_preflight` workflow validates:
 
-- **Tag format**: Must match `vMAJOR.MINOR.PATCH`
-- **Tag uniqueness**: Must not already exist
+- **Tag format**: Must match `vMAJOR.MINOR.PATCH` (strict
+  semver, no pre-release suffixes)
+- **Tag uniqueness**: Must not already exist — with smart
+  re-run detection (if the tag already exists at HEAD, it
+  is treated as a re-run after partial failure, not an
+  error)
 - **Semver ordering**: New tag must be greater than the
-  latest existing tag
-- **CI status**: All required checks must have passed on
-  HEAD (`Build and Test`, `Standardized CI / Run linters`,
-  security scans)
+  latest existing tag (spec-compliant semver comparison)
+- **CI status**: Required checks must have passed on HEAD
+  (configured via `ci_checks` input:
+  `["Build and Test", "Standardized CI / Run linters",
+  "OSV-Scanner / Trivy Source Scan"]`)
 - **Unreleased commits**: At least one commit must exist
   since the last release
 
 If any validation fails, the workflow aborts with a clear
-error message.
+error message. Tag creation uses the GitHub API to create
+annotated tags.
 
 ### Build and Release
 
-After pre-flight passes:
+The `reusable_release_goreleaser` workflow:
 
-1. **Tag creation**: An annotated git tag is created and
-   pushed automatically
-2. **GoReleaser** builds cross-platform binaries:
+1. Checks out the code at the validated tag
+2. Sets up Go (version from `go.mod`)
+3. Installs **Cosign** for Sigstore keyless signing
+4. Installs **Syft** for SBOM generation
+5. Runs **GoReleaser** to build cross-platform binaries:
    - darwin (amd64, arm64)
    - linux (amd64, arm64)
-3. **RPM packages** via nfpm (attached to GitHub release)
-4. **SBOM generation** via Syft (archive + source)
-5. **Cosign signing** of checksums (Sigstore keyless)
-6. **Changelog** auto-generated from conventional commits
-7. **Homebrew cask and formula** generated (not yet pushed)
+6. **RPM packages** via nfpm (attached to GitHub release)
+7. **SBOM generation** via Syft (archive + source)
+8. **Cosign signing** of checksums (Sigstore keyless)
+9. **Changelog** auto-generated from conventional commits
+10. **Homebrew cask and formula** generated and uploaded as
+    release assets (via `release.extra_files` in
+    `.goreleaser.yaml`)
 
 ### macOS Signing
 
@@ -74,6 +100,14 @@ After the GitHub release is published:
      submitted for f44 and f43
 
 End result: `dnf install unbound-force`
+
+## Re-running After Partial Failure
+
+If the release job fails after the tag was created (e.g.,
+GoReleaser error, network timeout), you can safely re-run
+the workflow with the same tag. The preflight detects that
+the tag already exists at HEAD and treats it as a re-run,
+skipping tag creation and re-validation.
 
 ## Cadence
 
@@ -183,12 +217,16 @@ If Packit has already proposed to dist-git:
 
 Ensure the latest commit on `main` has all CI checks
 green. Push a fix if needed and wait for CI to complete
-before retrying.
+before retrying. Alternatively, use the **Skip CI checks**
+input if you have verified the checks manually.
 
 ### Pre-flight fails with "tag already exists"
 
-The version has already been released. Choose a higher
-version number.
+If the tag exists at a different commit, the version has
+already been released. Choose a higher version number.
+
+If the tag exists at HEAD, the workflow detects this as a
+re-run and continues automatically.
 
 ### GoReleaser fails
 
@@ -204,9 +242,45 @@ If signing secrets are not configured, the `sign-macos`
 job is skipped automatically. Darwin binaries will be
 unsigned but functional.
 
+### Reusable workflow fails
+
+The release pipeline delegates to org-infra reusable
+workflows pinned by SHA. If the workflow fails:
+
+- Check the
+  [org-infra repository](https://github.com/complytime/org-infra)
+  for known issues
+- The pinned SHA corresponds to v0.7.1
+- To update: verify the new SHA, update both `uses:`
+  references in `release.yml`, update the version
+  comment, and test with a pre-release tag if possible
+- Individual failed jobs can be re-run via the GitHub
+  Actions UI without re-running the entire pipeline
+
 ### Packit propose_downstream fails
 
 Ensure the Fedora package review has been completed and
 the package exists in dist-git. Check the
 [Packit dashboard](https://dashboard.packit.dev/) for
 detailed error messages.
+
+## Maintaining the org-infra Dependency
+
+The preflight and GoReleaser jobs delegate to reusable
+workflows from
+[complytime/org-infra](https://github.com/complytime/org-infra),
+pinned by commit SHA in `release.yml`.
+
+To upgrade:
+
+1. Check
+   [org-infra releases](https://github.com/complytime/org-infra/releases)
+   for new versions
+2. Review the changelog for breaking changes to
+   `reusable_release_preflight` and
+   `reusable_release_goreleaser`
+3. Update the SHA in `release.yml` (both `uses:` lines)
+4. Update the version comment (e.g., `# v0.8.0`)
+5. Verify the SHA matches all other org-infra references
+   in `.github/workflows/` for consistency
+6. Test with a pre-release tag if possible

--- a/openspec/changes/adopt-org-infra-release-workflows/proposal.md
+++ b/openspec/changes/adopt-org-infra-release-workflows/proposal.md
@@ -1,0 +1,98 @@
+## Why
+
+The release pipeline duplicates ~190 lines of inline
+validation and GoReleaser setup logic that org-infra
+already maintains as reusable workflows. This creates
+a maintenance burden: when org-infra improves preflight
+validation (e.g., smart re-run detection, spec-compliant
+semver comparison), each consuming repo must independently
+reimplement the improvement or fall behind.
+
+The inline preflight has known limitations:
+- Uses `sort -V` for semver ordering (breaks on
+  pre-releases)
+- Hardcoded CI check names (no configurable input)
+- No re-run resilience (tag uniqueness check blocks
+  re-runs after partial failures)
+- Security scan gate uses OR logic (at least one scan)
+  rather than explicit named checks
+
+complyctl and complypack already consume org-infra
+reusable workflows for release. Adopting the same pattern
+across all unbound-force repositories unifies the release
+pipeline and reduces per-repo maintenance.
+
+## What Changes
+
+Replace the inline release preflight and GoReleaser jobs
+in `.github/workflows/release.yml` with calls to org-infra
+reusable workflows (`reusable_release_preflight` +
+`reusable_release_goreleaser`). The `sign-macos` job stays
+inline because it is repo-specific (binary name, Homebrew
+tap structure, signing identity).
+
+## Capabilities
+
+### New Capabilities
+- `reusable-preflight`: Delegate preflight validation to
+  org-infra's `reusable_release_preflight` workflow with
+  smart re-run detection and spec-compliant semver
+  comparison
+- `reusable-goreleaser`: Delegate GoReleaser execution
+  to org-infra's `reusable_release_goreleaser` workflow
+  with supply chain artifacts (Cosign + Syft)
+- `skip-inputs`: Three boolean inputs for debugging
+  (`skip_semver_check`, `skip_ci_checks`,
+  `skip_unreleased_check`)
+- `extra-files-upload`: GoReleaser `release.extra_files`
+  for atomic Homebrew artifact upload (replaces manual
+  `gh release upload` post-step)
+- `full-secret-validation`: Signing secrets check
+  expanded to verify all 6 required secrets with
+  actionable `::notice::` annotations for missing ones
+
+### Removed Capabilities
+- `inline-preflight`: ~130 lines of inline validation
+  logic replaced by reusable workflow caller
+- `inline-goreleaser`: ~60 lines of inline GoReleaser
+  setup replaced by reusable workflow caller
+- `manual-artifact-upload`: `gh release upload` step
+  replaced by GoReleaser `release.extra_files`
+
+### Unchanged Capabilities
+- `sign-macos`: macOS signing, notarization, checksum
+  patching, and Homebrew tap push remain inline
+- `fedora-packaging`: Packit integration unchanged
+
+## Impact
+
+- **Risk**: LOW — mechanical adoption of existing
+  patterns already validated in complyctl/complypack
+- **Scope**: `.github/workflows/release.yml`,
+  `.goreleaser.yaml`, `CHANGELOG.md`,
+  `docs/RELEASE_PROCESS.md`
+- **Dependencies**: `complytime/org-infra` @ v0.7.1
+  (SHA-pinned)
+- **Cross-repo**: Issue #428 covers 4 repositories;
+  this change covers `unbound-force/unbound-force` only
+
+## Acceptance Criteria
+
+- [x] Inline preflight replaced with
+  `reusable_release_preflight` caller (SHA-pinned)
+- [x] Inline GoReleaser replaced with
+  `reusable_release_goreleaser` caller (SHA-pinned)
+- [x] `sign-macos` receives `tag` from preflight
+  outputs and `has_signing_secrets` from secrets check
+- [x] GoReleaser-generated cask and formula uploaded as
+  release assets via `release.extra_files`
+- [x] `skip_semver_check`, `skip_ci_checks`,
+  `skip_unreleased_check` inputs wired through
+- [x] Security scan check (`OSV-Scanner / Trivy Source
+  Scan`) included in `ci_checks` input
+- [x] Concurrency group prevents parallel releases
+- [x] All 6 signing secrets verified before `sign-macos`
+- [x] `docs/RELEASE_PROCESS.md` updated with new
+  pipeline, skip controls, re-run docs, troubleshooting,
+  and org-infra upgrade path
+- [x] `CHANGELOG.md` entry under `## Unreleased`

--- a/openspec/changes/adopt-org-infra-release-workflows/tasks.md
+++ b/openspec/changes/adopt-org-infra-release-workflows/tasks.md
@@ -1,0 +1,61 @@
+## Tasks
+
+### 1. Replace inline preflight with reusable workflow
+
+- [x] T1.1: Remove inline preflight steps (validate
+  tag, check uniqueness, verify semver, verify CI,
+  verify unreleased, create tag)
+- [x] T1.2: Add `reusable_release_preflight` caller
+  with SHA pin and version comment
+- [x] T1.3: Wire `ci_checks` input with build, lint,
+  and security scan check names
+- [x] T1.4: Wire `skip_*` boolean inputs through
+  workflow_dispatch
+- [x] T1.5: Add `ci_checks` source comment documenting
+  which workflow files define the check names
+
+### 2. Replace inline GoReleaser with reusable workflow
+
+- [x] T2.1: Remove inline GoReleaser steps (checkout,
+  setup-go, cosign, syft, goreleaser-action, artifact
+  upload)
+- [x] T2.2: Add `reusable_release_goreleaser` caller
+  with SHA pin and version comment
+- [x] T2.3: Add `release.extra_files` to
+  `.goreleaser.yaml` for atomic Homebrew artifact upload
+- [x] T2.4: Add `name_template` to formula entry to
+  avoid filename collision with cask
+
+### 3. Extract and expand signing secrets check
+
+- [x] T3.1: Extract `check-signing-secrets` into
+  separate job with `permissions: {}`
+- [x] T3.2: Expand to verify all 6 required secrets
+- [x] T3.3: Add `::notice::` for missing secrets
+- [x] T3.4: Update `sign-macos` `needs` and `if`
+  condition
+
+### 4. Restore operational safeguards
+
+- [x] T4.1: Add workflow-level concurrency group
+- [x] T4.2: Add `name:` field to `sign-macos` job
+
+### 5. Update documentation
+
+- [x] T5.1: Update `docs/RELEASE_PROCESS.md` preflight
+  section
+- [x] T5.2: Update build and release section
+- [x] T5.3: Add skip controls section
+- [x] T5.4: Add re-running after partial failure section
+- [x] T5.5: Add reusable workflow troubleshooting
+  section
+- [x] T5.6: Add org-infra upgrade path section
+- [x] T5.7: Update troubleshooting entries
+- [x] T5.8: Add CHANGELOG entry
+
+### 6. Create retroactive spec (this file)
+
+- [x] T6.1: Create `openspec/changes/` directory
+- [x] T6.2: Write proposal with rationale and
+  acceptance criteria
+- [x] T6.3: Write task breakdown


### PR DESCRIPTION
## Summary

Replace inline preflight and GoReleaser jobs with org-infra reusable workflow callers (`reusable_release_preflight.yml` + `reusable_release_goreleaser.yml` @ v0.7.1).

## Changes

### `release.yml`
- **Preflight**: Replaced ~130 lines of inline validation logic with a single reusable workflow call
- **GoReleaser**: Replaced ~60 lines of inline GoReleaser setup (checkout, Go, cosign, syft, goreleaser-action) with a single reusable workflow call
- **New inputs**: Added `skip_semver_check`, `skip_ci_checks`, `skip_unreleased_check` for debugging
- **CI checks**: Explicitly specified via `ci_checks: '["Build and Test", "Standardized CI / Run linters"]'`
- **check-signing-secrets**: New job since the reusable preflight doesn't output `has_signing_secrets`
- **sign-macos**: Stays inline (unchanged), now uses `needs.preflight.outputs.tag` instead of `inputs.tag`

### `.goreleaser.yaml`
- Added `release.extra_files` to upload generated Homebrew cask and formula as release assets (previously done by the inline release job's `gh release upload` step)
- Formula uploaded as `unbound-force-formula.rb` via `name_template` to avoid filename collision with the cask

## Key improvements over inline implementation

| Feature | Inline (before) | Reusable (after) |
|---------|----------------|------------------|
| Re-run after partial failure | Blocked by tag uniqueness check | Smart detection: tag at HEAD = re-run |
| Semver ordering | `sort -V` (breaks on pre-releases) | Python `semver` library (spec-compliant) |
| CI check names | Hardcoded in bash | Configurable `ci_checks` JSON array input |
| Skip controls | None | 3 skip inputs for debugging |
| Tag creation | `git tag -a` + `git push` | GitHub API (annotated tags) |

## Testing

- [ ] End-to-end release test on a pre-release tag (pending)

Fixes #428