### PR TITLE
fix: make uf doctor install hints tool-agnostic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,12 @@ Each entry follows the format: `- <change-name>: <summary>`.
   Closes: #253)
 
 ### Fixed
+- fix-doctor-hints: Replace five hardcoded OpenCode-specific
+  `InstallHint` strings in `uf doctor` agent context checks
+  with tool-agnostic plain-language remediation instructions.
+  Adds regression guards for `/uf.` and `OpenCode` references
+  in hints, and a drift-detection test for Tier 1 sections.
+  (Spec: openspec/changes/fix-doctor-hints/, Fixes: #460)
 - fix-specify-init-invocation: Fixed `uf init` failing
   to create `.specify/` directory due to upstream
   specify-cli interface changes. Updated specify

--- a/internal/doctor/checks.go
+++ b/internal/doctor/checks.go
@@ -1665,7 +1665,7 @@ func checkAgentContext(opts *Options) CheckGroup {
 			Name:        "AGENTS.md",
 			Severity:    Fail,
 			Message:     "not found",
-			InstallHint: "Run: /uf.agent-brief in OpenCode",
+			InstallHint: "Create an AGENTS.md file in your project root describing the project for AI agents",
 		})
 		return group
 	}
@@ -1691,7 +1691,7 @@ func checkAgentContext(opts *Options) CheckGroup {
 				Name:        "Tier 1: " + sec.name,
 				Severity:    Fail,
 				Message:     "not found",
-				InstallHint: "Run: /uf.agent-brief in OpenCode",
+				InstallHint: fmt.Sprintf("Add a '%s' section to AGENTS.md", sec.name),
 			})
 		}
 	}
@@ -1720,7 +1720,7 @@ func checkAgentContext(opts *Options) CheckGroup {
 			Name:        "Line count",
 			Severity:    Warn,
 			Message:     fmt.Sprintf("%d lines (threshold: %d)", lineCount, agentContextLineCountThreshold),
-			InstallHint: "Run: /uf.agent-brief in OpenCode for condensing suggestions",
+			InstallHint: "Condense AGENTS.md — current line count exceeds threshold",
 		})
 	} else {
 		group.Results = append(group.Results, CheckResult{
@@ -1746,7 +1746,7 @@ func checkAgentContext(opts *Options) CheckGroup {
 				Name:        "Constitution reference",
 				Severity:    Warn,
 				Message:     "not referenced (.specify/ detected)",
-				InstallHint: "Run: /uf.agent-brief in OpenCode",
+				InstallHint: "Add a constitution reference to AGENTS.md (e.g., Instructions from: .specify/memory/constitution.md)",
 			})
 		}
 	}
@@ -1770,7 +1770,7 @@ func checkAgentContext(opts *Options) CheckGroup {
 				Name:        "Spec framework described",
 				Severity:    Warn,
 				Message:     "not described (specs/ or openspec/ detected)",
-				InstallHint: "Run: /uf.agent-brief in OpenCode",
+				InstallHint: "Add a Specification Workflow section to AGENTS.md describing your spec framework",
 			})
 		}
 	}

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -2617,12 +2617,25 @@ func TestDoctorHints_NoBareUnboundReferences(t *testing.T) {
 			if r.InstallHint == "" {
 				continue
 			}
-			// Check for bare "unbound " that is NOT "unbound-force".
 			hint := r.InstallHint
+
+			// Check for bare "unbound " that is NOT "unbound-force" (FR-006).
 			// Remove all "unbound-force" occurrences to isolate bare "unbound ".
 			cleaned := strings.ReplaceAll(hint, "unbound-force", "")
 			if strings.Contains(cleaned, "unbound ") || strings.Contains(cleaned, "unbound\t") {
 				t.Errorf("InstallHint for %q contains bare 'unbound' reference: %q (FR-006 violation)",
+					r.Name, r.InstallHint)
+			}
+
+			// Check for /uf. slash command patterns (tool-specific references).
+			if strings.Contains(hint, "/uf.") {
+				t.Errorf("InstallHint for %q contains /uf. slash command reference: %q",
+					r.Name, r.InstallHint)
+			}
+
+			// Check for OpenCode-specific references.
+			if strings.Contains(hint, "OpenCode") || strings.Contains(hint, "opencode") {
+				t.Errorf("InstallHint for %q contains OpenCode-specific reference: %q",
 					r.Name, r.InstallHint)
 			}
 		}
@@ -3252,8 +3265,9 @@ func TestCheckAgentContext_NoFile(t *testing.T) {
 	if r.Severity != Fail {
 		t.Errorf("severity = %v, want Fail", r.Severity)
 	}
-	if r.InstallHint != "Run: /uf.agent-brief in OpenCode" {
-		t.Errorf("install hint = %q, want 'Run: /uf.agent-brief in OpenCode'", r.InstallHint)
+	wantHint := "Create an AGENTS.md file in your project root describing the project for AI agents"
+	if r.InstallHint != wantHint {
+		t.Errorf("install hint = %q, want %q", r.InstallHint, wantHint)
 	}
 }
 
@@ -3294,34 +3308,40 @@ func TestCheckAgentContext_AllTier1Present(t *testing.T) {
 
 func TestCheckAgentContext_MissingTier1Section(t *testing.T) {
 	tests := []struct {
-		name    string
-		content string
-		missing string
+		name        string
+		content     string
+		missing     string
+		sectionName string // canonical name from agentContextTier1Sections
 	}{
 		{
-			name:    "missing overview",
-			content: "## Build\n## Project Structure\n## Code Conventions\n## Active Technologies\n",
-			missing: "Tier 1: Project Overview",
+			name:        "missing overview",
+			content:     "## Build\n## Project Structure\n## Code Conventions\n## Active Technologies\n",
+			missing:     "Tier 1: Project Overview",
+			sectionName: "Project Overview",
 		},
 		{
-			name:    "missing build",
-			content: "## Project Overview\n## Project Structure\n## Code Conventions\n## Active Technologies\n",
-			missing: "Tier 1: Build Commands",
+			name:        "missing build",
+			content:     "## Project Overview\n## Project Structure\n## Code Conventions\n## Active Technologies\n",
+			missing:     "Tier 1: Build Commands",
+			sectionName: "Build Commands",
 		},
 		{
-			name:    "missing structure",
-			content: "## Project Overview\n## Build\n## Code Conventions\n## Active Technologies\n",
-			missing: "Tier 1: Project Structure",
+			name:        "missing structure",
+			content:     "## Project Overview\n## Build\n## Code Conventions\n## Active Technologies\n",
+			missing:     "Tier 1: Project Structure",
+			sectionName: "Project Structure",
 		},
 		{
-			name:    "missing conventions",
-			content: "## Project Overview\n## Build\n## Project Structure\n## Active Technologies\n",
-			missing: "Tier 1: Code Conventions",
+			name:        "missing conventions",
+			content:     "## Project Overview\n## Build\n## Project Structure\n## Active Technologies\n",
+			missing:     "Tier 1: Code Conventions",
+			sectionName: "Code Conventions",
 		},
 		{
-			name:    "missing tech stack",
-			content: "## Project Overview\n## Build\n## Project Structure\n## Code Conventions\n",
-			missing: "Tier 1: Technology Stack",
+			name:        "missing tech stack",
+			content:     "## Project Overview\n## Build\n## Project Structure\n## Code Conventions\n",
+			missing:     "Tier 1: Technology Stack",
+			sectionName: "Technology Stack",
 		},
 	}
 
@@ -3348,6 +3368,10 @@ func TestCheckAgentContext_MissingTier1Section(t *testing.T) {
 			}
 			if r.Severity != Fail {
 				t.Errorf("%s severity = %v, want Fail", tt.missing, r.Severity)
+			}
+			wantHint := fmt.Sprintf("Add a '%s' section to AGENTS.md", tt.sectionName)
+			if r.InstallHint != wantHint {
+				t.Errorf("%s install hint = %q, want %q", tt.missing, r.InstallHint, wantHint)
 			}
 		})
 	}
@@ -3431,8 +3455,13 @@ func TestCheckAgentContext_LineCount(t *testing.T) {
 			results[r.Name] = r
 		}
 
-		if r := results["Line count"]; r.Severity != Warn {
+		r := results["Line count"]
+		if r.Severity != Warn {
 			t.Errorf("severity = %v, want Warn for 350 lines", r.Severity)
+		}
+		wantHint := "Condense AGENTS.md — current line count exceeds threshold"
+		if r.InstallHint != wantHint {
+			t.Errorf("install hint = %q, want %q", r.InstallHint, wantHint)
 		}
 	})
 }
@@ -3479,6 +3508,10 @@ func TestCheckAgentContext_ConstitutionReference(t *testing.T) {
 		}
 		if r.Severity != Warn {
 			t.Errorf("severity = %v, want Warn", r.Severity)
+		}
+		wantHint := "Add a constitution reference to AGENTS.md (e.g., Instructions from: .specify/memory/constitution.md)"
+		if r.InstallHint != wantHint {
+			t.Errorf("install hint = %q, want %q", r.InstallHint, wantHint)
 		}
 	})
 }
@@ -3542,6 +3575,10 @@ func TestCheckAgentContext_SpecFrameworkReference(t *testing.T) {
 		if r.Severity != Warn {
 			t.Errorf("severity = %v, want Warn", r.Severity)
 		}
+		wantHint := "Add a Specification Workflow section to AGENTS.md describing your spec framework"
+		if r.InstallHint != wantHint {
+			t.Errorf("install hint = %q, want %q", r.InstallHint, wantHint)
+		}
 	})
 }
 
@@ -3556,6 +3593,63 @@ func TestCheckAgentContext_SpecFrameworkSkipped(t *testing.T) {
 	for _, r := range group.Results {
 		if r.Name == "Spec framework described" {
 			t.Error("Spec framework check should be omitted when no specs/ or openspec/ exist")
+		}
+	}
+}
+
+// TestCheckAgentContext_ProjectAGENTSmdHasAllTier1Sections is a
+// drift-detection test that reads the project's own AGENTS.md and
+// asserts all five Tier 1 section patterns match. This prevents
+// silent drift between the doctor's expectations and the actual
+// project structure.
+func TestCheckAgentContext_ProjectAGENTSmdHasAllTier1Sections(t *testing.T) {
+	// Walk up from the test file directory to find the project root
+	// (directory containing go.mod).
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("os.Getwd: %v", err)
+	}
+	projectRoot := ""
+	for d := dir; ; d = filepath.Dir(d) {
+		if _, err := os.Stat(filepath.Join(d, "go.mod")); err == nil {
+			projectRoot = d
+			break
+		}
+		parent := filepath.Dir(d)
+		if parent == d {
+			break
+		}
+	}
+	if projectRoot == "" {
+		t.Skip("could not locate project root (no go.mod found)")
+	}
+
+	agentsMdPath := filepath.Join(projectRoot, "AGENTS.md")
+	if _, err := os.Stat(agentsMdPath); err != nil {
+		t.Skip("AGENTS.md not found at project root")
+	}
+
+	opts := &Options{
+		TargetDir: projectRoot,
+		ReadFile:  os.ReadFile,
+	}
+
+	group := checkAgentContext(opts)
+
+	results := make(map[string]CheckResult)
+	for _, r := range group.Results {
+		results[r.Name] = r
+	}
+
+	for _, sec := range agentContextTier1Sections {
+		checkName := "Tier 1: " + sec.name
+		r, ok := results[checkName]
+		if !ok {
+			t.Errorf("missing check result for %q", checkName)
+			continue
+		}
+		if r.Severity != Pass {
+			t.Errorf("%s: severity = %v, want Pass — project AGENTS.md is missing this section", checkName, r.Severity)
 		}
 	}
 }

--- a/openspec/changes/fix-doctor-hints/.openspec.yaml
+++ b/openspec/changes/fix-doctor-hints/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: unbound-force
+created: 2026-08-13

--- a/openspec/changes/fix-doctor-hints/design.md
+++ b/openspec/changes/fix-doctor-hints/design.md
@@ -1,0 +1,75 @@
+# Design: Tool-Agnostic Install Hints
+
+## Context
+
+The `uf doctor` command runs health checks on a project and
+reports findings with remediation hints. Five `InstallHint`
+strings in the agent context check group hardcode
+`"Run: /uf.agent-brief in OpenCode"`, coupling `uf doctor`
+output to OpenCode. Other hints in the same file already use
+tool-agnostic phrasing (e.g., `"Run: uf init"`,
+`"Add fenced code blocks with build/test commands"`).
+
+This change aligns the five outliers with the established
+pattern, serving Constitution Principle II (Composability
+First) — `uf doctor` must produce actionable output when
+deployed alone.
+
+## Goals / Non-Goals
+
+### Goals
+- Replace five `InstallHint` string literals with
+  tool-agnostic remediation instructions
+- Update the corresponding test assertion to match
+- Optionally add a drift-detection test for Tier 1 sections
+
+### Non-Goals
+- Changing the `CheckResult` struct or JSON output schema
+- Modifying the check logic (severity, thresholds, pass/fail)
+- Addressing other `uf doctor` issues from parent #212
+
+## Decisions
+
+### D-001: Descriptive hints over command references
+
+Each replacement hint describes what to do rather than which
+command to run. This makes hints useful regardless of the
+user's editor or workflow tool.
+
+Example: `"Add a '<section>' section to AGENTS.md"` instead of
+`"Run: /uf.agent-brief in OpenCode"`.
+
+Rationale: Consistent with the existing pattern in
+`checks.go` (lines 1712, 1790) and with Principle II — users
+should not need to know about OpenCode to act on doctor
+output.
+
+### D-002: Dynamic section name in Tier 1 hint
+
+The Tier 1 section missing hint (line 1694) runs in a loop
+over `agentContextTier1Sections`. The replacement hint
+includes the section name via `fmt.Sprintf` so the user knows
+exactly which section to add. This is already the pattern
+used for the check message itself.
+
+### D-003: Drift-detection test scope
+
+The optional drift-detection test reads the project's own
+`AGENTS.md` and asserts all five Tier 1 section headers are
+present. This test lives in `internal/doctor/` alongside
+existing drift tests (e.g.,
+`TestDoctorHints_NoBareUnboundReferences`). It does not
+validate content — only header presence.
+
+## Risks / Trade-offs
+
+- **Hint text changes are user-visible**: Users or downstream
+  tooling that pattern-match on hint text may need to update.
+  Risk is low because `InstallHint` is documented as a
+  display-only field and the JSON schema does not constrain
+  its value.
+- **No docs guide exists yet**: The AGENTS.md creation hint
+  references `docs/agents-md-guide.md` which may not exist.
+  The hint should use a generic phrasing that remains useful
+  even without the guide. Fallback: reference the project's
+  own `AGENTS.md` as an example.

--- a/openspec/changes/fix-doctor-hints/proposal.md
+++ b/openspec/changes/fix-doctor-hints/proposal.md
@@ -1,0 +1,69 @@
+# Proposal: Fix Doctor Install Hints to Be Tool-Agnostic
+
+Fixes: #460 | Split from: #212
+
+## Why
+
+Five `InstallHint` strings in `internal/doctor/checks.go` hardcode
+`"Run: /uf.agent-brief in OpenCode"`. This couples `uf doctor`
+output to a specific tool (OpenCode), producing unhelpful guidance
+for users who run `uf doctor` standalone or with a different editor
+integration.
+
+Other hints in the same file already follow a tool-agnostic pattern
+(e.g., `"Run: uf init"`, `"Add fenced code blocks with build/test
+commands"`, `"Add a Branch Protection section to AGENTS.md"`). The
+five `/uf.agent-brief` hints are inconsistent outliers.
+
+## What Changes
+
+Replace five `InstallHint` string literals in
+`internal/doctor/checks.go` with tool-agnostic plain-language
+instructions that tell the user what to do, not which tool to
+invoke:
+
+| Line | Current hint | Proposed replacement |
+|------|-------------|---------------------|
+| 1668 | `"Run: /uf.agent-brief in OpenCode"` | `"Create an AGENTS.md file in your project root describing the project for AI agents"` |
+| 1694 | `"Run: /uf.agent-brief in OpenCode"` | `"Add a '<section>' section to AGENTS.md"` (dynamic per Tier 1 section) |
+| 1723 | `"Run: /uf.agent-brief in OpenCode"` | `"Condense AGENTS.md — current line count exceeds threshold"` |
+| 1749 | `"Run: /uf.agent-brief in OpenCode"` | `"Add a constitution reference to AGENTS.md (e.g., Instructions from: path/to/constitution.md)"` |
+| 1773 | `"Run: /uf.agent-brief in OpenCode"` | `"Add a Specification Workflow section to AGENTS.md describing your spec framework"` |
+
+Update the corresponding test assertion in
+`internal/doctor/doctor_test.go` (line ~3255) to match the new hint
+text.
+
+Optionally add a drift-detection test that reads the project's own
+`AGENTS.md` and verifies all five Tier 1 sections are present.
+
+## Capabilities
+
+- `uf doctor` output becomes actionable regardless of editor or tool
+  environment
+- Hints describe the remediation action, not the mechanism to invoke
+  it
+- Existing JSON output schema (`install_hint` field in `CheckResult`)
+  is unchanged
+
+## Impact
+
+- **Files changed**: 2 (`internal/doctor/checks.go`,
+  `internal/doctor/doctor_test.go`)
+- **API changes**: None — `InstallHint` is a display-only string
+  field
+- **Breaking changes**: None — the `CheckResult` struct and JSON
+  schema are unmodified
+- **Dependencies**: None added or removed
+- **Risk**: Low — string literal replacements with no behavioral
+  change
+
+## Constitution Alignment
+
+| # | Principle | Status | Notes |
+|---|-----------|--------|-------|
+| I | Autonomous Collaboration | N/A | No inter-hero communication affected |
+| II | Composability First | PASS | This fix directly serves Principle II — `uf doctor` will produce actionable output when deployed alone, without requiring OpenCode |
+| III | Observable Quality | N/A | JSON output format and schema unchanged |
+| IV | Testability | PASS | Test assertion updated to match; optional drift-detection test strengthens regression protection |
+| V | Security by Default | N/A | No new inputs, dependencies, or privilege changes |

--- a/openspec/changes/fix-doctor-hints/proposal.md
+++ b/openspec/changes/fix-doctor-hints/proposal.md
@@ -27,7 +27,7 @@ invoke:
 | 1668 | `"Run: /uf.agent-brief in OpenCode"` | `"Create an AGENTS.md file in your project root describing the project for AI agents"` |
 | 1694 | `"Run: /uf.agent-brief in OpenCode"` | `"Add a '<section>' section to AGENTS.md"` (dynamic per Tier 1 section) |
 | 1723 | `"Run: /uf.agent-brief in OpenCode"` | `"Condense AGENTS.md — current line count exceeds threshold"` |
-| 1749 | `"Run: /uf.agent-brief in OpenCode"` | `"Add a constitution reference to AGENTS.md (e.g., Instructions from: path/to/constitution.md)"` |
+| 1749 | `"Run: /uf.agent-brief in OpenCode"` | `"Add a constitution reference to AGENTS.md (e.g., Instructions from: .specify/memory/constitution.md)"` |
 | 1773 | `"Run: /uf.agent-brief in OpenCode"` | `"Add a Specification Workflow section to AGENTS.md describing your spec framework"` |
 
 Update the corresponding test assertion in

--- a/openspec/changes/fix-doctor-hints/specs/install-hints.md
+++ b/openspec/changes/fix-doctor-hints/specs/install-hints.md
@@ -1,0 +1,82 @@
+# Spec: Tool-Agnostic Install Hints
+
+## MODIFIED Requirements
+
+### Requirement: FR-001 Agent Context Install Hints
+
+All `InstallHint` values produced by the agent context check
+group in `internal/doctor/checks.go` MUST describe the
+remediation action in tool-agnostic plain language. Hints
+MUST NOT reference specific editor integrations, slash
+commands, or third-party tool invocations.
+
+Previously: Five `InstallHint` strings hardcoded
+`"Run: /uf.agent-brief in OpenCode"`, coupling output to a
+specific tool.
+
+#### Scenario: AGENTS.md missing
+- **GIVEN** a project without an `AGENTS.md` file
+- **WHEN** `uf doctor` runs the agent context checks
+- **THEN** the `InstallHint` MUST instruct the user to create
+  an `AGENTS.md` file without referencing a specific tool
+
+#### Scenario: Tier 1 section missing
+- **GIVEN** a project with `AGENTS.md` that lacks one or more
+  Tier 1 sections
+- **WHEN** `uf doctor` runs the agent context checks
+- **THEN** the `InstallHint` MUST name the missing section and
+  instruct the user to add it, without referencing a specific
+  tool
+
+#### Scenario: AGENTS.md exceeds line threshold
+- **GIVEN** a project with `AGENTS.md` that exceeds the
+  configured line count threshold
+- **WHEN** `uf doctor` runs the agent context checks
+- **THEN** the `InstallHint` MUST instruct the user to
+  condense the file, without referencing a specific tool
+
+#### Scenario: Constitution reference missing
+- **GIVEN** a project with `AGENTS.md` that lacks a
+  constitution reference
+- **WHEN** `uf doctor` runs the agent context checks
+- **THEN** the `InstallHint` MUST instruct the user to add a
+  constitution reference, without referencing a specific tool
+
+#### Scenario: Spec framework not described
+- **GIVEN** a project with `AGENTS.md` that does not describe
+  the specification framework
+- **WHEN** `uf doctor` runs the agent context checks
+- **THEN** the `InstallHint` MUST instruct the user to add a
+  specification workflow section, without referencing a
+  specific tool
+
+## ADDED Requirements
+
+### Requirement: FR-002 No Bare Tool References in Hints
+
+The existing regression test
+`TestDoctorHints_NoBareUnboundReferences` MUST be extended
+to also scan for `/uf.` slash command patterns in
+`InstallHint` values. The current test only checks for bare
+`"unbound "` branding references (FR-006) and does not
+guard against tool-specific slash command reintroduction.
+
+#### Scenario: Regression guard
+- **GIVEN** the full doctor check suite
+- **WHEN** all check groups are executed via `Run()`
+- **THEN** no `InstallHint` value SHALL contain `/uf.` slash
+  command references or `OpenCode` tool-specific references
+
+### Requirement: FR-003 Drift Detection Test (Optional)
+
+A drift-detection test SHOULD verify that the project's own
+`AGENTS.md` contains all Tier 1 sections defined in
+`agentContextTier1Sections`.
+
+#### Scenario: Project AGENTS.md has all Tier 1 sections
+- **GIVEN** the project's `AGENTS.md` at repository root
+- **WHEN** the drift-detection test runs
+- **THEN** all five Tier 1 section headers as defined by
+  `agentContextTier1Sections` (Project Overview, Build
+  Commands, Project Structure, Code Conventions, Technology
+  Stack) MUST be matched by the section patterns in the file

--- a/openspec/changes/fix-doctor-hints/tasks.md
+++ b/openspec/changes/fix-doctor-hints/tasks.md
@@ -1,0 +1,67 @@
+# Tasks: Fix Doctor Install Hints
+
+## 1. Replace InstallHint strings
+
+- [x] 1.1 Replace `InstallHint` at line 1668 (AGENTS.md not
+  found) with `"Create an AGENTS.md file in your project root
+  describing the project for AI agents"`
+  — File: `internal/doctor/checks.go`
+- [x] 1.2 Replace `InstallHint` at line 1694 (Tier 1 section
+  missing) with `fmt.Sprintf("Add a '%s' section to
+  AGENTS.md", section.name)` — dynamic per section
+  — File: `internal/doctor/checks.go`
+- [x] 1.3 Replace `InstallHint` at line 1723 (line count
+  exceeds threshold) with `"Condense AGENTS.md — current line
+  count exceeds threshold"`
+  — File: `internal/doctor/checks.go`
+- [x] 1.4 Replace `InstallHint` at line 1749 (constitution
+  reference missing) with `"Add a constitution reference to
+  AGENTS.md (e.g., Instructions from:
+  .specify/memory/constitution.md)"`
+  — File: `internal/doctor/checks.go`
+- [x] 1.5 Replace `InstallHint` at line 1773 (spec framework
+  not described) with `"Add a Specification Workflow section
+  to AGENTS.md describing your spec framework"`
+  — File: `internal/doctor/checks.go`
+
+## 2. Update tests
+
+- [x] 2.1 Update `TestCheckAgentContext_NoFile` assertion at
+  line ~3255 in `internal/doctor/doctor_test.go` to match the
+  new hint text from task 1.1
+  — File: `internal/doctor/doctor_test.go`
+- [x] 2.2 Update `TestCheckAgentContext_MissingTier1Section`
+  to assert the new dynamic `InstallHint` text contains the
+  section name (e.g., `"Add a 'Project Overview' section to
+  AGENTS.md"`) for each missing Tier 1 section
+  — File: `internal/doctor/doctor_test.go`
+- [x] 2.3 Add `InstallHint` assertions to
+  `TestCheckAgentContext_LineCount` ("over threshold"
+  subtest), `TestCheckAgentContext_ConstitutionReference`
+  ("not referenced" subtest), and
+  `TestCheckAgentContext_SpecFrameworkReference` ("not
+  described" subtest) to verify the new tool-agnostic hint
+  text for each scenario
+  — File: `internal/doctor/doctor_test.go`
+- [x] 2.4 Extend `TestDoctorHints_NoBareUnboundReferences` to
+  also scan for `/uf.` slash command patterns and `OpenCode`
+  references in `InstallHint` values — the existing test only
+  checks for bare `"unbound "` branding
+  — File: `internal/doctor/doctor_test.go`
+- [x] 2.5 Add drift-detection test
+  `TestCheckAgentContext_ProjectAGENTSmdHasAllTier1Sections`
+  that reads the project's own `AGENTS.md` and asserts all
+  five Tier 1 section patterns from
+  `agentContextTier1Sections` match
+  — File: `internal/doctor/doctor_test.go`
+
+## 3. Verification
+
+- [x] 3.1 Run `go test -race -count=1 ./internal/doctor/...`
+  — all tests pass
+- [x] 3.2 Run `go vet ./internal/doctor/...` and
+  `golangci-lint run ./internal/doctor/...` — no warnings
+- [x] 3.3 Verify Constitution Principle II alignment:
+  `uf doctor` output contains no OpenCode-specific references
+  in any `InstallHint` value
+<!-- spec-review: passed -->


### PR DESCRIPTION
## Summary

Replace 5 hardcoded `InstallHint` strings in `uf doctor` agent context checks that referenced `Run: /uf.agent-brief in OpenCode` with tool-agnostic plain-language remediation instructions.

Fixes #460 | Split from #212

## Changes

### Production (`internal/doctor/checks.go`)
- Line 1668: AGENTS.md not found → "Create an AGENTS.md file..."
- Line 1694: Tier 1 section missing → `fmt.Sprintf("Add a '%s' section to AGENTS.md", sec.name)`
- Line 1723: Line count exceeded → "Condense AGENTS.md — current line count exceeds threshold"
- Line 1749: Constitution missing → "Add a constitution reference to AGENTS.md (e.g., ...)"
- Line 1773: Spec framework missing → "Add a Specification Workflow section to AGENTS.md..."

### Tests (`internal/doctor/doctor_test.go`)
- Updated `TestCheckAgentContext_NoFile` assertion
- Added `sectionName` field + `InstallHint` assertion to `TestCheckAgentContext_MissingTier1Section`
- Added `InstallHint` assertions to LineCount, ConstitutionReference, SpecFrameworkReference tests
- Extended `TestDoctorHints_NoBareUnboundReferences` with `/uf.` and `OpenCode` pattern checks
- Added `TestCheckAgentContext_ProjectAGENTSmdHasAllTier1Sections` drift-detection test

### Documentation
- `CHANGELOG.md` entry under `## Unreleased → ### Fixed`
- OpenSpec change artifacts at `openspec/changes/fix-doctor-hints/`

## Constitution Alignment

**Principle II (Composability First)**: `uf doctor` now produces actionable output without assuming any specific editor integration.

## Verification

- `go test -race -count=1 ./internal/doctor/...` — PASS
- `go vet ./...` — clean
- `golangci-lint run ./internal/doctor/...` — 0 issues
- Review council: 6/6 APPROVE