### PR TITLE
fix(commands): add mandatory gate to uf.triage-issue Phase 4

### DIFF
--- a/.opencode/commands/uf.triage-issue.md
+++ b/.opencode/commands/uf.triage-issue.md
@@ -214,6 +214,44 @@ If two or more agents recommend splitting the issue, synthesize their recommenda
 
 Present the analysis and execute triage actions with user confirmation.
 
+>>> MANDATORY GATE: HUMAN CONFIRMATION REQUIRED <<<
+
+**Session-resume guard**: If this session was resumed
+from compressed context, or if you cannot verify that
+the human explicitly confirmed the triage actions in the
+current uncompressed conversation history, you MUST
+re-present the Phase 4.1 summary and obtain fresh
+confirmation via the **question tool** before proceeding.
+Do NOT rely on confirmation recorded in compressed
+context. When in doubt, re-confirm -- false
+re-confirmation is harmless; executing mutations without
+consent is a violation.
+
+**Before presenting the gate question**: Execute step 4.1
+below to display the full triage summary. The human MUST
+see the summary before being asked to confirm.
+
+**Confirmation**: Use the **question tool** with options:
+`["Proceed -- execute triage actions",
+"Skip -- write artifact only"]`.
+
+- If the user selects **"Proceed"**: continue to steps
+  4.2, 4.3, and 4.4 as described below.
+- If the user selects **"Skip"**: skip steps 4.2, 4.3,
+  and 4.4 entirely. Jump directly to step 4.5 (artifact
+  generation). Record `actions_taken` with all fields
+  set to their "not executed" defaults.
+
+**Mutation safety reminder**: All GitHub mutations in
+steps 4.2, 4.3, and 4.4 MUST use the temp file +
+`--input` pattern (see Guardrail 8). Write all untrusted
+content to a temporary file with restrictive permissions
+(`chmod 600` or `umask 077`), pass via `gh api --input
+<tmpfile>`, and clean up the file on ALL exit paths.
+MUST NOT interpolate untrusted text into shell arguments.
+
+>>> END MANDATORY GATE <<<
+
 ### 4.1 Present Analysis Summary
 
 Display the consolidated classification to the user:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@ Each entry follows the format: `- <change-name>: <summary>`.
   scopes.
   (Spec: openspec/changes/pre-flight-file-scope-filter/,
   Fixes: #434)
+- triage-mandatory-gate: Add `>>> MANDATORY GATE <<<` to
+  `uf.triage-issue` Phase 4 entry. Agents now stop and
+  require explicit human confirmation before executing
+  mutations (labels, comments, child issues). Includes
+  compressed-context resume guard and mutation safety
+  reiteration.
+  (Spec: openspec/changes/triage-mandatory-gate/,
+  Fixes: #473)
 - adopt-org-infra-release-workflows: Replace inline
   release preflight and GoReleaser jobs with org-infra
   reusable workflow callers (`reusable_release_preflight`

--- a/internal/scaffold/assets/opencode/commands/uf.triage-issue.md
+++ b/internal/scaffold/assets/opencode/commands/uf.triage-issue.md
@@ -214,6 +214,44 @@ If two or more agents recommend splitting the issue, synthesize their recommenda
 
 Present the analysis and execute triage actions with user confirmation.
 
+>>> MANDATORY GATE: HUMAN CONFIRMATION REQUIRED <<<
+
+**Session-resume guard**: If this session was resumed
+from compressed context, or if you cannot verify that
+the human explicitly confirmed the triage actions in the
+current uncompressed conversation history, you MUST
+re-present the Phase 4.1 summary and obtain fresh
+confirmation via the **question tool** before proceeding.
+Do NOT rely on confirmation recorded in compressed
+context. When in doubt, re-confirm -- false
+re-confirmation is harmless; executing mutations without
+consent is a violation.
+
+**Before presenting the gate question**: Execute step 4.1
+below to display the full triage summary. The human MUST
+see the summary before being asked to confirm.
+
+**Confirmation**: Use the **question tool** with options:
+`["Proceed -- execute triage actions",
+"Skip -- write artifact only"]`.
+
+- If the user selects **"Proceed"**: continue to steps
+  4.2, 4.3, and 4.4 as described below.
+- If the user selects **"Skip"**: skip steps 4.2, 4.3,
+  and 4.4 entirely. Jump directly to step 4.5 (artifact
+  generation). Record `actions_taken` with all fields
+  set to their "not executed" defaults.
+
+**Mutation safety reminder**: All GitHub mutations in
+steps 4.2, 4.3, and 4.4 MUST use the temp file +
+`--input` pattern (see Guardrail 8). Write all untrusted
+content to a temporary file with restrictive permissions
+(`chmod 600` or `umask 077`), pass via `gh api --input
+<tmpfile>`, and clean up the file on ALL exit paths.
+MUST NOT interpolate untrusted text into shell arguments.
+
+>>> END MANDATORY GATE <<<
+
 ### 4.1 Present Analysis Summary
 
 Display the consolidated classification to the user:

--- a/openspec/changes/triage-mandatory-gate/.openspec.yaml
+++ b/openspec/changes/triage-mandatory-gate/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: unbound-force
+created: 2026-08-14

--- a/openspec/changes/triage-mandatory-gate/design.md
+++ b/openspec/changes/triage-mandatory-gate/design.md
@@ -46,10 +46,6 @@ in a separate section far from the Phase 4 entry point.
   question tool references remain as defense-in-depth)
 - Adding gates to other phases (Phase 1-3 are read-only)
 - Changing the triage artifact format (Phase 4.5)
-- Adding an `>>> END MANDATORY GATE <<<` closing marker
-  (the entire remainder of Phase 4 is gated; closing markers
-  are used in `uf.finale` for conditional gates that have
-  ungated content following them)
 
 ## Decisions
 

--- a/openspec/changes/triage-mandatory-gate/design.md
+++ b/openspec/changes/triage-mandatory-gate/design.md
@@ -1,0 +1,124 @@
+## Context
+
+`uf.triage-issue.md` Phase 4 is labeled "(Interactive)" but
+the only enforcement of interactivity is scattered `question
+tool` references within individual sub-steps (4.2, 4.3, 4.4).
+When an agent operates under compressed context or loses
+instruction fidelity, these scattered references are
+insufficient to prevent autonomous mutation. Three other
+commands (`uf.review-council`, `uf.review-pr`, `uf.finale`)
+solve this with `>>> MANDATORY GATE <<<` markers -- a proven
+pattern that this command lacks.
+
+The current Phase 4 structure:
+
+```
+Phase 4: Act (Interactive)       <-- no gate marker
+  4.1 Present Analysis Summary   <-- display-only, no stop
+  4.2 Label Application          <-- inline question tool ref
+  4.3 Comment Posting            <-- inline question tool ref
+  4.4 Child Issue Creation       <-- inline question tool ref
+  4.5 Artifact                   <-- write-only, no mutation
+```
+
+Phase 4 guardrails (section at end of file) include rules like
+"never post comments without user confirmation" and "never
+create child issues without user confirmation," but these are
+in a separate section far from the Phase 4 entry point.
+
+## Goals / Non-Goals
+
+### Goals
+- Add a `>>> MANDATORY GATE <<<` block at Phase 4 entry that
+  creates an enforceable hard stop between classification
+  (Phase 3) and mutation (Phase 4)
+- Include a compressed-context resume guard following the same
+  pattern as `uf.review-council.md` Step 7f
+- Reiterate the `gh api --input <tmpfile>` requirement at the
+  mutation boundary (already a guardrail, but not at the gate)
+- Require Phase 4.1 summary display as a precondition for
+  proceeding through the gate
+- Keep both copies of the file in sync
+  (`.opencode/commands/` and `internal/scaffold/assets/`)
+
+### Non-Goals
+- Refactoring Phase 4 sub-step structure (4.2/4.3/4.4 inline
+  question tool references remain as defense-in-depth)
+- Adding gates to other phases (Phase 1-3 are read-only)
+- Changing the triage artifact format (Phase 4.5)
+- Adding an `>>> END MANDATORY GATE <<<` closing marker
+  (the entire remainder of Phase 4 is gated; closing markers
+  are used in `uf.finale` for conditional gates that have
+  ungated content following them)
+
+## Decisions
+
+### D1: Single gate at Phase 4 entry, not per-sub-step
+
+**Rationale**: The individual sub-steps (4.2, 4.3, 4.4) already
+have inline `question tool` references for per-action
+confirmation. Adding `>>> MANDATORY GATE <<<` to each would be
+redundant. The root cause from #473 was that the agent skipped
+all of Phase 4's interactivity, not that it selectively skipped
+one sub-step. A single gate at Phase 4 entry addresses the root
+cause.
+
+### D2: Gate positioned between Phase 4 heading and 4.1
+
+**Rationale**: The gate block sits immediately after the Phase 4
+heading and before 4.1 (summary display). The gate instructions
+require the agent to display the 4.1 summary first, then present
+the confirmation question. This ensures the user sees the full
+triage analysis before being asked to approve mutations.
+
+### D3: Follow exact `uf.review-council` gate pattern
+
+**Rationale**: The `uf.review-council.md` Step 7f gate is the
+most battle-tested pattern -- it includes the marker, the
+session-resume guard, the question tool confirmation, and
+explicit stop instructions for each user response. Reusing this
+pattern verbatim (adapted to triage context) ensures consistency
+and leverages proven effectiveness.
+
+### D4: Reiterate `--input` requirement in gate block
+
+**Rationale**: The guardrails section already specifies the
+`gh api --input <tmpfile>` requirement for shell injection
+prevention, but it is 250+ lines away from the mutation
+boundary. Reiterating it in the gate block puts the safety
+requirement at the point of maximum relevance -- when the agent
+is about to execute mutations. This aligns with Principle V
+(Security by Default) from the proposal's constitution
+alignment.
+
+### D5: Both files updated identically
+
+**Rationale**: `.opencode/commands/uf.triage-issue.md` is the
+deployed command file; `internal/scaffold/assets/opencode/
+commands/uf.triage-issue.md` is the scaffold canonical. The
+existing drift-detection test in the build verifies these match.
+Both must be updated with identical content.
+
+## Risks / Trade-offs
+
+### R1: Gate adds friction to triage workflow
+
+**Risk**: Users may find the additional confirmation step
+slightly slower for straightforward triage runs.
+
+**Mitigation**: The gate fires once at Phase 4 entry, not per
+sub-step. For most triage runs, this adds a single confirmation.
+The sub-step confirmations (4.2/4.3/4.4) remain but are not
+duplicated -- they handle per-action granularity (e.g., "apply
+this label?" vs "create these child issues?").
+
+### R2: Compressed-context resume guard may re-confirm
+
+**Risk**: If an agent session is resumed from compressed
+context, the guard requires re-displaying the summary and
+re-confirming. This could feel redundant to users who already
+confirmed in a prior context window.
+
+**Mitigation**: This is the intended behavior -- identical to
+the `uf.review-council` pattern. False re-confirmation is
+harmless; posting without consent is a violation.

--- a/openspec/changes/triage-mandatory-gate/proposal.md
+++ b/openspec/changes/triage-mandatory-gate/proposal.md
@@ -1,0 +1,113 @@
+## Why
+
+During triage of issue #465 via `uf.triage-issue`, the agent
+executed all Phase 4 mutations autonomously -- posting a triage
+comment, creating 4 child issues, and writing an artifact -- all
+without pausing for user confirmation. The root cause is that
+Phase 4 is labeled "(Interactive)" but lacks an explicit
+`>>> MANDATORY GATE <<<` marker. Other commands
+(`uf.review-council` Step 7f, `uf.finale` Steps 2/5) use this
+marker pattern successfully to enforce hard stops.
+
+Additionally, the agent used `gh issue create`/`gh issue comment`
+instead of the `gh api --input <tmpfile>` pattern, which is a
+shell injection safety violation already covered by the command's
+guardrails but not reiterated at the mutation boundary.
+
+Severity: HIGH. Mutations without confirmation violate the
+interactive contract and Principle V (Security by Default).
+
+Fixes #473.
+
+## What Changes
+
+Add a mandatory gate block at the Phase 4 entry point in
+`uf.triage-issue.md`. The gate follows the same proven pattern
+used by `uf.review-council.md` and `uf.finale.md`:
+
+1. `>>> MANDATORY GATE <<<` marker at Phase 4 entry
+2. Compressed-context resume guard (re-read instructions)
+3. Temp file + `--input` requirement reiterated at the
+   mutation boundary
+4. Phase 4.1 summary display required before any mutation
+
+## Capabilities
+
+### New Capabilities
+- `mandatory-gate-phase-4`: Enforceable hard stop at the
+  boundary between classification (Phase 3) and mutation
+  (Phase 4) in the triage workflow
+
+### Modified Capabilities
+- `uf.triage-issue Phase 4`: Phase 4 entry now includes an
+  explicit mandatory gate block that prevents autonomous
+  execution of mutations
+
+### Removed Capabilities
+- None
+
+## Impact
+
+- **Files modified**: `.opencode/commands/uf.triage-issue.md`
+  and `internal/scaffold/assets/opencode/commands/uf.triage-issue.md`
+  (kept in sync, identical content)
+- **Behavioral change**: Agents executing `uf.triage-issue`
+  will be required to stop at Phase 4 entry, display the
+  triage summary, and obtain explicit user confirmation
+  before proceeding to any mutation (labels, comments,
+  child issues)
+- **No breaking changes**: The command's external interface
+  and output format are unchanged
+- **No new dependencies**: Uses existing `question` tool
+  pattern already available in the agent runtime
+
+## Constitution Alignment
+
+Assessed against the Unbound Force org constitution.
+
+### I. Autonomous Collaboration
+
+**Assessment**: N/A
+
+This change modifies an interactive command workflow, not
+inter-hero artifact communication. The triage artifact
+(Phase 4.5) output format is unchanged.
+
+### II. Composability First
+
+**Assessment**: PASS
+
+The change is self-contained within the `uf.triage-issue`
+command. No other hero or command is affected. The command
+remains independently usable.
+
+### III. Observable Quality
+
+**Assessment**: PASS
+
+The triage summary (Phase 4.1) is displayed to the user
+before mutations proceed, improving observability of the
+agent's classification decisions before they become
+irreversible GitHub state changes.
+
+### IV. Testability
+
+**Assessment**: N/A
+
+This change modifies a Markdown command specification, not
+executable code. The behavioral contract is verified by the
+existing drift-detection test that ensures the scaffold
+asset matches the deployed command file. The pipeline test
+suite for `council-review-action` provides the pattern for
+testing similar gate behaviors.
+
+### V. Security by Default
+
+**Assessment**: PASS
+
+This change directly strengthens security: it prevents
+agents from executing GitHub mutations (issue comments,
+child issue creation) without user confirmation, and
+reiterates the `gh api --input <tmpfile>` requirement at the
+mutation boundary to prevent shell injection via
+interpolated issue content.

--- a/openspec/changes/triage-mandatory-gate/specs/mandatory-gate.md
+++ b/openspec/changes/triage-mandatory-gate/specs/mandatory-gate.md
@@ -1,0 +1,96 @@
+## ADDED Requirements
+
+### Requirement: Phase 4 Mandatory Gate
+
+The `uf.triage-issue` command MUST include a
+`>>> MANDATORY GATE: HUMAN CONFIRMATION REQUIRED <<<`
+marker block at the entry to Phase 4, immediately after the
+Phase 4 heading and before any sub-step instructions.
+
+#### Scenario: Agent reaches Phase 4 boundary
+- **GIVEN** the agent has completed Phase 3 (Classify) and
+  is about to begin Phase 4 (Act)
+- **WHEN** the agent reads the Phase 4 instructions
+- **THEN** the agent MUST encounter the mandatory gate
+  marker before any mutation instructions
+
+#### Scenario: Agent displays triage summary before gate
+- **GIVEN** the agent has reached the mandatory gate in
+  Phase 4
+- **WHEN** the agent processes the gate instructions
+- **THEN** the agent MUST display the Phase 4.1 triage
+  summary to the user before presenting the confirmation
+  question
+
+#### Scenario: User approves mutations
+- **GIVEN** the agent has displayed the triage summary and
+  presented the confirmation question via the question tool
+- **WHEN** the user selects the approval option
+- **THEN** the agent MAY proceed to execute Phase 4
+  sub-steps (4.2, 4.3, 4.4) with their individual
+  per-action confirmations
+
+#### Scenario: User declines mutations
+- **GIVEN** the agent has displayed the triage summary and
+  presented the confirmation question via the question tool
+- **WHEN** the user selects the decline option
+- **THEN** the agent MUST skip all mutation sub-steps
+  (4.2, 4.3, 4.4) and proceed directly to Phase 4.5
+  (artifact writing)
+
+### Requirement: Compressed-Context Resume Guard
+
+The mandatory gate block MUST include a session-resume guard
+that requires re-confirmation when the session has been
+resumed from compressed context.
+
+#### Scenario: Session resumed from compressed context
+- **GIVEN** the agent session was resumed from compressed
+  context and the agent cannot verify that the user
+  explicitly confirmed mutations in the current
+  uncompressed conversation history
+- **WHEN** the agent reaches the Phase 4 mandatory gate
+- **THEN** the agent MUST re-display the triage summary
+  and obtain fresh confirmation via the question tool
+  before proceeding to any mutation
+
+### Requirement: Mutation Safety Reiteration
+
+The mandatory gate block MUST reiterate the `gh api --input
+<tmpfile>` requirement for all GitHub mutations (comments,
+child issue creation).
+
+#### Scenario: Agent prepares to post comment
+- **GIVEN** the user has confirmed mutations through the
+  mandatory gate
+- **WHEN** the agent reaches a step that involves posting
+  a GitHub comment or creating a child issue
+- **THEN** the agent MUST use the `gh api --input <tmpfile>`
+  pattern (write payload to a temporary file, pass via
+  `--input`) and MUST NOT use `gh issue comment` or
+  `gh issue create` with inline content
+
+### Requirement: File Sync
+
+Both copies of `uf.triage-issue.md` MUST contain identical
+content after the change is applied.
+
+#### Scenario: Scaffold asset matches deployed command
+- **GIVEN** the change has been applied to both
+  `.opencode/commands/uf.triage-issue.md` and
+  `internal/scaffold/assets/opencode/commands/uf.triage-issue.md`
+- **WHEN** the drift-detection test compares the two files
+- **THEN** the files MUST have identical content
+
+## MODIFIED Requirements
+
+### Requirement: Phase 4 heading
+
+The Phase 4 heading retains its "(Interactive)" label.
+Previously: the heading was the sole indicator of
+interactivity. Now: the heading is supplemented by a
+mandatory gate block that enforces the interactive contract.
+
+## REMOVED Requirements
+
+None.

--- a/openspec/changes/triage-mandatory-gate/tasks.md
+++ b/openspec/changes/triage-mandatory-gate/tasks.md
@@ -1,0 +1,50 @@
+<!--
+  [P] marks tasks eligible for parallel execution.
+  Add [P] when a task: (a) touches different files from
+  other [P] tasks in the group, (b) has no dependency
+  on prior tasks in the group, (c) can safely execute
+  without ordering constraints.
+  Do NOT add [P] when tasks modify the same file —
+  parallel workers will cause merge conflicts.
+  Tasks without [P] run sequentially first, then [P]
+  tasks run in parallel.
+-->
+
+## 1. Add mandatory gate block to uf.triage-issue.md
+
+- [x] 1.1 Insert `>>> MANDATORY GATE: HUMAN CONFIRMATION
+  REQUIRED <<<` marker block immediately after the Phase 4
+  heading (`## Phase 4: Act (Interactive)`, currently line 211) in
+  `.opencode/commands/uf.triage-issue.md`. The gate block
+  MUST include:
+  (a) the mandatory gate marker,
+  (b) a session-resume guard identical in structure to
+  `uf.review-council.md` Step 7f (lines 662-673),
+  (c) instruction to display the Phase 4.1 summary before
+  presenting the confirmation question,
+  (d) a `question tool` call with options
+  `["Proceed -- execute triage actions", "Skip -- write
+  artifact only"]`,
+  (e) stop instruction if user selects "Skip",
+  (f) reiteration of the `gh api --input <tmpfile>`
+  requirement for all GitHub mutations in Phase 4
+
+## 2. Sync scaffold canonical
+
+- [x] 2.1 Copy the updated content from
+  `.opencode/commands/uf.triage-issue.md` to
+  `internal/scaffold/assets/opencode/commands/uf.triage-issue.md`
+  so both files are identical
+
+## 3. Verification
+
+- [x] 3.1 Run `make test` to verify the drift-detection
+  test passes (confirms the two files are in sync)
+- [x] 3.2 Verify constitution alignment: the change
+  strengthens Principle V (Security by Default) by
+  enforcing the `--input` pattern at the mutation boundary,
+  and does not violate Principles I-IV (per proposal.md
+  assessment)
+
+<!-- spec-review: passed -->
+<!-- code-review: passed -->


### PR DESCRIPTION
## Summary

Adds a `>>> MANDATORY GATE: HUMAN CONFIRMATION REQUIRED <<<`
block to Phase 4 of the `uf.triage-issue` command.

During triage of issue #465, the agent executed all Phase 4
mutations autonomously -- posting a triage comment and creating
4 child issues -- without pausing for user confirmation. The
root cause: Phase 4 was labeled "(Interactive)" but lacked an
explicit mandatory gate marker. Other commands
(`uf.review-council` Step 7f, `uf.finale` Steps 2/5) use this
marker pattern successfully to enforce hard stops.

The gate includes a session-resume guard, requires displaying
the triage summary before proceeding, offers Proceed/Skip
options via the question tool, and reiterates the
`gh api --input <tmpfile>` injection safety requirement at the
mutation boundary.

Fixes #473

## How to Test

1. Run `/uf.triage-issue <N>` on any open issue
2. Verify the agent stops at Phase 4 entry with a mandatory
   gate prompt displaying the triage summary
3. Select "Proceed" -- confirm mutations execute with per-step
   confirmations (labels, comment, child issues)
4. On a separate test, select "Skip" -- confirm only the
   artifact is written and no GitHub mutations occur
5. Run `make test` -- verify all 20 packages pass including
   the drift-detection test for scaffold file sync

## How to Demo

1. Open any GitHub issue in the repository
2. Run `/uf.triage-issue <issue-number>`
3. Observe the 5-agent triage assessment (Phase 2) and
   classification (Phase 3) execute normally
4. At Phase 4 entry, observe the mandatory gate prompt with
   the triage summary displayed above it
5. The question tool presents two options:
   - "Proceed -- execute triage actions"
   - "Skip -- write artifact only"
6. Selecting "Proceed" continues to per-action confirmations
   for labels, comments, and child issues
7. Selecting "Skip" jumps directly to artifact generation

## Key Files Changed

**.opencode/commands/**
- `uf.triage-issue.md` -- 38-line mandatory gate block inserted
  at Phase 4 entry (between heading and 4.1)

**internal/scaffold/assets/opencode/commands/**
- `uf.triage-issue.md` -- identical sync copy of the above

**openspec/changes/triage-mandatory-gate/**
- `.openspec.yaml` -- change metadata
- `proposal.md` -- motivation and what changes
- `design.md` -- 5 design decisions, risks, non-goals
- `specs/mandatory-gate.md` -- delta spec with 6 scenarios
- `tasks.md` -- 3 task groups, all complete

_This PR was generated by /uf.finale (AI-assisted)._
