### PR TITLE
fix(ci): remove duplicate concurrency group and enable pre-releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,16 +41,13 @@ on:
 
 permissions: {}
 
-concurrency:
-  group: release-${{ github.repository }}
-  cancel-in-progress: false
-
 jobs:
   preflight:
     name: Preflight
     uses: complytime/org-infra/.github/workflows/reusable_release_preflight.yml@0c784711926c9864f027ec565fd7c06a382d80f8 # v0.7.1
     with:
       tag: ${{ inputs.tag }}
+      allow_prerelease: true
       # Check names from ci_local.yml, ci_checks.yml, ci_security.yml
       ci_checks: '["Build and Test", "Standardized CI / Run linters", "OSV-Scanner / Trivy Source Scan"]'
       skip_semver_check: ${{ inputs.skip_semver_check }}


### PR DESCRIPTION
## Summary

Two fixes for the release workflow adopted in #433.

### 1. Remove duplicate concurrency group

The workflow-level `concurrency` block duplicates the one already defined inside the reusable preflight workflow. Both use:

```yaml
concurrency:
  group: release-${{ github.repository }}
  cancel-in-progress: false
```

This nested conflict causes GitHub Actions to reject the preflight job at the platform level — instant failure, no runner assigned, no logs. complyctl's `release.yml` works because it does **not** declare a workflow-level concurrency block.

### 2. Enable pre-release tags

Pass `allow_prerelease: true` to the reusable preflight workflow so pre-release tags (e.g., `v0.16.0-rc.1`) are accepted. The reusable workflow defaults to strict semver (`vMAJOR.MINOR.PATCH` only), which rejected the RC tag.

## Verification

- `actionlint` passes
- complyctl confirms the pattern (same reusable workflow SHA, no caller concurrency, successful releases)
- GoReleaser `--snapshot` dry run passed locally (all 4 platform builds, RPMs, SBOMs, checksums)

Fixes the v0.16.0 release pipeline.