### PR TITLE
fix(setup): resolve companion tool versions independently for RPM URLs

### DIFF
--- a/.uf/dewey/learnings/setup-architecture-20260811T210707-jay-flowers.md
+++ b/.uf/dewey/learnings/setup-architecture-20260811T210707-jay-flowers.md
@@ -1,0 +1,10 @@
+---
+tag: setup-architecture
+author: jay-flowers
+category: pattern
+created_at: 2026-08-11T21:07:07Z
+identity: setup-architecture-20260811T210707-jay-flowers
+tier: draft
+---
+
+buildSteps() in internal/setup/setup.go defines the step execution order for uf setup. When adding a new DI field that depends on another tool (e.g., ResolveRelease depends on gh CLI), verify the step ordering ensures the dependency is installed first. Issue #455 revealed that Gaze was installed before GitHub CLI — the fix reordered buildSteps() so installGH runs before installGaze. A test (TestBuildSteps_GHBeforeGaze) now locks this ordering invariant.

--- a/.uf/dewey/learnings/setup-testing-20260811T210704-jay-flowers.md
+++ b/.uf/dewey/learnings/setup-testing-20260811T210704-jay-flowers.md
@@ -1,0 +1,10 @@
+---
+tag: setup-testing
+author: jay-flowers
+category: gotcha
+created_at: 2026-08-11T21:07:04Z
+identity: setup-testing-20260811T210704-jay-flowers
+tier: draft
+---
+
+When adding new injectable DI fields to the Options struct in internal/setup/setup.go, all existing tests that exercise code paths using the new field must be updated to inject a stub. For the ResolveRelease field added in issue #455, 6 existing tests that hit the dnf/RPM path panicked with nil pointer dereference until ResolveRelease stubs were added. Pattern: `ResolveRelease: func(repo string) (string, error) { return "1.0.0", nil }`. The defaults() method sets non-nil fields only when nil, so tests that call defaults() can set the field before calling defaults() to prevent the production implementation from being used.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,16 @@ Each entry follows the format: `- <change-name>: <summary>`.
   AGENTS.md review-council rule. Extends reverse-drift
   test to cover `.opencode/skills/`.
   (Spec: openspec/changes/unleash-demo-output-fidelity/)
+- fix-rpm-version-skew: `uf setup` RPM install path now
+  resolves each companion tool's latest release
+  independently via `gh release view` instead of using
+  the uf binary's own version. Fixes 404 errors on
+  Fedora/RHEL when gaze or replicator versions diverge
+  from uf. Adds `ResolveRelease` injectable dependency
+  to `Options` for testability. Reorders `buildSteps()`
+  so GitHub CLI is installed before Gaze.
+  (Spec: openspec/changes/fix-rpm-version-skew/,
+  Fixes: #455)
 - fix-incorrect-guardrails: Step 6 of `/uf.init` now
   injects command-specific guardrails for
   `speckit.implement.md`, `speckit.constitution.md`,

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strconv"
 	"strings"
@@ -64,10 +65,16 @@ type Options struct {
 	// Defaults to runtime.GOOS when empty.
 	GOOS string
 
-	// Version is the current binary version (e.g., "0.12.0"),
-	// used to construct GitHub Release RPM URLs. Set by the CLI
-	// from the build-time version variable.
+	// Version is the current uf binary version (e.g., "0.12.0").
+	// Set by the CLI from the build-time version variable.
+	// NOT used for companion tool RPM URLs — use ResolveRelease instead.
 	Version string
+
+	// ResolveRelease resolves the latest release tag for a GitHub
+	// repository (e.g., "unbound-force/gaze" → "0.15.0"). Returns
+	// the version string without the "v" prefix. Returns an error
+	// if resolution fails (network, no releases, invalid format).
+	ResolveRelease func(repo string) (string, error)
 
 	// PackageManager is the preferred package manager from config.
 	// Valid: "auto", "homebrew", "dnf", "apt", "manual".
@@ -123,11 +130,59 @@ func (o *Options) defaults() {
 	if o.GOOS == "" {
 		o.GOOS = runtime.GOOS
 	}
+	if o.ResolveRelease == nil {
+		o.ResolveRelease = o.defaultResolveRelease
+	}
 }
 
 // defaultExecCmd is the production implementation of ExecCmd.
 func defaultExecCmd(name string, args ...string) ([]byte, error) {
 	return exec.Command(name, args...).CombinedOutput()
+}
+
+// repoPattern validates the GitHub "owner/repo" format per D7.
+var repoPattern = regexp.MustCompile(`^[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+$`)
+
+// semverPattern validates a basic semver version string (major.minor.patch)
+// with bounded digit counts per D3.
+var semverPattern = regexp.MustCompile(`^[0-9]{1,5}\.[0-9]{1,5}\.[0-9]{1,5}$`)
+
+// defaultResolveRelease is the production implementation of ResolveRelease.
+// It invokes `gh release view --repo {repo} --json tagName -q .tagName`
+// and validates the returned tag per D1, D3, D7.
+func (o *Options) defaultResolveRelease(repo string) (string, error) {
+	// D7: validate repo parameter format before passing to ExecCmd.
+	if !repoPattern.MatchString(repo) {
+		return "", fmt.Errorf("invalid repo format %q: must match owner/repo", repo)
+	}
+
+	out, err := o.ExecCmd("gh", "release", "view", "--repo", repo, "--json", "tagName", "-q", ".tagName")
+	if err != nil {
+		return "", fmt.Errorf("resolve latest release for %s: %w", repo, err)
+	}
+
+	// D3 step 0: trim whitespace (including trailing newlines from ExecCmd).
+	tag := strings.TrimSpace(string(out))
+
+	// D3 step 1: strip leading "v" prefix.
+	tag = strings.TrimPrefix(tag, "v")
+
+	if tag == "" {
+		return "", fmt.Errorf("resolve latest release for %s: no release tag found", repo)
+	}
+
+	// D3 step 2: reject tags longer than 20 characters (defense-in-depth).
+	// Checked before semver regex for early rejection of oversized input.
+	if len(tag) > 20 {
+		return "", fmt.Errorf("resolve latest release for %s: tag too long (%d chars)", repo, len(tag))
+	}
+
+	// D3 step 3: verify basic semver format.
+	if !semverPattern.MatchString(tag) {
+		return "", fmt.Errorf("resolve latest release for %s: invalid release tag format %q", repo, tag)
+	}
+
+	return tag, nil
 }
 
 // stepResult tracks the outcome of a setup step.
@@ -379,8 +434,8 @@ func Run(opts Options) error {
 func buildSteps(opts *Options, nodeAvailable, uvAvailable, replicatorAvailable *bool) []stepDef {
 	return []stepDef{
 		{name: "OpenCode", tool: "opencode", install: installOpenCode},
-		{name: "Gaze", tool: "gaze", install: installGaze},
 		{name: "GitHub CLI", tool: "gh", install: installGH},
+		{name: "Gaze", tool: "gaze", install: installGaze},
 		{
 			name: "Node.js", tool: "node", install: ensureNodeJS,
 			effect: func(r stepResult) {
@@ -666,7 +721,17 @@ func installGaze(opts *Options, env doctor.DetectedEnvironment) stepResult {
 	case "homebrew":
 		return installViaBrew(opts, "Gaze", "unbound-force/tap/gaze")
 	case "rpm", "dnf":
-		return installViaRpm(opts, "Gaze", "unbound-force/gaze", opts.Version)
+		version, err := opts.ResolveRelease("unbound-force/gaze")
+		if err != nil {
+			return stepResult{
+				name:   "Gaze",
+				action: "failed",
+				detail: "cannot resolve latest release: " + err.Error() +
+					" — try --method go or set tool_methods.gaze: go in config",
+				err: err,
+			}
+		}
+		return installViaRpm(opts, "Gaze", "unbound-force/gaze", version)
 	case "go":
 		result := installViaGo(opts, "Gaze", "github.com/unbound-force/gaze/cmd/gaze")
 		if result.action != "skipped" {
@@ -854,7 +919,17 @@ func installReplicator(opts *Options, env doctor.DetectedEnvironment) stepResult
 	case "homebrew":
 		return installViaBrew(opts, "Replicator", "unbound-force/tap/replicator")
 	case "rpm", "dnf":
-		return installViaRpm(opts, "Replicator", "unbound-force/replicator", opts.Version)
+		version, err := opts.ResolveRelease("unbound-force/replicator")
+		if err != nil {
+			return stepResult{
+				name:   "Replicator",
+				action: "failed",
+				detail: "cannot resolve latest release: " + err.Error() +
+					" — try --method go or set tool_methods.replicator: go in config",
+				err: err,
+			}
+		}
+		return installViaRpm(opts, "Replicator", "unbound-force/replicator", version)
 	case "go":
 		result := installViaGo(opts, "Replicator", "github.com/unbound-force/replicator/cmd/replicator")
 		if result.action != "skipped" {

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -153,7 +153,7 @@ var semverPattern = regexp.MustCompile(`^[0-9]{1,5}\.[0-9]{1,5}\.[0-9]{1,5}$`)
 func (o *Options) defaultResolveRelease(repo string) (string, error) {
 	// D7: validate repo parameter format before passing to ExecCmd.
 	if !repoPattern.MatchString(repo) {
-		return "", fmt.Errorf("invalid repo format %q: must match owner/repo", repo)
+		return "", fmt.Errorf("invalid repository format %q: must match owner/repo", repo)
 	}
 
 	out, err := o.ExecCmd("gh", "release", "view", "--repo", repo, "--json", "tagName", "-q", ".tagName")
@@ -167,14 +167,10 @@ func (o *Options) defaultResolveRelease(repo string) (string, error) {
 	// D3 step 1: strip leading "v" prefix.
 	tag = strings.TrimPrefix(tag, "v")
 
-	if tag == "" {
-		return "", fmt.Errorf("resolve latest release for %s: no release tag found", repo)
-	}
-
 	// D3 step 2: reject tags longer than 20 characters (defense-in-depth).
 	// Checked before semver regex for early rejection of oversized input.
 	if len(tag) > 20 {
-		return "", fmt.Errorf("resolve latest release for %s: tag too long (%d chars)", repo, len(tag))
+		return "", fmt.Errorf("resolve latest release for %s: release tag too long (%d chars)", repo, len(tag))
 	}
 
 	// D3 step 3: verify basic semver format.

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -1924,8 +1924,8 @@ func TestDefaultResolveRelease_TagTooLong(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for tag too long")
 	}
-	if !strings.Contains(err.Error(), "tag too long") {
-		t.Errorf("error = %q, want to contain 'tag too long'", err.Error())
+	if !strings.Contains(err.Error(), "release tag too long") {
+		t.Errorf("error = %q, want to contain 'release tag too long'", err.Error())
 	}
 }
 
@@ -1972,8 +1972,8 @@ func TestDefaultResolveRelease_EmptyOutput(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for empty output")
 	}
-	if !strings.Contains(err.Error(), "no release tag found") {
-		t.Errorf("error = %q, want to contain 'no release tag found'", err.Error())
+	if !strings.Contains(err.Error(), "invalid release tag format") {
+		t.Errorf("error = %q, want to contain 'invalid release tag format'", err.Error())
 	}
 }
 
@@ -2001,8 +2001,8 @@ func TestDefaultResolveRelease_MalformedRepo(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for malformed repo")
 	}
-	if !strings.Contains(err.Error(), "invalid repo format") {
-		t.Errorf("error = %q, want to contain 'invalid repo format'", err.Error())
+	if !strings.Contains(err.Error(), "invalid repository format") {
+		t.Errorf("error = %q, want to contain 'invalid repository format'", err.Error())
 	}
 }
 
@@ -2123,6 +2123,32 @@ func TestInstallGaze_ResolveReleaseError(t *testing.T) {
 		},
 	}
 	result := installGaze(opts, env)
+	if result.action != "failed" {
+		t.Errorf("action = %q, want failed", result.action)
+	}
+	if !strings.Contains(result.detail, "cannot resolve latest release") {
+		t.Errorf("detail should contain 'cannot resolve latest release', got %q", result.detail)
+	}
+	if !strings.Contains(result.detail, "--method go") {
+		t.Errorf("detail should contain actionable guidance '--method go', got %q", result.detail)
+	}
+}
+
+func TestInstallReplicator_ResolveReleaseError(t *testing.T) {
+	opts := &Options{
+		LookPath: stubLookPath(map[string]string{}),
+		Stdout:   &bytes.Buffer{},
+		Stderr:   &bytes.Buffer{},
+		ResolveRelease: func(repo string) (string, error) {
+			return "", fmt.Errorf("resolve latest release for %s: network timeout", repo)
+		},
+	}
+	env := doctor.DetectedEnvironment{
+		Managers: []doctor.ManagerInfo{
+			{Kind: doctor.ManagerDnf, Path: "/usr/bin/dnf"},
+		},
+	}
+	result := installReplicator(opts, env)
 	if result.action != "failed" {
 		t.Errorf("action = %q, want failed", result.action)
 	}

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -1863,6 +1863,338 @@ func TestInstallViaRpm_DryRun(t *testing.T) {
 	}
 }
 
+// --- defaultResolveRelease tests (Task 3.1) ---
+
+func TestDefaultResolveRelease_ValidTagWithVPrefix(t *testing.T) {
+	ghCmd := "gh release view --repo unbound-force/gaze --json tagName -q .tagName"
+	opts := &Options{
+		ExecCmd: (&cmdRecorder{
+			outputs: map[string]string{ghCmd: "v1.2.3\n"},
+		}).execCmd,
+	}
+	got, err := opts.defaultResolveRelease("unbound-force/gaze")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "1.2.3" {
+		t.Errorf("got %q, want %q", got, "1.2.3")
+	}
+}
+
+func TestDefaultResolveRelease_ValidTagNoPrefix(t *testing.T) {
+	ghCmd := "gh release view --repo unbound-force/gaze --json tagName -q .tagName"
+	opts := &Options{
+		ExecCmd: (&cmdRecorder{
+			outputs: map[string]string{ghCmd: "1.2.3\n"},
+		}).execCmd,
+	}
+	got, err := opts.defaultResolveRelease("unbound-force/gaze")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "1.2.3" {
+		t.Errorf("got %q, want %q", got, "1.2.3")
+	}
+}
+
+func TestDefaultResolveRelease_InvalidFormat(t *testing.T) {
+	ghCmd := "gh release view --repo unbound-force/gaze --json tagName -q .tagName"
+	opts := &Options{
+		ExecCmd: (&cmdRecorder{
+			outputs: map[string]string{ghCmd: "latest\n"},
+		}).execCmd,
+	}
+	_, err := opts.defaultResolveRelease("unbound-force/gaze")
+	if err == nil {
+		t.Fatal("expected error for invalid format")
+	}
+	if !strings.Contains(err.Error(), "invalid release tag format") {
+		t.Errorf("error = %q, want to contain 'invalid release tag format'", err.Error())
+	}
+}
+
+func TestDefaultResolveRelease_TagTooLong(t *testing.T) {
+	ghCmd := "gh release view --repo unbound-force/gaze --json tagName -q .tagName"
+	opts := &Options{
+		ExecCmd: (&cmdRecorder{
+			outputs: map[string]string{ghCmd: "v1.2.3-very-long-tag-name-here"},
+		}).execCmd,
+	}
+	_, err := opts.defaultResolveRelease("unbound-force/gaze")
+	if err == nil {
+		t.Fatal("expected error for tag too long")
+	}
+	if !strings.Contains(err.Error(), "tag too long") {
+		t.Errorf("error = %q, want to contain 'tag too long'", err.Error())
+	}
+}
+
+func TestDefaultResolveRelease_GhCliFailure(t *testing.T) {
+	ghCmd := "gh release view --repo unbound-force/gaze --json tagName -q .tagName"
+	opts := &Options{
+		ExecCmd: (&cmdRecorder{
+			errors: map[string]error{ghCmd: fmt.Errorf("gh: not found")},
+		}).execCmd,
+	}
+	_, err := opts.defaultResolveRelease("unbound-force/gaze")
+	if err == nil {
+		t.Fatal("expected error when gh CLI fails")
+	}
+	if !strings.Contains(err.Error(), "resolve latest release for") {
+		t.Errorf("error = %q, want to contain 'resolve latest release for'", err.Error())
+	}
+}
+
+func TestDefaultResolveRelease_WhitespacePadded(t *testing.T) {
+	ghCmd := "gh release view --repo unbound-force/gaze --json tagName -q .tagName"
+	opts := &Options{
+		ExecCmd: (&cmdRecorder{
+			outputs: map[string]string{ghCmd: "  v1.2.3  \n"},
+		}).execCmd,
+	}
+	got, err := opts.defaultResolveRelease("unbound-force/gaze")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "1.2.3" {
+		t.Errorf("got %q, want %q", got, "1.2.3")
+	}
+}
+
+func TestDefaultResolveRelease_EmptyOutput(t *testing.T) {
+	ghCmd := "gh release view --repo unbound-force/gaze --json tagName -q .tagName"
+	opts := &Options{
+		ExecCmd: (&cmdRecorder{
+			outputs: map[string]string{ghCmd: ""},
+		}).execCmd,
+	}
+	_, err := opts.defaultResolveRelease("unbound-force/gaze")
+	if err == nil {
+		t.Fatal("expected error for empty output")
+	}
+	if !strings.Contains(err.Error(), "no release tag found") {
+		t.Errorf("error = %q, want to contain 'no release tag found'", err.Error())
+	}
+}
+
+func TestDefaultResolveRelease_PreReleaseRejected(t *testing.T) {
+	ghCmd := "gh release view --repo unbound-force/gaze --json tagName -q .tagName"
+	opts := &Options{
+		ExecCmd: (&cmdRecorder{
+			outputs: map[string]string{ghCmd: "v1.2.3-rc.1"},
+		}).execCmd,
+	}
+	_, err := opts.defaultResolveRelease("unbound-force/gaze")
+	if err == nil {
+		t.Fatal("expected error for pre-release tag")
+	}
+	if !strings.Contains(err.Error(), "invalid release tag format") {
+		t.Errorf("error = %q, want to contain 'invalid release tag format'", err.Error())
+	}
+}
+
+func TestDefaultResolveRelease_MalformedRepo(t *testing.T) {
+	opts := &Options{
+		ExecCmd: (&cmdRecorder{}).execCmd,
+	}
+	_, err := opts.defaultResolveRelease("not-a-repo")
+	if err == nil {
+		t.Fatal("expected error for malformed repo")
+	}
+	if !strings.Contains(err.Error(), "invalid repo format") {
+		t.Errorf("error = %q, want to contain 'invalid repo format'", err.Error())
+	}
+}
+
+func TestDefaultResolveRelease_ValidRepo(t *testing.T) {
+	ghCmd := "gh release view --repo unbound-force/gaze --json tagName -q .tagName"
+	opts := &Options{
+		ExecCmd: (&cmdRecorder{
+			outputs: map[string]string{ghCmd: "v0.15.0\n"},
+		}).execCmd,
+	}
+	got, err := opts.defaultResolveRelease("unbound-force/gaze")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "0.15.0" {
+		t.Errorf("got %q, want %q", got, "0.15.0")
+	}
+}
+
+// --- Regression tests for issue #455 (Tasks 3.2, 3.3) ---
+
+func TestInstallGaze_Issue455_UsesResolvedVersionNotOptsVersion(t *testing.T) {
+	// Regression test: The RPM URL must use the resolved version (0.15.0)
+	// from ResolveRelease, NOT opts.Version (0.16.0). Issue #455.
+	rec := &cmdRecorder{}
+	opts := &Options{
+		Version:  "0.16.0", // uf's version — must NOT appear in RPM URL
+		LookPath: stubLookPath(map[string]string{}),
+		ExecCmd:  rec.execCmd,
+		Stdout:   &bytes.Buffer{},
+		Stderr:   &bytes.Buffer{},
+		ResolveRelease: func(repo string) (string, error) {
+			return "0.15.0", nil // gaze's version — must appear in RPM URL
+		},
+	}
+	env := doctor.DetectedEnvironment{
+		Managers: []doctor.ManagerInfo{
+			{Kind: doctor.ManagerDnf, Path: "/usr/bin/dnf"},
+		},
+	}
+	result := installGaze(opts, env)
+	if result.action != "installed" {
+		t.Fatalf("action = %q, want installed", result.action)
+	}
+	// Verify the dnf install URL contains resolved version.
+	found := false
+	for _, call := range rec.calls {
+		if strings.Contains(call, "dnf install") {
+			found = true
+			if !strings.Contains(call, "v0.15.0") {
+				t.Errorf("RPM URL should contain resolved version v0.15.0, got: %s", call)
+			}
+			if strings.Contains(call, "v0.16.0") {
+				t.Errorf("RPM URL should NOT contain uf version v0.16.0, got: %s", call)
+			}
+		}
+	}
+	if !found {
+		t.Error("no dnf install call recorded")
+	}
+}
+
+func TestInstallReplicator_Issue455_UsesResolvedVersionNotOptsVersion(t *testing.T) {
+	// Regression test: The RPM URL must use the resolved version (2.1.0)
+	// from ResolveRelease, NOT opts.Version (0.16.0). Issue #455.
+	rec := &cmdRecorder{}
+	opts := &Options{
+		Version:  "0.16.0", // uf's version — must NOT appear in RPM URL
+		LookPath: stubLookPath(map[string]string{}),
+		ExecCmd:  rec.execCmd,
+		Stdout:   &bytes.Buffer{},
+		Stderr:   &bytes.Buffer{},
+		ResolveRelease: func(repo string) (string, error) {
+			return "2.1.0", nil // replicator's version — must appear in RPM URL
+		},
+	}
+	env := doctor.DetectedEnvironment{
+		Managers: []doctor.ManagerInfo{
+			{Kind: doctor.ManagerDnf, Path: "/usr/bin/dnf"},
+		},
+	}
+	result := installReplicator(opts, env)
+	if result.action != "installed" {
+		t.Fatalf("action = %q, want installed", result.action)
+	}
+	// Verify the dnf install URL contains resolved version.
+	found := false
+	for _, call := range rec.calls {
+		if strings.Contains(call, "dnf install") {
+			found = true
+			if !strings.Contains(call, "v2.1.0") {
+				t.Errorf("RPM URL should contain resolved version v2.1.0, got: %s", call)
+			}
+			if strings.Contains(call, "v0.16.0") {
+				t.Errorf("RPM URL should NOT contain uf version v0.16.0, got: %s", call)
+			}
+		}
+	}
+	if !found {
+		t.Error("no dnf install call recorded")
+	}
+}
+
+// --- Error path tests (Task 3.4) ---
+
+func TestInstallGaze_ResolveReleaseError(t *testing.T) {
+	opts := &Options{
+		LookPath: stubLookPath(map[string]string{}),
+		Stdout:   &bytes.Buffer{},
+		Stderr:   &bytes.Buffer{},
+		ResolveRelease: func(repo string) (string, error) {
+			return "", fmt.Errorf("resolve latest release for %s: network timeout", repo)
+		},
+	}
+	env := doctor.DetectedEnvironment{
+		Managers: []doctor.ManagerInfo{
+			{Kind: doctor.ManagerDnf, Path: "/usr/bin/dnf"},
+		},
+	}
+	result := installGaze(opts, env)
+	if result.action != "failed" {
+		t.Errorf("action = %q, want failed", result.action)
+	}
+	if !strings.Contains(result.detail, "cannot resolve latest release") {
+		t.Errorf("detail should contain 'cannot resolve latest release', got %q", result.detail)
+	}
+	if !strings.Contains(result.detail, "--method go") {
+		t.Errorf("detail should contain actionable guidance '--method go', got %q", result.detail)
+	}
+}
+
+// --- Dry-run with resolved version (Task 3.5) ---
+
+func TestInstallGaze_DryRunDnfWithResolvedVersion(t *testing.T) {
+	opts := &Options{
+		DryRun:   true,
+		Version:  "0.16.0",
+		LookPath: stubLookPath(map[string]string{}),
+		ExecCmd:  (&cmdRecorder{}).execCmd,
+		Stdout:   &bytes.Buffer{},
+		Stderr:   &bytes.Buffer{},
+		ResolveRelease: func(repo string) (string, error) {
+			return "0.15.0", nil
+		},
+	}
+	env := doctor.DetectedEnvironment{
+		Managers: []doctor.ManagerInfo{
+			{Kind: doctor.ManagerDnf, Path: "/usr/bin/dnf"},
+		},
+	}
+	result := installGaze(opts, env)
+	if result.action != "dry-run" {
+		t.Errorf("action = %q, want dry-run", result.action)
+	}
+	if !strings.Contains(result.detail, "v0.15.0") {
+		t.Errorf("dry-run detail should contain resolved version v0.15.0, got %q", result.detail)
+	}
+	if strings.Contains(result.detail, "v0.16.0") {
+		t.Errorf("dry-run detail should NOT contain uf version v0.16.0, got %q", result.detail)
+	}
+}
+
+// --- buildSteps order test (Task 3.6) ---
+
+func TestBuildSteps_GHBeforeGaze(t *testing.T) {
+	opts := &Options{
+		Stdout: &bytes.Buffer{},
+		Stderr: &bytes.Buffer{},
+	}
+	var node, uv, repl bool
+	steps := buildSteps(opts, &node, &uv, &repl)
+
+	ghIdx, gazeIdx := -1, -1
+	for i, s := range steps {
+		if s.name == "GitHub CLI" {
+			ghIdx = i
+		}
+		if s.name == "Gaze" {
+			gazeIdx = i
+		}
+	}
+	if ghIdx < 0 {
+		t.Fatal("GitHub CLI step not found")
+	}
+	if gazeIdx < 0 {
+		t.Fatal("Gaze step not found")
+	}
+	if ghIdx >= gazeIdx {
+		t.Errorf("GitHub CLI (index %d) must come before Gaze (index %d) per D6", ghIdx, gazeIdx)
+	}
+}
+
 // --- GitHub CLI installation tests ---
 
 func TestSetupRun_GHMissing_BrewInstall(t *testing.T) {
@@ -3871,6 +4203,9 @@ func TestInstallGaze_DnfFallback(t *testing.T) {
 		ExecCmd:  rec.execCmd,
 		Stdout:   &bytes.Buffer{},
 		Stderr:   &bytes.Buffer{},
+		ResolveRelease: func(repo string) (string, error) {
+			return "1.0.0", nil
+		},
 	}
 	env := doctor.DetectedEnvironment{
 		Managers: []doctor.ManagerInfo{
@@ -3934,6 +4269,9 @@ func TestInstallGaze_PackageManagerDnf(t *testing.T) {
 		ExecCmd:        rec.execCmd,
 		Stdout:         &bytes.Buffer{},
 		Stderr:         &bytes.Buffer{},
+		ResolveRelease: func(repo string) (string, error) {
+			return "1.0.0", nil
+		},
 	}
 	opts.defaults()
 	env := doctor.DetectedEnvironment{
@@ -3996,6 +4334,9 @@ func TestInstallReplicator_DnfFallback(t *testing.T) {
 		ExecCmd:  rec.execCmd,
 		Stdout:   &bytes.Buffer{},
 		Stderr:   &bytes.Buffer{},
+		ResolveRelease: func(repo string) (string, error) {
+			return "1.0.0", nil
+		},
 	}
 	env := doctor.DetectedEnvironment{
 		Managers: []doctor.ManagerInfo{
@@ -4056,6 +4397,9 @@ func TestInstallReplicator_PackageManagerDnf(t *testing.T) {
 		ExecCmd:        rec.execCmd,
 		Stdout:         &bytes.Buffer{},
 		Stderr:         &bytes.Buffer{},
+		ResolveRelease: func(repo string) (string, error) {
+			return "1.0.0", nil
+		},
 	}
 	opts.defaults()
 	env := doctor.DetectedEnvironment{
@@ -4327,6 +4671,9 @@ func TestInstallGaze_DryRunDnfFallback(t *testing.T) {
 		ExecCmd:  (&cmdRecorder{}).execCmd,
 		Stdout:   &bytes.Buffer{},
 		Stderr:   &bytes.Buffer{},
+		ResolveRelease: func(repo string) (string, error) {
+			return "1.0.0", nil
+		},
 	}
 	env := doctor.DetectedEnvironment{
 		Managers: []doctor.ManagerInfo{
@@ -4372,6 +4719,9 @@ func TestInstallReplicator_DryRunDnfFallback(t *testing.T) {
 		ExecCmd:  (&cmdRecorder{}).execCmd,
 		Stdout:   &bytes.Buffer{},
 		Stderr:   &bytes.Buffer{},
+		ResolveRelease: func(repo string) (string, error) {
+			return "1.0.0", nil
+		},
 	}
 	env := doctor.DetectedEnvironment{
 		Managers: []doctor.ManagerInfo{

--- a/openspec/changes/fix-rpm-version-skew/.openspec.yaml
+++ b/openspec/changes/fix-rpm-version-skew/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: unbound-force
+created: 2026-08-11

--- a/openspec/changes/fix-rpm-version-skew/design.md
+++ b/openspec/changes/fix-rpm-version-skew/design.md
@@ -1,0 +1,247 @@
+## Context
+
+`uf setup` installs companion tools (Gaze, Replicator) using a
+fallback chain: Homebrew → dnf (RPM) → `go install` → skip. The
+dnf path constructs GitHub Release RPM URLs via `rpmURL()`, which
+takes a version parameter. Today, `installGaze()` (line 669) and
+`installReplicator()` (line 857) pass `opts.Version` — the uf
+binary's own build-time version — as that parameter.
+
+Since companion tools are independently versioned (e.g., Dewey
+v3.2.0 vs uf v0.15.0), the constructed URL references a
+non-existent release, producing 404 errors on Fedora/RHEL.
+
+This design describes how to resolve each companion tool's actual
+latest release version before constructing the RPM URL.
+
+## Goals / Non-Goals
+
+### Goals
+- Resolve the correct latest release version per companion tool
+  before constructing RPM download URLs
+- Preserve the existing DI pattern (`Options` struct with
+  injectable functions) for testability
+- Fail gracefully when version resolution is unavailable — fall
+  through to the next install method in the chain
+- Validate resolved version tags before URL interpolation
+
+### Non-Goals
+- Adding RPM support for Dewey (currently uses Homebrew/go only)
+- Pinning companion tools to specific versions (always latest)
+- Supporting pre-release or draft GitHub Releases
+- GPG signature verification of downloaded RPMs (separate concern)
+- Caching resolved versions across `uf setup` invocations
+
+## Decisions
+
+### D1: Resolution strategy — `gh release view`
+
+Use `gh release view --repo {repo} --json tagName` to resolve
+the latest release tag. This approach:
+
+- Reuses the `gh` CLI already required by `uf setup`
+- Inherits the user's GitHub authentication context
+- Avoids rate-limiting issues (authenticated requests get
+  5,000 req/hr vs 60 req/hr unauthenticated)
+- Returns structured JSON, simplifiable to `--json tagName -q .tagName`
+
+**Step ordering note**: `buildSteps()` installs Gaze at step 2
+and `gh` CLI at step 3. On a fresh system without `gh`
+pre-installed, `ResolveRelease` will fail for Gaze because `gh`
+is not yet available. This is addressed by D6 (step reorder)
+below. Replicator (step 8) is unaffected since it runs after
+`gh` installation.
+
+`gh` handles auth negotiation internally and works without a
+token for public repos. No unauthenticated API fallback is
+needed.
+
+### D2: Injectable dependency via `Options.ResolveRelease`
+
+Add a new field to `Options`:
+
+```go
+// ResolveRelease resolves the latest release tag for a GitHub
+// repository (e.g., "unbound-force/gaze" → "0.15.0"). Returns
+// the version string without the "v" prefix. Returns an error
+// if resolution fails (network, no releases, invalid format).
+ResolveRelease func(repo string) (string, error)
+```
+
+The production default calls `gh release view`. Tests inject a
+stub that returns controlled values without network access.
+
+This follows the established pattern: `ExecCmd`, `LookPath`,
+`EvalSymlinks`, `Getenv`, `ReadFile`, `WriteFile` are all
+injectable functions on `Options`.
+
+### D3: Version tag validation
+
+The resolved tag MUST be validated before URL interpolation:
+
+0. Trim leading and trailing whitespace (including newlines) from
+   the raw `ExecCmd` output (`strings.TrimSpace`)
+1. Strip leading `v` prefix if present (GoReleaser tags as `v1.2.3`)
+2. Verify the result matches `^[0-9]{1,5}\.[0-9]{1,5}\.[0-9]{1,5}$`
+   (basic semver — major.minor.patch, bounded digit counts, end
+   anchor to reject trailing content like `-rc.1`)
+3. Reject tags longer than 20 characters (defense-in-depth)
+
+Invalid tags produce an error, causing the RPM path to return a
+`stepResult` with action "failed" and a descriptive detail. The
+caller (`installGaze` / `installReplicator`) falls through to
+the next method in the chain.
+
+### D4: Call site changes
+
+Both `installGaze()` and `installReplicator()` change from:
+
+```go
+return installViaRpm(opts, "Gaze", "unbound-force/gaze", opts.Version)
+```
+
+to:
+
+```go
+version, err := opts.ResolveRelease("unbound-force/gaze")
+if err != nil {
+    return stepResult{
+        name:   "Gaze",
+        action: "failed",
+        detail: "cannot resolve latest release: " + err.Error(),
+        err:    err,
+    }
+}
+return installViaRpm(opts, "Gaze", "unbound-force/gaze", version)
+```
+
+The fallback chain in the `switch` statement handles the "failed"
+result by falling through to the `go install` or skip path, matching
+the existing pattern where RPM failures are recoverable.
+
+**Correction**: The current fallback chain does NOT automatically
+retry with the next method — each `case` branch returns directly.
+The failed RPM result will be returned as-is. This is acceptable:
+the user sees a clear error message with context, and can either
+re-run with `--method go` or configure `tool_methods.gaze: go` in
+their config. This matches the existing behavior when dnf itself
+fails (line 993-1001).
+
+### D5: `opts.Version` field — no removal
+
+The `opts.Version` field is NOT removed. It may still be used for
+other purposes (e.g., displaying the uf binary version during
+setup). The GoDoc comment is updated to clarify it is the uf
+binary's version, not used for companion tool RPM URLs.
+
+This design resolves versions independently per tool, making
+coordinated releases unnecessary. Issue #455's alternative
+approach ("OR decision documented to coordinate releases") is
+rejected because it would re-introduce the Principle II violation
+by coupling hero release cadences.
+
+### D6: Step reorder — `installGH` before `installGaze`
+
+`buildSteps()` MUST be modified to install the GitHub CLI before
+Gaze. The current order places Gaze at step index 1 and `gh` at
+step index 2. Since `ResolveRelease` requires `gh`, the `gh`
+installation step MUST precede any step that may invoke
+`ResolveRelease`.
+
+New step order (affected steps only):
+1. OpenCode (unchanged)
+2. GitHub CLI (moved up from step 3)
+3. Gaze (moved down from step 2)
+4. Node.js (unchanged)
+...remaining steps unchanged.
+
+This is a minimal reorder that preserves all other step
+dependencies. `installGH` has no dependency on Gaze or OpenCode,
+so moving it earlier is safe.
+
+### D7: `repo` parameter validation
+
+The `repo` parameter passed to `ResolveRelease` MUST be validated
+before being interpolated into the `gh release view --repo {repo}`
+command. Although today's callers pass hardcoded string literals,
+the function signature accepts arbitrary strings. Per Constitution
+Principle V (Security by Default), inputs to security-sensitive
+operations MUST be validated.
+
+The `repo` parameter MUST match `^[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+$`
+(GitHub owner/repo format). Invalid values MUST produce an error
+before `ExecCmd` is called.
+
+## Risks / Trade-offs
+
+### R1: Network dependency at resolution time
+
+Version resolution adds a network call (`gh release view`) before
+the RPM download. The resolution uses the GitHub API (via `gh`)
+while the RPM download uses GitHub Releases CDN — these are
+different services. However, since the current code always
+produces 404s with the wrong version, the resolution step adds
+no new failure mode in practice. If the API is unreachable, the
+error handling causes a graceful failure with an actionable
+error message.
+
+### R2: gh CLI version requirements
+
+`gh release view --json` requires gh >= 2.0. The `installGH`
+step checks for `gh` availability but not its version. On older
+systems with gh 1.x, the `--json` flag will produce an error
+caught by `ResolveRelease`'s error handling, causing a graceful
+fallback. This is acceptable — gh 2.0 was released in 2021 and
+all supported platforms ship recent versions.
+
+### R3: Rate limiting on public repos
+
+`gh` uses the user's auth token when available. For unauthenticated
+users on public repos, GitHub allows 60 API requests/hour. A single
+`uf setup` run resolves at most 2 versions (Gaze, Replicator),
+well within this limit.
+
+### R4: TOCTOU between resolution and download
+
+There is a theoretical window between resolving the latest tag and
+downloading the RPM where a new release could be published. This is
+harmless — the user gets the version that was latest at resolution
+time, which is a valid release. Accepted.
+
+### R5: RPM content integrity — accepted risk
+
+Constitution Principle V requires content-hash verification for
+downloads outside a package manager's built-in verification.
+`dnf install -y {url}` downloads an RPM from a GitHub Release URL.
+For direct URL installs, `dnf` does not apply `gpgcheck` — the
+RPM is installed without signature verification unless the signing
+key is in the RPM keyring. GoReleaser does not sign RPMs by
+default.
+
+This is an accepted risk for this bugfix scope:
+- The RPM is served over HTTPS from GitHub's CDN (transport
+  security)
+- GoReleaser produces `checksums.txt` but `dnf` cannot consume it
+- Adding manual checksum verification is a separate enhancement
+  (not in scope for this change)
+- This pre-existing gap exists in the current code and is not
+  introduced by this change
+
+## Test Strategy
+
+All tests are unit tests using injected `ResolveRelease` stubs.
+No integration or e2e tests are required — the `ExecCmd` DI
+pattern provides hermetic testing without network access.
+
+Coverage targets:
+- All FR-002 validation paths (valid, invalid, whitespace, empty,
+  pre-release, too long, CLI failure)
+- Both FR-003 call sites (Gaze and Replicator)
+- Error path (resolution failure returns descriptive stepResult)
+- Dry-run path (URL displayed with resolved version)
+- Repo validation (FR-004 malformed input)
+
+Coverage ratchets in CI will enforce no regression from the
+existing baseline.
+
+<!-- scaffolded by uf vdev -->

--- a/openspec/changes/fix-rpm-version-skew/proposal.md
+++ b/openspec/changes/fix-rpm-version-skew/proposal.md
@@ -1,0 +1,111 @@
+## Why
+
+`uf setup` constructs RPM download URLs for companion tools (Gaze,
+Replicator) using the `uf` binary's own build-time version
+(`opts.Version`). Since these tools are independently versioned —
+Dewey is at v3.2.0 while uf is at v0.15.0 — the constructed URLs
+point to non-existent GitHub Releases, producing 404 errors on
+Fedora/RHEL systems using the dnf/RPM fallback path.
+
+This violates Constitution Principle II (Composability First):
+heroes must be independently installable. Coupling companion tool
+installation to uf's release cadence creates a time bomb — every
+release where versions diverge breaks the RPM install path.
+
+Fixes #455. Related: #268 (introduced RPM support), #214
+(Fedora/RHEL workarounds), PR #270 (implementation that introduced
+the coupling).
+
+## What Changes
+
+Replace the hardcoded `opts.Version` at the two `installViaRpm()`
+call sites with a dynamically resolved latest release version for
+each companion tool. Add a `resolveLatestRelease()` helper that
+queries the companion tool's actual latest GitHub Release tag.
+
+## Capabilities
+
+### New Capabilities
+- `resolveLatestRelease`: Resolves the latest release tag for a
+  given GitHub repository, using `gh release view` or the GitHub
+  API. Handles network failures gracefully.
+
+### Modified Capabilities
+- `installGaze`: Uses the resolved Gaze version instead of
+  `opts.Version` when constructing RPM URLs.
+- `installReplicator`: Uses the resolved Replicator version
+  instead of `opts.Version` when constructing RPM URLs.
+
+### Removed Capabilities
+- None.
+
+## Impact
+
+- **Files**: `internal/setup/setup.go` (primary),
+  `internal/setup/setup_test.go` (test updates)
+- **Affected paths**: RPM/dnf fallback only. Homebrew (`@latest`)
+  and `go install` (`@latest`) paths are unaffected.
+- **Tools affected**: Gaze and Replicator only. Dewey does not
+  use the RPM install path (line 1373: `"homebrew", "go"` only).
+- **Runtime dependency**: `gh` CLI (already installed during
+  setup). Graceful error with actionable message when resolution
+  fails (e.g., `gh` not yet installed or network unavailable).
+- **User-facing change**: `uf setup` on Fedora/RHEL will correctly
+  install the latest version of companion tools regardless of uf's
+  own version.
+
+## Constitution Alignment
+
+Assessed against the Unbound Force org constitution (v1.2.0).
+
+### I. Autonomous Collaboration
+
+**Assessment**: PASS
+
+This change does not alter artifact-based communication between
+heroes. The version resolution is a build-time/install-time
+concern that operates independently. No inter-hero runtime
+coupling is introduced.
+
+### II. Composability First
+
+**Assessment**: PASS (fixes existing violation)
+
+The current code violates this principle by coupling companion
+tool installation to uf's version. This fix restores independent
+installability — each companion tool's RPM URL will use its own
+latest release version, not uf's. Heroes remain independently
+versioned and installable.
+
+### III. Observable Quality
+
+**Assessment**: N/A
+
+This change does not produce artifacts or quality metrics. The
+RPM install step already reports structured `stepResult` output
+with action and detail fields, which is preserved.
+
+### IV. Testability
+
+**Assessment**: PASS
+
+The existing DI patterns (`opts.ExecCmd`, `opts.LookPath`) support
+adding a version resolver as an injectable dependency. The
+`rpmURL()` function is already a pure function testable in
+isolation. New tests will verify the resolved version is used in
+URL construction, and mock the GitHub API call for hermetic testing.
+
+### V. Security by Default
+
+**Assessment**: PASS (with design constraints)
+
+The fix introduces a new external input (GitHub API response for
+latest release tag). The design MUST:
+- Validate the resolved tag format (semver pattern, bounded length)
+  before interpolating into a URL
+- Handle API failures gracefully (fall through to next install
+  method, not crash)
+- Use `gh` CLI (inherits user's auth context); `gh` works without
+  a token for public repos
+- Respect rate limits (5,000 req/hr authenticated, 60 req/hr
+  unauthenticated via `gh`)

--- a/openspec/changes/fix-rpm-version-skew/specs/setup-rpm-version-resolution.md
+++ b/openspec/changes/fix-rpm-version-skew/specs/setup-rpm-version-resolution.md
@@ -1,0 +1,194 @@
+# Setup RPM Version Resolution
+
+Delta spec for `internal/setup/setup.go` — resolves companion
+tool versions independently for RPM download URLs.
+
+## ADDED Requirements
+
+### FR-001: ResolveRelease injectable dependency
+
+The `Options` struct MUST include a `ResolveRelease` field of
+type `func(repo string) (string, error)` that resolves the
+latest release tag for a given GitHub repository. The function
+MUST return the version string without the `v` prefix. The
+`defaults()` method MUST initialize this field to a production
+implementation when nil.
+
+#### Scenario: Default initialization
+
+- **GIVEN** an `Options` struct with `ResolveRelease` set to nil
+- **WHEN** `defaults()` is called
+- **THEN** `ResolveRelease` MUST be set to a function that
+  invokes `gh release view --repo {repo} --json tagName
+  -q .tagName` via `ExecCmd`
+
+#### Scenario: Test injection
+
+- **GIVEN** an `Options` struct with `ResolveRelease` set to a
+  stub function
+- **WHEN** `defaults()` is called
+- **THEN** the stub function MUST NOT be overwritten
+
+### FR-002: Version tag validation
+
+The production `ResolveRelease` implementation MUST validate
+the resolved tag before returning it:
+
+0. Trim leading and trailing whitespace (including newlines)
+   from the raw `ExecCmd` output
+1. Strip a leading `v` prefix if present
+2. Verify the result matches `^[0-9]{1,5}\.[0-9]{1,5}\.[0-9]{1,5}$`
+3. Reject values longer than 20 characters
+
+Invalid tags MUST produce an error with a descriptive message
+including the raw tag value.
+
+#### Scenario: Valid tag with v prefix
+
+- **GIVEN** `gh release view` returns tag `v1.2.3`
+- **WHEN** `ResolveRelease("unbound-force/gaze")` is called
+- **THEN** it MUST return `("1.2.3", nil)`
+
+#### Scenario: Valid tag without prefix
+
+- **GIVEN** `gh release view` returns tag `1.2.3`
+- **WHEN** `ResolveRelease("unbound-force/gaze")` is called
+- **THEN** it MUST return `("1.2.3", nil)`
+
+#### Scenario: Invalid tag format
+
+- **GIVEN** `gh release view` returns tag `latest`
+- **WHEN** `ResolveRelease("unbound-force/gaze")` is called
+- **THEN** it MUST return an error containing "invalid release
+  tag format"
+
+#### Scenario: Tag too long
+
+- **GIVEN** `gh release view` returns a tag exceeding 20
+  characters
+- **WHEN** `ResolveRelease("unbound-force/gaze")` is called
+- **THEN** it MUST return an error containing "release tag
+  too long"
+
+#### Scenario: Tag with trailing whitespace
+
+- **GIVEN** `gh release view` returns `"v1.2.3\n"` (trailing
+  newline)
+- **WHEN** `ResolveRelease("unbound-force/gaze")` is called
+- **THEN** it MUST return `("1.2.3", nil)`
+
+#### Scenario: Empty tag
+
+- **GIVEN** `gh release view` returns an empty string (no
+  releases or null jq result)
+- **WHEN** `ResolveRelease("unbound-force/gaze")` is called
+- **THEN** it MUST return an error containing "invalid release
+  tag format"
+
+#### Scenario: Pre-release tag rejected
+
+- **GIVEN** `gh release view` returns tag `v1.2.3-rc.1`
+- **WHEN** `ResolveRelease("unbound-force/gaze")` is called
+- **THEN** it MUST return an error containing "invalid release
+  tag format"
+
+#### Scenario: gh CLI failure
+
+- **GIVEN** `gh release view` returns an error (network, auth,
+  no releases)
+- **WHEN** `ResolveRelease("unbound-force/gaze")` is called
+- **THEN** it MUST return the error wrapped with context:
+  `"resolve latest release for {repo}: {err}"`
+
+### FR-004: `repo` parameter validation
+
+The `repo` parameter passed to `ResolveRelease` MUST be
+validated to match the GitHub `owner/repo` format before being
+passed to `ExecCmd`. Invalid values MUST produce an error.
+
+#### Scenario: Valid repo format
+
+- **GIVEN** repo is `"unbound-force/gaze"`
+- **WHEN** `ResolveRelease` is called
+- **THEN** validation MUST pass (proceed to `gh` invocation)
+
+#### Scenario: Malformed repo format
+
+- **GIVEN** repo is `"not-a-valid-repo"`
+- **WHEN** `ResolveRelease` is called
+- **THEN** it MUST return an error containing "invalid
+  repository format" without invoking `ExecCmd`
+
+### FR-003: RPM path uses resolved version
+
+`installGaze()` and `installReplicator()` MUST call
+`opts.ResolveRelease()` to obtain the companion tool's version
+before passing it to `installViaRpm()`. The functions MUST NOT
+pass `opts.Version` to `installViaRpm()`.
+
+#### Scenario: Successful RPM install with resolved version
+
+- **GIVEN** `ResolveRelease("unbound-force/gaze")` returns
+  `"0.15.0"`
+- **AND** uf's `opts.Version` is `"0.16.0"`
+- **WHEN** `installGaze()` selects the dnf method
+- **THEN** the RPM URL MUST contain `v0.15.0` (Gaze's version)
+- **AND** the RPM URL MUST NOT contain `v0.16.0` (uf's version)
+
+#### Scenario: Successful RPM install with resolved Replicator version
+
+- **GIVEN** `ResolveRelease("unbound-force/replicator")` returns
+  `"2.1.0"`
+- **AND** uf's `opts.Version` is `"0.16.0"`
+- **WHEN** `installReplicator()` selects the dnf method
+- **THEN** the RPM URL MUST contain `v2.1.0` (Replicator's version)
+- **AND** the RPM URL MUST NOT contain `v0.16.0` (uf's version)
+
+#### Scenario: Resolution failure returns descriptive error
+
+- **GIVEN** `ResolveRelease("unbound-force/gaze")` returns an
+  error
+- **WHEN** `installGaze()` selects the dnf method
+- **THEN** it MUST return a `stepResult` with action "failed"
+- **AND** the detail MUST include the resolution error message
+
+#### Scenario: Dry run with resolved version
+
+- **GIVEN** `opts.DryRun` is true
+- **AND** `ResolveRelease("unbound-force/gaze")` returns
+  `"0.15.0"`
+- **WHEN** `installGaze()` selects the dnf method
+- **THEN** the dry-run detail MUST show the URL with `v0.15.0`
+
+## MODIFIED Requirements
+
+### Requirement: Options.Version field documentation
+
+The GoDoc comment on `Options.Version` MUST be updated to
+clarify it is the uf binary's own version and MUST NOT be used
+for companion tool RPM URL construction.
+
+Previously: "Version is the current binary version (e.g.,
+'0.12.0'), used to construct GitHub Release RPM URLs."
+
+New: "Version is the uf binary's build-time version (e.g.,
+'0.12.0'). Not used for companion tool RPM URLs — those use
+ResolveRelease to obtain the tool's own latest version."
+
+### Requirement: installViaRpm version parameter semantics
+
+The `version` parameter to `installViaRpm()` MUST represent
+the target tool's version, not the uf binary's version. No
+signature change is required — the semantics are clarified by
+the callers' responsibility to resolve the correct version.
+
+Previously: callers passed `opts.Version` (uf's version).
+
+New: callers MUST pass a version obtained from
+`opts.ResolveRelease()` or an equivalent per-tool resolution.
+
+## REMOVED Requirements
+
+None. No requirements are removed by this change.
+
+<!-- scaffolded by uf vdev -->

--- a/openspec/changes/fix-rpm-version-skew/tasks.md
+++ b/openspec/changes/fix-rpm-version-skew/tasks.md
@@ -1,0 +1,87 @@
+<!--
+  [P] marks tasks eligible for parallel execution.
+  Add [P] when a task: (a) touches different files from
+  other [P] tasks in the group, (b) has no dependency
+  on prior tasks in the group, (c) can safely execute
+  without ordering constraints.
+  Do NOT add [P] when tasks modify the same file —
+  parallel workers will cause merge conflicts.
+  Tasks without [P] run sequentially first, then [P]
+  tasks run in parallel.
+-->
+
+## 1. Add ResolveRelease to Options
+
+- [x] 1.1 Add `ResolveRelease func(repo string) (string, error)`
+  field to the `Options` struct in `internal/setup/setup.go`
+  with GoDoc comment per FR-001. Include `repo` parameter
+  validation (`^[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+$`) per FR-004
+- [x] 1.2 Implement the production default in `defaults()`:
+  invoke `gh release view --repo {repo} --json tagName
+  -q .tagName` via `opts.ExecCmd`, trim whitespace, strip
+  `v` prefix, validate semver format
+  (`^[0-9]{1,5}\.[0-9]{1,5}\.[0-9]{1,5}$`) and length
+  per FR-002
+- [x] 1.3 Update the `Options.Version` GoDoc comment to
+  clarify it is the uf binary's version and is not used
+  for companion tool RPM URLs
+- [x] 1.4 Reorder `buildSteps()` to place `installGH` before
+  `installGaze` per D6 — move GitHub CLI from step 3 to
+  step 2, shift Gaze from step 2 to step 3
+
+## 2. Wire resolved versions into RPM call sites
+
+- [x] 2.1 Modify `installGaze()`: call
+  `opts.ResolveRelease("unbound-force/gaze")` before
+  `installViaRpm()`. On error, return a `stepResult` with
+  action "failed" and the resolution error per FR-003
+- [x] 2.2 Modify `installReplicator()`: same pattern as 2.1
+  for `"unbound-force/replicator"` per FR-003
+
+## 3. Tests
+
+All test tasks modify `internal/setup/setup_test.go`.
+
+- [x] 3.1 Add unit tests for the production `ResolveRelease`
+  default: valid tag with `v` prefix, valid tag without
+  prefix, invalid format, tag too long, `gh` CLI failure,
+  whitespace-padded output, empty output, pre-release tag
+  format, malformed repo format (FR-002 + FR-004 scenarios).
+  Use `&Options{}` consistently (pointer receiver)
+- [x] 3.2 Add regression test for issue #455:
+  `TestInstallGaze_Issue455_UsesResolvedVersionNotOptsVersion`
+  — inject `ResolveRelease` returning a version distinct
+  from `opts.Version`, verify via `cmdRecorder` that the
+  `dnf install` URL contains the resolved version and NOT
+  `opts.Version` (FR-003 scenario)
+- [x] 3.3 Add test for `installReplicator` dnf path with
+  injected `ResolveRelease` — same regression assertions
+  as 3.2 for `"unbound-force/replicator"`. Use `&Options{}`
+  (pointer receiver)
+- [x] 3.4 Add test for `installGaze` dnf path when
+  `ResolveRelease` returns an error — verify the result
+  has action "failed" and detail includes the error message
+  with actionable context
+- [x] 3.5 Add test for dry-run mode with resolved version —
+  verify the dry-run detail shows the URL with the
+  resolved version
+- [x] 3.6 Add test for `buildSteps` order — verify `installGH`
+  step index is less than `installGaze` step index (D6)
+
+## 4. Verification
+
+- [x] 4.1 Run `make check` (lint + test + build) — all
+  checks MUST pass
+- [x] 4.2 Verify constitution alignment: Principle II
+  (Composability First) — confirm RPM URLs use per-tool
+  versions; Principle IV (Testability) — confirm
+  `ResolveRelease` is injectable and all tests run
+  without network access
+- [x] 4.3 Verify error messages from failed `ResolveRelease`
+  include actionable guidance (e.g., suggest `--method go`
+  or `tool_methods.gaze: go` config)
+- [x] 4.4 [P] Update CHANGELOG.md with a bugfix entry under
+  the Unreleased section referencing issue #455
+
+<!-- spec-review: passed -->
+<!-- scaffolded by uf vdev -->


### PR DESCRIPTION
## Summary

`uf setup`'s RPM/dnf install path was using the uf binary's own build-time version (`opts.Version`) to construct download URLs for companion tools (Gaze, Replicator). Since these tools are independently versioned (e.g., Dewey v3.2.0 vs uf v0.15.0), the constructed URLs pointed to non-existent releases, producing 404 errors on Fedora/RHEL systems.

This change adds a `ResolveRelease` injectable dependency to the `Options` struct that queries each companion tool's latest release via `gh release view`. The resolved version is validated (repo format, semver format, length bound) before being used in the RPM URL. The `buildSteps()` ordering is also corrected so `installGH` runs before `installGaze`, ensuring `gh` is available when needed.

Fixes #455. Restores Constitution Principle II (Composability First) compliance.

## How to Test

1. **Unit tests**: `go test -race -count=1 ./internal/setup/` -- all 198 tests pass
2. **Full check**: `make check` -- lint, test, build all pass
3. **Regression verification**: `TestInstallGaze_Issue455_UsesResolvedVersionNotOptsVersion` and `TestInstallReplicator_Issue455_UsesResolvedVersionNotOptsVersion` verify RPM URLs use the resolved version, not `opts.Version`
4. **Validation coverage**: 10 `TestDefaultResolveRelease_*` tests cover valid tags (with/without v prefix), invalid format, tag too long, gh CLI failure, whitespace padding, empty output, pre-release rejection, and malformed repo format
5. **Step ordering**: `TestBuildSteps_GHBeforeGaze` verifies GitHub CLI is installed before Gaze

## How to Demo

On a Fedora/RHEL system (or in dry-run mode):
```bash
# Dry-run shows the resolved RPM URL with the companion tool's actual version
uf setup --dry-run
# The Gaze and Replicator steps should show RPM URLs with each tool's
# latest release version, not uf's version
```

## Key Files Changed

| File | Changes |
|------|---------|
| `internal/setup/setup.go` | +87, -6 -- Added `ResolveRelease` DI field, `defaultResolveRelease` with validation, wired into `installGaze`/`installReplicator`, reordered `buildSteps` |
| `internal/setup/setup_test.go` | +350 -- 15 new tests + 6 existing tests fixed for new DI field |
| `CHANGELOG.md` | +10 -- Bugfix entry under Unreleased/Fixed |
| `openspec/changes/fix-rpm-version-skew/` | Spec artifacts: proposal, design (D1-D7, R1-R5), specs (FR-001-004), tasks (16) |
| `.uf/dewey/learnings/` | 2 learnings stored (setup-testing gotcha, setup-architecture pattern) |
| `.uf/artifacts/issue-triage/issue-455.json` | Triage artifact from 5-agent panel |

_This PR was generated by /uf.finale (AI-assisted)._
