### PR TITLE
fix(scaffold): differentiate guardrails for speckit and uf.init commands

### DIFF
--- a/.opencode/commands/speckit.constitution.md
+++ b/.opencode/commands/speckit.constitution.md
@@ -86,14 +86,11 @@ Do not create a new template; always operate on the existing `.specify/memory/co
 
 ## Guardrails
 
-- **NEVER modify source code** — this command updates
-  spec artifacts ONLY. Implementation changes belong in
-  `/speckit.implement`, `/uf.unleash`, or `/uf.cobalt-crush`.
-- **NEVER modify test files, Go source, Markdown agents,
-  convention packs, or config files** outside the
-  `specs/NNN-*/` feature directory.
+- This command updates the project constitution and
+  propagates changes to dependent templates.
 - The ONLY files this command may write are:
-  - `FEATURE_SPEC` (the spec.md file)
-  - Files within `FEATURE_DIR` (spec artifacts:
-    plan.md, tasks.md, research.md, data-model.md,
-    quickstart.md, contracts/, checklists/)
+  - `.specify/memory/constitution.md`
+  - `.specify/templates/*-template.md` (consistency
+    propagation)
+- Do NOT modify source code, test files, or any files
+  outside the `.specify/` directory.

--- a/.opencode/commands/speckit.implement.md
+++ b/.opencode/commands/speckit.implement.md
@@ -175,14 +175,10 @@ Note: This command assumes a complete task breakdown exists in tasks.md. If task
 
 ## Guardrails
 
-- **NEVER modify source code** — this command updates
-  spec artifacts ONLY. Implementation changes belong in
-  `/speckit.implement`, `/uf.unleash`, or `/uf.cobalt-crush`.
-- **NEVER modify test files, Go source, Markdown agents,
-  convention packs, or config files** outside the
-  `specs/NNN-*/` feature directory.
-- The ONLY files this command may write are:
-  - `FEATURE_SPEC` (the spec.md file)
-  - Files within `FEATURE_DIR` (spec artifacts:
-    plan.md, tasks.md, research.md, data-model.md,
-    quickstart.md, contracts/, checklists/)
+- This command **writes source code** — implementation
+  is its primary purpose. It executes the tasks defined
+  in the active feature's `tasks.md`.
+- Scope modifications to the active feature's
+  implementation plan. Do not make changes unrelated to
+  the current task group.
+- Mark task checkboxes `[x]` as each task is completed.

--- a/.opencode/commands/speckit.taskstoissues.md
+++ b/.opencode/commands/speckit.taskstoissues.md
@@ -32,14 +32,10 @@ git config --get remote.origin.url
 
 ## Guardrails
 
-- **NEVER modify source code** — this command updates
-  spec artifacts ONLY. Implementation changes belong in
-  `/speckit.implement`, `/uf.unleash`, or `/uf.cobalt-crush`.
-- **NEVER modify test files, Go source, Markdown agents,
-  convention packs, or config files** outside the
-  `specs/NNN-*/` feature directory.
-- The ONLY files this command may write are:
-  - `FEATURE_SPEC` (the spec.md file)
-  - Files within `FEATURE_DIR` (spec artifacts:
-    plan.md, tasks.md, research.md, data-model.md,
-    quickstart.md, contracts/, checklists/)
+- This command creates **GitHub issues via** the MCP API.
+  It does NOT write local files.
+- Issues MUST only be created in the repository matching
+  the current Git remote. NEVER create issues in
+  unrelated repositories.
+- Do NOT modify source code, spec artifacts, or any
+  local files.

--- a/.opencode/commands/uf.init.md
+++ b/.opencode/commands/uf.init.md
@@ -546,7 +546,7 @@ step: run `.specify/scripts/bash/check-prerequisites.sh
 ### Step 6: Speckit Command Guardrails
 
 Inject a `## Guardrails` section into ALL 9
-`.opencode/commands/speckit.*.md` files. Use two
+`.opencode/commands/speckit.*.md` files. Use four
 variants depending on the command type.
 
 **Spec-phase commands** (get Guardrails WITH
@@ -558,29 +558,53 @@ review-rationale sentence):
 - `speckit.analyze.md`
 - `speckit.checklist.md`
 
-**Execution/utility commands** (get Guardrails WITHOUT
-review-rationale sentence):
-- `speckit.implement.md`
-- `speckit.constitution.md`
-- `speckit.taskstoissues.md`
+**`speckit.implement.md`** (command-specific: implementation
+guardrails — this command writes source code)
+
+**`speckit.constitution.md`** (command-specific: constitution
+guardrails — writes to `.specify/memory/` and templates)
+
+**`speckit.taskstoissues.md`** (command-specific: issue creation
+guardrails — creates GitHub issues via MCP API)
 
 For each file:
 
 1. **Read** the file content
 2. **Check** if a `## Guardrails` section already exists
-   (search for the heading text `## Guardrails`)
+   (search for the heading text `## Guardrails` as a
+   markdown heading outside of fenced code blocks)
 3. **If NOT present**: Append the appropriate guardrails
    variant at the very end of the file. Report
    `✅ <filename>: guardrails injected`
-4. **If already present**: Perform a secondary check
-   for spec-phase commands only -- search for the phrase
-   "review defeats the purpose". If the Guardrails
-   heading exists but the review-rationale sentence is
-   missing, append the sentence to the existing
-   Guardrails section. Report
-   `✅ <filename>: review-rationale added`.
+4. **If already present — spec-phase commands**: Perform
+   a secondary check — search for the phrase "review
+   defeats the purpose". If the Guardrails heading exists
+   but the review-rationale sentence is missing, append
+   the sentence to the existing Guardrails section.
+   Report `✅ <filename>: review-rationale added`.
    If the sentence is already present, report
    `⊘ <filename>: guardrails already present (skipped)`
+5. **If already present — command-specific commands**
+   (`implement`, `constitution`, `taskstoissues`):
+   Check for the command's correctness marker:
+
+   | Command | Correctness marker |
+   |---------|-------------------|
+   | `speckit.implement.md` | "writes source code" |
+   | `speckit.constitution.md` | ".specify/memory/" |
+   | `speckit.taskstoissues.md` | "GitHub issues via" |
+
+   If the correctness marker IS present in the existing
+   `## Guardrails` section, the guardrails are correct.
+   Report
+   `⊘ <filename>: guardrails already present (skipped)`
+
+   If the correctness marker is ABSENT, the guardrails
+   are incorrect (likely the old shared template).
+   Replace the entire `## Guardrails` section (from the
+   heading to the next `##` heading or end of file) with
+   the command-specific guardrail block. Report
+   `✅ <filename>: guardrails corrected`
 
 **Spec-phase guardrails block** (with review-rationale):
 
@@ -604,32 +628,51 @@ For each file:
   defeats the purpose of the spec-first workflow.
 ```
 
-**Execution/utility guardrails block** (no
-review-rationale):
+**Implement guardrails block** (`speckit.implement.md`):
 
 ```markdown
 
 ## Guardrails
 
-- **NEVER modify source code** — this command updates
-  spec artifacts ONLY. Implementation changes belong in
-  `/speckit.implement`, `/uf.unleash`, or `/uf.cobalt-crush`.
-- **NEVER modify test files, Go source, Markdown agents,
-  convention packs, or config files** outside the
-  `specs/NNN-*/` feature directory.
-- The ONLY files this command may write are:
-  - `FEATURE_SPEC` (the spec.md file)
-  - Files within `FEATURE_DIR` (spec artifacts:
-    plan.md, tasks.md, research.md, data-model.md,
-    quickstart.md, contracts/, checklists/)
+- This command **writes source code** — implementation
+  is its primary purpose. It executes the tasks defined
+  in the active feature's `tasks.md`.
+- Scope modifications to the active feature's
+  implementation plan. Do not make changes unrelated to
+  the current task group.
+- Mark task checkboxes `[x]` as each task is completed.
 ```
 
-**Note**: `speckit.implement.md` is an exception — it IS
-allowed to modify source code. However, the guardrails
-section is still injected for consistency. The implement
-command's own instructions override the guardrails where
-they conflict (implement's instructions explicitly say
-to write source code).
+**Constitution guardrails block** (`speckit.constitution.md`):
+
+```markdown
+
+## Guardrails
+
+- This command updates the project constitution and
+  propagates changes to dependent templates.
+- The ONLY files this command may write are:
+  - `.specify/memory/constitution.md`
+  - `.specify/templates/*-template.md` (consistency
+    propagation)
+- Do NOT modify source code, test files, or any files
+  outside the `.specify/` directory.
+```
+
+**Taskstoissues guardrails block** (`speckit.taskstoissues.md`):
+
+```markdown
+
+## Guardrails
+
+- This command creates **GitHub issues via** the MCP API.
+  It does NOT write local files.
+- Issues MUST only be created in the repository matching
+  the current Git remote. NEVER create issues in
+  unrelated repositories.
+- Do NOT modify source code, spec artifacts, or any
+  local files.
+```
 
 ### Step 7: Speckit UF Customizations
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,18 @@ Each entry follows the format: `- <change-name>: <summary>`.
   Closes: #253)
 
 ### Fixed
+- fix-incorrect-guardrails: Step 6 of `/uf.init` now
+  injects command-specific guardrails for
+  `speckit.implement.md`, `speckit.constitution.md`,
+  and `speckit.taskstoissues.md` instead of sharing
+  the spec-phase guardrails that contradicted each
+  command's operational model. Existing repos with
+  incorrect guardrails are automatically corrected
+  on next `/uf.init` run via replace-if-incorrect
+  idempotency. Added guardrail content regression
+  tests.
+  (Spec: openspec/changes/fix-incorrect-guardrails/,
+  Fixes: #256)
 - fix-review-pr-step7-gate: Step 7 verdict-posting offer
   in `/uf.review-pr` was gated behind a HIGH+ findings
   condition, causing the `AskUserQuestion` to be skipped

--- a/internal/scaffold/assets/opencode/commands/uf.init.md
+++ b/internal/scaffold/assets/opencode/commands/uf.init.md
@@ -546,7 +546,7 @@ step: run `.specify/scripts/bash/check-prerequisites.sh
 ### Step 6: Speckit Command Guardrails
 
 Inject a `## Guardrails` section into ALL 9
-`.opencode/commands/speckit.*.md` files. Use two
+`.opencode/commands/speckit.*.md` files. Use four
 variants depending on the command type.
 
 **Spec-phase commands** (get Guardrails WITH
@@ -558,29 +558,53 @@ review-rationale sentence):
 - `speckit.analyze.md`
 - `speckit.checklist.md`
 
-**Execution/utility commands** (get Guardrails WITHOUT
-review-rationale sentence):
-- `speckit.implement.md`
-- `speckit.constitution.md`
-- `speckit.taskstoissues.md`
+**`speckit.implement.md`** (command-specific: implementation
+guardrails — this command writes source code)
+
+**`speckit.constitution.md`** (command-specific: constitution
+guardrails — writes to `.specify/memory/` and templates)
+
+**`speckit.taskstoissues.md`** (command-specific: issue creation
+guardrails — creates GitHub issues via MCP API)
 
 For each file:
 
 1. **Read** the file content
 2. **Check** if a `## Guardrails` section already exists
-   (search for the heading text `## Guardrails`)
+   (search for the heading text `## Guardrails` as a
+   markdown heading outside of fenced code blocks)
 3. **If NOT present**: Append the appropriate guardrails
    variant at the very end of the file. Report
    `✅ <filename>: guardrails injected`
-4. **If already present**: Perform a secondary check
-   for spec-phase commands only -- search for the phrase
-   "review defeats the purpose". If the Guardrails
-   heading exists but the review-rationale sentence is
-   missing, append the sentence to the existing
-   Guardrails section. Report
-   `✅ <filename>: review-rationale added`.
+4. **If already present — spec-phase commands**: Perform
+   a secondary check — search for the phrase "review
+   defeats the purpose". If the Guardrails heading exists
+   but the review-rationale sentence is missing, append
+   the sentence to the existing Guardrails section.
+   Report `✅ <filename>: review-rationale added`.
    If the sentence is already present, report
    `⊘ <filename>: guardrails already present (skipped)`
+5. **If already present — command-specific commands**
+   (`implement`, `constitution`, `taskstoissues`):
+   Check for the command's correctness marker:
+
+   | Command | Correctness marker |
+   |---------|-------------------|
+   | `speckit.implement.md` | "writes source code" |
+   | `speckit.constitution.md` | ".specify/memory/" |
+   | `speckit.taskstoissues.md` | "GitHub issues via" |
+
+   If the correctness marker IS present in the existing
+   `## Guardrails` section, the guardrails are correct.
+   Report
+   `⊘ <filename>: guardrails already present (skipped)`
+
+   If the correctness marker is ABSENT, the guardrails
+   are incorrect (likely the old shared template).
+   Replace the entire `## Guardrails` section (from the
+   heading to the next `##` heading or end of file) with
+   the command-specific guardrail block. Report
+   `✅ <filename>: guardrails corrected`
 
 **Spec-phase guardrails block** (with review-rationale):
 
@@ -604,32 +628,51 @@ For each file:
   defeats the purpose of the spec-first workflow.
 ```
 
-**Execution/utility guardrails block** (no
-review-rationale):
+**Implement guardrails block** (`speckit.implement.md`):
 
 ```markdown
 
 ## Guardrails
 
-- **NEVER modify source code** — this command updates
-  spec artifacts ONLY. Implementation changes belong in
-  `/speckit.implement`, `/uf.unleash`, or `/uf.cobalt-crush`.
-- **NEVER modify test files, Go source, Markdown agents,
-  convention packs, or config files** outside the
-  `specs/NNN-*/` feature directory.
-- The ONLY files this command may write are:
-  - `FEATURE_SPEC` (the spec.md file)
-  - Files within `FEATURE_DIR` (spec artifacts:
-    plan.md, tasks.md, research.md, data-model.md,
-    quickstart.md, contracts/, checklists/)
+- This command **writes source code** — implementation
+  is its primary purpose. It executes the tasks defined
+  in the active feature's `tasks.md`.
+- Scope modifications to the active feature's
+  implementation plan. Do not make changes unrelated to
+  the current task group.
+- Mark task checkboxes `[x]` as each task is completed.
 ```
 
-**Note**: `speckit.implement.md` is an exception — it IS
-allowed to modify source code. However, the guardrails
-section is still injected for consistency. The implement
-command's own instructions override the guardrails where
-they conflict (implement's instructions explicitly say
-to write source code).
+**Constitution guardrails block** (`speckit.constitution.md`):
+
+```markdown
+
+## Guardrails
+
+- This command updates the project constitution and
+  propagates changes to dependent templates.
+- The ONLY files this command may write are:
+  - `.specify/memory/constitution.md`
+  - `.specify/templates/*-template.md` (consistency
+    propagation)
+- Do NOT modify source code, test files, or any files
+  outside the `.specify/` directory.
+```
+
+**Taskstoissues guardrails block** (`speckit.taskstoissues.md`):
+
+```markdown
+
+## Guardrails
+
+- This command creates **GitHub issues via** the MCP API.
+  It does NOT write local files.
+- Issues MUST only be created in the repository matching
+  the current Git remote. NEVER create issues in
+  unrelated repositories.
+- Do NOT modify source code, spec artifacts, or any
+  local files.
+```
 
 ### Step 7: Speckit UF Customizations
 

--- a/internal/scaffold/scaffold_test.go
+++ b/internal/scaffold/scaffold_test.go
@@ -6491,3 +6491,108 @@ func TestPrintSummary_SuccessUnchanged(t *testing.T) {
 		t.Errorf("expected 'opencode.json created' in output")
 	}
 }
+
+// TestGuardrailTemplates_CommandSpecificContent is a regression guard
+// for issue #256: the uf.init.md Step 6 guardrail templates must
+// contain command-specific content for implement, constitution, and
+// taskstoissues commands. Previously all 9 commands shared identical
+// guardrails that were factually wrong for these 3 commands.
+func TestGuardrailTemplates_CommandSpecificContent(t *testing.T) {
+	content, err := assetContent("opencode/commands/uf.init.md")
+	if err != nil {
+		t.Fatalf("read embedded uf.init.md: %v", err)
+	}
+	text := string(content)
+
+	// Extract each guardrail template block by its heading label.
+	// The blocks are fenced in ```markdown ... ``` and preceded by
+	// a bold label like **Implement guardrails block**.
+	type guardrailBlock struct {
+		label        string
+		mustContain  []string
+		mustNotContain []string
+	}
+
+	blocks := []guardrailBlock{
+		{
+			label: "Implement guardrails block",
+			mustContain: []string{
+				"writes source code",
+			},
+			mustNotContain: []string{
+				"NEVER modify source code",
+				"FEATURE_DIR",
+				"FEATURE_SPEC",
+			},
+		},
+		{
+			label: "Constitution guardrails block",
+			mustContain: []string{
+				".specify/memory/",
+				".specify/templates/",
+			},
+			mustNotContain: []string{
+				"NEVER modify source code",
+				"FEATURE_DIR",
+				"FEATURE_SPEC",
+			},
+		},
+		{
+			label: "Taskstoissues guardrails block",
+			mustContain: []string{
+				"GitHub issues via",
+				"the current Git remote",
+			},
+			mustNotContain: []string{
+				"NEVER modify source code",
+				"files this command may write",
+				"FEATURE_DIR",
+				"FEATURE_SPEC",
+			},
+		},
+		{
+			label: "Spec-phase guardrails block",
+			mustContain: []string{
+				"NEVER modify source code",
+				"FEATURE_DIR",
+				"defeats the purpose",
+			},
+			mustNotContain: nil, // spec-phase guardrails are the baseline
+		},
+	}
+
+	for _, b := range blocks {
+		t.Run(b.label, func(t *testing.T) {
+			// Find the block: look for the label, then extract the
+			// next ```markdown ... ``` fenced block after it.
+			idx := strings.Index(text, b.label)
+			if idx < 0 {
+				t.Fatalf("guardrail block label %q not found in uf.init.md", b.label)
+			}
+
+			remainder := text[idx:]
+			fenceStart := strings.Index(remainder, "```markdown")
+			if fenceStart < 0 {
+				t.Fatalf("no ```markdown fence found after %q", b.label)
+			}
+			fenceEnd := strings.Index(remainder[fenceStart+len("```markdown"):], "```")
+			if fenceEnd < 0 {
+				t.Fatalf("no closing ``` found for %q block", b.label)
+			}
+			blockContent := remainder[fenceStart : fenceStart+len("```markdown")+fenceEnd+len("```")]
+
+			for _, pattern := range b.mustContain {
+				if !strings.Contains(blockContent, pattern) {
+					t.Errorf("%s: MUST contain %q but does not\nBlock content:\n%s",
+						b.label, pattern, blockContent)
+				}
+			}
+			for _, pattern := range b.mustNotContain {
+				if strings.Contains(blockContent, pattern) {
+					t.Errorf("%s: MUST NOT contain %q but does\nBlock content:\n%s",
+						b.label, pattern, blockContent)
+				}
+			}
+		})
+	}
+}

--- a/openspec/changes/fix-incorrect-guardrails/.openspec.yaml
+++ b/openspec/changes/fix-incorrect-guardrails/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: unbound-force
+created: 2026-08-05

--- a/openspec/changes/fix-incorrect-guardrails/README.md
+++ b/openspec/changes/fix-incorrect-guardrails/README.md
@@ -1,0 +1,3 @@
+# fix-incorrect-guardrails
+
+Differentiate guardrails for 3 speckit execution/utility commands in uf.init Step 6

--- a/openspec/changes/fix-incorrect-guardrails/design.md
+++ b/openspec/changes/fix-incorrect-guardrails/design.md
@@ -1,0 +1,148 @@
+## Context
+
+`uf.init.md` Step 6 injects a `## Guardrails` section into all
+9 speckit command files. The current implementation uses two
+template variants that differ only by the presence of a
+review-rationale sentence — the restrictive content ("NEVER
+modify source code", "ONLY files this command may write are
+FEATURE_SPEC/FEATURE_DIR") is identical in both.
+
+This is factually wrong for 3 execution/utility commands whose
+operational models differ from spec-artifact authoring. A
+workaround Note (lines 627–632) acknowledges the `implement`
+contradiction but relies on "instructions override guardrails."
+
+Both `.opencode/commands/uf.init.md` and
+`internal/scaffold/assets/opencode/commands/uf.init.md` are
+byte-identical and must be updated in lockstep. The drift
+detection test (`TestEmbeddedAssets_MatchSource`) enforces this.
+
+## Goals / Non-Goals
+
+### Goals
+- Replace the shared execution/utility guardrail template with
+  3 command-specific guardrail blocks that accurately describe
+  each command's operational model
+- Add idempotency logic that detects and replaces incorrect
+  guardrails (not just injects when absent)
+- Remove the workaround Note (lines 627–632) that documents
+  the implement override conflict
+- Add guardrail content regression tests to prevent recurrence
+- Keep both file copies (deployed + scaffold asset) in sync
+
+### Non-Goals
+- Preset migration (#257) — that is a strategic architectural
+  change to the guardrail delivery mechanism, not this fix
+- Upstream speckit changes (#258) — separate proposal
+- Fixing `speckit.testreview.md` guardrail — its read-only
+  constraints are stricter than the guardrail, making the
+  error harmless (noted for future cleanup)
+- Changing the 6 spec-phase command guardrails — those are
+  correct as-is
+
+## Decisions
+
+### D1: Three command-specific variants, not one parameterized template
+
+**Decision**: Define 3 separate markdown blocks — one for each
+execution/utility command — rather than a parameterized template
+with placeholder substitution.
+
+**Rationale**: Each command has a fundamentally different
+operational model (source code writes vs. config file writes
+vs. API calls). A parameterized template would need so many
+conditionals that it would be harder to read than distinct
+blocks. The existing Step 6 structure already uses distinct
+markdown code blocks; adding 3 more follows the pattern.
+
+### D2: Replace-if-incorrect idempotency
+
+**Decision**: When `## Guardrails` already exists but contains
+incorrect content (e.g., "NEVER modify source code" in
+`speckit.implement.md`), replace the entire guardrails section
+with the correct variant. Report:
+`✅ <filename>: guardrails corrected`
+
+**Rationale**: The current idempotency logic skips files that
+already have a `## Guardrails` heading, which means running
+`/uf.init` after this fix would NOT correct existing incorrect
+guardrails. The replace-if-incorrect behavior ensures the fix
+is applied to all repos on next `/uf.init` run, not just new
+scaffolds.
+
+**Implementation**: For each execution/utility command, define
+a "correctness marker" — a unique phrase that MUST appear in
+the correct guardrail. If `## Guardrails` exists but the
+correctness marker is absent, replace the section.
+
+| Command | Correctness marker |
+|---------|-------------------|
+| `speckit.implement.md` | "writes source code" |
+| `speckit.constitution.md` | ".specify/memory/" |
+| `speckit.taskstoissues.md` | "GitHub issues via" |
+
+### D3: Remove the workaround Note
+
+**Decision**: Delete the Note at current lines 627–632 that
+documents the implement override conflict.
+
+**Rationale**: The Note documents a workaround for a problem
+that the fix eliminates. Keeping it would be zero-waste
+violation — documenting a conflict that no longer exists.
+
+### D4: Guardrail content regression tests
+
+**Decision**: Add tests that verify the guardrail templates
+in `uf.init.md` contain correct content for each command type.
+
+**Rationale**: The triage panel unanimously identified zero
+existing guardrail content validation tests. The existing
+regression test pattern (`TestScaffoldOutput_No*References`)
+provides a natural home for these assertions.
+
+**Test assertions**:
+- Spec-phase variant MUST contain "NEVER modify source code"
+- Implement variant MUST NOT contain "NEVER modify source code"
+- Implement variant MUST contain "writes source code"
+- Constitution variant MUST contain ".specify/memory/"
+- Constitution variant MUST NOT restrict writes to FEATURE_DIR
+- Taskstoissues variant MUST contain "GitHub issues"
+- Taskstoissues variant MUST contain "matching the current
+  Git remote" (repository-scoping constraint)
+- Taskstoissues variant MUST NOT contain "files this command
+  may write"
+
+## Risks / Trade-offs
+
+### R1: Existing repos need a re-run
+
+Repos that already have incorrect guardrails injected will
+retain them until `/uf.init` is re-run. Decision D2
+(replace-if-incorrect) mitigates this — the next `/uf.init`
+run will correct the guardrails automatically.
+
+### R2: Three more template blocks increase Step 6 length
+
+Step 6 grows from ~90 lines to ~140 lines. This is acceptable
+because the content is now correct — shorter-but-wrong is not
+a valid trade-off against longer-but-right.
+
+### R3: speckit.testreview.md not addressed
+
+The 4th potentially-incorrect guardrail (`speckit.testreview.md`
+claims file write permissions but is read-only) is deferred.
+The error is harmless since the command's own `STRICTLY READ-ONLY`
+constraint is stricter. Including it would expand scope beyond
+the 3 cases identified in #256. To be addressed as part of
+the preset migration (#257) or a standalone cleanup chore.
+
+### R4: Replace-if-incorrect may overwrite user customizations
+
+If a downstream repo has manually customized the guardrails
+section (added constraints, reworded content), the
+replace-if-incorrect logic (D2) would overwrite those
+customizations when the correctness marker is absent.
+Mitigation: guardrails are generated by `/uf.init`, not
+hand-authored; files are under VCS for recovery; the
+`✅ guardrails corrected` report line makes replacement
+observable.

--- a/openspec/changes/fix-incorrect-guardrails/proposal.md
+++ b/openspec/changes/fix-incorrect-guardrails/proposal.md
@@ -1,0 +1,123 @@
+## Why
+
+Issue #256: `/uf.init` Step 6 injects identical guardrails into
+all 9 speckit command files. The guardrails are correct for the
+6 spec-authoring commands but factually wrong for the 3
+execution/utility commands:
+
+| Command | Guardrail Says | Command Actually Does |
+|---------|---------------|----------------------|
+| `speckit.implement.md` | "NEVER modify source code" | Entire purpose is writing source code |
+| `speckit.constitution.md` | May only write to `FEATURE_SPEC`/`FEATURE_DIR` | Writes to `.specify/memory/` and `.specify/templates/` |
+| `speckit.taskstoissues.md` | May only write to `FEATURE_SPEC`/`FEATURE_DIR` | Creates GitHub issues via MCP API; writes no local files |
+
+The current workaround (Note at lines 627–632) acknowledges the
+`implement` contradiction but relies on "instructions override
+guardrails" — an anti-pattern that trains agents to distrust
+guardrails generally ("guardrail habituation"). The `constitution`
+and `taskstoissues` contradictions are unacknowledged.
+
+**Related issues**: #257 (strategic preset migration), #258
+(upstream proposal). This fix is tactical and independent of both.
+
+## What Changes
+
+Modify Step 6 of `uf.init.md` to use command-specific guardrail
+blocks for the 3 execution/utility commands instead of a single
+shared template. Remove the workaround Note (lines 627–632).
+Update both copies in lockstep:
+
+1. `.opencode/commands/uf.init.md` (deployed — affects current users)
+2. `internal/scaffold/assets/opencode/commands/uf.init.md` (canonical — affects new scaffolds)
+
+Add idempotency logic to detect and replace incorrect guardrails
+in existing command files (not just inject when absent).
+
+## Capabilities
+
+### New Capabilities
+- `Command-specific guardrail variants`: Step 6 produces
+  3 distinct guardrail blocks tailored to each execution/utility
+  command's actual operational model
+
+### Modified Capabilities
+- `Guardrails injection (Step 6)`: Extended from 2 variants
+  (spec-phase, execution/utility) to 5 variants (spec-phase,
+  implement, constitution, taskstoissues, and the shared
+  execution/utility variant is removed)
+- `Guardrail idempotency check`: Enhanced to detect and
+  replace incorrect guardrails, not just skip when a
+  `## Guardrails` heading exists
+
+### Removed Capabilities
+- `Workaround Note (lines 627–632)`: The Note documenting the
+  implement override conflict is removed — the fix eliminates
+  the conflict it worked around
+
+## Impact
+
+- **Files modified**: `.opencode/commands/uf.init.md` and
+  `internal/scaffold/assets/opencode/commands/uf.init.md`
+  (both must stay byte-identical per scaffold engine contract)
+- **Downstream effect**: All repos running `/uf.init` will
+  receive correct, command-specific guardrails for the 3
+  execution/utility commands
+- **Risk**: Low. Guardrail content changes only — no Go source,
+  no test files, no config files. Existing drift detection test
+  (`TestEmbeddedAssets_MatchSource`) enforces file sync.
+- **Blast radius**: 3 of 9 speckit commands across all projects
+  using the Unbound Force scaffold
+
+## Constitution Alignment
+
+Assessed against the Unbound Force org constitution.
+
+### I. Autonomous Collaboration
+
+**Assessment**: PASS
+
+This change modifies a slash command (Markdown instructions)
+that produces file-based artifacts. No runtime coupling or
+synchronous interaction is introduced. The corrected guardrails
+make each command's behavioral constraints self-describing —
+an improvement over the current state where guardrails
+contradict the command's own instructions.
+
+### II. Composability First
+
+**Assessment**: PASS
+
+`/uf.init` already handles missing files gracefully. The new
+command-specific variants follow the same idempotent pattern.
+No new mandatory dependencies are introduced. Each command
+remains independently usable.
+
+### III. Observable Quality
+
+**Assessment**: PASS
+
+The command produces a structured summary report with status
+indicators for every file processed. The new variants follow
+the existing reporting pattern. No output format changes.
+
+### IV. Testability
+
+**Assessment**: PASS
+
+The existing drift detection test
+(`TestEmbeddedAssets_MatchSource`) ensures both copies stay in
+sync. The fix should include guardrail content regression tests
+to verify each command type receives appropriate guardrails —
+this closes a gap identified by the triage panel (zero guardrail
+content validation tests exist today).
+
+### V. Security by Default
+
+**Assessment**: PASS
+
+Incorrect guardrails for `speckit.taskstoissues.md` currently
+fail to mention the command's most security-sensitive operation
+(creating GitHub issues via external API) while granting
+irrelevant local file write permissions. The fix corrects this
+by describing the actual operation model, improving security
+awareness for agents executing the command.

--- a/openspec/changes/fix-incorrect-guardrails/specs/guardrail-differentiation.md
+++ b/openspec/changes/fix-incorrect-guardrails/specs/guardrail-differentiation.md
@@ -1,0 +1,169 @@
+## ADDED Requirements
+
+### Requirement: Implement-specific guardrails
+
+Step 6 MUST inject a command-specific guardrail block for
+`speckit.implement.md` that:
+- States this command writes source code as its primary
+  purpose
+- Restricts modifications to the active feature's
+  implementation scope
+- MUST NOT contain "NEVER modify source code"
+
+#### Scenario: Fresh inject on implement command
+- **GIVEN** `speckit.implement.md` has no `## Guardrails`
+  section
+- **WHEN** `/uf.init` Step 6 runs
+- **THEN** the implement-specific guardrail block is
+  appended, and the report shows
+  `✅ speckit.implement.md: guardrails injected`
+
+#### Scenario: Replace incorrect guardrails on implement
+- **GIVEN** `speckit.implement.md` has a `## Guardrails`
+  section containing "NEVER modify source code"
+- **WHEN** `/uf.init` Step 6 runs
+- **THEN** the entire `## Guardrails` section is replaced
+  with the implement-specific variant, and the report
+  shows `✅ speckit.implement.md: guardrails corrected`
+
+### Requirement: Constitution-specific guardrails
+
+Step 6 MUST inject a command-specific guardrail block for
+`speckit.constitution.md` that:
+- Lists `.specify/memory/constitution.md` and
+  `.specify/templates/*-template.md` as allowed write
+  targets (intentionally broad to cover template additions)
+- MUST NOT restrict writes to `FEATURE_SPEC` or
+  `FEATURE_DIR`
+- MUST NOT contain "NEVER modify source code"
+
+#### Scenario: Fresh inject on constitution command
+- **GIVEN** `speckit.constitution.md` has no `## Guardrails`
+  section
+- **WHEN** `/uf.init` Step 6 runs
+- **THEN** the constitution-specific guardrail block is
+  appended, and the report shows
+  `✅ speckit.constitution.md: guardrails injected`
+
+#### Scenario: Replace incorrect guardrails on constitution
+- **GIVEN** `speckit.constitution.md` has a `## Guardrails`
+  section containing "ONLY files this command may write"
+  with `FEATURE_SPEC`
+- **WHEN** `/uf.init` Step 6 runs
+- **THEN** the entire `## Guardrails` section is replaced
+  with the constitution-specific variant, and the report
+  shows `✅ speckit.constitution.md: guardrails corrected`
+
+### Requirement: Taskstoissues-specific guardrails
+
+Step 6 MUST inject a command-specific guardrail block for
+`speckit.taskstoissues.md` that:
+- States this command creates GitHub issues via MCP API
+- States issues MUST only be created in the repository
+  matching the current Git remote
+- States this command does NOT write local files
+- MUST NOT contain "files this command may write"
+
+#### Scenario: Fresh inject on taskstoissues command
+- **GIVEN** `speckit.taskstoissues.md` has no `## Guardrails`
+  section
+- **WHEN** `/uf.init` Step 6 runs
+- **THEN** the taskstoissues-specific guardrail block is
+  appended, and the report shows
+  `✅ speckit.taskstoissues.md: guardrails injected`
+
+#### Scenario: Replace incorrect guardrails on taskstoissues
+- **GIVEN** `speckit.taskstoissues.md` has a `## Guardrails`
+  section containing "ONLY files this command may write"
+- **WHEN** `/uf.init` Step 6 runs
+- **THEN** the entire `## Guardrails` section is replaced
+  with the taskstoissues-specific variant, and the report
+  shows `✅ speckit.taskstoissues.md: guardrails corrected`
+
+### Requirement: Correctness marker detection
+
+Step 6 MUST use a correctness marker for each
+execution/utility command to detect whether existing
+guardrails are correct or incorrect:
+
+| Command | Correctness marker |
+|---------|-------------------|
+| `speckit.implement.md` | "writes source code" |
+| `speckit.constitution.md` | ".specify/memory/" |
+| `speckit.taskstoissues.md` | "GitHub issues via" |
+
+If `## Guardrails` exists but the correctness marker is
+absent, the guardrails MUST be replaced.
+
+**Known limitation**: The correctness marker is a positive
+substring check only. The regression tests (requirement
+below) provide negative checks (e.g., implement MUST NOT
+contain "NEVER modify source code") that catch
+contradictory content at test time, even if the marker is
+present. This two-layer defense (runtime marker + test-time
+negative assertions) is acceptable for this change.
+
+**Heading detection**: The `## Guardrails` check MUST match
+a markdown heading outside of fenced code blocks. This is
+important because `uf.init.md` itself contains `## Guardrails`
+inside template code fences.
+
+#### Scenario: Correct guardrails already present
+- **GIVEN** `speckit.implement.md` has a `## Guardrails`
+  section containing "writes source code"
+- **WHEN** `/uf.init` Step 6 runs
+- **THEN** the guardrails are not modified, and the report
+  shows
+  `⊘ speckit.implement.md: guardrails already present (skipped)`
+
+### Requirement: Guardrail content regression tests
+
+The test suite MUST include assertions verifying the
+guardrail templates in `uf.init.md` contain correct content
+for each command type. These tests MUST fail if incorrect
+restrictions are reintroduced.
+
+#### Scenario: Regression test catches reintroduced error
+- **GIVEN** someone modifies the implement guardrail in
+  `uf.init.md` to include "NEVER modify source code"
+- **WHEN** `go test ./...` runs
+- **THEN** the guardrail content regression test fails
+
+## MODIFIED Requirements
+
+### Requirement: Step 6 command categorization
+
+Previously: Step 6 defined two categories — spec-phase
+(6 commands) and execution/utility (3 commands) — using
+two guardrail templates that differed only by the
+review-rationale sentence.
+
+Now: Step 6 defines five categories:
+1. Spec-phase (6 commands): unchanged guardrails with
+   review-rationale
+2. `speckit.implement.md`: command-specific guardrails
+3. `speckit.constitution.md`: command-specific guardrails
+4. `speckit.taskstoissues.md`: command-specific guardrails
+5. (The shared execution/utility variant is removed)
+
+### Requirement: Dual-file lockstep update
+
+Both `.opencode/commands/uf.init.md` and
+`internal/scaffold/assets/opencode/commands/uf.init.md`
+MUST be updated with identical content.
+
+Previously: This was an implicit requirement enforced by
+`TestEmbeddedAssets_MatchSource`.
+
+Now: Explicitly stated. The test continues to enforce it.
+
+## REMOVED Requirements
+
+### Requirement: Workaround Note for implement exception
+
+The Note at lines 627–632 documenting that
+`speckit.implement.md` is an exception and that "the
+implement command's own instructions override the guardrails
+where they conflict" is removed. The fix eliminates the
+conflict, making the workaround unnecessary. Retaining it
+would violate the zero-waste principle.

--- a/openspec/changes/fix-incorrect-guardrails/tasks.md
+++ b/openspec/changes/fix-incorrect-guardrails/tasks.md
@@ -1,0 +1,123 @@
+<!-- spec-review: passed -->
+<!--
+  All tasks in Group 1 modify the same file (uf.init.md),
+  so no [P] markers — parallel execution would cause merge
+  conflicts. Tasks run sequentially in order.
+
+  Group 2 tasks modify a different file (*_test.go) and
+  can run in parallel with each other but depend on Group 1.
+
+  Group 3 modifies the 3 speckit command files and depends
+  on Group 1 being complete to verify correctness.
+-->
+
+## 1. Update Step 6 in uf.init.md
+
+All subtasks modify
+`internal/scaffold/assets/opencode/commands/uf.init.md`.
+After Group 1 is complete, the deployed copy at
+`.opencode/commands/uf.init.md` MUST be synced to match
+(byte-identical, enforced by
+`TestEmbeddedAssets_MatchSource`).
+
+- [x] 1.1 Replace the "Execution/utility commands" category
+  (lines 561–565) with three individual command entries,
+  each referencing its own guardrail block below. Update the
+  Step 6 preamble (lines 548–550) to say "Use five variants
+  depending on the command type" instead of "two variants".
+
+- [x] 1.2 Replace the "Execution/utility guardrails block"
+  (lines 607–625) with three command-specific guardrail
+  blocks:
+
+  **Implement guardrails** (`speckit.implement.md`):
+  - This command writes source code — implementation is
+    its purpose
+  - Scope: implement only what is defined in the active
+    feature's `tasks.md`
+  - MUST NOT contain "NEVER modify source code"
+  - Correctness marker: "writes source code"
+
+  **Constitution guardrails** (`speckit.constitution.md`):
+  - Allowed write targets: `.specify/memory/constitution.md`,
+    `.specify/templates/`
+  - MUST NOT restrict writes to `FEATURE_SPEC`/`FEATURE_DIR`
+  - MUST NOT contain "NEVER modify source code"
+  - Correctness marker: ".specify/memory/"
+
+  **Taskstoissues guardrails** (`speckit.taskstoissues.md`):
+  - This command creates GitHub issues via the MCP API
+  - Issues MUST only be created in the repository matching
+    the current Git remote
+  - This command does NOT write local files
+  - MUST NOT contain "files this command may write"
+  - Correctness marker: "GitHub issues via"
+
+- [x] 1.3 Remove the workaround Note (lines 627–632) that
+  documents the implement override conflict. The fix
+  eliminates the conflict it worked around.
+
+- [x] 1.4 Update the idempotency logic (lines 567–583) to
+  handle replace-if-incorrect for execution/utility
+  commands: when `## Guardrails` exists but the
+  command-specific correctness marker is absent, replace
+  the entire guardrails section. Add report line:
+  `✅ <filename>: guardrails corrected`
+  Note: The existing secondary check for spec-phase
+  commands (review-rationale sentence detection) MUST
+  remain unchanged. The `## Guardrails` heading check
+  MUST match headings outside of fenced code blocks.
+
+- [x] 1.5 Copy the updated
+  `internal/scaffold/assets/opencode/commands/uf.init.md`
+  to `.opencode/commands/uf.init.md` to maintain byte
+  parity. Verify with diff.
+
+## 2. Add Guardrail Content Regression Tests
+
+- [x] 2.1 Add a test function in the scaffold test file that
+  reads the `uf.init.md` content and verifies:
+  - The spec-phase guardrail block contains
+    "NEVER modify source code"
+  - The implement guardrail block contains
+    "writes source code" and does NOT contain
+    "NEVER modify source code"
+  - The constitution guardrail block contains
+    ".specify/memory/" and does NOT restrict writes
+    to "FEATURE_DIR" only
+  - The taskstoissues guardrail block contains
+    "GitHub issues" and does NOT contain
+    "files this command may write"
+
+- [x] 2.2 Run `make test` to verify all tests pass,
+  including the new regression tests and the existing
+  `TestEmbeddedAssets_MatchSource` drift detection.
+
+## 3. Verify Corrected Guardrails in Command Files
+
+- [x] 3.1 [P] Verify `speckit.implement.md` guardrails are
+  correct: contains "writes source code", does NOT contain
+  "NEVER modify source code"
+
+- [x] 3.2 [P] Verify `speckit.constitution.md` guardrails
+  are correct: contains ".specify/memory/", does NOT
+  restrict to "FEATURE_DIR" only
+
+- [x] 3.3 [P] Verify `speckit.taskstoissues.md` guardrails
+  are correct: contains "GitHub issues via", does NOT
+  contain "files this command may write"
+
+## 4. Constitution Alignment Verification
+
+- [x] 4.1 Verify Phase Discipline: each command's guardrails
+  accurately describe the command's operational scope
+  (no false restrictions, no missing constraints)
+
+- [x] 4.2 Verify Gatekeeping Integrity: guardrails serve as
+  governance gates with correct content — no
+  known-incorrect gates that require override workarounds
+
+- [x] 4.3 Verify Zero-Waste: the workaround Note is
+  removed, no aspirational or contradictory content
+  remains
+<!-- code-review: passed -->


### PR DESCRIPTION
Fixes #256

### Problem

`/uf.init` Step 6 injected identical guardrails into all 9 speckit command files. These guardrails were factually wrong for 3 commands:

| Command | Guardrail Said | Actually Does |
|---------|---------------|---------------|
| `speckit.implement.md` | "NEVER modify source code" | Writes source code (its purpose) |
| `speckit.constitution.md` | Only write to `FEATURE_DIR` | Writes to `.specify/memory/` and `.specify/templates/` |
| `speckit.taskstoissues.md` | Only write local files | Creates GitHub issues via MCP API |

### Solution

- Replace the shared 2-variant guardrail template with 4 command-specific variants
- Add replace-if-incorrect idempotency using correctness markers so existing repos are automatically corrected on next `/uf.init` run
- Remove the obsolete workaround Note that documented the implement override conflict
- Add `TestGuardrailTemplates_CommandSpecificContent` regression test

### Review

- Spec review: 5/5 Divisor agents APPROVE (2 iterations)
- Code review: 5/5 Divisor agents APPROVE (2 iterations)
- Pre-flight: `make check` PASS

### Spec

`openspec/changes/fix-incorrect-guardrails/`

### Related

- #257 (strategic: preset migration)
- #258 (upstream: speckit proposal)