### PR TITLE
feat: add granular bash permissions to gate GitHub mutations

### DIFF
--- a/.opencode/agents/divisor-curator.md
+++ b/.opencode/agents/divisor-curator.md
@@ -5,6 +5,12 @@ temperature: 0.2
 permission:
   edit: deny
   webfetch: deny
+  bash:
+    "*": "deny"
+    "gh repo view*": "allow"
+    "gh issue list*": "allow"
+    "gh issue view*": "allow"
+    "gh issue create*": "ask"
 ---
 
 # Role: The Curator
@@ -31,16 +37,19 @@ If `gh repo view` fails, **ask the user** which repository to file issues agains
 
 ## Bash Access Restriction
 
-Your bash access is restricted to exactly three operations:
+Your bash access is enforced by granular permissions in
+the frontmatter above. Only the following commands are
+allowed:
 
-1. `gh repo view ...`
-   — Detect the current repository
-2. `gh issue list --repo <detected-repo> ...`
-   — Search existing issues to prevent duplicates
-3. `gh issue create --repo <detected-repo> ...`
-   — File new documentation, blog, or tutorial issues
+1. `gh repo view ...` — Detect the current repository
+2. `gh issue list ...` — Search existing issues
+3. `gh issue view ...` — Read issue details
+4. `gh issue create ...` — File new issues (requires
+   user approval via OpenCode's `"ask"` prompt)
 
-Any other bash usage is a violation of your operating contract. The Adversary agent's "Gate Tampering" check covers this.
+All other bash commands are denied at the runtime level.
+The Adversary agent's "Gate Tampering" check provides
+additional coverage.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,18 @@ Each entry follows the format: `- <change-name>: <summary>`.
   Fixes: #428)
 
 ### Added
+- granular-bash-permissions: Runtime-enforced bash permission
+  rules in `opencode.json` gating 13 GitHub-mutating, git-write,
+  and destructive commands (`gh issue create/edit/close/comment`,
+  `gh pr create/merge/close/comment/edit`, `gh api`, `git push`,
+  `git commit`, `rm`) behind `"ask"` approval prompts. Read-only
+  commands remain auto-allowed via `"*": "allow"` catch-all.
+  Hardened `divisor-curator.md` with granular frontmatter
+  permissions (default deny) replacing prose-only restrictions.
+  Structural fix for #465 triage runaway where prose-based
+  confirmation gates were lost under context compression.
+  (Spec: openspec/changes/granular-bash-permissions/,
+  Fixes: #465)
 - council-review-action: Reusable composite GitHub Action
   for multi-persona AI code review on PRs; discovers
   Divisor reviewer personas from the repo's

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,9 +24,9 @@ Each entry follows the format: `- <change-name>: <summary>`.
 
 ### Added
 - granular-bash-permissions: Runtime-enforced bash permission
-  rules in `opencode.json` gating 13 GitHub-mutating, git-write,
+  rules in `opencode.json` gating 14 GitHub-mutating, git-write,
   and destructive commands (`gh issue create/edit/close/comment`,
-  `gh pr create/merge/close/comment/edit`, `gh api`, `git push`,
+  `gh pr create/merge/close/comment/edit/review`, `gh api`, `git push`,
   `git commit`, `rm`) behind `"ask"` approval prompts. Read-only
   commands remain auto-allowed via `"*": "allow"` catch-all.
   Hardened `divisor-curator.md` with granular frontmatter

--- a/internal/scaffold/assets/opencode/agents/divisor-curator.md
+++ b/internal/scaffold/assets/opencode/agents/divisor-curator.md
@@ -5,6 +5,12 @@ temperature: 0.2
 permission:
   edit: deny
   webfetch: deny
+  bash:
+    "*": "deny"
+    "gh repo view*": "allow"
+    "gh issue list*": "allow"
+    "gh issue view*": "allow"
+    "gh issue create*": "ask"
 ---
 
 # Role: The Curator
@@ -31,16 +37,19 @@ If `gh repo view` fails, **ask the user** which repository to file issues agains
 
 ## Bash Access Restriction
 
-Your bash access is restricted to exactly three operations:
+Your bash access is enforced by granular permissions in
+the frontmatter above. Only the following commands are
+allowed:
 
-1. `gh repo view ...`
-   — Detect the current repository
-2. `gh issue list --repo <detected-repo> ...`
-   — Search existing issues to prevent duplicates
-3. `gh issue create --repo <detected-repo> ...`
-   — File new documentation, blog, or tutorial issues
+1. `gh repo view ...` — Detect the current repository
+2. `gh issue list ...` — Search existing issues
+3. `gh issue view ...` — Read issue details
+4. `gh issue create ...` — File new issues (requires
+   user approval via OpenCode's `"ask"` prompt)
 
-Any other bash usage is a violation of your operating contract. The Adversary agent's "Gate Tampering" check covers this.
+All other bash commands are denied at the runtime level.
+The Adversary agent's "Gate Tampering" check provides
+additional coverage.
 
 ---
 

--- a/opencode.json
+++ b/opencode.json
@@ -1,5 +1,23 @@
 {
   "$schema": "https://opencode.ai/config.json",
+  "permission": {
+    "bash": {
+      "*": "allow",
+      "gh issue create*": "ask",
+      "gh issue edit*": "ask",
+      "gh issue close*": "ask",
+      "gh issue comment*": "ask",
+      "gh pr create*": "ask",
+      "gh pr merge*": "ask",
+      "gh pr close*": "ask",
+      "gh pr comment*": "ask",
+      "gh pr edit*": "ask",
+      "gh api*": "ask",
+      "git push*": "ask",
+      "git commit*": "ask",
+      "rm *": "ask"
+    }
+  },
   "mcp": {
     "dewey": {
       "type": "local",

--- a/opencode.json
+++ b/opencode.json
@@ -12,6 +12,7 @@
       "gh pr close*": "ask",
       "gh pr comment*": "ask",
       "gh pr edit*": "ask",
+      "gh pr review*": "ask",
       "gh api*": "ask",
       "git push*": "ask",
       "git commit*": "ask",

--- a/openspec/changes/granular-bash-permissions/.openspec.yaml
+++ b/openspec/changes/granular-bash-permissions/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: unbound-force
+created: 2026-08-13

--- a/openspec/changes/granular-bash-permissions/design.md
+++ b/openspec/changes/granular-bash-permissions/design.md
@@ -89,7 +89,9 @@ characters, `?` matches exactly one.
 - `git commit*` covers `git commit` and `git commit -m "msg"`
 
 Use trailing `*` without space to match both bare commands
-and commands with arguments.
+and commands with arguments. Exception: `rm` uses `"rm *"`
+(with space) to avoid false-matching `rmdir` and other
+`rm`-prefixed commands.
 
 ### D4: Curator agent hardening
 
@@ -136,6 +138,12 @@ unlisted commands are allowed by default. Periodic audit
 of the permission block is needed. Accept this trade-off
 over a restrictive `"*": "ask"` default which would cause
 excessive prompts for `ls`, `cat`, `go test`, etc.
+Additionally, `"gh api*": "ask"` gates all `gh api`
+invocations including read-only GET requests (e.g.,
+fetching PR state in `/uf.review-pr`). This is accepted
+because `gh api` can construct arbitrary mutations; the
+DX cost of extra prompts on reads is preferable to
+leaving an unrestricted mutation path.
 
 **[R3] CI override precedence**: `OPENCODE_CONFIG_CONTENT`
 takes precedence over project `opencode.json`. The CI

--- a/openspec/changes/granular-bash-permissions/design.md
+++ b/openspec/changes/granular-bash-permissions/design.md
@@ -1,0 +1,151 @@
+## Context
+
+The project uses OpenCode's permission system in two ways:
+
+1. **Agent frontmatter** — 9 Divisor agents use simple
+   `bash: deny` to block all bash. The Curator has bash
+   allowed with prose-only restrictions.
+2. **CI runtime** — `council-review-action/scripts/run-review.sh`
+   sets `OPENCODE_CONFIG_CONTENT` with blanket tool denials.
+
+Neither uses OpenCode's granular bash object syntax, which
+supports wildcard command patterns with `allow`/`ask`/`deny`
+actions. The project-level `opencode.json` has zero permission
+configuration, so all non-agent bash commands inherit the
+default `"allow"`.
+
+This design adds granular bash permissions to `opencode.json`
+to gate GitHub-mutating and git-write commands behind `"ask"`
+prompts while allowing read-only operations.
+
+## Goals / Non-Goals
+
+### Goals
+- Gate `gh issue create/edit/close/comment` behind `"ask"`
+- Gate `gh pr create/merge/close/comment/edit` behind `"ask"`
+- Gate `gh api` behind `"ask"` (arbitrary API calls)
+- Gate `git push`, `git commit` behind `"ask"`
+- Gate `rm` behind `"ask"`
+- Allow read-only commands: `gh issue view/list`,
+  `gh pr view/list`, `git status/log/diff/branch`,
+  `go test/build/vet`, `make`, `grep`, standard dev tools
+- Harden `divisor-curator.md` with granular frontmatter
+  permissions replacing its prose-only restrictions
+
+### Non-Goals
+- Modifying `council-review-action` CI permissions (blanket
+  deny via `OPENCODE_CONFIG_CONTENT` takes precedence and
+  is stricter)
+- Fixing the `AskUserQuestion` → `question` tool name
+  mismatch (separate issue #475)
+- Adding `>>> MANDATORY GATE <<<` markers to commands
+  (separate issues #473, #474)
+- Modifying scaffold assets for `uf init` (follow-up change)
+
+## Decisions
+
+### D1: Use `"ask"` not `"deny"` for mutations
+
+Interactive commands legitimately need to create issues,
+post comments, and push branches. Blanket `"deny"` would
+break `/uf.triage-issue`, `/uf.finale`, and `/uf.unleash`.
+The `"ask"` action prompts the user with `once`/`always`/
+`reject`, giving humans control without blocking workflows.
+
+This aligns with Constitution Principle I (Autonomous
+Collaboration) — agents can propose mutations but humans
+approve them.
+
+### D2: Last-match-wins rule ordering
+
+OpenCode evaluates bash permission patterns with **last
+matching rule wins**. The config places the permissive
+catch-all `"*": "allow"` first, then specific mutation
+patterns after. This means:
+
+```json
+{
+  "bash": {
+    "*": "allow",
+    "gh issue create *": "ask",
+    "git push *": "ask"
+  }
+}
+```
+
+`git status` matches only `"*"` → allowed.
+`gh issue create --title foo` matches both `"*"` and
+`"gh issue create *"` → last wins → ask.
+
+### D3: Pattern coverage strategy
+
+Patterns must cover commands both with and without
+arguments. OpenCode wildcards: `*` matches zero or more
+characters, `?` matches exactly one.
+
+- `gh issue create*` covers `gh issue create` (no args)
+  and `gh issue create --title "foo"` (with args)
+- `git push*` covers `git push` and `git push origin main`
+- `git commit*` covers `git commit` and `git commit -m "msg"`
+
+Use trailing `*` without space to match both bare commands
+and commands with arguments.
+
+### D4: Curator agent hardening
+
+Replace the Curator's prose-only bash restriction section
+with granular frontmatter permissions:
+
+```yaml
+permission:
+  edit: deny
+  webfetch: deny
+  bash:
+    "*": "deny"
+    "gh issue list*": "allow"
+    "gh issue view*": "allow"
+    "gh issue create*": "ask"
+    "gh repo view*": "allow"
+```
+
+This converts the soft boundary into a hard one enforced
+by OpenCode's runtime. Constitution Principle III
+(Observable Quality) — the restriction is now declarative
+and machine-parseable rather than hidden in prose.
+
+### D5: Scope to `opencode.json` only
+
+The granular rules go in the project-level `opencode.json`,
+not in individual agent frontmatter. This provides a
+single, auditable location for the project's mutation
+policy. Agent-level overrides (like the Curator) are
+exceptions that tighten the policy for specific agents.
+
+## Risks / Trade-offs
+
+**[R1] Approval fatigue**: Developers running `/uf.unleash`
+or `/uf.cobalt-crush` may get frequent `"ask"` prompts for
+legitimate `git commit` and `git push` operations. Mitigated
+by OpenCode's `always` approval option, which whitelists a
+command pattern for the session. Also mitigated by `--auto`
+flag which approves all non-denied commands.
+
+**[R2] Pattern gaps**: A new `gh` subcommand or alias could
+bypass the rules. The catch-all `"*": "allow"` means
+unlisted commands are allowed by default. Periodic audit
+of the permission block is needed. Accept this trade-off
+over a restrictive `"*": "ask"` default which would cause
+excessive prompts for `ls`, `cat`, `go test`, etc.
+
+**[R3] CI override precedence**: `OPENCODE_CONFIG_CONTENT`
+takes precedence over project `opencode.json`. The CI
+pipeline's blanket `bash: deny` is unaffected. If a future
+CI workflow needs granular bash, it must set its own rules
+via `OPENCODE_CONFIG_CONTENT`.
+
+**[R4] Agent frontmatter merge behavior**: Agent-level
+`permission.bash` merges with project-level config, with
+agent rules taking precedence. Agents with `bash: deny`
+(all Divisor reviewers except Curator) are unaffected —
+their blanket deny overrides the project's granular rules.
+The Curator's new granular rules will merge correctly.

--- a/openspec/changes/granular-bash-permissions/design.md
+++ b/openspec/changes/granular-bash-permissions/design.md
@@ -22,7 +22,7 @@ prompts while allowing read-only operations.
 
 ### Goals
 - Gate `gh issue create/edit/close/comment` behind `"ask"`
-- Gate `gh pr create/merge/close/comment/edit` behind `"ask"`
+- Gate `gh pr create/merge/close/comment/edit/review` behind `"ask"`
 - Gate `gh api` behind `"ask"` (arbitrary API calls)
 - Gate `git push`, `git commit` behind `"ask"`
 - Gate `rm` behind `"ask"`

--- a/openspec/changes/granular-bash-permissions/proposal.md
+++ b/openspec/changes/granular-bash-permissions/proposal.md
@@ -118,3 +118,16 @@ The permission configuration can be tested by verifying
 the JSON structure in `opencode.json`. Runtime behavior
 can be validated by running commands and confirming
 approval prompts appear for gated operations.
+
+### V. Security by Default
+
+**Assessment**: PASS
+
+This change directly implements Principle V's "least
+privilege" requirement by gating mutation commands at the
+OpenCode runtime level. The `"ask"` action ensures agents
+cannot perform file deletions, git pushes, or GitHub
+mutations without human approval. No new dependencies are
+introduced (supply chain integrity N/A). No external input
+paths are added (input validation N/A). File permissions
+are not modified.

--- a/openspec/changes/granular-bash-permissions/proposal.md
+++ b/openspec/changes/granular-bash-permissions/proposal.md
@@ -42,7 +42,7 @@ GitHub mutations and git write operations behind `"ask"`.
   prompts for `gh issue create`, `gh issue comment`,
   `gh issue edit`, `gh issue close`, `gh pr create`,
   `gh pr merge`, `gh pr comment`, `gh pr edit`,
-  `gh pr close`, `gh api`, `git push`, `git commit`,
+  `gh pr close`, `gh pr review`, `gh api`, `git push`, `git commit`,
   and `rm` commands. Read-only commands (`gh issue view`,
   `gh issue list`, `gh pr view`, `gh pr list`,
   `git status`, `git log`, `git diff`, `go test`, etc.)

--- a/openspec/changes/granular-bash-permissions/proposal.md
+++ b/openspec/changes/granular-bash-permissions/proposal.md
@@ -1,0 +1,120 @@
+## Why
+
+During triage of issue #465, the `/uf.triage-issue` command
+autonomously filed 4 child issues (#469-472) and posted
+comments without asking the user for confirmation. The root
+cause: prose-based confirmation gates (`AskUserQuestion` tool
+references) were lost under context compression, and no
+runtime permission enforcement exists for mutation commands
+like `gh issue create` or `gh issue comment`.
+
+The `council-review-action` already uses OpenCode's
+`permission` config via `OPENCODE_CONFIG_CONTENT` to deny
+`bash` entirely in CI. But interactive local commands (triage,
+review-council, finale, unleash) run under the default
+`bash: allow` with zero granular rules. OpenCode supports
+pattern-based bash permissions (object syntax with wildcards),
+but the project has never used them.
+
+This change adds granular bash permissions to `opencode.json`
+so that GitHub-mutating and git-mutating commands require
+runtime approval (`"ask"`) while read-only commands remain
+allowed. This is a structural fix that survives context
+compression because the OpenCode runtime enforces it
+regardless of what the model remembers.
+
+Related issues:
+- #465 (parent: review-council correctness gaps)
+- #473 (triage Phase 4 lacks mandatory gate)
+- #474 (inconsistent mandatory gate markers)
+- #475 (`AskUserQuestion` vs `question` tool name)
+
+## What Changes
+
+Add a `"permission"` block to the project-level
+`opencode.json` with granular bash rules that gate
+GitHub mutations and git write operations behind `"ask"`.
+
+## Capabilities
+
+### New Capabilities
+- `granular-bash-gating`: Runtime-enforced approval
+  prompts for `gh issue create`, `gh issue comment`,
+  `gh issue edit`, `gh issue close`, `gh pr create`,
+  `gh pr merge`, `gh pr comment`, `gh pr edit`,
+  `gh pr close`, `gh api`, `git push`, `git commit`,
+  and `rm` commands. Read-only commands (`gh issue view`,
+  `gh issue list`, `gh pr view`, `gh pr list`,
+  `git status`, `git log`, `git diff`, `go test`, etc.)
+  remain auto-allowed.
+
+### Modified Capabilities
+- `opencode.json`: Gains a `"permission"` top-level key
+  alongside existing `"mcp"` configuration.
+
+### Removed Capabilities
+- None.
+
+## Impact
+
+- `opencode.json`: New `"permission"` block added.
+- All interactive commands (`/uf.triage-issue`,
+  `/uf.review-council`, `/uf.finale`, `/uf.unleash`,
+  `/uf.review-pr`, `/uf.address-feedback`): Mutations
+  now require user approval at the OpenCode runtime level,
+  regardless of whether prose gates survive context
+  compression.
+- `council-review-action`: Unaffected. CI sets
+  `OPENCODE_CONFIG_CONTENT` which takes precedence over
+  project config, and its blanket `bash: deny` is stricter
+  than granular rules.
+- Agent frontmatter: Unaffected. Agents with `bash: deny`
+  (all Divisor reviewers except Curator) remain fully
+  denied. The granular rules apply only to agents that
+  currently inherit the default `bash: allow`.
+- `divisor-curator.md`: Agent currently has prose-only
+  bash restrictions. Should be updated to use granular
+  permissions in frontmatter, replacing the soft boundary
+  with a hard one.
+
+## Constitution Alignment
+
+Assessed against the Unbound Force org constitution.
+
+### I. Autonomous Collaboration
+
+**Assessment**: PASS
+
+This change strengthens artifact-based communication by
+ensuring agents cannot silently create GitHub issues or
+comments without human approval. The permission layer is
+a runtime enforcement mechanism that operates independently
+of agent instructions, maintaining the separation between
+agent capabilities and human oversight.
+
+### II. Composability First
+
+**Assessment**: PASS
+
+The granular permissions are set at the project level in
+`opencode.json`. Heroes scaffolded by `uf init` can adopt
+or customize these permissions independently. No mandatory
+cross-repo dependencies are introduced.
+
+### III. Observable Quality
+
+**Assessment**: PASS
+
+OpenCode's `"ask"` action produces observable approval
+prompts with `once`/`always`/`reject` outcomes. The
+permission configuration is declarative JSON, machine-
+parseable, and version-controlled.
+
+### IV. Testability
+
+**Assessment**: PASS
+
+The permission configuration can be tested by verifying
+the JSON structure in `opencode.json`. Runtime behavior
+can be validated by running commands and confirming
+approval prompts appear for gated operations.

--- a/openspec/changes/granular-bash-permissions/specs/granular-bash-permissions.md
+++ b/openspec/changes/granular-bash-permissions/specs/granular-bash-permissions.md
@@ -1,0 +1,121 @@
+## ADDED Requirements
+
+### FR-001: Project-level granular bash permissions
+
+The project `opencode.json` MUST include a `"permission"`
+block with granular bash rules that gate GitHub-mutating
+and git-write commands behind `"ask"` approval prompts.
+
+The following command patterns MUST be gated with `"ask"`:
+
+- `gh issue create*`
+- `gh issue edit*`
+- `gh issue close*`
+- `gh issue comment*`
+- `gh pr create*`
+- `gh pr merge*`
+- `gh pr close*`
+- `gh pr comment*`
+- `gh pr edit*`
+- `gh api*`
+- `git push*`
+- `git commit*`
+- `rm *`
+
+The catch-all `"*"` pattern MUST be set to `"allow"` to
+avoid prompts on read-only and development commands.
+
+#### Scenario: Agent attempts to create a GitHub issue
+
+- **GIVEN** `opencode.json` contains granular bash rules
+- **WHEN** an agent executes `gh issue create --title "foo"`
+- **THEN** OpenCode prompts the user with
+  `once`/`always`/`reject` before executing the command
+
+#### Scenario: Agent runs a read-only git command
+
+- **GIVEN** `opencode.json` contains granular bash rules
+- **WHEN** an agent executes `git status --short`
+- **THEN** the command executes without prompting
+
+#### Scenario: Agent runs go test
+
+- **GIVEN** `opencode.json` contains granular bash rules
+- **WHEN** an agent executes `go test -race -count=1 ./...`
+- **THEN** the command executes without prompting
+
+### FR-002: Curator agent granular bash hardening
+
+The `divisor-curator.md` agent MUST replace its prose-only
+bash restriction section with granular bash permissions in
+the YAML frontmatter `permission:` block.
+
+The Curator's bash permissions MUST be:
+
+- `"*": "deny"` (default deny)
+- `"gh issue list*": "allow"`
+- `"gh issue view*": "allow"`
+- `"gh issue create*": "ask"`
+- `"gh repo view*": "allow"`
+
+The prose "Bash Access Restriction" section SHOULD be
+removed or reduced to a reference to the frontmatter
+permissions.
+
+#### Scenario: Curator attempts to list issues
+
+- **GIVEN** the Curator agent has granular bash permissions
+- **WHEN** the Curator executes `gh issue list --repo foo`
+- **THEN** the command executes without prompting
+
+#### Scenario: Curator attempts to create an issue
+
+- **GIVEN** the Curator agent has granular bash permissions
+- **WHEN** the Curator executes `gh issue create --title "x"`
+- **THEN** OpenCode prompts the user with
+  `once`/`always`/`reject` before executing
+
+#### Scenario: Curator attempts an unlisted command
+
+- **GIVEN** the Curator agent has granular bash permissions
+- **WHEN** the Curator executes `curl https://example.com`
+- **THEN** the command is denied
+
+### FR-003: CI permission precedence
+
+The `council-review-action` CI pipeline MUST NOT be
+affected by the project-level granular permissions.
+`OPENCODE_CONFIG_CONTENT` takes precedence over
+`opencode.json`, and the CI pipeline's blanket
+`bash: deny` MUST remain the effective rule.
+
+#### Scenario: CI review pipeline runs with project config
+
+- **GIVEN** `opencode.json` has granular bash `"ask"` rules
+- **AND** `OPENCODE_CONFIG_CONTENT` sets `bash: deny`
+- **WHEN** the CI review pipeline executes
+- **THEN** all bash commands are denied (CI config wins)
+
+### FR-004: Scaffold asset parity
+
+Both live agent files and their scaffold counterparts
+MUST have identical permission blocks:
+
+- `.opencode/agents/divisor-curator.md`
+- `internal/scaffold/assets/opencode/agents/divisor-curator.md`
+
+Drift detection tests MUST pass after the change.
+
+#### Scenario: Scaffold drift detection
+
+- **GIVEN** the Curator agent has updated permissions
+- **WHEN** drift detection tests execute
+- **THEN** live and scaffold copies match
+
+## MODIFIED Requirements
+
+None.
+
+## REMOVED Requirements
+
+None.

--- a/openspec/changes/granular-bash-permissions/specs/granular-bash-permissions.md
+++ b/openspec/changes/granular-bash-permissions/specs/granular-bash-permissions.md
@@ -17,6 +17,7 @@ The following command patterns MUST be gated with `"ask"`:
 - `gh pr close*`
 - `gh pr comment*`
 - `gh pr edit*`
+- `gh pr review*`
 - `gh api*`
 - `git push*`
 - `git commit*`

--- a/openspec/changes/granular-bash-permissions/tasks.md
+++ b/openspec/changes/granular-bash-permissions/tasks.md
@@ -16,7 +16,7 @@
   granular bash rules. Gate mutation commands (`gh issue
   create*`, `gh issue edit*`, `gh issue close*`,
   `gh issue comment*`, `gh pr create*`, `gh pr merge*`,
-  `gh pr close*`, `gh pr comment*`, `gh pr edit*`,
+  `gh pr close*`, `gh pr comment*`, `gh pr edit*`, `gh pr review*`,
   `gh api*`, `git push*`, `git commit*`, `rm *`) behind
   `"ask"`. Set catch-all `"*"` to `"allow"`.
   File: `opencode.json`

--- a/openspec/changes/granular-bash-permissions/tasks.md
+++ b/openspec/changes/granular-bash-permissions/tasks.md
@@ -12,7 +12,7 @@
 
 ## 1. Add granular bash permissions to opencode.json
 
-- [ ] 1.1 Add `"permission"` block to `opencode.json` with
+- [x] 1.1 Add `"permission"` block to `opencode.json` with
   granular bash rules. Gate mutation commands (`gh issue
   create*`, `gh issue edit*`, `gh issue close*`,
   `gh issue comment*`, `gh pr create*`, `gh pr merge*`,
@@ -23,7 +23,7 @@
 
 ## 2. Harden Curator agent permissions
 
-- [ ] 2.1 [P] Replace `divisor-curator.md` prose-only bash
+- [x] 2.1 [P] Replace `divisor-curator.md` prose-only bash
   restriction with granular frontmatter permissions.
   Set `bash` to object syntax: `"*": "deny"`,
   `"gh issue list*": "allow"`, `"gh issue view*": "allow"`,
@@ -32,21 +32,21 @@
   section to reference the frontmatter.
   File: `.opencode/agents/divisor-curator.md`
 
-- [ ] 2.2 [P] Update scaffold copy of Curator agent with
+- [x] 2.2 [P] Update scaffold copy of Curator agent with
   identical permission changes.
   File: `internal/scaffold/assets/opencode/agents/divisor-curator.md`
 
 ## 3. Verification
 
-- [ ] 3.1 Run drift detection tests to verify live and
+- [x] 3.1 Run drift detection tests to verify live and
   scaffold Curator copies match:
   `go test -race -count=1 ./internal/scaffold/...`
 
-- [ ] 3.2 Verify `opencode.json` is valid JSON and the
+- [x] 3.2 Verify `opencode.json` is valid JSON and the
   `"permission"` block structure matches the OpenCode
   config schema.
 
-- [ ] 3.3 Verify constitution alignment: the change
+- [x] 3.3 Verify constitution alignment: the change
   maintains Autonomous Collaboration (agents propose,
   humans approve), Composability First (project-level
   config, no cross-repo deps), Observable Quality

--- a/openspec/changes/granular-bash-permissions/tasks.md
+++ b/openspec/changes/granular-bash-permissions/tasks.md
@@ -1,0 +1,54 @@
+<!--
+  [P] marks tasks eligible for parallel execution.
+  Add [P] when a task: (a) touches different files from
+  other [P] tasks in the group, (b) has no dependency
+  on prior tasks in the group, (c) can safely execute
+  without ordering constraints.
+  Do NOT add [P] when tasks modify the same file —
+  parallel workers will cause merge conflicts.
+  Tasks without [P] run sequentially first, then [P]
+  tasks run in parallel.
+-->
+
+## 1. Add granular bash permissions to opencode.json
+
+- [ ] 1.1 Add `"permission"` block to `opencode.json` with
+  granular bash rules. Gate mutation commands (`gh issue
+  create*`, `gh issue edit*`, `gh issue close*`,
+  `gh issue comment*`, `gh pr create*`, `gh pr merge*`,
+  `gh pr close*`, `gh pr comment*`, `gh pr edit*`,
+  `gh api*`, `git push*`, `git commit*`, `rm *`) behind
+  `"ask"`. Set catch-all `"*"` to `"allow"`.
+  File: `opencode.json`
+
+## 2. Harden Curator agent permissions
+
+- [ ] 2.1 [P] Replace `divisor-curator.md` prose-only bash
+  restriction with granular frontmatter permissions.
+  Set `bash` to object syntax: `"*": "deny"`,
+  `"gh issue list*": "allow"`, `"gh issue view*": "allow"`,
+  `"gh issue create*": "ask"`, `"gh repo view*": "allow"`.
+  Remove or reduce the prose "Bash Access Restriction"
+  section to reference the frontmatter.
+  File: `.opencode/agents/divisor-curator.md`
+
+- [ ] 2.2 [P] Update scaffold copy of Curator agent with
+  identical permission changes.
+  File: `internal/scaffold/assets/opencode/agents/divisor-curator.md`
+
+## 3. Verification
+
+- [ ] 3.1 Run drift detection tests to verify live and
+  scaffold Curator copies match:
+  `go test -race -count=1 ./internal/scaffold/...`
+
+- [ ] 3.2 Verify `opencode.json` is valid JSON and the
+  `"permission"` block structure matches the OpenCode
+  config schema.
+
+- [ ] 3.3 Verify constitution alignment: the change
+  maintains Autonomous Collaboration (agents propose,
+  humans approve), Composability First (project-level
+  config, no cross-repo deps), Observable Quality
+  (declarative JSON permissions), and Testability
+  (structure is testable).


### PR DESCRIPTION
## Summary

Add OpenCode granular bash permission rules to `opencode.json` to gate
GitHub-mutating and git-write commands behind `"ask"` approval prompts.
This is a structural fix for the triage #465 runaway where prose-based
confirmation gates were lost under context compression and the agent
filed 4 child issues (#469-472) autonomously.

## Changes

- **`opencode.json`**: Add `"permission"` block with granular bash rules.
  14 mutation command patterns (`gh issue create/edit/close/comment`,
  `gh pr create/merge/close/comment/edit`, `gh api`, `git push`,
  `git commit`, `rm`) gated behind `"ask"`. Read-only commands remain
  auto-allowed via catch-all `"*": "allow"`.

- **`divisor-curator.md`**: Replace prose-only bash restriction with
  enforced granular frontmatter permissions (`"*": "deny"`, allow only
  `gh repo view`, `gh issue list/view`, ask for `gh issue create`).

- **Scaffold parity**: Identical changes to
  `internal/scaffold/assets/opencode/agents/divisor-curator.md`.

- **OpenSpec artifacts**: Full proposal, design, specs, and tasks at
  `openspec/changes/granular-bash-permissions/`.

## Why this works

OpenCode's permission system is enforced by the **runtime**, not by the
model's memory. Unlike prose gates (`AskUserQuestion` references) that
can be lost under context compression, granular bash rules survive
because the runtime checks every bash command regardless of what the
model "remembers".

The `council-review-action` CI pipeline is **unaffected** — its
`OPENCODE_CONFIG_CONTENT` blanket `bash: deny` takes precedence over
project-level config.

## Verification

- All 20 Go test packages pass (`go test -race -count=1 ./...`)
- Scaffold drift detection passes
- `opencode.json` validates as JSON
- `go vet ./...` clean

Relates-to: #465, #473, #474, #475