### PR TITLE
fix(commands): rename AskUserQuestion to question tool

### DIFF
--- a/.opencode/agents/muti-mind-po.md
+++ b/.opencode/agents/muti-mind-po.md
@@ -66,7 +66,7 @@ When evaluating a Gaze Quality Report against a backlog item's acceptance criter
 - `rationale`: Markdown explanation
 - `criteria_met` / `criteria_failed`
 
-**Interactive Approval**: Before running the `bash` tool to record an acceptance decision using the `go run cmd/mutimind/main.go decide` command, you MUST use the **AskUserQuestion tool** to present:
+**Interactive Approval**: Before running the `bash` tool to record an acceptance decision using the `go run cmd/mutimind/main.go decide` command, you MUST use the **question tool** to present:
 - The target backlog item (e.g., `BI-NNN`)
 - The proposed decision (`accept`, `reject`, or `conditional`)
 - The rationale summary

--- a/.opencode/commands/muti-mind.sync-push.md
+++ b/.opencode/commands/muti-mind.sync-push.md
@@ -40,7 +40,7 @@ Pushes local backlog items to GitHub Issues using the Go backend, which relies o
    - Otherwise: present the sync-status output to the user
      and continue to step 3.
 
-3. **Confirmation gate**: Use the **AskUserQuestion tool**
+3. **Confirmation gate**: Use the **question tool**
    with the following options:
    - "Yes -- sync to GitHub"
    - "No -- abort"

--- a/.opencode/commands/opsx-apply.md
+++ b/.opencode/commands/opsx-apply.md
@@ -13,7 +13,7 @@ Implement tasks from an OpenSpec change.
    If a name is provided, use it. Otherwise:
    - Infer from conversation context if the user mentioned a change
    - Auto-select if only one active change exists
-   - If ambiguous, run `openspec list --json` to get available changes and use the **AskUserQuestion tool** to let the user select
+   - If ambiguous, run `openspec list --json` to get available changes and use the **question tool** to let the user select
 
    Always announce: "Using change: <name>" and how to override (e.g., `/opsx-apply <other>`).
 

--- a/.opencode/commands/opsx-archive.md
+++ b/.opencode/commands/opsx-archive.md
@@ -10,7 +10,7 @@ Archive a completed change in the experimental workflow.
 
 1. **If no change name provided, prompt for selection**
 
-   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+   Run `openspec list --json` to get available changes. Use the **question tool** to let the user select.
 
    Show only active changes (not already archived).
    Include the schema used for each change if available.
@@ -80,7 +80,7 @@ Archive a completed change in the experimental workflow.
 6. **Return to main branch**
 
    After the archive move completes, use the
-   **AskUserQuestion tool** to confirm branch switching:
+   **question tool** to confirm branch switching:
 
    > The archive is complete. Would you like to return
    > to the main branch?

--- a/.opencode/commands/opsx-propose.md
+++ b/.opencode/commands/opsx-propose.md
@@ -19,7 +19,7 @@ When ready to implement, run /uf.unleash (autonomous) or /opsx-apply (sequential
 
 1. **If no input provided, ask what they want to build**
 
-   Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
+   Use the **question tool** (open-ended, no preset options) to ask:
    > "What change do you want to work on? Describe what you want to build or fix."
 
    From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
@@ -52,7 +52,7 @@ When ready to implement, run /uf.unleash (autonomous) or /opsx-apply (sequential
       (e.g., `/opsx-propose fix-typos`).
 
       When `git status --short` output is non-empty, invoke
-      the **AskUserQuestion tool** with:
+      the **question tool** with:
       - **Question**: Include the full `git status --short`
         output, the target branch name (`opsx/<name>`), and
         a warning that switching branches with uncommitted
@@ -140,7 +140,7 @@ use direct file reads of local specs and backlog items instead.
       - Stop when all `applyRequires` artifacts are done
 
    c. **If an artifact requires user input** (unclear context):
-      - Use **AskUserQuestion tool** to clarify
+      - Use **question tool** to clarify
       - Then continue with creation
 
 6. **Show final status**

--- a/.opencode/commands/speckit.clarify.md
+++ b/.opencode/commands/speckit.clarify.md
@@ -107,11 +107,11 @@ Execution steps:
 4. Sequential questioning loop (interactive):
 
     ---
-    **MANDATORY GATE — AskUserQuestion Required**
+    **MANDATORY GATE — question Required**
 
     Each question MUST be delivered as a single
-    **AskUserQuestion tool call**. Do NOT present the next
-    question until the previous AskUserQuestion response has
+    **question tool call**. Do NOT present the next
+    question until the previous question response has
     been received. Do NOT batch questions together.
 
     ---
@@ -135,16 +135,16 @@ Execution steps:
        | Short | Provide a different short answer (<=5 words) (Include only if free-form alternative is appropriate) |
 
        - After the table, add: `You can reply with the option letter (e.g., "A"), accept the recommendation by saying "yes" or "recommended", or provide your own short answer.`
-       - Deliver the question using the **AskUserQuestion tool** with options matching the table rows. List the recommended option first with "(Recommended)" appended to its label. Enable custom text for free-form alternatives.
+       - Deliver the question using the **question tool** with options matching the table rows. List the recommended option first with "(Recommended)" appended to its label. Enable custom text for free-form alternatives.
     - For short‑answer style (no meaningful discrete options):
        - Provide your **suggested answer** based on best practices and context.
        - Format as: `**Suggested:** <your proposed answer> - <brief reasoning>`
        - Then output: `Format: Short answer (<=5 words). You can accept the suggestion by saying "yes" or "suggested", or provide your own answer.`
-       - Deliver the question using the **AskUserQuestion tool** in open-ended mode (no preset options). Include the suggested answer in the question text.
-    - After the AskUserQuestion tool returns a response:
-       - When the AskUserQuestion tool returns "yes", "recommended", or "suggested", use your previously stated recommendation/suggestion as the answer.
+       - Deliver the question using the **question tool** in open-ended mode (no preset options). Include the suggested answer in the question text.
+    - After the question tool returns a response:
+       - When the question tool returns "yes", "recommended", or "suggested", use your previously stated recommendation/suggestion as the answer.
        - Otherwise, validate the answer maps to one option or fits the <=5 word constraint.
-       - If ambiguous, ask for a quick disambiguation via a follow-up **AskUserQuestion tool call** (count still belongs to same question; do not advance).
+       - If ambiguous, ask for a quick disambiguation via a follow-up **question tool call** (count still belongs to same question; do not advance).
        - Once satisfactory, record it in working memory (do not yet write to disk) and move to the next queued question.
     - Stop asking further questions when:
        - All critical ambiguities resolved early (remaining queued items become unnecessary), OR

--- a/.opencode/commands/speckit.implement.md
+++ b/.opencode/commands/speckit.implement.md
@@ -37,7 +37,7 @@ You **MUST** consider the user input before proceeding (if not empty).
 
    - **If any checklist is incomplete**:
      - Display the table with incomplete item counts
-     - Use the **AskUserQuestion tool** with options
+     - Use the **question tool** with options
        `["Proceed anyway", "Stop -- fix checklists first"]`
      - Wait for the user's selection before continuing
      - If user selects "Stop -- fix checklists first", halt
@@ -45,7 +45,7 @@ You **MUST** consider the user input before proceeding (if not empty).
      - If user selects "Proceed anyway", proceed to step 3
 
    - **CRITICAL RULE**: NEVER proceed past this gate without
-     an **AskUserQuestion tool** call response. This gate
+     a **question tool** call response. This gate
      cannot be inherited from compressed or resumed session
      context — it MUST be executed fresh in every session.
 
@@ -146,7 +146,7 @@ You **MUST** consider the user input before proceeding (if not empty).
      BEFORE suggesting any next steps (PR creation, merging,
      or branch switching).
    - Run `git status --short` to check for uncommitted changes.
-   - If uncommitted changes exist, use the **AskUserQuestion
+   - If uncommitted changes exist, use the **question
      tool** with options `["Yes -- all committed and pushed",
      "Not yet -- let me commit first"]`.
    - If user selects "Not yet -- let me commit first", halt
@@ -166,7 +166,7 @@ You **MUST** consider the user input before proceeding (if not empty).
 
    - **CRITICAL RULE**: NEVER suggest next steps (PR creation,
      merging, branch switching, archiving) without an
-     **AskUserQuestion tool** call response confirming changes
+     **question tool** call response confirming changes
      are committed and pushed. This gate cannot be inherited
      from compressed or resumed session context — it MUST be
      executed fresh in every session.

--- a/.opencode/commands/speckit.specify.md
+++ b/.opencode/commands/speckit.specify.md
@@ -48,7 +48,7 @@ Given that feature description, do this:
 
    a. Run `git status --short` to check for uncommitted changes.
       - **If uncommitted changes exist**: use the
-        **AskUserQuestion tool** to confirm before proceeding.
+        **question tool** to confirm before proceeding.
         Include the `git status --short` output in the question
         so the user can see which files are uncommitted:
 

--- a/.opencode/commands/uf.address-feedback.md
+++ b/.opencode/commands/uf.address-feedback.md
@@ -282,16 +282,16 @@ If the item has a GitHub suggestion block, display it clearly as an applicable c
 
 ### 3.2 Author Decision
 
-For each item, use the **AskUserQuestion tool** with
+For each item, use the **question tool** with
 options `["Accept", "Modify", "Reject", "Ask"]`. The
 author chooses exactly one:
 
 | Decision | Follow-up | Queued action |
 |---|---|---|
 | **Accept** | (none) | Code change using suggested approach |
-| **Modify** | Use **AskUserQuestion tool** (open-ended, no preset options) to collect the alternative approach | Code change using author's approach |
-| **Reject** | Use **AskUserQuestion tool** (open-ended, no preset options) to collect evidence-based reasoning | Reply comment with reasoning |
-| **Ask** | Use **AskUserQuestion tool** (open-ended, no preset options) to collect the clarification question | Reply comment with question |
+| **Modify** | Use **question tool** (open-ended, no preset options) to collect the alternative approach | Code change using author's approach |
+| **Reject** | Use **question tool** (open-ended, no preset options) to collect evidence-based reasoning | Reply comment with reasoning |
+| **Ask** | Use **question tool** (open-ended, no preset options) to collect the clarification question | Reply comment with question |
 
 **No item may be skipped or deferred.** Every item MUST receive a decision before the triage phase completes.
 
@@ -314,7 +314,7 @@ Total:   N items
 ```
 
 List each item with its decision. Use the
-**AskUserQuestion tool** with options `["Confirm --
+**question tool** with options `["Confirm --
 proceed with execution", "Revise -- change decisions"]`
 before execution proceeds.
 
@@ -399,7 +399,7 @@ git status
 
 **If branch has diverged** (another contributor pushed
 commits): warn the author and use the
-**AskUserQuestion tool** with options `["Rebase onto
+**question tool** with options `["Rebase onto
 remote and push", "Abort -- preserve local commits"]`.
 
 Push all commits:
@@ -418,7 +418,7 @@ git push origin <branch>
 
 After push succeeds (or if there are no code changes),
 post reply comments to the PR. Before posting, use the
-**AskUserQuestion tool** with options `["Yes -- post
+**question tool** with options `["Yes -- post
 reply comments", "No -- skip posting"]`.
 
 **Checklist gate**: Before presenting comments for posting,
@@ -478,7 +478,7 @@ After posting reply comments for accepted items, offer to resolve those threads:
 gh api graphql -f query='mutation { resolveReviewThread(input: {threadId: "<thread_id>"}) { thread { isResolved } } }'
 ```
 
-Use the **AskUserQuestion tool** with options
+Use the **question tool** with options
 `["Yes -- resolve accepted threads", "No -- leave
 threads open"]` before resolving.
 

--- a/.opencode/commands/uf.finale.md
+++ b/.opencode/commands/uf.finale.md
@@ -39,7 +39,7 @@ stays open for human review. Works with both Speckit
    in the current uncompressed conversation history, you
    MUST re-read this entire template, recover state from
    the execution checklist below, and re-confirm any
-   pending gates via the **AskUserQuestion tool** before
+   pending gates via the **question tool** before
    proceeding. Do NOT rely on gate confirmations recorded
    in compressed context. Do NOT infer step completion
    from compressed summaries. When in doubt, re-confirm
@@ -124,7 +124,7 @@ Run `git status --short` to inspect the working tree.
   > Proceed with staging all files? These files will be
   > included in the commit."
 
-  Use the **AskUserQuestion tool** with options
+  Use the **question tool** with options
   `["Yes -- stage all files and continue", "No -- stop here"]`.
 
   - If the user selects **"Yes -- stage all files and
@@ -234,7 +234,7 @@ git status
 in the local branch): warn the user about the divergence
 before presenting the confirmation gate.
 
-Use the **AskUserQuestion tool** with options
+Use the **question tool** with options
 `["Push to remote", "Abort -- keep commits local"]`.
 
 - If the user selects **"Push to remote"**:
@@ -397,7 +397,7 @@ gh pr view --json number,url 2>/dev/null
   > <body>
   > ```
 
-  Use the **AskUserQuestion tool** with options
+  Use the **question tool** with options
   `["Approve — create PR", "Edit title or body",
   "Provide my own title and body", "Abort — do not
   create PR"]`.
@@ -465,7 +465,7 @@ gh pr checks <number> --watch
   > 2. Re-run the checks
   > 3. Stop here and fix manually"
 
-  Use the **AskUserQuestion tool** to ask the user how
+  Use the **question tool** to ask the user how
   to proceed.
 
   >>> END MANDATORY GATE <<<
@@ -543,7 +543,7 @@ conflict to the user and present recovery options:
 > 5. Spawn sub-agent to resolve conflicts
 >    (AI-assisted)"
 
-Use the **AskUserQuestion tool** to ask the user
+Use the **question tool** to ask the user
 which option to take. After the user selects an option,
 update the execution checklist: set
 `CONFLICT_OPTION=<N>` (where N is the selected option

--- a/.opencode/commands/uf.review-council.md
+++ b/.opencode/commands/uf.review-council.md
@@ -490,13 +490,13 @@ Review the current codebase for compliance with the Behavioral Constraints in `A
    - If a prior review with the **same verdict** exists:
      Inform the user that a prior review exists and the
      latest review takes precedence. Use the
-     **AskUserQuestion tool** with options
+     **question tool** with options
      `["Yes -- post new review", "No -- skip posting"]`.
 
    - If a prior review with a **different verdict** exists:
      Inform the user of the prior verdict and that the new
      review will override it. Use the
-     **AskUserQuestion tool** with options
+     **question tool** with options
      `["Yes -- override with <new_verdict>",
      "No -- keep existing <old_verdict>"]`.
 
@@ -665,7 +665,7 @@ Review the current codebase for compliance with the Behavioral Constraints in `A
    current uncompressed conversation history, you MUST
    re-present the review content (verdict + all comments)
    and obtain fresh confirmation via the
-   **AskUserQuestion tool** before posting. Do NOT rely
+   **question tool** before posting. Do NOT rely
    on confirmation recorded in compressed context. When
    in doubt, re-confirm — false re-confirmation is
    harmless; posting without consent is a violation.
@@ -681,7 +681,7 @@ Review the current codebase for compliance with the Behavioral Constraints in `A
    | APPROVE WITH ADVISORIES | `COMMENT` |
 
    Display the verdict context, then use the
-   **AskUserQuestion tool** for confirmation:
+   **question tool** for confirmation:
 
    For APPROVE verdicts:
    > "This will post an APPROVE review, which may unblock
@@ -709,7 +709,7 @@ Review the current codebase for compliance with the Behavioral Constraints in `A
      COMMENT).
 
    **CRITICAL RULE**: NEVER post reviews without explicit
-   human confirmation via the **AskUserQuestion tool**.
+   human confirmation via the **question tool**.
    Always show the exact content (verdict type + all
    comments) that will be posted and wait for the user
    to select a confirming option. Mark `Step 7f` as

--- a/.opencode/commands/uf.review-pr.md
+++ b/.opencode/commands/uf.review-pr.md
@@ -108,7 +108,7 @@ Categorize each check as:
 - **SKIPPED**: Check was skipped
 
 If checks are still PENDING, inform the user and use
-the **AskUserQuestion tool** with options
+the **question tool** with options
 `["Wait for checks to complete", "Proceed with
 available results"]`.
 
@@ -155,11 +155,11 @@ from Step 2 metadata:
 
 **If total diff lines > 2000 OR changed files > 50**:
 
-Use the **AskUserQuestion tool** with options
+Use the **question tool** with options
 `["Review all files", "Focus on specific files"]`.
 
 If the user selects "Focus on specific files", follow up
-with the **AskUserQuestion tool** (open-ended, no preset
+with the **question tool** (open-ended, no preset
 options) to ask which files or directories to focus on.
 
 Record the user's choice as `FILE_FOCUS_SCOPE`:
@@ -758,7 +758,7 @@ I identified <N> pre-existing CI failure(s) that are NOT caused by this PR:
 These failures also occur on the base branch (<BASE_BRANCH>).
 ```
 
-Use the **AskUserQuestion tool** with options
+Use the **question tool** with options
 `["Yes -- create fix branch", "No -- skip"]`.
 
 **If the user selects "Yes -- create fix branch"**:
@@ -873,7 +873,7 @@ Verdict: <APPROVE / REQUEST CHANGES / COMMENT>
 
 Regardless of finding severities, always offer to post
 the review as a formal GitHub review on the PR. Use the
-**AskUserQuestion tool** with options
+**question tool** with options
 `["Yes -- post as GitHub review", "No -- terminal
 summary is sufficient"]`.
 
@@ -893,13 +893,13 @@ review fetch):
 - If a prior review with the **same verdict** exists:
   Inform the user that a prior review exists and the
   latest review takes precedence. Use the
-  **AskUserQuestion tool** with options
+  **question tool** with options
   `["Yes -- post new review", "No -- skip posting"]`.
 
 - If a prior review with a **different verdict** exists:
   Inform the user of the prior verdict and that the new
   review will override it. Use the
-  **AskUserQuestion tool** with options
+  **question tool** with options
   `["Yes -- override with <new_verdict>",
   "No -- keep existing <old_verdict>"]`.
 
@@ -976,7 +976,7 @@ account is not listed in CODEOWNERS.
    in the current uncompressed conversation history, you
    MUST re-present the review content (verdict + all
    comments) and obtain fresh confirmation via the
-   **AskUserQuestion tool** before posting. Do NOT rely
+   **question tool** before posting. Do NOT rely
    on confirmation recorded in compressed context. When
    in doubt, re-confirm — false re-confirmation is
    harmless; posting without consent is a violation.
@@ -1032,18 +1032,18 @@ account is not listed in CODEOWNERS.
    - COMMENT → `"event": "COMMENT"`
 
    Display the verdict context, then use the
-   **AskUserQuestion tool** for confirmation:
+   **question tool** for confirmation:
 
    For APPROVE verdicts: inform the user that this may
    unblock merge in repos with branch protection and
    that the review will be labeled as AI-generated.
-   Use the **AskUserQuestion tool** with options
+   Use the **question tool** with options
    `["Approve -- post review", "No -- skip posting",
    "Edit comments first", "Change verdict"]`.
 
    For REQUEST CHANGES or COMMENT verdicts: inform the
    user that this will block merge in repos with branch
-   protection. Use the **AskUserQuestion tool** with
+   protection. Use the **question tool** with
    options `["Yes -- post review", "No -- skip posting",
    "Edit comments first", "Change verdict"]`.
 
@@ -1084,10 +1084,10 @@ account is not listed in CODEOWNERS.
    suggest re-authenticating with `gh auth login`.
 
    - **"No -- skip posting"**: Skip posting, the terminal summary is sufficient
-   - **"Edit comments first"**: Let the user modify comments before posting, then re-confirm with the **AskUserQuestion tool**
+   - **"Edit comments first"**: Let the user modify comments before posting, then re-confirm with the **question tool**
 
 5. **CRITICAL RULE**: NEVER post reviews without explicit
-   human confirmation via the **AskUserQuestion tool**.
+   human confirmation via the **question tool**.
    Always show the exact content (verdict type + all
    comments) that will be posted and wait for the user
    to select a confirming option. For APPROVE verdicts,

--- a/.opencode/commands/uf.triage-issue.md
+++ b/.opencode/commands/uf.triage-issue.md
@@ -240,7 +240,7 @@ Split:        <"recommended" with count, or "not recommended">
 
 ### 4.2 Label Application
 
-**All label mutations require user confirmation.** Before creating or applying any label, use the **AskUserQuestion tool** to obtain explicit confirmation. The `duplicate` label has an additional supplementary confirmation gate because it carries implicit "close" semantics.
+**All label mutations require user confirmation.** Before creating or applying any label, use the **question tool** to obtain explicit confirmation. The `duplicate` label has an additional supplementary confirmation gate because it carries implicit "close" semantics.
 
 **Label mapping**:
 
@@ -260,7 +260,7 @@ Split:        <"recommended" with count, or "not recommended">
 
 **Path A — Label does NOT exist in the repository**:
 
-Inform the user: "The label '<label>' does not exist in the repository." Use the **AskUserQuestion tool** with options `["Yes -- create and apply label '<label>'", "No -- skip"]`.
+Inform the user: "The label '<label>' does not exist in the repository." Use the **question tool** with options `["Yes -- create and apply label '<label>'", "No -- skip"]`.
 
 If the user selects "No -- skip", skip both label creation and application. Record `labels_applied: []` and `label_creation_failed: false` in `actions_taken`. Proceed to Section 4.3.
 
@@ -280,7 +280,7 @@ gh issue edit <ISSUE_NUMBER> --add-label "<label>"
 
 **Path B — Label already EXISTS in the repository**:
 
-Use the **AskUserQuestion tool** with options `["Yes -- apply label '<label>'", "No -- skip"]`.
+Use the **question tool** with options `["Yes -- apply label '<label>'", "No -- skip"]`.
 
 If the user selects "No -- skip", skip label application. Record `labels_applied: []` in `actions_taken`. Proceed to Section 4.3.
 
@@ -290,7 +290,7 @@ If the user confirms, apply the label:
 gh issue edit <ISSUE_NUMBER> --add-label "<label>"
 ```
 
-**For `duplicate` label only** (supplementary gate, applies after either Path A or Path B confirmation): Inform the user that the `duplicate` label signals the issue should be closed. Use the **AskUserQuestion tool** with options `["Yes -- apply duplicate label", "No -- skip"]`. Only execute the `gh issue edit --add-label` command if the user confirms this supplementary gate. If the user declines, skip label application, record `labels_applied: []` in `actions_taken`, and proceed to Section 4.3.
+**For `duplicate` label only** (supplementary gate, applies after either Path A or Path B confirmation): Inform the user that the `duplicate` label signals the issue should be closed. Use the **question tool** with options `["Yes -- apply duplicate label", "No -- skip"]`. Only execute the `gh issue edit --add-label` command if the user confirms this supplementary gate. If the user declines, skip label application, record `labels_applied: []` in `actions_taken`, and proceed to Section 4.3.
 
 ### 4.3 Comment Composition and Posting
 
@@ -312,21 +312,21 @@ _This triage was performed by the Divisor review panel._
 **Re-run check**: If a previous triage comment was
 detected in Phase 1.2, warn the user that posting
 another comment may cause confusion. Use the
-**AskUserQuestion tool** with options `["Yes -- post
+**question tool** with options `["Yes -- post
 another comment", "No -- skip comment"]`. If the user
 selects "No -- skip comment", record
 `comment_posted: false` in the artifact and skip to
 Phase 4.4.
 
 **Present the composed comment to the user for
-confirmation**: Use the **AskUserQuestion tool** with
+confirmation**: Use the **question tool** with
 options `["Approve -- post as-is", "Modify -- adjust
 comment text", "Abort -- do not post"]`.
 
 | Selection | Action |
 |---|---|
 | **Approve -- post as-is** | Post the comment as-is |
-| **Modify -- adjust comment text** | Use **AskUserQuestion tool** (open-ended, no preset options) to collect the adjusted comment text; post the adjusted version |
+| **Modify -- adjust comment text** | Use **question tool** (open-ended, no preset options) to collect the adjusted comment text; post the adjusted version |
 | **Abort -- do not post** | Do not post any comment; record `comment_posted: false` in artifact |
 
 **Post the comment** (on Approve or Modify):
@@ -358,7 +358,7 @@ This section applies only when Phase 3.5 produced split recommendations.
 For each proposed child issue:
 
 1. **Present to user**: Show the proposed title and body.
-   Use the **AskUserQuestion tool** with options
+   Use the **question tool** with options
    `["Yes -- create this child issue", "No -- skip"]`
    for each child issue individually.
 
@@ -369,7 +369,7 @@ gh issue list --search "<sanitized-child-title>" --state open --json number,titl
 ```
 
    If a close match is found, warn the user about the
-   potential duplicate and use the **AskUserQuestion
+   potential duplicate and use the **question
    tool** with options `["Yes -- create anyway",
    "No -- skip this child issue"]`.
 

--- a/.opencode/skills/openspec-apply-change/SKILL.md
+++ b/.opencode/skills/openspec-apply-change/SKILL.md
@@ -22,7 +22,7 @@ Implement tasks from an OpenSpec change.
    If a name is provided, use it. Otherwise:
    - Infer from conversation context if the user mentioned a change
    - Auto-select if only one active change exists
-   - If ambiguous, run `openspec list --json` to get available changes and use the **AskUserQuestion tool** to let the user select
+   - If ambiguous, run `openspec list --json` to get available changes and use the **question tool** to let the user select
 
    Always announce: "Using change: <name>" and how to override (e.g., `/opsx-apply <other>`).
 

--- a/.opencode/skills/openspec-archive-change/SKILL.md
+++ b/.opencode/skills/openspec-archive-change/SKILL.md
@@ -17,7 +17,7 @@ Archive a completed change in the experimental workflow.
 
 1. **If no change name provided, prompt for selection**
 
-   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+   Run `openspec list --json` to get available changes. Use the **question tool** to let the user select.
 
    Show only active changes (not already archived).
    Include the schema used for each change if available.
@@ -34,7 +34,7 @@ Archive a completed change in the experimental workflow.
 
    **If any artifacts are not `done`:**
    - Display warning listing incomplete artifacts
-   - Use **AskUserQuestion tool** to confirm user wants to proceed
+   - Use **question tool** to confirm user wants to proceed
    - Proceed if user confirms
 
 3. **Check task completion status**
@@ -45,7 +45,7 @@ Archive a completed change in the experimental workflow.
 
    **If incomplete tasks found:**
    - Display warning showing count of incomplete tasks
-   - Use **AskUserQuestion tool** to confirm user wants to proceed
+   - Use **question tool** to confirm user wants to proceed
    - Proceed if user confirms
 
    **If no tasks file exists:** Proceed without task-related warning.
@@ -91,7 +91,7 @@ Archive a completed change in the experimental workflow.
    d. **Commit-state confirmation gate**: Before
       proceeding to step 6, run `git status --short` and
       present the output to the user. Use the
-      **AskUserQuestion tool** with options:
+      **question tool** with options:
       - "Changes committed and pushed — proceed to archive"
       - "Abort — need to commit first"
 
@@ -134,7 +134,7 @@ Archive a completed change in the experimental workflow.
    git push
    ```
 
-   Then use the **AskUserQuestion tool** to confirm
+   Then use the **question tool** to confirm
    before switching branches:
    - **Options**: `["Return to main", "Stay on branch"]`
 

--- a/.opencode/skills/openspec-explore/SKILL.md
+++ b/.opencode/skills/openspec-explore/SKILL.md
@@ -345,7 +345,7 @@ But this summary is optional. Sometimes the thinking IS the value.
      warn the user that switching branches with a dirty working
      tree may cause changes to be applied to the wrong branch.
 
-  3. **Get explicit confirmation**: Use the **AskUserQuestion
+  3. **Get explicit confirmation**: Use the **question
      tool** with the proposed branch name included in the prompt
      text (e.g., "Create branch `opsx/<name>` and start a
      proposal?") and options:

--- a/.opencode/skills/openspec-propose/SKILL.md
+++ b/.opencode/skills/openspec-propose/SKILL.md
@@ -26,7 +26,7 @@ When ready to implement, run /uf.unleash (autonomous) or /opsx-apply (sequential
 
 1. **If no clear input provided, ask what they want to build**
 
-   Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
+   Use the **question tool** (open-ended, no preset options) to ask:
    > "What change do you want to work on? Describe what you want to build or fix."
 
    From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
@@ -59,7 +59,7 @@ When ready to implement, run /uf.unleash (autonomous) or /opsx-apply (sequential
       (e.g., `/opsx:propose fix-typos`).
 
       **When `git status --short` output is non-empty, the
-      agent MUST invoke the AskUserQuestion tool** with:
+      agent MUST invoke the question tool** with:
       - **Question**: Include the full `git status --short`
         output, the target branch name (`opsx/<name>`), and
         a warning that switching branches with uncommitted
@@ -172,7 +172,7 @@ cross-repo context but are never required.
       - Stop when all `applyRequires` artifacts are done
 
    c. **If an artifact requires user input** (unclear context):
-      - Use **AskUserQuestion tool** to clarify
+      - Use **question tool** to clarify
       - Then continue with creation
 
 6. **Show final status**

--- a/.opencode/skills/speckit-workflow/SKILL.md
+++ b/.opencode/skills/speckit-workflow/SKILL.md
@@ -37,7 +37,7 @@ current feature branch before any branch switch occurs.
   `main`.
 - Before creating a new feature branch (via `/speckit.specify`),
   check `git status --short` for uncommitted changes. If
-  uncommitted changes exist, use the **AskUserQuestion tool**
+  uncommitted changes exist, use the **question tool**
   to confirm before proceeding. Include the `git status --short`
   output in the question so the user can see which files are
   uncommitted:

--- a/.uf/dewey/learnings/fix-ask-user-question-tool-name-20260814T174707-jay-flowers.md
+++ b/.uf/dewey/learnings/fix-ask-user-question-tool-name-20260814T174707-jay-flowers.md
@@ -1,0 +1,10 @@
+---
+tag: fix-ask-user-question-tool-name
+author: jay-flowers
+category: pattern
+created_at: 2026-08-14T17:47:07Z
+identity: fix-ask-user-question-tool-name-20260814T174707-jay-flowers
+tier: draft
+---
+
+When performing a mechanical text rename across many files (like renaming AskUserQuestion to question across 24 markdown files), the most efficient approach is to parallelize by file group: commands, agents, skills, and scaffold assets as separate worker batches. Each worker handles its file group independently, verifies zero remaining occurrences via rg -c, and reports back. The scaffold assets must be updated in lockstep with their source counterparts — the drift detection test TestEmbeddedAssets_MatchSource catches any mismatch. A grammar check after rename is important: changing AskUserQuestion to question required an article fix from "an" to "a" in speckit.implement.md. This is easy to miss in bulk renames.

--- a/.uf/dewey/learnings/fix-ask-user-question-tool-name-20260814T174722-jay-flowers.md
+++ b/.uf/dewey/learnings/fix-ask-user-question-tool-name-20260814T174722-jay-flowers.md
@@ -1,0 +1,10 @@
+---
+tag: fix-ask-user-question-tool-name
+author: jay-flowers
+category: gotcha
+created_at: 2026-08-14T17:47:22Z
+identity: fix-ask-user-question-tool-name-20260814T174722-jay-flowers
+tier: draft
+---
+
+The review council code review for the AskUserQuestion-to-question rename (issue #475) surfaced one actionable finding across 5 agents: a missing CHANGELOG entry. This was the only finding that required a fix — two LOW findings (pre-existing formatting inconsistency in speckit.clarify.md lines 144-145, and an optional stale-pattern regression test) were correctly deferred as non-blocking. The CHANGELOG documentation gate from AGENTS.md is consistently enforced by multiple Divisor agents (Guard at MEDIUM, Architect at LOW) and should be addressed proactively during implementation rather than waiting for review to catch it.

--- a/.uf/dewey/learnings/uf-unleash-20260814T174736-jay-flowers.md
+++ b/.uf/dewey/learnings/uf-unleash-20260814T174736-jay-flowers.md
@@ -1,0 +1,10 @@
+---
+tag: uf-unleash
+author: jay-flowers
+category: gotcha
+created_at: 2026-08-14T17:47:36Z
+identity: uf-unleash-20260814T174736-jay-flowers
+tier: draft
+---
+
+The /uf.unleash command requires strict autonomous execution through all 10 steps without pausing for human confirmation. The only valid exit points are: unanswerable clarification questions, HIGH/CRITICAL spec findings, build/test failures, merge conflicts, and 3 review iterations exhausted. After code review passes, the pipeline must write the code-review marker to tasks.md, then proceed directly to retrospective (Step 9) and demo (Step 10) without asking the user what to do next. The execution checklist in the command file should be maintained in-place using the Edit tool as each step completes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,13 @@ Each entry follows the format: `- <change-name>: <summary>`.
   Closes: #253)
 
 ### Fixed
+- fix-ask-user-question-tool-name: Rename all `AskUserQuestion`
+  tool references to `question` across 24 command, agent, skill,
+  and scaffold files. The actual OpenCode tool is named `question`;
+  the incorrect name could cause agents to silently skip
+  interactive confirmation gates.
+  (Spec: openspec/changes/fix-ask-user-question-tool-name/,
+  Fixes: #475)
 - fix-constitution-scaffold: `uf init` now scaffolds a working
   starter constitution at `.specify/memory/constitution.md`
   instead of delegating to `specify init` (which fails

--- a/internal/scaffold/assets/opencode/commands/uf.address-feedback.md
+++ b/internal/scaffold/assets/opencode/commands/uf.address-feedback.md
@@ -282,16 +282,16 @@ If the item has a GitHub suggestion block, display it clearly as an applicable c
 
 ### 3.2 Author Decision
 
-For each item, use the **AskUserQuestion tool** with
+For each item, use the **question tool** with
 options `["Accept", "Modify", "Reject", "Ask"]`. The
 author chooses exactly one:
 
 | Decision | Follow-up | Queued action |
 |---|---|---|
 | **Accept** | (none) | Code change using suggested approach |
-| **Modify** | Use **AskUserQuestion tool** (open-ended, no preset options) to collect the alternative approach | Code change using author's approach |
-| **Reject** | Use **AskUserQuestion tool** (open-ended, no preset options) to collect evidence-based reasoning | Reply comment with reasoning |
-| **Ask** | Use **AskUserQuestion tool** (open-ended, no preset options) to collect the clarification question | Reply comment with question |
+| **Modify** | Use **question tool** (open-ended, no preset options) to collect the alternative approach | Code change using author's approach |
+| **Reject** | Use **question tool** (open-ended, no preset options) to collect evidence-based reasoning | Reply comment with reasoning |
+| **Ask** | Use **question tool** (open-ended, no preset options) to collect the clarification question | Reply comment with question |
 
 **No item may be skipped or deferred.** Every item MUST receive a decision before the triage phase completes.
 
@@ -314,7 +314,7 @@ Total:   N items
 ```
 
 List each item with its decision. Use the
-**AskUserQuestion tool** with options `["Confirm --
+**question tool** with options `["Confirm --
 proceed with execution", "Revise -- change decisions"]`
 before execution proceeds.
 
@@ -399,7 +399,7 @@ git status
 
 **If branch has diverged** (another contributor pushed
 commits): warn the author and use the
-**AskUserQuestion tool** with options `["Rebase onto
+**question tool** with options `["Rebase onto
 remote and push", "Abort -- preserve local commits"]`.
 
 Push all commits:
@@ -418,7 +418,7 @@ git push origin <branch>
 
 After push succeeds (or if there are no code changes),
 post reply comments to the PR. Before posting, use the
-**AskUserQuestion tool** with options `["Yes -- post
+**question tool** with options `["Yes -- post
 reply comments", "No -- skip posting"]`.
 
 **Checklist gate**: Before presenting comments for posting,
@@ -478,7 +478,7 @@ After posting reply comments for accepted items, offer to resolve those threads:
 gh api graphql -f query='mutation { resolveReviewThread(input: {threadId: "<thread_id>"}) { thread { isResolved } } }'
 ```
 
-Use the **AskUserQuestion tool** with options
+Use the **question tool** with options
 `["Yes -- resolve accepted threads", "No -- leave
 threads open"]` before resolving.
 

--- a/internal/scaffold/assets/opencode/commands/uf.finale.md
+++ b/internal/scaffold/assets/opencode/commands/uf.finale.md
@@ -39,7 +39,7 @@ stays open for human review. Works with both Speckit
    in the current uncompressed conversation history, you
    MUST re-read this entire template, recover state from
    the execution checklist below, and re-confirm any
-   pending gates via the **AskUserQuestion tool** before
+   pending gates via the **question tool** before
    proceeding. Do NOT rely on gate confirmations recorded
    in compressed context. Do NOT infer step completion
    from compressed summaries. When in doubt, re-confirm
@@ -124,7 +124,7 @@ Run `git status --short` to inspect the working tree.
   > Proceed with staging all files? These files will be
   > included in the commit."
 
-  Use the **AskUserQuestion tool** with options
+  Use the **question tool** with options
   `["Yes -- stage all files and continue", "No -- stop here"]`.
 
   - If the user selects **"Yes -- stage all files and
@@ -234,7 +234,7 @@ git status
 in the local branch): warn the user about the divergence
 before presenting the confirmation gate.
 
-Use the **AskUserQuestion tool** with options
+Use the **question tool** with options
 `["Push to remote", "Abort -- keep commits local"]`.
 
 - If the user selects **"Push to remote"**:
@@ -397,7 +397,7 @@ gh pr view --json number,url 2>/dev/null
   > <body>
   > ```
 
-  Use the **AskUserQuestion tool** with options
+  Use the **question tool** with options
   `["Approve — create PR", "Edit title or body",
   "Provide my own title and body", "Abort — do not
   create PR"]`.
@@ -465,7 +465,7 @@ gh pr checks <number> --watch
   > 2. Re-run the checks
   > 3. Stop here and fix manually"
 
-  Use the **AskUserQuestion tool** to ask the user how
+  Use the **question tool** to ask the user how
   to proceed.
 
   >>> END MANDATORY GATE <<<
@@ -543,7 +543,7 @@ conflict to the user and present recovery options:
 > 5. Spawn sub-agent to resolve conflicts
 >    (AI-assisted)"
 
-Use the **AskUserQuestion tool** to ask the user
+Use the **question tool** to ask the user
 which option to take. After the user selects an option,
 update the execution checklist: set
 `CONFLICT_OPTION=<N>` (where N is the selected option

--- a/internal/scaffold/assets/opencode/commands/uf.review-council.md
+++ b/internal/scaffold/assets/opencode/commands/uf.review-council.md
@@ -490,13 +490,13 @@ Review the current codebase for compliance with the Behavioral Constraints in `A
    - If a prior review with the **same verdict** exists:
      Inform the user that a prior review exists and the
      latest review takes precedence. Use the
-     **AskUserQuestion tool** with options
+     **question tool** with options
      `["Yes -- post new review", "No -- skip posting"]`.
 
    - If a prior review with a **different verdict** exists:
      Inform the user of the prior verdict and that the new
      review will override it. Use the
-     **AskUserQuestion tool** with options
+     **question tool** with options
      `["Yes -- override with <new_verdict>",
      "No -- keep existing <old_verdict>"]`.
 
@@ -665,7 +665,7 @@ Review the current codebase for compliance with the Behavioral Constraints in `A
    current uncompressed conversation history, you MUST
    re-present the review content (verdict + all comments)
    and obtain fresh confirmation via the
-   **AskUserQuestion tool** before posting. Do NOT rely
+   **question tool** before posting. Do NOT rely
    on confirmation recorded in compressed context. When
    in doubt, re-confirm — false re-confirmation is
    harmless; posting without consent is a violation.
@@ -681,7 +681,7 @@ Review the current codebase for compliance with the Behavioral Constraints in `A
    | APPROVE WITH ADVISORIES | `COMMENT` |
 
    Display the verdict context, then use the
-   **AskUserQuestion tool** for confirmation:
+   **question tool** for confirmation:
 
    For APPROVE verdicts:
    > "This will post an APPROVE review, which may unblock
@@ -709,7 +709,7 @@ Review the current codebase for compliance with the Behavioral Constraints in `A
      COMMENT).
 
    **CRITICAL RULE**: NEVER post reviews without explicit
-   human confirmation via the **AskUserQuestion tool**.
+   human confirmation via the **question tool**.
    Always show the exact content (verdict type + all
    comments) that will be posted and wait for the user
    to select a confirming option. Mark `Step 7f` as

--- a/internal/scaffold/assets/opencode/commands/uf.review-pr.md
+++ b/internal/scaffold/assets/opencode/commands/uf.review-pr.md
@@ -108,7 +108,7 @@ Categorize each check as:
 - **SKIPPED**: Check was skipped
 
 If checks are still PENDING, inform the user and use
-the **AskUserQuestion tool** with options
+the **question tool** with options
 `["Wait for checks to complete", "Proceed with
 available results"]`.
 
@@ -155,11 +155,11 @@ from Step 2 metadata:
 
 **If total diff lines > 2000 OR changed files > 50**:
 
-Use the **AskUserQuestion tool** with options
+Use the **question tool** with options
 `["Review all files", "Focus on specific files"]`.
 
 If the user selects "Focus on specific files", follow up
-with the **AskUserQuestion tool** (open-ended, no preset
+with the **question tool** (open-ended, no preset
 options) to ask which files or directories to focus on.
 
 Record the user's choice as `FILE_FOCUS_SCOPE`:
@@ -758,7 +758,7 @@ I identified <N> pre-existing CI failure(s) that are NOT caused by this PR:
 These failures also occur on the base branch (<BASE_BRANCH>).
 ```
 
-Use the **AskUserQuestion tool** with options
+Use the **question tool** with options
 `["Yes -- create fix branch", "No -- skip"]`.
 
 **If the user selects "Yes -- create fix branch"**:
@@ -873,7 +873,7 @@ Verdict: <APPROVE / REQUEST CHANGES / COMMENT>
 
 Regardless of finding severities, always offer to post
 the review as a formal GitHub review on the PR. Use the
-**AskUserQuestion tool** with options
+**question tool** with options
 `["Yes -- post as GitHub review", "No -- terminal
 summary is sufficient"]`.
 
@@ -893,13 +893,13 @@ review fetch):
 - If a prior review with the **same verdict** exists:
   Inform the user that a prior review exists and the
   latest review takes precedence. Use the
-  **AskUserQuestion tool** with options
+  **question tool** with options
   `["Yes -- post new review", "No -- skip posting"]`.
 
 - If a prior review with a **different verdict** exists:
   Inform the user of the prior verdict and that the new
   review will override it. Use the
-  **AskUserQuestion tool** with options
+  **question tool** with options
   `["Yes -- override with <new_verdict>",
   "No -- keep existing <old_verdict>"]`.
 
@@ -976,7 +976,7 @@ account is not listed in CODEOWNERS.
    in the current uncompressed conversation history, you
    MUST re-present the review content (verdict + all
    comments) and obtain fresh confirmation via the
-   **AskUserQuestion tool** before posting. Do NOT rely
+   **question tool** before posting. Do NOT rely
    on confirmation recorded in compressed context. When
    in doubt, re-confirm — false re-confirmation is
    harmless; posting without consent is a violation.
@@ -1032,18 +1032,18 @@ account is not listed in CODEOWNERS.
    - COMMENT → `"event": "COMMENT"`
 
    Display the verdict context, then use the
-   **AskUserQuestion tool** for confirmation:
+   **question tool** for confirmation:
 
    For APPROVE verdicts: inform the user that this may
    unblock merge in repos with branch protection and
    that the review will be labeled as AI-generated.
-   Use the **AskUserQuestion tool** with options
+   Use the **question tool** with options
    `["Approve -- post review", "No -- skip posting",
    "Edit comments first", "Change verdict"]`.
 
    For REQUEST CHANGES or COMMENT verdicts: inform the
    user that this will block merge in repos with branch
-   protection. Use the **AskUserQuestion tool** with
+   protection. Use the **question tool** with
    options `["Yes -- post review", "No -- skip posting",
    "Edit comments first", "Change verdict"]`.
 
@@ -1084,10 +1084,10 @@ account is not listed in CODEOWNERS.
    suggest re-authenticating with `gh auth login`.
 
    - **"No -- skip posting"**: Skip posting, the terminal summary is sufficient
-   - **"Edit comments first"**: Let the user modify comments before posting, then re-confirm with the **AskUserQuestion tool**
+   - **"Edit comments first"**: Let the user modify comments before posting, then re-confirm with the **question tool**
 
 5. **CRITICAL RULE**: NEVER post reviews without explicit
-   human confirmation via the **AskUserQuestion tool**.
+   human confirmation via the **question tool**.
    Always show the exact content (verdict type + all
    comments) that will be posted and wait for the user
    to select a confirming option. For APPROVE verdicts,

--- a/internal/scaffold/assets/opencode/commands/uf.triage-issue.md
+++ b/internal/scaffold/assets/opencode/commands/uf.triage-issue.md
@@ -240,7 +240,7 @@ Split:        <"recommended" with count, or "not recommended">
 
 ### 4.2 Label Application
 
-**All label mutations require user confirmation.** Before creating or applying any label, use the **AskUserQuestion tool** to obtain explicit confirmation. The `duplicate` label has an additional supplementary confirmation gate because it carries implicit "close" semantics.
+**All label mutations require user confirmation.** Before creating or applying any label, use the **question tool** to obtain explicit confirmation. The `duplicate` label has an additional supplementary confirmation gate because it carries implicit "close" semantics.
 
 **Label mapping**:
 
@@ -260,7 +260,7 @@ Split:        <"recommended" with count, or "not recommended">
 
 **Path A — Label does NOT exist in the repository**:
 
-Inform the user: "The label '<label>' does not exist in the repository." Use the **AskUserQuestion tool** with options `["Yes -- create and apply label '<label>'", "No -- skip"]`.
+Inform the user: "The label '<label>' does not exist in the repository." Use the **question tool** with options `["Yes -- create and apply label '<label>'", "No -- skip"]`.
 
 If the user selects "No -- skip", skip both label creation and application. Record `labels_applied: []` and `label_creation_failed: false` in `actions_taken`. Proceed to Section 4.3.
 
@@ -280,7 +280,7 @@ gh issue edit <ISSUE_NUMBER> --add-label "<label>"
 
 **Path B — Label already EXISTS in the repository**:
 
-Use the **AskUserQuestion tool** with options `["Yes -- apply label '<label>'", "No -- skip"]`.
+Use the **question tool** with options `["Yes -- apply label '<label>'", "No -- skip"]`.
 
 If the user selects "No -- skip", skip label application. Record `labels_applied: []` in `actions_taken`. Proceed to Section 4.3.
 
@@ -290,7 +290,7 @@ If the user confirms, apply the label:
 gh issue edit <ISSUE_NUMBER> --add-label "<label>"
 ```
 
-**For `duplicate` label only** (supplementary gate, applies after either Path A or Path B confirmation): Inform the user that the `duplicate` label signals the issue should be closed. Use the **AskUserQuestion tool** with options `["Yes -- apply duplicate label", "No -- skip"]`. Only execute the `gh issue edit --add-label` command if the user confirms this supplementary gate. If the user declines, skip label application, record `labels_applied: []` in `actions_taken`, and proceed to Section 4.3.
+**For `duplicate` label only** (supplementary gate, applies after either Path A or Path B confirmation): Inform the user that the `duplicate` label signals the issue should be closed. Use the **question tool** with options `["Yes -- apply duplicate label", "No -- skip"]`. Only execute the `gh issue edit --add-label` command if the user confirms this supplementary gate. If the user declines, skip label application, record `labels_applied: []` in `actions_taken`, and proceed to Section 4.3.
 
 ### 4.3 Comment Composition and Posting
 
@@ -312,21 +312,21 @@ _This triage was performed by the Divisor review panel._
 **Re-run check**: If a previous triage comment was
 detected in Phase 1.2, warn the user that posting
 another comment may cause confusion. Use the
-**AskUserQuestion tool** with options `["Yes -- post
+**question tool** with options `["Yes -- post
 another comment", "No -- skip comment"]`. If the user
 selects "No -- skip comment", record
 `comment_posted: false` in the artifact and skip to
 Phase 4.4.
 
 **Present the composed comment to the user for
-confirmation**: Use the **AskUserQuestion tool** with
+confirmation**: Use the **question tool** with
 options `["Approve -- post as-is", "Modify -- adjust
 comment text", "Abort -- do not post"]`.
 
 | Selection | Action |
 |---|---|
 | **Approve -- post as-is** | Post the comment as-is |
-| **Modify -- adjust comment text** | Use **AskUserQuestion tool** (open-ended, no preset options) to collect the adjusted comment text; post the adjusted version |
+| **Modify -- adjust comment text** | Use **question tool** (open-ended, no preset options) to collect the adjusted comment text; post the adjusted version |
 | **Abort -- do not post** | Do not post any comment; record `comment_posted: false` in artifact |
 
 **Post the comment** (on Approve or Modify):
@@ -358,7 +358,7 @@ This section applies only when Phase 3.5 produced split recommendations.
 For each proposed child issue:
 
 1. **Present to user**: Show the proposed title and body.
-   Use the **AskUserQuestion tool** with options
+   Use the **question tool** with options
    `["Yes -- create this child issue", "No -- skip"]`
    for each child issue individually.
 
@@ -369,7 +369,7 @@ gh issue list --search "<sanitized-child-title>" --state open --json number,titl
 ```
 
    If a close match is found, warn the user about the
-   potential duplicate and use the **AskUserQuestion
+   potential duplicate and use the **question
    tool** with options `["Yes -- create anyway",
    "No -- skip this child issue"]`.
 

--- a/internal/scaffold/assets/opencode/skills/speckit-workflow/SKILL.md
+++ b/internal/scaffold/assets/opencode/skills/speckit-workflow/SKILL.md
@@ -37,7 +37,7 @@ current feature branch before any branch switch occurs.
   `main`.
 - Before creating a new feature branch (via `/speckit.specify`),
   check `git status --short` for uncommitted changes. If
-  uncommitted changes exist, use the **AskUserQuestion tool**
+  uncommitted changes exist, use the **question tool**
   to confirm before proceeding. Include the `git status --short`
   output in the question so the user can see which files are
   uncommitted:

--- a/openspec/changes/fix-ask-user-question-tool-name/.openspec.yaml
+++ b/openspec/changes/fix-ask-user-question-tool-name/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: unbound-force
+created: 2026-08-14

--- a/openspec/changes/fix-ask-user-question-tool-name/design.md
+++ b/openspec/changes/fix-ask-user-question-tool-name/design.md
@@ -1,0 +1,86 @@
+## Context
+
+Across 24 files (18 source + 6 scaffold assets), interactive
+confirmation gates reference `AskUserQuestion tool` — a name
+that does not exist in OpenCode's tool registry. The actual
+tool is `question`. This mismatch may cause agents to skip
+interactive gates entirely.
+
+The proposal (proposal.md) confirmed constitution alignment:
+all five principles are N/A or PASS since this is a text-only
+rename with no functional changes.
+
+## Goals / Non-Goals
+
+### Goals
+- Replace all occurrences of `AskUserQuestion tool` (and
+  variants) with `question tool` across all 24 affected files
+- Maintain drift detection parity between `.opencode/` source
+  files and `internal/scaffold/assets/opencode/` embedded copies
+- Preserve all existing gate logic unchanged
+
+### Non-Goals
+- Refactoring gate logic or adding new interactive gates
+- Adding a tool alias mechanism to OpenCode
+- Addressing mandatory gate markers (#474) or guardrail
+  hardening (#473) — those are separate issues
+- Modifying any Go source code or test logic
+- Updating historical OpenSpec change artifacts or CHANGELOG
+  entries that reference the old tool name — these are accurate
+  historical records of what was implemented at the time
+
+## Decisions
+
+### D1: Direct rename (Option A from #475)
+
+Replace all occurrences directly rather than defining an alias.
+The tool name should match the actual tool. Relying on agents
+to infer the mapping is fragile and adds indirection.
+
+### D2: Case-sensitive replacement patterns
+
+The occurrences use several formatting variants that must all
+be caught:
+
+| Pattern | Replacement |
+|---|---|
+| `**AskUserQuestion tool**` | `**question tool**` |
+| `**AskUserQuestion**` (bold, no "tool") | `**question**` |
+| `AskUserQuestion tool` (plain) | `question tool` |
+| `AskUserQuestion` (standalone reference) | `question` |
+
+The core replacement is `AskUserQuestion` → `question` in all
+contexts, preserving surrounding formatting (bold markers,
+backticks) and suffixes (`tool`, `tool call`, `response`,
+`Required`). Each file must be reviewed individually to ensure
+the replacement reads naturally in context.
+
+### D3: Scaffold asset lockstep update
+
+The embedded scaffold assets under
+`internal/scaffold/assets/opencode/` are canonical copies of
+the `.opencode/` source files. Both must be updated in the same
+commit to pass drift detection tests. The 6 affected scaffold
+files are:
+
+- `internal/scaffold/assets/opencode/commands/uf.address-feedback.md`
+- `internal/scaffold/assets/opencode/commands/uf.finale.md`
+- `internal/scaffold/assets/opencode/commands/uf.review-council.md`
+- `internal/scaffold/assets/opencode/commands/uf.review-pr.md`
+- `internal/scaffold/assets/opencode/commands/uf.triage-issue.md`
+- `internal/scaffold/assets/opencode/skills/speckit-workflow/SKILL.md`
+
+## Risks / Trade-offs
+
+### Low risk: Mechanical edit scope
+
+The change is entirely mechanical (text replacement). However,
+with 24 files and 100+ occurrences, manual review of each
+replacement is warranted to avoid breaking surrounding markdown
+formatting or instruction context.
+
+### Mitigation: Drift detection
+
+Existing drift detection tests will catch any mismatch between
+`.opencode/` and `internal/scaffold/assets/opencode/` files,
+providing a safety net against incomplete updates.

--- a/openspec/changes/fix-ask-user-question-tool-name/proposal.md
+++ b/openspec/changes/fix-ask-user-question-tool-name/proposal.md
@@ -1,0 +1,109 @@
+## Why
+
+Across 18 files (12 commands, 1 agent, 5 skills), interactive
+confirmation gates reference **`AskUserQuestion tool`** — a tool
+name that does not exist in OpenCode's tool registry. The actual
+tool is named **`question`**.
+
+When an agent reads these instructions literally and looks for a
+tool named `AskUserQuestion`, it may:
+- Silently skip the interactive gate entirely (most likely)
+- Map it to the `question` tool by inference (best case)
+- Fail with an error about a missing tool
+
+This was identified during triage of #465 where the agent skipped
+all interactive gates in `uf.triage-issue.md` Phase 4. Fixing the
+tool name is a defense-in-depth measure alongside #473 (guardrail
+hardening) and #474 (mandatory gate markers).
+
+Additionally, the embedded scaffold assets under
+`internal/scaffold/assets/opencode/` contain the same stale
+references in 6 files and must be updated in lockstep to maintain
+drift detection parity.
+
+Fixes #475.
+
+## What Changes
+
+Rename all occurrences of `AskUserQuestion tool` (and variants
+like `AskUserQuestion`) to `question tool` across all affected
+files. This is a mechanical search-and-replace with no functional
+changes to gate logic.
+
+## Capabilities
+
+### New Capabilities
+- None
+
+### Modified Capabilities
+- `interactive-gates`: All 18 command/agent/skill files now
+  reference the correct OpenCode tool name (`question`), improving
+  agent compliance with interactive confirmation gates.
+
+### Removed Capabilities
+- None
+
+## Impact
+
+- **Commands** (12 files): `uf.triage-issue.md`,
+  `uf.address-feedback.md`, `uf.review-council.md`,
+  `uf.review-pr.md`, `uf.finale.md`, `opsx-propose.md`,
+  `opsx-apply.md`, `opsx-archive.md`, `speckit.clarify.md`,
+  `speckit.implement.md`, `speckit.specify.md`,
+  `muti-mind.sync-push.md`
+- **Agents** (1 file): `muti-mind-po.md`
+- **Skills** (5 files): `openspec-apply-change/SKILL.md`,
+  `openspec-explore/SKILL.md`, `speckit-workflow/SKILL.md`,
+  `openspec-archive-change/SKILL.md`,
+  `openspec-propose/SKILL.md`
+- **Scaffold assets** (6 files): Embedded copies under
+  `internal/scaffold/assets/opencode/` must be updated in
+  lockstep to maintain drift detection parity.
+- **Total**: 24 files, 73 occurrences (source) + 42
+  occurrences (scaffold assets) = 115 total
+- **Risk**: Very low — text-only changes to tool name references,
+  no logic changes
+
+## Constitution Alignment
+
+Assessed against the Unbound Force org constitution.
+
+### I. Autonomous Collaboration
+
+**Assessment**: N/A
+
+This change modifies instruction text within agent prompts. It
+does not affect artifact-based communication or inter-hero
+collaboration patterns.
+
+### II. Composability First
+
+**Assessment**: N/A
+
+No dependencies are added or removed. Each file remains
+independently functional. The change is purely cosmetic to
+the tool name reference.
+
+### III. Observable Quality
+
+**Assessment**: N/A
+
+No output formats, provenance metadata, or machine-parseable
+artifacts are affected. This change modifies agent instruction
+files only.
+
+### IV. Testability
+
+**Assessment**: PASS
+
+Drift detection tests verify that `.opencode/` source files
+match their embedded copies under `internal/scaffold/assets/`.
+Both sets of files are updated in lockstep, maintaining test
+parity. No new code is introduced that would require coverage.
+
+### V. Security by Default
+
+**Assessment**: N/A
+
+No dependencies, inputs, permissions, or security-sensitive
+operations are affected.

--- a/openspec/changes/fix-ask-user-question-tool-name/specs/tool-name-rename.md
+++ b/openspec/changes/fix-ask-user-question-tool-name/specs/tool-name-rename.md
@@ -1,0 +1,46 @@
+## ADDED Requirements
+
+No new requirements are added by this change.
+
+## MODIFIED Requirements
+
+### Requirement: Interactive gate tool references
+
+All command, agent, and skill files that instruct agents to
+use an interactive confirmation gate MUST reference the tool
+by its actual OpenCode registry name: `question`.
+
+Previously: Files referenced `AskUserQuestion tool`, which
+does not exist in OpenCode's tool registry, causing agents
+to potentially skip interactive gates.
+
+#### Scenario: Agent encounters an interactive gate instruction
+
+- **GIVEN** an agent is executing a command that contains an
+  interactive confirmation gate
+- **WHEN** the agent reads the instruction to invoke a tool
+  for user confirmation
+- **THEN** the tool name in the instruction MUST be `question`,
+  matching OpenCode's actual tool registry entry
+
+#### Scenario: Scaffold asset drift detection
+
+- **GIVEN** the `.opencode/` source files have been updated
+  with the corrected tool name
+- **WHEN** drift detection tests compare source files against
+  their embedded copies in `internal/scaffold/assets/opencode/`
+- **THEN** the embedded copies MUST contain the same corrected
+  tool name references, and drift detection tests MUST pass
+
+#### Scenario: Gate logic preservation
+
+- **GIVEN** a command file contains interactive gate logic
+  (conditions, options, abort behavior)
+- **WHEN** the tool name reference is updated from
+  `AskUserQuestion` to `question`
+- **THEN** all surrounding gate logic (conditions, option
+  lists, abort handling) MUST remain unchanged
+
+## REMOVED Requirements
+
+No requirements are removed by this change.

--- a/openspec/changes/fix-ask-user-question-tool-name/tasks.md
+++ b/openspec/changes/fix-ask-user-question-tool-name/tasks.md
@@ -1,0 +1,77 @@
+<!--
+  [P] marks tasks eligible for parallel execution.
+  Add [P] when a task: (a) touches different files from
+  other [P] tasks in the group, (b) has no dependency
+  on prior tasks in the group, (c) can safely execute
+  without ordering constraints.
+  Do NOT add [P] when tasks modify the same file —
+  parallel workers will cause merge conflicts.
+  Tasks without [P] run sequentially first, then [P]
+  tasks run in parallel.
+-->
+
+## 1. Commands — source files (.opencode/commands/)
+
+Replace all `AskUserQuestion` references with `question`
+in each command file. Preserve surrounding formatting and
+gate logic.
+
+- [x] 1.1 [P] `.opencode/commands/uf.review-pr.md` (13 occurrences)
+- [x] 1.2 [P] `.opencode/commands/uf.triage-issue.md` (9 occurrences)
+- [x] 1.3 [P] `.opencode/commands/uf.address-feedback.md` (8 occurrences)
+- [x] 1.4 [P] `.opencode/commands/speckit.clarify.md` (8 occurrences)
+- [x] 1.5 [P] `.opencode/commands/uf.finale.md` (6 occurrences)
+- [x] 1.6 [P] `.opencode/commands/uf.review-council.md` (5 occurrences)
+- [x] 1.7 [P] `.opencode/commands/speckit.implement.md` (4 occurrences)
+- [x] 1.8 [P] `.opencode/commands/opsx-propose.md` (3 occurrences)
+- [x] 1.9 [P] `.opencode/commands/opsx-archive.md` (2 occurrences)
+- [x] 1.10 [P] `.opencode/commands/opsx-apply.md` (1 occurrence)
+- [x] 1.11 [P] `.opencode/commands/speckit.specify.md` (1 occurrence)
+- [x] 1.12 [P] `.opencode/commands/muti-mind.sync-push.md` (1 occurrence)
+
+**Checkpoint**: `rg -c "AskUserQuestion" .opencode/commands/`
+returns no results.
+
+## 2. Agent files (.opencode/agents/)
+
+- [x] 2.1 [P] `.opencode/agents/muti-mind-po.md` (1 occurrence)
+
+**Checkpoint**: `rg -c "AskUserQuestion" .opencode/agents/`
+returns no results.
+
+## 3. Skill files (.opencode/skills/)
+
+- [x] 3.1 [P] `.opencode/skills/openspec-archive-change/SKILL.md` (5 occurrences)
+- [x] 3.2 [P] `.opencode/skills/openspec-propose/SKILL.md` (3 occurrences)
+- [x] 3.3 [P] `.opencode/skills/openspec-apply-change/SKILL.md` (1 occurrence)
+- [x] 3.4 [P] `.opencode/skills/openspec-explore/SKILL.md` (1 occurrence)
+- [x] 3.5 [P] `.opencode/skills/speckit-workflow/SKILL.md` (1 occurrence)
+
+**Checkpoint**: `rg -c "AskUserQuestion" .opencode/skills/`
+returns no results.
+
+## 4. Scaffold assets (internal/scaffold/assets/opencode/)
+
+Update the embedded scaffold copies in lockstep with their
+`.opencode/` source counterparts. These files MUST match
+their source exactly to pass drift detection tests.
+
+- [x] 4.1 [P] `internal/scaffold/assets/opencode/commands/uf.review-pr.md` (13 occurrences)
+- [x] 4.2 [P] `internal/scaffold/assets/opencode/commands/uf.triage-issue.md` (9 occurrences)
+- [x] 4.3 [P] `internal/scaffold/assets/opencode/commands/uf.address-feedback.md` (8 occurrences)
+- [x] 4.4 [P] `internal/scaffold/assets/opencode/commands/uf.finale.md` (6 occurrences)
+- [x] 4.5 [P] `internal/scaffold/assets/opencode/commands/uf.review-council.md` (5 occurrences)
+- [x] 4.6 [P] `internal/scaffold/assets/opencode/skills/speckit-workflow/SKILL.md` (1 occurrence)
+
+**Checkpoint**: `rg -c "AskUserQuestion" internal/scaffold/assets/opencode/`
+returns no results.
+
+## 5. Verification
+
+- [x] 5.1 Run `rg -c "AskUserQuestion" .opencode/ internal/scaffold/assets/opencode/` — MUST return no results
+- [x] 5.2 Run drift detection tests: `go test ./internal/scaffold/... -run TestEmbeddedAssets_MatchSource -race -count=1`
+- [x] 5.3 Run full test suite: `make test`
+- [x] 5.4 Verify constitution alignment: Testability principle PASS confirmed — drift detection parity maintained
+<!-- spec-review: passed -->
+<!-- implement: done -->
+<!-- code-review: passed -->


### PR DESCRIPTION
## Summary

Replace all references to the non-existent `AskUserQuestion` tool with
`question` — the actual OpenCode tool name — across 24 command, agent,
skill, and scaffold asset files.

Fixes #475

## Problem

18 files under `.opencode/` reference `AskUserQuestion tool` in agent
instructions for interactive confirmation gates. This tool name does not
exist in OpenCode's tool registry — the actual tool is named `question`.
When agents encounter these instructions, they may silently skip the
confirmation gate because the tool cannot be resolved, undermining
safety-critical interactive gates.

## Changes

- **Commands** (12 files): Renamed 61 occurrences across
  `uf.review-pr.md`, `uf.triage-issue.md`, `uf.address-feedback.md`,
  `speckit.clarify.md`, `uf.finale.md`, `uf.review-council.md`,
  `speckit.implement.md`, `opsx-propose.md`, `opsx-archive.md`,
  `opsx-apply.md`, `speckit.specify.md`, `muti-mind.sync-push.md`
- **Agents** (1 file): Renamed 1 occurrence in `muti-mind-po.md`
- **Skills** (5 files): Renamed 12 occurrences across
  `openspec-archive-change`, `openspec-propose`,
  `openspec-apply-change`, `openspec-explore`, `speckit-workflow`
- **Scaffold assets** (6 files): Renamed 42 occurrences to maintain
  drift detection parity with source files
- **Grammar**: Fixed `an **question tool**` → `a **question tool**`
  in `speckit.implement.md` (article change required after rename)
- **CHANGELOG**: Added entry under `### Fixed`

## Verification

- `rg -c "AskUserQuestion" .opencode/ internal/scaffold/assets/opencode/`
  → zero results
- `go test ./internal/scaffold/... -run TestEmbeddedAssets_MatchSource
  -race -count=1` → PASS (drift detection parity confirmed)
- `make test` → all 20 packages pass
- `make check` → all checks pass (vet, lint, test, build)

## Spec

OpenSpec: `openspec/changes/fix-ask-user-question-tool-name/`