### PR TITLE
fix: add explicit autonomy guardrails to /uf.unleash pipeline

### DIFF
--- a/.opencode/commands/uf.unleash.md
+++ b/.opencode/commands/uf.unleash.md
@@ -75,7 +75,8 @@ If `swarm_worktree_list` is not available (Replicator
 not installed), skip this step silently.
 
 > CHECKPOINT: Mark Step 0 complete in the execution
-> checklist before proceeding.
+> checklist before proceeding. Proceed immediately to
+> Step 1. Do NOT ask for confirmation.
 
 ### 1. Branch Safety Gate
 
@@ -129,7 +130,8 @@ git rev-parse --abbrev-ref HEAD
   > `/opsx-propose` to create one."
 
 > CHECKPOINT: Mark Step 1 complete in the execution
-> checklist before proceeding.
+> checklist before proceeding. Proceed immediately to
+> Step 2. Do NOT ask for confirmation.
 
 ### 2. Resumability Detection
 
@@ -192,7 +194,8 @@ skip directly to step 7 (retrospective) since it is
 idempotent.
 
 > CHECKPOINT: Mark Step 2 complete in the execution
-> checklist before proceeding.
+> checklist before proceeding. Proceed immediately to
+> Step 3. Do NOT ask for confirmation.
 
 ### 3. Step 1 -- Clarify
 
@@ -270,7 +273,8 @@ needed" and proceed to step 2.
   ```
 
 > CHECKPOINT: Mark Step 3 complete in the execution
-> checklist before proceeding.
+> checklist before proceeding. Proceed immediately to
+> Step 4. Do NOT ask for confirmation.
 
 ### 4. Step 2 -- Plan
 
@@ -294,7 +298,8 @@ Generate the implementation plan by delegating to the
    > Check the agent output for errors."
 
 > CHECKPOINT: Mark Step 4 complete in the execution
-> checklist before proceeding.
+> checklist before proceeding. Proceed immediately to
+> Step 5. Do NOT ask for confirmation.
 
 ### 5. Step 3 -- Tasks
 
@@ -317,7 +322,8 @@ Generate the task list by delegating to the
    > Check the agent output for errors."
 
 > CHECKPOINT: Mark Step 5 complete in the execution
-> checklist before proceeding.
+> checklist before proceeding. Proceed immediately to
+> Step 6. Do NOT ask for confirmation.
 
 ### 6. Step 4 -- Spec Review
 
@@ -377,7 +383,8 @@ analysis + quality validation) in a single pass.
   ```
 
 > CHECKPOINT: Mark Step 6 complete in the execution
-> checklist before proceeding.
+> checklist before proceeding. Proceed immediately to
+> Step 7. Do NOT ask for confirmation.
 
 ### 7. Step 5 -- Implement
 
@@ -534,7 +541,8 @@ logic used by `/uf.review-council` and `/uf.review-pr`.
      ```
 
 > CHECKPOINT: Mark Step 7 complete in the execution
-> checklist before proceeding.
+> checklist before proceeding. Proceed immediately to
+> Step 8. Do NOT ask for confirmation.
 
 ### 8. Step 6 -- Code Review
 
@@ -605,7 +613,8 @@ quality data.
   ```
 
 > CHECKPOINT: Mark Step 8 complete in the execution
-> checklist before proceeding.
+> checklist before proceeding. Proceed immediately to
+> Step 9. Do NOT ask for confirmation.
 
 ### 9. Step 7 -- Retrospective
 
@@ -644,7 +653,8 @@ memory.
    lost.
 
 > CHECKPOINT: Mark Step 9 complete in the execution
-> checklist before proceeding.
+> checklist before proceeding. Proceed immediately to
+> Step 10. Do NOT ask for confirmation.
 
 ### 10. Step 8 -- Demo
 
@@ -724,6 +734,13 @@ Format the output as:
 
 ## Guardrails
 
+- **NEVER pause between steps to ask for human
+  confirmation** -- proceed immediately from one step to
+  the next. The only valid reasons to exit the pipeline
+  are: unanswerable clarification questions,
+  HIGH/CRITICAL spec findings, build/test failures,
+  merge conflicts, and 3 review iterations exhausted.
+  All other transitions are autonomous.
 - **NEVER run on `main`** -- the command is for Speckit
   (`NNN-*`) and OpenSpec (`opsx/*`) feature branches
 - **NEVER skip spec review exit on HIGH/CRITICAL** --

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,16 @@ Each entry follows the format: `- <change-name>: <summary>`.
   Adds regression guards for `/uf.` and `OpenCode` references
   in hints, and a drift-detection test for Tier 1 sections.
   (Spec: openspec/changes/fix-doctor-hints/, Fixes: #460)
+- fix-unleash-autonomy: `/uf.unleash` no longer halts
+  between pipeline steps to ask for human confirmation.
+  Added an inter-step autonomy guardrail and explicit
+  "proceed immediately" transition instructions at all
+  10 step checkpoints (Steps 0-9). All existing
+  STOP/EXIT conditions (HIGH/CRITICAL spec findings,
+  build failures, merge conflicts, review iteration
+  exhaustion) remain unchanged.
+  (Spec: openspec/changes/fix-unleash-autonomy/,
+  Fixes: #457)
 - fix-specify-init-invocation: Fixed `uf init` failing
   to create `.specify/` directory due to upstream
   specify-cli interface changes. Updated specify

--- a/internal/scaffold/assets/opencode/commands/uf.unleash.md
+++ b/internal/scaffold/assets/opencode/commands/uf.unleash.md
@@ -75,7 +75,8 @@ If `swarm_worktree_list` is not available (Replicator
 not installed), skip this step silently.
 
 > CHECKPOINT: Mark Step 0 complete in the execution
-> checklist before proceeding.
+> checklist before proceeding. Proceed immediately to
+> Step 1. Do NOT ask for confirmation.
 
 ### 1. Branch Safety Gate
 
@@ -129,7 +130,8 @@ git rev-parse --abbrev-ref HEAD
   > `/opsx-propose` to create one."
 
 > CHECKPOINT: Mark Step 1 complete in the execution
-> checklist before proceeding.
+> checklist before proceeding. Proceed immediately to
+> Step 2. Do NOT ask for confirmation.
 
 ### 2. Resumability Detection
 
@@ -192,7 +194,8 @@ skip directly to step 7 (retrospective) since it is
 idempotent.
 
 > CHECKPOINT: Mark Step 2 complete in the execution
-> checklist before proceeding.
+> checklist before proceeding. Proceed immediately to
+> Step 3. Do NOT ask for confirmation.
 
 ### 3. Step 1 -- Clarify
 
@@ -270,7 +273,8 @@ needed" and proceed to step 2.
   ```
 
 > CHECKPOINT: Mark Step 3 complete in the execution
-> checklist before proceeding.
+> checklist before proceeding. Proceed immediately to
+> Step 4. Do NOT ask for confirmation.
 
 ### 4. Step 2 -- Plan
 
@@ -294,7 +298,8 @@ Generate the implementation plan by delegating to the
    > Check the agent output for errors."
 
 > CHECKPOINT: Mark Step 4 complete in the execution
-> checklist before proceeding.
+> checklist before proceeding. Proceed immediately to
+> Step 5. Do NOT ask for confirmation.
 
 ### 5. Step 3 -- Tasks
 
@@ -317,7 +322,8 @@ Generate the task list by delegating to the
    > Check the agent output for errors."
 
 > CHECKPOINT: Mark Step 5 complete in the execution
-> checklist before proceeding.
+> checklist before proceeding. Proceed immediately to
+> Step 6. Do NOT ask for confirmation.
 
 ### 6. Step 4 -- Spec Review
 
@@ -377,7 +383,8 @@ analysis + quality validation) in a single pass.
   ```
 
 > CHECKPOINT: Mark Step 6 complete in the execution
-> checklist before proceeding.
+> checklist before proceeding. Proceed immediately to
+> Step 7. Do NOT ask for confirmation.
 
 ### 7. Step 5 -- Implement
 
@@ -534,7 +541,8 @@ logic used by `/uf.review-council` and `/uf.review-pr`.
      ```
 
 > CHECKPOINT: Mark Step 7 complete in the execution
-> checklist before proceeding.
+> checklist before proceeding. Proceed immediately to
+> Step 8. Do NOT ask for confirmation.
 
 ### 8. Step 6 -- Code Review
 
@@ -605,7 +613,8 @@ quality data.
   ```
 
 > CHECKPOINT: Mark Step 8 complete in the execution
-> checklist before proceeding.
+> checklist before proceeding. Proceed immediately to
+> Step 9. Do NOT ask for confirmation.
 
 ### 9. Step 7 -- Retrospective
 
@@ -644,7 +653,8 @@ memory.
    lost.
 
 > CHECKPOINT: Mark Step 9 complete in the execution
-> checklist before proceeding.
+> checklist before proceeding. Proceed immediately to
+> Step 10. Do NOT ask for confirmation.
 
 ### 10. Step 8 -- Demo
 
@@ -724,6 +734,13 @@ Format the output as:
 
 ## Guardrails
 
+- **NEVER pause between steps to ask for human
+  confirmation** -- proceed immediately from one step to
+  the next. The only valid reasons to exit the pipeline
+  are: unanswerable clarification questions,
+  HIGH/CRITICAL spec findings, build/test failures,
+  merge conflicts, and 3 review iterations exhausted.
+  All other transitions are autonomous.
 - **NEVER run on `main`** -- the command is for Speckit
   (`NNN-*`) and OpenSpec (`opsx/*`) feature branches
 - **NEVER skip spec review exit on HIGH/CRITICAL** --

--- a/openspec/changes/fix-unleash-autonomy/.openspec.yaml
+++ b/openspec/changes/fix-unleash-autonomy/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: unbound-force
+created: 2026-08-12

--- a/openspec/changes/fix-unleash-autonomy/design.md
+++ b/openspec/changes/fix-unleash-autonomy/design.md
@@ -1,0 +1,123 @@
+## Context
+
+`/uf.unleash` executes a sequential pipeline (Steps 0-10)
+designed for fully autonomous operation. The command file
+(`uf.unleash.md`) contains 8 guardrails and 11 checkpoint
+instructions. Agents are halting between steps to ask for
+human confirmation because:
+
+1. No guardrail explicitly prohibits inter-step
+   confirmation-seeking
+2. Checkpoint instructions say "before proceeding" without
+   specifying what "proceeding" means (immediate
+   continuation vs. awaiting permission)
+
+The prior learning `inline-stop-instructions-1` established
+that behavioral instructions MUST be positioned at the
+decision point. This fix applies that same pattern --
+placing "proceed immediately" instructions at each
+transition checkpoint.
+
+## Goals / Non-Goals
+
+### Goals
+- Add an explicit autonomy guardrail to the Guardrails
+  section prohibiting inter-step confirmation-seeking
+- Add explicit "proceed immediately" transition
+  instructions at all step checkpoints that precede
+  another step (Steps 0-9)
+- Audit all 11 checkpoint transitions for consistency,
+  not just the three identified in the issue (7->8,
+  8->9, 9->10)
+- Preserve all existing STOP/EXIT conditions unchanged
+
+### Non-Goals
+- Modifying the pipeline's step logic or order
+- Changing the documented exit points (HIGH/CRITICAL
+  findings, build failures, merge conflicts, review
+  iteration exhaustion)
+- Adding automated testing for prompt behavior (not
+  feasible for prompt engineering changes)
+- Modifying the scaffold engine or Go source code
+
+## Decisions
+
+### D1: Audit all 11 checkpoints, not just 3
+
+The issue identifies Steps 7->8, 8->9, and 9->10 as
+affected. However, the same ambiguous "before proceeding"
+language appears at all 11 checkpoint transitions. For
+consistency and to prevent the same bug from manifesting
+at earlier transitions, the fix will add transition
+instructions at all checkpoints that precede another step
+(Steps 0-9). Step 10's checkpoint says "Pipeline
+complete" and does not need a transition instruction.
+
+This aligns with the proposal's constitution assessment
+(Principle I: Autonomous Collaboration) -- the entire
+pipeline should operate autonomously, not just the
+later steps.
+
+### D2: Guardrail uses existing format
+
+The new guardrail will follow the established
+`**NEVER/ALWAYS verb**` format used by the existing 8
+guardrails. It will be placed as the first guardrail
+in the section since autonomy is the command's primary
+design property.
+
+### D3: Checkpoint transition instructions are additive
+
+The existing checkpoint text ("Mark Step N complete in
+the execution checklist before proceeding") is retained
+unchanged. New transition instructions are added as
+additional lines after the checkpoint, following the
+same blockquote format. This preserves the checkpoint's
+original purpose (execution tracking) while adding
+behavioral guidance.
+
+### D4: Both files must stay in sync
+
+The command exists in two locations:
+- `internal/scaffold/assets/opencode/commands/uf.unleash.md`
+  (canonical source embedded in the binary)
+- `.opencode/commands/uf.unleash.md` (deployed copy)
+
+Both files MUST receive identical changes. The scaffold
+drift detection tests verify this synchronization.
+
+## Risks / Trade-offs
+
+### Risk: LLM non-determinism
+
+The fix is a prompt engineering change. LLM behavior is
+non-deterministic -- adding "do not ask for confirmation"
+instructions makes spurious halts less likely but cannot
+guarantee elimination. This is an inherent limitation of
+prompt-based behavioral control.
+
+**Mitigation**: The guardrail + inline instruction
+combination follows the proven `inline-stop-instructions`
+pattern, which has been effective for the inverse problem
+(preventing agents from continuing past boundaries).
+
+### Risk: Over-indexing on autonomy
+
+Adding strong "never pause" language could theoretically
+reduce an agent's willingness to exit at legitimate safety
+gates.
+
+**Mitigation**: The guardrail explicitly enumerates the
+valid exit points (HIGH/CRITICAL spec findings, build
+failures, merge conflicts, 3 review iterations). The
+transition instructions are scoped to inter-step
+boundaries only, not intra-step decision points. Each
+step's internal exit logic remains unchanged.
+
+### Trade-off: Consistency vs. minimal change
+
+Auditing all 11 checkpoints (D1) increases the change
+size compared to fixing only the 3 checkpoints identified
+in the issue. This trades minimal diff for consistency --
+preventing the same bug from appearing at other
+transitions later.

--- a/openspec/changes/fix-unleash-autonomy/proposal.md
+++ b/openspec/changes/fix-unleash-autonomy/proposal.md
@@ -1,0 +1,110 @@
+## Why
+
+`/uf.unleash` is designed as a fully autonomous pipeline
+(Steps 0-10) that takes a spec from draft to demo-ready
+code in a single command. However, agents consistently
+halt between Step 7 (Implement) and Step 8 (Code Review)
+to ask the human for permission to proceed. This has been
+observed in at least two independent sessions on the same
+day (issue #457).
+
+The root cause is twofold:
+
+1. The Guardrails section (8 rules) does not include an
+   explicit autonomy rule prohibiting confirmation-seeking
+   between steps.
+2. All 11 checkpoint instructions use ambiguous "before
+   proceeding" language without explicitly stating "proceed
+   immediately to the next step without asking."
+
+This violates Spec 018's acceptance criteria: "The
+developer never has to intervene." The prior learning
+`inline-stop-instructions-1` documents the same class of
+problem in reverse -- behavioral instructions must be
+positioned at the decision point, not in a separate
+section.
+
+## What Changes
+
+Add explicit autonomy instructions to the `/uf.unleash`
+command template to prevent agents from inserting spurious
+confirmation checks at step boundaries.
+
+## Capabilities
+
+### New Capabilities
+- None
+
+### Modified Capabilities
+- `uf.unleash autonomy`: Add a 9th guardrail prohibiting
+  inter-step confirmation-seeking, and add explicit
+  "proceed immediately" transition instructions at each
+  step checkpoint that precedes another step
+
+### Removed Capabilities
+- None
+
+## Impact
+
+- **File**: `internal/scaffold/assets/opencode/commands/uf.unleash.md`
+  (canonical source; `.opencode/commands/uf.unleash.md` is
+  the deployed copy)
+- **Behavior**: Agents will receive explicit instructions to
+  proceed autonomously between steps, reducing spurious
+  halts at step boundaries
+- **Safety**: All existing STOP/EXIT conditions remain
+  unchanged (HIGH/CRITICAL spec findings, build failures,
+  merge conflicts, 3 review iterations exhausted)
+- **Scope**: Prompt engineering change only -- no Go source
+  code, CI workflows, or test files are modified
+
+## Constitution Alignment
+
+Assessed against the Unbound Force org constitution.
+
+### I. Autonomous Collaboration
+
+**Assessment**: PASS
+
+This change strengthens autonomous collaboration. The
+`/uf.unleash` pipeline's entire purpose is autonomous
+execution through well-defined steps with artifact-based
+handoffs between phases. Agents halting for unnecessary
+human confirmation breaks this autonomy. The fix ensures
+the pipeline operates as designed -- fully autonomous with
+exits only at documented safety gates.
+
+### II. Composability First
+
+**Assessment**: N/A
+
+This change modifies a single command template's internal
+instructions. It does not affect hero composability,
+standalone functionality, or introduce dependencies.
+
+### III. Observable Quality
+
+**Assessment**: N/A
+
+This change does not affect machine-parseable output or
+provenance metadata. The `/uf.unleash` pipeline's output
+structure and execution checklist remain unchanged.
+
+### IV. Testability
+
+**Assessment**: N/A
+
+The behavioral outcome (agent does not halt for
+confirmation) is a prompt engineering change that cannot
+be verified through automated testing. However, the
+structural fix (guardrail text and transition instructions
+exist in the file) is verifiable by content inspection.
+The existing scaffold drift detection tests continue to
+verify file existence and ownership.
+
+### V. Security by Default
+
+**Assessment**: N/A
+
+This change modifies prompt text only. No external inputs,
+dependencies, or privilege boundaries are affected.

--- a/openspec/changes/fix-unleash-autonomy/specs/unleash-autonomy.md
+++ b/openspec/changes/fix-unleash-autonomy/specs/unleash-autonomy.md
@@ -1,0 +1,69 @@
+## ADDED Requirements
+
+### Requirement: Inter-step autonomy guardrail
+
+The `/uf.unleash` command MUST include a guardrail that
+explicitly prohibits pausing between pipeline steps for
+human confirmation. The guardrail MUST enumerate the only
+valid exit points where the pipeline MAY halt.
+
+#### Scenario: Agent reaches a step checkpoint
+
+- **GIVEN** the agent completes a pipeline step (Steps 0-9)
+- **WHEN** the agent processes the step's CHECKPOINT block
+- **THEN** the agent MUST proceed immediately to the next
+  step without asking the human for confirmation
+
+#### Scenario: Agent encounters a valid exit condition
+
+- **GIVEN** the agent is executing any pipeline step
+- **WHEN** the agent encounters a documented STOP/EXIT
+  condition (HIGH/CRITICAL spec findings, build/test
+  failure, merge conflict, 3 review iterations exhausted)
+- **THEN** the agent MUST halt and present the exit
+  message with actionable next steps, as before
+
+### Requirement: Explicit checkpoint transitions
+
+Each step checkpoint (Steps 0-9) that precedes another
+step MUST include an explicit transition instruction
+directing the agent to proceed immediately to the next
+step. The transition instruction MUST state:
+1. The specific next step to proceed to
+2. An explicit prohibition on asking for confirmation
+
+The final checkpoint (Step 10) MUST NOT include a
+transition instruction since no subsequent step exists.
+
+#### Scenario: Step 7 checkpoint transition
+
+- **GIVEN** the agent completes Step 7 (Implement)
+- **WHEN** the agent marks Step 7 complete in the
+  execution checklist
+- **THEN** the checkpoint MUST instruct the agent to
+  "proceed immediately to Step 8" and "do NOT ask for
+  confirmation"
+
+#### Scenario: Consistent checkpoint format
+
+- **GIVEN** the `/uf.unleash` command template
+- **WHEN** inspecting checkpoint blocks for Steps 0-9
+- **THEN** each checkpoint MUST contain both the
+  execution checklist marker AND an explicit transition
+  instruction to the next step
+
+## MODIFIED Requirements
+
+### Requirement: Guardrails section completeness
+
+The Guardrails section MUST include an autonomy guardrail
+as the first rule. Previously: the section contained 8
+guardrails covering branch safety, spec review exits,
+merge conflicts, exit messages, retrospective storage,
+worktree cleanup, WorkflowInstance prohibition, and build
+command derivation, but did not address inter-step
+autonomy.
+
+## REMOVED Requirements
+
+None.

--- a/openspec/changes/fix-unleash-autonomy/tasks.md
+++ b/openspec/changes/fix-unleash-autonomy/tasks.md
@@ -1,0 +1,68 @@
+<!--
+  [P] marks tasks eligible for parallel execution.
+  Add [P] when a task: (a) touches different files from
+  other [P] tasks in the group, (b) has no dependency
+  on prior tasks in the group, (c) can safely execute
+  without ordering constraints.
+  Do NOT add [P] when tasks modify the same file —
+  parallel workers will cause merge conflicts.
+  Tasks without [P] run sequentially first, then [P]
+  tasks run in parallel.
+-->
+
+## 1. Add autonomy guardrail and checkpoint transitions
+
+All tasks in this group modify the same file
+(`uf.unleash.md`), so no tasks are parallel-eligible.
+
+- [x] 1.1 Add the inter-step autonomy guardrail as the
+  first rule in the Guardrails section of
+  `internal/scaffold/assets/opencode/commands/uf.unleash.md`.
+  Use the established `**NEVER verb**` format:
+  `**NEVER pause between steps for human confirmation**`
+  followed by the enumerated valid exit points.
+
+- [x] 1.2 Add explicit transition instructions after each
+  checkpoint block for Steps 0-9 in
+  `internal/scaffold/assets/opencode/commands/uf.unleash.md`.
+  Each transition instruction MUST follow the checkpoint's
+  existing blockquote and state: "Proceed immediately to
+  Step N+1. Do NOT ask for confirmation." Step 10's
+  checkpoint already says "Pipeline complete" and does
+  not need a transition instruction.
+  Affected checkpoints (line numbers from current file):
+  - Step 0 checkpoint (line 77)
+  - Step 1 checkpoint (line 131)
+  - Step 2 checkpoint (line 194)
+  - Step 3 checkpoint (line 272)
+  - Step 4 checkpoint (line 296)
+  - Step 5 checkpoint (line 319)
+  - Step 6 checkpoint (line 379)
+  - Step 7 checkpoint (line 536)
+  - Step 8 checkpoint (line 607)
+  - Step 9 checkpoint (line 646)
+
+## 2. Sync deployed copy
+
+- [x] 2.1 Copy the updated scaffold asset to the deployed
+  location: `.opencode/commands/uf.unleash.md`. Both files
+  MUST be identical. Verify with `diff` after copying.
+
+## 3. Verification
+
+- [x] 3.1 Run `make check` to verify no build, test, or
+  lint regressions.
+
+- [x] 3.2 Verify content correctness: confirm the new
+  guardrail exists in the Guardrails section, all 10
+  checkpoint transitions (Steps 0-9) include explicit
+  "proceed immediately" instructions, and Step 10's
+  checkpoint does NOT include a transition instruction.
+
+- [x] 3.3 Verify constitution alignment: confirm the
+  change strengthens Principle I (Autonomous
+  Collaboration) and does not introduce violations of
+  Principles II-V (per proposal assessment).
+
+<!-- spec-review: passed -->
+<!-- code-review: passed -->


### PR DESCRIPTION
## Summary

Fixes #457 — agents halt between Step 7 (Implement) and Step 8
(Code Review) of the `/uf.unleash` pipeline to ask for human
confirmation, violating Spec 018's acceptance criteria that "the
developer never has to intervene."

Root cause: the Guardrails section lacked an explicit autonomy
rule, and all 11 checkpoint instructions used ambiguous "before
proceeding" language without stating "proceed immediately."

This change adds a 9th guardrail prohibiting inter-step
confirmation-seeking and adds explicit "Proceed immediately to
Step N+1. Do NOT ask for confirmation." transition instructions
at each of the 10 step checkpoints (Steps 0-9).

## How to Test

1. Verify the autonomy guardrail exists as the first rule in
   the Guardrails section of `uf.unleash.md`:
   ```bash
   grep -A2 "NEVER pause between steps" \
     internal/scaffold/assets/opencode/commands/uf.unleash.md
   ```

2. Verify all 10 checkpoints (Steps 0-9) include transition
   instructions:
   ```bash
   grep -c "Proceed immediately to Step" \
     internal/scaffold/assets/opencode/commands/uf.unleash.md
   ```
   Expected: 10

3. Verify Step 10 does NOT include a transition instruction:
   ```bash
   grep -A5 "Step 10" \
     internal/scaffold/assets/opencode/commands/uf.unleash.md \
     | grep "Proceed immediately"
   ```
   Expected: no output

4. Verify canonical and deployed copies are identical:
   ```bash
   diff internal/scaffold/assets/opencode/commands/uf.unleash.md \
     .opencode/commands/uf.unleash.md
   ```
   Expected: no diff

5. Run `make check` to confirm no regressions.

## How to Demo

Run `/uf.unleash` on a spec. Observe that the agent proceeds
through Steps 7-10 without halting to ask for human permission
at step boundaries. The pipeline should only stop at documented
safety gates (build failures, HIGH/CRITICAL findings, merge
conflicts, 3 review iterations exhausted).

## Key Files Changed

- `internal/scaffold/assets/opencode/commands/uf.unleash.md` —
  canonical source: added autonomy guardrail and 10 checkpoint
  transition instructions
- `.opencode/commands/uf.unleash.md` — deployed copy synced
  from canonical source
- `CHANGELOG.md` — added entry for autonomy fix
- `openspec/changes/fix-unleash-autonomy/` — OpenSpec change
  artifacts (proposal, design, specs, tasks)

_This PR was generated by /uf.finale (AI-assisted)._
