### PR TITLE
fix(scaffold): protect constitution from --force overwrite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,14 @@ Each entry follows the format: `- <change-name>: <summary>`.
   from "create" to "customize".
   (Spec: openspec/changes/fix-constitution-scaffold/,
   Fixes: #213)
+- shield-constitution-from-force: `uf init --force` no
+  longer overwrites `.specify/memory/constitution.md`,
+  preserving user governance customizations. Adds an
+  `isNeverOverwrite` guard that protects the constitution
+  from force-overwrite while still allowing first-time
+  creation from the embedded starter template.
+  (Spec: openspec/changes/shield-constitution-from-force/,
+  Fixes: #495)
 - fix-doctor-hints: Replace five hardcoded OpenCode-specific
   `InstallHint` strings in `uf doctor` agent context checks
   with tool-agnostic plain-language remediation instructions.

--- a/internal/scaffold/scaffold.go
+++ b/internal/scaffold/scaffold.go
@@ -174,6 +174,13 @@ func Run(opts Options) (*Result, error) {
 		}
 
 		// File exists
+
+		// Protected files are never overwritten, even with --force.
+		if isNeverOverwrite(relPath) {
+			result.Skipped = append(result.Skipped, outRel)
+			return nil
+		}
+
 		if opts.Force {
 			// Force mode -- overwrite everything
 			if err := os.WriteFile(outPath, out, 0o644); err != nil {
@@ -426,6 +433,16 @@ func isToolOwned(relPath string) bool {
 		return !strings.Contains(base, "-custom")
 	}
 	return false
+}
+
+// isNeverOverwrite returns true if the file must never be
+// overwritten, even with --force. These are governance
+// artifacts that users customize and must not lose.
+// The predicate performs exact string comparison on the
+// embedded asset path (without leading dot). Path
+// normalization is the caller's responsibility.
+func isNeverOverwrite(relPath string) bool {
+	return relPath == "specify/memory/constitution.md"
 }
 
 // isDivisorAsset returns true if the asset belongs to the

--- a/internal/scaffold/scaffold_test.go
+++ b/internal/scaffold/scaffold_test.go
@@ -408,7 +408,7 @@ func TestRun_ConstitutionPreservedOnRerun(t *testing.T) {
 	}
 }
 
-func TestRun_ConstitutionOverwrittenWithForce(t *testing.T) {
+func TestRun_ConstitutionProtectedWithForce(t *testing.T) {
 	dir := t.TempDir()
 	var buf bytes.Buffer
 
@@ -424,11 +424,12 @@ func TestRun_ConstitutionOverwrittenWithForce(t *testing.T) {
 
 	// User customizes the constitution.
 	constitutionPath := filepath.Join(dir, ".specify", "memory", "constitution.md")
-	if err := os.WriteFile(constitutionPath, []byte("user content"), 0o644); err != nil {
+	customContent := "# My Custom Constitution\n\nCustomized governance."
+	if err := os.WriteFile(constitutionPath, []byte(customContent), 0o644); err != nil {
 		t.Fatalf("write custom constitution: %v", err)
 	}
 
-	// Re-run with --force: constitution should be overwritten.
+	// Re-run with --force: constitution should be protected (skipped).
 	buf.Reset()
 	result, err := Run(Options{
 		TargetDir: dir,
@@ -441,27 +442,34 @@ func TestRun_ConstitutionOverwrittenWithForce(t *testing.T) {
 	}
 
 	constitutionOut := ".specify/memory/constitution.md"
-	foundOverwritten := false
-	for _, f := range result.Overwritten {
+
+	// Constitution MUST be in Skipped.
+	foundSkipped := false
+	for _, f := range result.Skipped {
 		if f == constitutionOut {
-			foundOverwritten = true
+			foundSkipped = true
 			break
 		}
 	}
-	if !foundOverwritten {
-		t.Errorf("expected %s in result.Overwritten", constitutionOut)
+	if !foundSkipped {
+		t.Errorf("expected %s in result.Skipped, got Skipped=%v", constitutionOut, result.Skipped)
 	}
 
-	// Content should be the starter constitution, not "user content".
+	// Constitution MUST NOT be in Overwritten.
+	for _, f := range result.Overwritten {
+		if f == constitutionOut {
+			t.Errorf("constitution must not be in result.Overwritten")
+			break
+		}
+	}
+
+	// Content should be the user's customized content, not the starter.
 	got, err := os.ReadFile(constitutionPath)
 	if err != nil {
 		t.Fatalf("read constitution after force: %v", err)
 	}
-	if strings.Contains(string(got), "user content") {
-		t.Error("constitution was not overwritten by --force")
-	}
-	if !strings.Contains(string(got), "### I. Autonomous Collaboration") {
-		t.Error("constitution missing principle heading after --force overwrite")
+	if string(got) != customContent {
+		t.Errorf("constitution content changed; got %q, want %q", string(got), customContent)
 	}
 }
 
@@ -555,12 +563,34 @@ func TestRun_ForceOverwrites(t *testing.T) {
 		t.Fatalf("force Run() error: %v", err)
 	}
 
-	if len(result.Overwritten) != len(expectedAssetPaths) {
+	// Protected files (isNeverOverwrite) are skipped even with --force,
+	// so Overwritten count is total assets minus protected files.
+	neverOverwriteCount := 0
+	for _, p := range expectedAssetPaths {
+		if isNeverOverwrite(p) {
+			neverOverwriteCount++
+		}
+	}
+	wantOverwritten := len(expectedAssetPaths) - neverOverwriteCount
+	if len(result.Overwritten) != wantOverwritten {
 		t.Errorf("expected %d overwritten files, got %d",
-			len(expectedAssetPaths), len(result.Overwritten))
+			wantOverwritten, len(result.Overwritten))
 	}
 	if len(result.Created) != 0 {
 		t.Errorf("expected no created files with force, got %d", len(result.Created))
+	}
+	// Protected files should be in Skipped.
+	if neverOverwriteCount > 0 {
+		foundProtected := false
+		for _, f := range result.Skipped {
+			if f == ".specify/memory/constitution.md" {
+				foundProtected = true
+				break
+			}
+		}
+		if !foundProtected {
+			t.Error("expected protected constitution in result.Skipped with --force")
+		}
 	}
 }
 
@@ -801,6 +831,33 @@ func TestIsToolOwned(t *testing.T) {
 		got := isToolOwned(tt.path)
 		if got != tt.expected {
 			t.Errorf("isToolOwned(%q) = %v, want %v", tt.path, got, tt.expected)
+		}
+	}
+}
+
+func TestIsNeverOverwrite(t *testing.T) {
+	tests := []struct {
+		path     string
+		expected bool
+	}{
+		// Protected: constitution
+		{"specify/memory/constitution.md", true},
+		// Not protected: filesystem path with leading dot (not asset path)
+		{".specify/memory/constitution.md", false},
+		// Not protected: tool-owned command
+		{"opencode/commands/uf.init.md", false},
+		// Not protected: user-owned agent
+		{"opencode/agents/cobalt-crush-dev.md", false},
+		// Not protected: convention pack
+		{"opencode/uf/packs/default.md", false},
+		// Not protected: empty path
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		got := isNeverOverwrite(tt.path)
+		if got != tt.expected {
+			t.Errorf("isNeverOverwrite(%q) = %v, want %v", tt.path, got, tt.expected)
 		}
 	}
 }

--- a/openspec/changes/shield-constitution-from-force/.openspec.yaml
+++ b/openspec/changes/shield-constitution-from-force/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: unbound-force
+created: 2026-08-14

--- a/openspec/changes/shield-constitution-from-force/design.md
+++ b/openspec/changes/shield-constitution-from-force/design.md
@@ -1,0 +1,102 @@
+## Context
+
+The scaffold engine (`internal/scaffold/scaffold.go`) walks
+embedded assets and writes them to the target directory. The
+`Run()` function has three file-writing paths:
+
+1. **File does not exist**: Create it (lines 167-173)
+2. **File exists + `--force`**: Overwrite unconditionally
+   (lines 177-184)
+3. **File exists + no force**: Skip user-owned files, update
+   tool-owned files only on content diff (lines 186-201)
+
+The constitution (`specify/memory/constitution.md`) is correctly
+classified as user-owned by `isToolOwned()`, so path 3 protects
+it on normal re-runs. But path 2 bypasses all ownership checks,
+destroying user customizations when `--force` is used.
+
+## Goals / Non-Goals
+
+### Goals
+- Protect the constitution from `--force` overwrite
+- Introduce an extensible "never overwrite" predicate for
+  files that must survive all scaffold operations
+- Maintain the existing `Result` reporting contract (protected
+  files appear in `Skipped`)
+- Keep the change minimal and surgical
+
+### Non-Goals
+- General user-file protection beyond the constitution (the
+  existing `isToolOwned` + skip-on-rerun behavior handles this)
+- Adding CLI flags to control which files `--force` affects
+- Changing the UX to warn or prompt about protected files
+- Protecting the constitution from first-time creation (it
+  should still be created if it does not exist)
+
+## Decisions
+
+### D1: Separate predicate, not extension of `isToolOwned`
+
+The `isNeverOverwrite` function is a separate predicate rather
+than a modification to `isToolOwned`. Rationale:
+
+- `isToolOwned` answers "should this file be auto-updated on
+  content diff?" — a different question from "should this file
+  survive `--force`?"
+- The constitution is user-owned AND never-overwritable. These
+  are orthogonal properties. Conflating them into `isToolOwned`
+  would invert its semantics for this file.
+- A separate predicate is independently testable and clearly
+  communicates intent.
+
+### D2: Guard placement before the force block
+
+The `isNeverOverwrite` check is inserted before the `opts.Force`
+block (before line 177), not inside it. This means:
+
+- Protected files are skipped before any force logic executes
+- The control flow is: exists? → never-overwrite? → force? →
+  tool-owned?
+- This is the simplest insertion point with no risk of
+  disrupting the existing force or tool-owned paths
+
+### D3: Silent skip to `Skipped` list
+
+Protected files are added to `result.Skipped` with no special
+notice, warning, or separate result category. Rationale:
+
+- Consistent with how user-owned files are already reported
+  on normal re-runs
+- Adding a new result category (e.g., `Protected`) would
+  change the `Result` struct, affecting all consumers
+- The constitution is the only file in this set; special UX
+  treatment is not justified
+
+### D4: Hardcoded path, not configuration
+
+The never-overwrite set is a hardcoded list (currently one
+entry: `specify/memory/constitution.md`), not a configurable
+option. Rationale:
+
+- The constitution's protected status is a design invariant,
+  not a user preference
+- Configuration adds complexity with no current use case
+- If more files need protection, the predicate is trivially
+  extensible
+
+## Risks / Trade-offs
+
+### R1: User expects `--force` to reset everything
+
+A user running `--force` to reset a broken project setup might
+expect the constitution to also be reset. Mitigation: the
+starter constitution is still created on first run. If a user
+truly needs to reset it, they can delete the file and re-run
+`uf init` (without `--force`).
+
+### R2: Future protected files
+
+If more files are added to the never-overwrite set, there is
+no mechanism to communicate to the user which files were
+protected. Acceptable risk: the current set has one member,
+and the `Skipped` list is visible in the output.

--- a/openspec/changes/shield-constitution-from-force/proposal.md
+++ b/openspec/changes/shield-constitution-from-force/proposal.md
@@ -1,0 +1,96 @@
+## Why
+
+`uf init --force` unconditionally overwrites all existing files,
+including `.specify/memory/constitution.md`. The constitution is a
+user-customized governance document that anchors all spec-driven
+work. Overwriting it with the embedded starter template destroys
+project-specific principles, hero alignment references, and
+governance history.
+
+The `--force` flag was designed to refresh tool-owned assets
+(commands, schemas, convention packs) to the latest version. It
+was never intended to destroy user governance artifacts. This
+defect was introduced in PR #480 when the starter constitution
+was added as an embedded scaffold asset without an exception to
+the force-overwrite path.
+
+Fixes #495.
+
+## What Changes
+
+Add a "never overwrite" guard in the scaffold engine that
+protects designated files from being overwritten even when
+`--force` is specified. The constitution file is the first
+(and currently only) member of this protected set.
+
+## Capabilities
+
+### New Capabilities
+- `isNeverOverwrite`: Predicate function that identifies files
+  exempt from `--force` overwrite (returns `true` for
+  `specify/memory/constitution.md`)
+
+### Modified Capabilities
+- `Run()`: Force-overwrite path now checks `isNeverOverwrite`
+  before writing; protected files are silently added to
+  `Skipped` instead of `Overwritten`
+
+### Removed Capabilities
+- None
+
+## Impact
+
+- **internal/scaffold/scaffold.go**: New `isNeverOverwrite`
+  function; guard clause inserted before the `opts.Force` block
+- **internal/scaffold/scaffold_test.go**: Updated force test
+  to assert constitution lands in `Skipped`; new table-driven
+  `TestIsNeverOverwrite`
+- **UX**: Silent skip — no warning or special notice. The file
+  appears in the `Skipped` list alongside other user-owned files
+  that were not overwritten.
+
+## Constitution Alignment
+
+Assessed against the Unbound Force org constitution (v1.2.0).
+
+### I. Autonomous Collaboration
+
+**Assessment**: N/A
+
+This change is internal to the scaffold engine and does not
+affect artifact-based communication between heroes or
+inter-hero data exchange.
+
+### II. Composability First
+
+**Assessment**: N/A
+
+This change does not affect hero independence or integration
+points. The scaffold engine remains standalone.
+
+### III. Observable Quality
+
+**Assessment**: PASS
+
+The scaffold `Result` struct continues to report all file
+dispositions (Created, Skipped, Overwritten, Updated). Protected
+files appear in `Skipped`, maintaining full observability of what
+happened during a scaffold run.
+
+### IV. Testability
+
+**Assessment**: PASS
+
+The fix adds a pure predicate function (`isNeverOverwrite`) that
+is trivially testable in isolation. The existing scaffold test
+infrastructure (`t.TempDir()`, no external services) covers the
+integration behavior. A table-driven test for the new predicate
+is included.
+
+### V. Security by Default
+
+**Assessment**: N/A
+
+This change does not introduce dependencies, handle external
+input, or modify privilege boundaries. File permissions remain
+at the existing 0o644 default.

--- a/openspec/changes/shield-constitution-from-force/specs/scaffold-force-protection.md
+++ b/openspec/changes/shield-constitution-from-force/specs/scaffold-force-protection.md
@@ -1,0 +1,91 @@
+## ADDED Requirements
+
+### Requirement: Never-Overwrite File Protection
+
+The scaffold engine MUST define an `isNeverOverwrite` predicate
+that identifies files exempt from `--force` overwrite. The
+predicate MUST return `true` for `specify/memory/constitution.md`.
+
+FR-001: `isNeverOverwrite` MUST be a pure function accepting a
+relative path (using the embedded asset path convention, without
+the leading dot) and returning a boolean. The predicate performs
+exact string comparison. Path normalization (case, separators,
+traversal components) is the caller's responsibility.
+
+FR-002: `isNeverOverwrite` MUST return `true` for the path
+`specify/memory/constitution.md`.
+
+FR-003: `isNeverOverwrite` MUST return `false` for all other
+paths, including tool-owned files and other user-owned files.
+
+### Test Strategy
+
+- **Unit**: `TestIsNeverOverwrite` — table-driven test for the
+  pure predicate function.
+- **Integration**: Updated `TestRun_ConstitutionProtectedWithForce`
+  — full scaffold run with `--force`, verifying the constitution
+  is in `Skipped` and retains user content.
+- **Coverage target**: 100% of new lines (guard clause +
+  predicate).
+
+#### SC-001: Constitution file exists and force is specified
+
+- **GIVEN** `.specify/memory/constitution.md` exists in the
+  target directory with user-customized content
+- **WHEN** `uf init --force` is executed
+- **THEN** the constitution file MUST NOT be overwritten
+- **AND** the file MUST appear in `Result.Skipped`
+- **AND** the file MUST NOT appear in `Result.Overwritten`
+
+#### SC-002: Constitution file does not exist
+
+- **GIVEN** `.specify/memory/constitution.md` does not exist
+  in the target directory
+- **WHEN** `uf init` is executed (with or without `--force`)
+- **THEN** the constitution file MUST be created from the
+  embedded starter template
+- **AND** the file MUST appear in `Result.Created`
+
+#### SC-003: Non-protected file with force
+
+- **GIVEN** a tool-owned file (e.g., `.opencode/commands/uf.init.md`)
+  exists in the target directory
+- **WHEN** `uf init --force` is executed
+- **THEN** the file MUST be overwritten as before
+- **AND** the file MUST appear in `Result.Overwritten`
+
+#### SC-004: Predicate returns false for tool-owned files
+
+- **GIVEN** a relative path matching a tool-owned file
+  (e.g., `opencode/commands/uf.init.md`)
+- **WHEN** `isNeverOverwrite` is called with that path
+- **THEN** it MUST return `false`
+
+#### SC-005: Predicate returns false for other user-owned files
+
+- **GIVEN** a relative path matching a user-owned file that
+  is not the constitution
+  (e.g., `opencode/agents/cobalt-crush-dev.md`)
+- **WHEN** `isNeverOverwrite` is called with that path
+- **THEN** it MUST return `false`
+
+#### SC-006: Predicate handles empty path
+
+- **GIVEN** an empty string
+- **WHEN** `isNeverOverwrite` is called with that path
+- **THEN** it MUST return `false`
+
+## MODIFIED Requirements
+
+### Requirement: Force-overwrite behavior
+
+Previously: `--force` overwrites all existing files
+unconditionally.
+
+Modified: `--force` overwrites all existing files except those
+identified by `isNeverOverwrite`. Protected files MUST be added
+to `Result.Skipped` and MUST NOT be written.
+
+## REMOVED Requirements
+
+None.

--- a/openspec/changes/shield-constitution-from-force/tasks.md
+++ b/openspec/changes/shield-constitution-from-force/tasks.md
@@ -1,0 +1,71 @@
+<!--
+  [P] marks tasks eligible for parallel execution.
+  Add [P] when a task: (a) touches different files from
+  other [P] tasks in the group, (b) has no dependency
+  on prior tasks in the group, (c) can safely execute
+  without ordering constraints.
+  Do NOT add [P] when tasks modify the same file —
+  parallel workers will cause merge conflicts.
+  Tasks without [P] run sequentially first, then [P]
+  tasks run in parallel.
+-->
+
+## 1. Add `isNeverOverwrite` predicate
+
+- [x] 1.1 Add `isNeverOverwrite(relPath string) bool` function
+  in `internal/scaffold/scaffold.go`, immediately after
+  `isToolOwned`. Returns `true` for
+  `"specify/memory/constitution.md"`, `false` otherwise.
+  Files: `internal/scaffold/scaffold.go`
+  Refs: FR-001, FR-002, FR-003
+
+- [x] 1.2 Insert guard clause in `Run()` before the
+  `opts.Force` block (before line 177): if the file exists
+  and `isNeverOverwrite(relPath)` returns `true`, append
+  `outRel` to `result.Skipped` and `return nil`.
+  Files: `internal/scaffold/scaffold.go`
+  Refs: SC-001, D2
+
+## 2. Update tests
+
+- [x] 2.1 Rename `TestRun_ConstitutionOverwrittenWithForce` to
+  `TestRun_ConstitutionProtectedWithForce` in
+  `internal/scaffold/scaffold_test.go`. Update assertions:
+  assert the constitution path is in `res.Skipped` (not
+  `res.Overwritten`). Verify it is NOT in `res.Overwritten`.
+  Verify the file content is the user's customized content,
+  not the embedded starter. Remove the existing assertion
+  that checks for starter template content
+  (`### I. Autonomous Collaboration`).
+  Files: `internal/scaffold/scaffold_test.go`
+  Refs: SC-001
+
+- [x] 2.2 [P] Add `TestIsNeverOverwrite` table-driven test in
+  `internal/scaffold/scaffold_test.go` (near the existing
+  `TestIsToolOwned`). Test cases:
+  - `specify/memory/constitution.md` → `true`
+  - `.specify/memory/constitution.md` → `false` (filesystem
+    path with leading dot, not asset path)
+  - `opencode/commands/uf.init.md` → `false` (tool-owned)
+  - `opencode/agents/cobalt-crush-dev.md` → `false`
+    (user-owned, not protected)
+  - `opencode/uf/packs/default.md` → `false` (convention
+    pack)
+  - `""` → `false` (empty path)
+  Files: `internal/scaffold/scaffold_test.go`
+  Refs: SC-004, SC-005, SC-006
+
+## 3. Verification
+
+- [x] 3.1 Run `go test -race -count=1 ./internal/scaffold/...`
+  and confirm all tests pass.
+
+- [x] 3.2 Run `make lint` and confirm no issues.
+
+- [x] 3.3 Verify constitution alignment: this change maintains
+  Observable Quality (protected files reported in `Skipped`)
+  and Testability (new predicate has table-driven test,
+  integration behavior covered by existing test
+  infrastructure).
+<!-- spec-review: passed -->
+<!-- code-review: passed -->


### PR DESCRIPTION
## Summary

Fixes a defect where `uf init --force` unconditionally overwrites `.specify/memory/constitution.md`, destroying user-customized governance content. The `--force` flag was designed to refresh tool-owned assets (commands, schemas, convention packs) to the latest version — it was never intended to destroy user governance artifacts. This defect was introduced in PR #480 when the starter constitution was added as an embedded scaffold asset without an exception to the force-overwrite path.

The fix adds an `isNeverOverwrite` predicate that identifies files exempt from `--force` overwrite, with a guard clause inserted before the force block in `Run()`. Protected files are silently added to `Result.Skipped` instead of being overwritten.

Fixes #495
Spec: `openspec/changes/shield-constitution-from-force/`

## How to Test

1. **Run the unit test for the predicate:**
   ```bash
   go test -race -count=1 ./internal/scaffold/... -run TestIsNeverOverwrite
   ```
   Verifies 6 table-driven cases: protected path returns `true`, dot-prefix variant returns `false`, tool-owned/user-owned/convention-pack/empty all return `false`.

2. **Run the integration test for force protection:**
   ```bash
   go test -race -count=1 ./internal/scaffold/... -run TestRun_ConstitutionProtectedWithForce
   ```
   Verifies that when `--force` is used and the constitution exists with custom content, the constitution is in `Skipped` (not `Overwritten`) and the file retains user content.

3. **Run the full scaffold test suite:**
   ```bash
   go test -race -count=1 ./internal/scaffold/...
   ```
   All tests pass including the updated `TestRun_ForceOverwrites` which dynamically accounts for never-overwrite files.

## How to Demo

```bash
mkdir /tmp/uf-demo && cd /tmp/uf-demo
uf init                              # Creates .specify/memory/constitution.md with starter template
echo "# My Custom Constitution" > .specify/memory/constitution.md
uf init --force                      # Force re-scaffold
cat .specify/memory/constitution.md  # Should show "# My Custom Constitution" (preserved)
```

The constitution should appear in the "skipped" summary line, not in "overwritten".

## Key Files Changed

**internal/scaffold/**
- `scaffold.go` — Added `isNeverOverwrite()` predicate (pure function, exact string match) and guard clause before `opts.Force` block (+17 lines)
- `scaffold_test.go` — Renamed `TestRun_ConstitutionOverwrittenWithForce` to `TestRun_ConstitutionProtectedWithForce` with updated assertions; added `TestIsNeverOverwrite` table-driven test (6 cases); updated `TestRun_ForceOverwrites` to dynamically compute expected overwrite count (+89/-16 lines)

**openspec/changes/shield-constitution-from-force/**
- `proposal.md` — Motivation, capabilities, impact, constitution alignment
- `design.md` — 4 design decisions (separate predicate, guard placement, silent skip, hardcoded path)
- `specs/scaffold-force-protection.md` — FR-001 through FR-003, SC-001 through SC-006, test strategy
- `tasks.md` — 3 task groups, 7 tasks (all completed)

**Root**
- `CHANGELOG.md` — Added Fixed entry under Unreleased

## Known Issues

The following findings from the review council were acknowledged but not resolved:

- **LOW**: `printSummary` shows "(use --force to overwrite)" hint for skipped files even when `--force` is already active — misleading for never-overwrite files
- **LOW**: `warnStaleCommandRefs` suggests `--force` will "overwrite customizations" which is now slightly imprecise for the constitution

_This PR was generated by /uf.finale (AI-assisted)._
