### PR TITLE
chore: add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# Unbound Force code ownership
+# See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+* @unbound-force/overlords
+.github/ @unbound-force/overlords
+.specify/memory/constitution.md @unbound-force/overlords
+.opencode/ @unbound-force/overlords


### PR DESCRIPTION
## Summary

Add a `.github/CODEOWNERS` file to activate the `require_code_owner_reviews: true` branch protection rule already configured in `.github/settings.yml`.

Without a CODEOWNERS file, that setting is a no-op — any contributor with write access can approve PRs. With CODEOWNERS, every PR now requires an approving review from a member of `@unbound-force/overlords` specifically.

## Changes

Single new file: `.github/CODEOWNERS`

| Pattern | Owner | Purpose |
|---------|-------|---------|
| `*` | `@unbound-force/overlords` | Catch-all for all paths |
| `.github/` | `@unbound-force/overlords` | CI workflows, settings, dependabot |
| `.specify/memory/constitution.md` | `@unbound-force/overlords` | Org constitution |
| `.opencode/` | `@unbound-force/overlords` | Agent configs and skills |

Mirrors the CODEOWNERS file in the replicator repo exactly.

## Impact

- **Branch protection**: Activates code owner review requirements. PRs can no longer be merged with approval from arbitrary write-access contributors alone.
- **Dependabot**: Bot auto-approval via `GITHUB_TOKEN` will **not** satisfy code owner review requirements. A human `@unbound-force/overlords` member must also approve dependabot PRs (or the bot must be added to the team).
- **No code changes**: Governance-only, zero risk to build/test/runtime.

## Related

Refs: #430