### PR TITLE
chore(commands): add <protect> tags to slash command files

### DIFF
--- a/.opencode/commands/uf.address-feedback.md
+++ b/.opencode/commands/uf.address-feedback.md
@@ -10,6 +10,8 @@ You are a token-efficient feedback analyst. The user will provide a PR number or
 
 The command follows four sequential phases (Ingest → Assess → Triage → Execute). Phases are not independently invocable — run all four in sequence every invocation.
 
+<protect>
+
 > **SESSION-RESUME GUARD**: If this session has been resumed
 > from compressed context, or if you cannot locate the
 > execution checklist in the current conversation, you MUST:
@@ -23,6 +25,7 @@ The command follows four sequential phases (Ingest → Assess → Triage → Exe
 >    execution checklist are authoritative
 > 5. Resume from the first incomplete phase
 
+
 ## Arguments
 
 - **PR number** (optional): The pull request number to address feedback for (e.g., `42`). If omitted, auto-detect the open PR for the current branch.
@@ -30,6 +33,7 @@ The command follows four sequential phases (Ingest → Assess → Triage → Exe
 **Argument parsing** (before any tool calls): Check the user's message for a PR number argument. If present, set `PR_NUMBER` to that value immediately. All subsequent steps use `<PR_NUMBER>` — no auto-detection commands are needed or permitted.
 
 ---
+
 
 ## Execution Checklist
 
@@ -52,6 +56,7 @@ of progress.
 
 Replace `_N_`, `_M_`, etc. with actual counts as you
 progress. Mark each line `[x]` when the phase completes.
+
 
 ---
 
@@ -293,7 +298,9 @@ author chooses exactly one:
 | **Reject** | Use **question tool** (open-ended, no preset options) to collect evidence-based reasoning | Reply comment with reasoning |
 | **Ask** | Use **question tool** (open-ended, no preset options) to collect the clarification question | Reply comment with question |
 
+
 **No item may be skipped or deferred.** Every item MUST receive a decision before the triage phase completes.
+
 
 ### 3.3 Conflicting Items
 
@@ -421,6 +428,7 @@ post reply comments to the PR. Before posting, use the
 **question tool** with options `["Yes -- post
 reply comments", "No -- skip posting"]`.
 
+
 **Checklist gate**: Before presenting comments for posting,
 verify the execution checklist shows:
 1. Phase 3 is marked `[x]` with all items decided
@@ -430,6 +438,7 @@ If the checklist is missing, incomplete, or shows Phase 3
 as not complete, you MUST re-read this command template and
 rebuild state from `state.json` and the git log. Do NOT
 post comments without verified checklist state.
+
 
 For each item, compose the reply:
 
@@ -546,6 +555,7 @@ Fields `file`, `line`, `decision_reasoning`, and `commit_sha` may be `null` (gen
 
 ---
 
+
 ## Guardrails
 
 1. **No auto-merge**: This command addresses feedback. It NEVER merges the PR, approves the PR, or dismisses reviews.
@@ -567,3 +577,6 @@ Fields `file`, `line`, `decision_reasoning`, and `commit_sha` may be `null` (gen
 9. **File permissions**: Cache files `600`, cache directories `700`. The `.uf/feedback/` directory MUST be in `.gitignore`.
 
 10. **Commit scope**: Only commit files directly related to addressing the specific feedback item. Do not bundle unrelated changes into feedback fix commits.
+
+</protect>
+

--- a/.opencode/commands/uf.finale.md
+++ b/.opencode/commands/uf.finale.md
@@ -33,6 +33,8 @@ stays open for human review. Works with both Speckit
 
 ## Instructions
 
+<protect>
+
 **Session-resume guard**: If this session has been
    resumed from compressed context, or if you cannot
    verify that the human explicitly confirmed a gate
@@ -969,3 +971,5 @@ the OpenSpec and Speckit workflows:
 - All changes are committed before any branch switch
 - The remote branch is NOT deleted — it stays open with
   the PR until a reviewer merges
+
+</protect>

--- a/.opencode/commands/uf.review-council.md
+++ b/.opencode/commands/uf.review-council.md
@@ -4,6 +4,8 @@ description: Run the reviewer governance council to audit codebase or spec compl
 <!-- scaffolded by uf vdev -->
 # Command: /uf.review-council
 
+<protect>
+
 > **Session-resume guard**: If this session was resumed
 > from compressed context, re-read this entire template
 > before continuing. Do NOT infer step completion from
@@ -13,6 +15,8 @@ description: Run the reviewer governance council to audit codebase or spec compl
 > item. When in doubt, re-read — false re-reads are
 > harmless; skipping steps due to stale context causes
 > incomplete reviews or unauthorized actions.
+
+
 
 > **EXECUTION CHECKLIST** — Update each item using the
 > Edit tool as you complete it. Mark `[x]` when done.
@@ -32,6 +36,7 @@ description: Run the reviewer governance council to audit codebase or spec compl
 > - [ ] Step 7e: Inline comment preparation
 > - [ ] Step 7f: Human confirmation (MANDATORY GATE)
 > - [ ] Step 7g: Post review
+
 
 ## User Input
 
@@ -295,6 +300,7 @@ Review the current codebase for compliance with the Behavioral Constraints in `A
 
 2. Delegate the review to all **discovered** reviewer agents in parallel using the Task tool. For each discovered agent, use the focus area from the Known Reviewer Roles reference table to provide targeted context. For any discovered agent not in the table, use a generic prompt: "Review the current changes for quality, correctness, and compliance. Return your verdict (APPROVE or REQUEST CHANGES) along with all findings."
 
+
    **CRITICAL — Review Scope Rule**: The review scope is
    ALWAYS the **full branch diff** (`git diff main...HEAD`),
    meaning ALL files changed on the branch relative to
@@ -306,6 +312,7 @@ Review the current codebase for compliance with the Behavioral Constraints in `A
    be included in each agent's prompt. Violating this rule
    produces incomplete reviews that miss findings in
    earlier commits on the branch.
+
 
    **Review context enrichment**: Append the following
    context sections to each Divisor agent's review
@@ -655,6 +662,7 @@ Review the current codebase for compliance with the Behavioral Constraints in `A
 
    **Checkpoint**: Mark `Step 7e` complete in the EXECUTION CHECKLIST using the Edit tool before proceeding.
 
+
    #### Step 7f -- Verdict Mapping and Human Confirmation
 
    >>> MANDATORY GATE: HUMAN CONFIRMATION REQUIRED <<<
@@ -717,6 +725,7 @@ Review the current codebase for compliance with the Behavioral Constraints in `A
    human confirms.
 
    >>> END MANDATORY GATE <<<
+
 
    #### Step 7g -- Post Review
 
@@ -868,8 +877,12 @@ step, determine which artifacts to review:
 
 ---
 
+
 ## Verdict
 
 The council returns **APPROVE** only when all discovered reviewers return **APPROVE**. Any single **REQUEST CHANGES** from a discovered reviewer means the council verdict is **REQUEST CHANGES**. Absent reviewers (known roles whose agent files were not found during discovery) do not affect the verdict but are noted in the discovery summary.
 
 In Spec Review Mode, the council may return **APPROVE WITH ADVISORIES** when all LOW/MEDIUM findings have been auto-fixed but HIGH/CRITICAL findings remain that require human judgment. The advisories are the outstanding HIGH/CRITICAL findings. The discovery summary is included regardless of the verdict.
+
+</protect>
+

--- a/.opencode/commands/uf.review-pr.md
+++ b/.opencode/commands/uf.review-pr.md
@@ -6,6 +6,8 @@ description: "Review PR #$ARGUMENTS — alignment, security, and constitution co
 
 You are a token-efficient code reviewer. The user will provide a PR number or you will auto-detect it from the current branch. Delegate deterministic checks to local tools and CI results first, then apply AI judgment only where tools cannot reach: intent alignment, security patterns, and architectural concerns.
 
+<protect>
+
 ## Arguments
 
 - **PR number** (optional): The pull request number to review (e.g., `42`). If omitted, the command auto-detects the open PR for the current branch.
@@ -65,6 +67,7 @@ tool execution. The local tool results are the
 foundation of the review — without them, AI-only
 findings lack verification and the review does not
 meet the command's quality standard.
+
 
 ### 1. Resolve PR Number
 
@@ -430,6 +433,7 @@ When the combined comment text exceeds this limit:
 4. Truncate the remainder with a note: "N additional
    prior comments truncated for token budget"
 
+
 ###### Step E.5. Error Handling
 
 If any `gh api` call in this step returns 403, 404, or
@@ -464,6 +468,7 @@ analysis. For each finding:
 - Do NOT fully suppress findings — the current review may
   have additional context or a different severity
   assessment. Annotate, don't hide.
+
 
 **Path-based review focus and walkthrough**: Use the
 file classifications and walkthrough summaries from
@@ -981,6 +986,7 @@ account is not listed in CODEOWNERS.
    in doubt, re-confirm — false re-confirmation is
    harmless; posting without consent is a violation.
 
+
 1. **Prepare comments**: For each finding that maps to a
    specific file and line range in the diff, prepare an
    in-line comment with:
@@ -1096,3 +1102,6 @@ account is not listed in CODEOWNERS.
    merge-unblocking consequence.
 
 >>> END MANDATORY GATE <<<
+
+</protect>
+

--- a/.opencode/commands/uf.triage-issue.md
+++ b/.opencode/commands/uf.triage-issue.md
@@ -10,6 +10,8 @@ You are a token-efficient issue analyst. The user provides a GitHub issue number
 
 The command follows four sequential phases (Ingest → Assess → Classify → Act). Phases are not independently invocable — run all four in sequence every invocation.
 
+<protect>
+
 ## Arguments
 
 - **Issue number** (required): The GitHub issue number to triage (e.g., `42`).
@@ -495,3 +497,5 @@ Fields may be `null` when not applicable (e.g., `duplicate_of` when the issue is
 8. **Shell injection prevention**: All untrusted text (issue content, agent output, synthesized comments, child issue content) MUST be written to temporary files and passed via `--input` for all `gh api` calls. Untrusted text MUST NOT be interpolated into shell arguments. Temp files MUST use restrictive permissions (`chmod 600`) and be cleaned up in all exit paths (success, failure, abort).
 
 9. **Safe artifact paths**: The issue number is validated as a positive integer (matching `^[1-9][0-9]*$`) before use in any file path. This validation occurs in the Arguments section before any other processing.
+
+</protect>

--- a/.opencode/commands/uf.unleash.md
+++ b/.opencode/commands/uf.unleash.md
@@ -29,6 +29,8 @@ off on re-run.
 
 ## Instructions
 
+<protect>
+
 > **SESSION-RESUME GUARD**: If you are resuming this
 > command after context compression or a session restart,
 > STOP and re-read this entire template before continuing.
@@ -767,3 +769,5 @@ Format the output as:
 - **NEVER improvise Demo exit text** -- the "Next Steps"
   section in Step 10 prescribes the exact output; re-read
   and reproduce it verbatim
+
+</protect>

--- a/internal/scaffold/assets/opencode/commands/uf.address-feedback.md
+++ b/internal/scaffold/assets/opencode/commands/uf.address-feedback.md
@@ -10,6 +10,8 @@ You are a token-efficient feedback analyst. The user will provide a PR number or
 
 The command follows four sequential phases (Ingest → Assess → Triage → Execute). Phases are not independently invocable — run all four in sequence every invocation.
 
+<protect>
+
 > **SESSION-RESUME GUARD**: If this session has been resumed
 > from compressed context, or if you cannot locate the
 > execution checklist in the current conversation, you MUST:
@@ -23,6 +25,7 @@ The command follows four sequential phases (Ingest → Assess → Triage → Exe
 >    execution checklist are authoritative
 > 5. Resume from the first incomplete phase
 
+
 ## Arguments
 
 - **PR number** (optional): The pull request number to address feedback for (e.g., `42`). If omitted, auto-detect the open PR for the current branch.
@@ -30,6 +33,7 @@ The command follows four sequential phases (Ingest → Assess → Triage → Exe
 **Argument parsing** (before any tool calls): Check the user's message for a PR number argument. If present, set `PR_NUMBER` to that value immediately. All subsequent steps use `<PR_NUMBER>` — no auto-detection commands are needed or permitted.
 
 ---
+
 
 ## Execution Checklist
 
@@ -52,6 +56,7 @@ of progress.
 
 Replace `_N_`, `_M_`, etc. with actual counts as you
 progress. Mark each line `[x]` when the phase completes.
+
 
 ---
 
@@ -293,7 +298,9 @@ author chooses exactly one:
 | **Reject** | Use **question tool** (open-ended, no preset options) to collect evidence-based reasoning | Reply comment with reasoning |
 | **Ask** | Use **question tool** (open-ended, no preset options) to collect the clarification question | Reply comment with question |
 
+
 **No item may be skipped or deferred.** Every item MUST receive a decision before the triage phase completes.
+
 
 ### 3.3 Conflicting Items
 
@@ -421,6 +428,7 @@ post reply comments to the PR. Before posting, use the
 **question tool** with options `["Yes -- post
 reply comments", "No -- skip posting"]`.
 
+
 **Checklist gate**: Before presenting comments for posting,
 verify the execution checklist shows:
 1. Phase 3 is marked `[x]` with all items decided
@@ -430,6 +438,7 @@ If the checklist is missing, incomplete, or shows Phase 3
 as not complete, you MUST re-read this command template and
 rebuild state from `state.json` and the git log. Do NOT
 post comments without verified checklist state.
+
 
 For each item, compose the reply:
 
@@ -546,6 +555,7 @@ Fields `file`, `line`, `decision_reasoning`, and `commit_sha` may be `null` (gen
 
 ---
 
+
 ## Guardrails
 
 1. **No auto-merge**: This command addresses feedback. It NEVER merges the PR, approves the PR, or dismisses reviews.
@@ -567,3 +577,6 @@ Fields `file`, `line`, `decision_reasoning`, and `commit_sha` may be `null` (gen
 9. **File permissions**: Cache files `600`, cache directories `700`. The `.uf/feedback/` directory MUST be in `.gitignore`.
 
 10. **Commit scope**: Only commit files directly related to addressing the specific feedback item. Do not bundle unrelated changes into feedback fix commits.
+
+</protect>
+

--- a/internal/scaffold/assets/opencode/commands/uf.finale.md
+++ b/internal/scaffold/assets/opencode/commands/uf.finale.md
@@ -33,6 +33,8 @@ stays open for human review. Works with both Speckit
 
 ## Instructions
 
+<protect>
+
 **Session-resume guard**: If this session has been
    resumed from compressed context, or if you cannot
    verify that the human explicitly confirmed a gate
@@ -969,3 +971,5 @@ the OpenSpec and Speckit workflows:
 - All changes are committed before any branch switch
 - The remote branch is NOT deleted — it stays open with
   the PR until a reviewer merges
+
+</protect>

--- a/internal/scaffold/assets/opencode/commands/uf.review-council.md
+++ b/internal/scaffold/assets/opencode/commands/uf.review-council.md
@@ -4,6 +4,8 @@ description: Run the reviewer governance council to audit codebase or spec compl
 <!-- scaffolded by uf vdev -->
 # Command: /uf.review-council
 
+<protect>
+
 > **Session-resume guard**: If this session was resumed
 > from compressed context, re-read this entire template
 > before continuing. Do NOT infer step completion from
@@ -13,6 +15,8 @@ description: Run the reviewer governance council to audit codebase or spec compl
 > item. When in doubt, re-read — false re-reads are
 > harmless; skipping steps due to stale context causes
 > incomplete reviews or unauthorized actions.
+
+
 
 > **EXECUTION CHECKLIST** — Update each item using the
 > Edit tool as you complete it. Mark `[x]` when done.
@@ -32,6 +36,7 @@ description: Run the reviewer governance council to audit codebase or spec compl
 > - [ ] Step 7e: Inline comment preparation
 > - [ ] Step 7f: Human confirmation (MANDATORY GATE)
 > - [ ] Step 7g: Post review
+
 
 ## User Input
 
@@ -295,6 +300,7 @@ Review the current codebase for compliance with the Behavioral Constraints in `A
 
 2. Delegate the review to all **discovered** reviewer agents in parallel using the Task tool. For each discovered agent, use the focus area from the Known Reviewer Roles reference table to provide targeted context. For any discovered agent not in the table, use a generic prompt: "Review the current changes for quality, correctness, and compliance. Return your verdict (APPROVE or REQUEST CHANGES) along with all findings."
 
+
    **CRITICAL — Review Scope Rule**: The review scope is
    ALWAYS the **full branch diff** (`git diff main...HEAD`),
    meaning ALL files changed on the branch relative to
@@ -306,6 +312,7 @@ Review the current codebase for compliance with the Behavioral Constraints in `A
    be included in each agent's prompt. Violating this rule
    produces incomplete reviews that miss findings in
    earlier commits on the branch.
+
 
    **Review context enrichment**: Append the following
    context sections to each Divisor agent's review
@@ -655,6 +662,7 @@ Review the current codebase for compliance with the Behavioral Constraints in `A
 
    **Checkpoint**: Mark `Step 7e` complete in the EXECUTION CHECKLIST using the Edit tool before proceeding.
 
+
    #### Step 7f -- Verdict Mapping and Human Confirmation
 
    >>> MANDATORY GATE: HUMAN CONFIRMATION REQUIRED <<<
@@ -717,6 +725,7 @@ Review the current codebase for compliance with the Behavioral Constraints in `A
    human confirms.
 
    >>> END MANDATORY GATE <<<
+
 
    #### Step 7g -- Post Review
 
@@ -868,8 +877,12 @@ step, determine which artifacts to review:
 
 ---
 
+
 ## Verdict
 
 The council returns **APPROVE** only when all discovered reviewers return **APPROVE**. Any single **REQUEST CHANGES** from a discovered reviewer means the council verdict is **REQUEST CHANGES**. Absent reviewers (known roles whose agent files were not found during discovery) do not affect the verdict but are noted in the discovery summary.
 
 In Spec Review Mode, the council may return **APPROVE WITH ADVISORIES** when all LOW/MEDIUM findings have been auto-fixed but HIGH/CRITICAL findings remain that require human judgment. The advisories are the outstanding HIGH/CRITICAL findings. The discovery summary is included regardless of the verdict.
+
+</protect>
+

--- a/internal/scaffold/assets/opencode/commands/uf.review-pr.md
+++ b/internal/scaffold/assets/opencode/commands/uf.review-pr.md
@@ -6,6 +6,8 @@ description: "Review PR #$ARGUMENTS — alignment, security, and constitution co
 
 You are a token-efficient code reviewer. The user will provide a PR number or you will auto-detect it from the current branch. Delegate deterministic checks to local tools and CI results first, then apply AI judgment only where tools cannot reach: intent alignment, security patterns, and architectural concerns.
 
+<protect>
+
 ## Arguments
 
 - **PR number** (optional): The pull request number to review (e.g., `42`). If omitted, the command auto-detects the open PR for the current branch.
@@ -65,6 +67,7 @@ tool execution. The local tool results are the
 foundation of the review — without them, AI-only
 findings lack verification and the review does not
 meet the command's quality standard.
+
 
 ### 1. Resolve PR Number
 
@@ -430,6 +433,7 @@ When the combined comment text exceeds this limit:
 4. Truncate the remainder with a note: "N additional
    prior comments truncated for token budget"
 
+
 ###### Step E.5. Error Handling
 
 If any `gh api` call in this step returns 403, 404, or
@@ -464,6 +468,7 @@ analysis. For each finding:
 - Do NOT fully suppress findings — the current review may
   have additional context or a different severity
   assessment. Annotate, don't hide.
+
 
 **Path-based review focus and walkthrough**: Use the
 file classifications and walkthrough summaries from
@@ -981,6 +986,7 @@ account is not listed in CODEOWNERS.
    in doubt, re-confirm — false re-confirmation is
    harmless; posting without consent is a violation.
 
+
 1. **Prepare comments**: For each finding that maps to a
    specific file and line range in the diff, prepare an
    in-line comment with:
@@ -1096,3 +1102,6 @@ account is not listed in CODEOWNERS.
    merge-unblocking consequence.
 
 >>> END MANDATORY GATE <<<
+
+</protect>
+

--- a/internal/scaffold/assets/opencode/commands/uf.triage-issue.md
+++ b/internal/scaffold/assets/opencode/commands/uf.triage-issue.md
@@ -10,6 +10,8 @@ You are a token-efficient issue analyst. The user provides a GitHub issue number
 
 The command follows four sequential phases (Ingest → Assess → Classify → Act). Phases are not independently invocable — run all four in sequence every invocation.
 
+<protect>
+
 ## Arguments
 
 - **Issue number** (required): The GitHub issue number to triage (e.g., `42`).
@@ -495,3 +497,5 @@ Fields may be `null` when not applicable (e.g., `duplicate_of` when the issue is
 8. **Shell injection prevention**: All untrusted text (issue content, agent output, synthesized comments, child issue content) MUST be written to temporary files and passed via `--input` for all `gh api` calls. Untrusted text MUST NOT be interpolated into shell arguments. Temp files MUST use restrictive permissions (`chmod 600`) and be cleaned up in all exit paths (success, failure, abort).
 
 9. **Safe artifact paths**: The issue number is validated as a positive integer (matching `^[1-9][0-9]*$`) before use in any file path. This validation occurs in the Arguments section before any other processing.
+
+</protect>

--- a/internal/scaffold/assets/opencode/commands/uf.unleash.md
+++ b/internal/scaffold/assets/opencode/commands/uf.unleash.md
@@ -29,6 +29,8 @@ off on re-run.
 
 ## Instructions
 
+<protect>
+
 > **SESSION-RESUME GUARD**: If you are resuming this
 > command after context compression or a session restart,
 > STOP and re-read this entire template before continuing.
@@ -767,3 +769,5 @@ Format the output as:
 - **NEVER improvise Demo exit text** -- the "Next Steps"
   section in Step 10 prescribes the exact output; re-read
   and reproduce it verbatim
+
+</protect>

--- a/openspec/changes/add-protect-tags/.openspec.yaml
+++ b/openspec/changes/add-protect-tags/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: unbound-force
+created: 2026-08-15

--- a/openspec/changes/add-protect-tags/design.md
+++ b/openspec/changes/add-protect-tags/design.md
@@ -1,0 +1,106 @@
+## Context
+
+OpenCode's DCP plugin compresses user messages during long
+sessions but respects `<protect>` tags as non-compressible
+markers. Slash commands are injected as user messages and
+therefore subject to compression. Six command templates in
+`internal/scaffold/assets/opencode/commands/` contain
+critical sections that MUST survive compression:
+
+| Category | Examples | Risk if Lost |
+|----------|----------|--------------|
+| Session-resume guards | Re-read-template instructions | Agent proceeds with stale/missing context |
+| Execution checklists | State variables (BRANCH, COMMIT, PR_URL) | Duplicate actions, lost progress |
+| Mandatory gates | Human confirmation before posting/pushing | Unconfirmed destructive actions |
+| Guardrails | MUST/MUST NOT behavioral constraints | Constitution violations |
+| Critical algorithms | Verdict resolution, diff scope rules | Incorrect decisions |
+
+## Goals / Non-Goals
+
+### Goals
+- Wrap all critical sections in `<protect>` tags across
+  6 command templates.
+- Preserve existing content verbatim -- no rewording,
+  reordering, or behavioral changes.
+- Follow a consistent tagging pattern so future commands
+  can apply the same approach.
+
+### Non-Goals
+- Modifying command behavior or logic.
+- Adding `<protect>` tags to non-command files (skills,
+  agents, convention packs).
+- Updating already-scaffolded projects (users run
+  `uf init --force` to pull updates).
+
+## Decisions
+
+**What to protect**: Each command file's entire
+instruction body -- from the `## Instructions` heading
+(or first functional section) through the `## Guardrails`
+section -- is wrapped in a single `<protect>` tag.
+
+These command files are orchestration pipelines where
+every section is execution-critical: step sequences,
+branching logic, exit conditions, checkpoint markers,
+session-resume guards, mandatory gates, and guardrails.
+Selectively protecting a few sections leaves the actual
+pipeline steps vulnerable to compression, which causes
+skipped steps, lost context, and incorrect execution.
+
+Only the informational header (description, usage, and
+arguments) is left outside the tag. This content is
+non-critical -- losing it does not affect execution.
+
+**Tag placement**: One `<protect>` tag per file wrapping
+the entire instruction body. Example:
+
+```markdown
+## Description
+[informational -- outside protect]
+
+## Instructions
+
+<protect>
+
+> **SESSION-RESUME GUARD**: ...
+[all steps, checklists, gates, guardrails]
+
+</protect>
+```
+
+**No nesting**: Only one `<protect>` tag per file.
+Inner `<protect>` tags from the previous implementation
+are removed.
+
+**Whitespace**: One blank line after `<protect>` open
+tag, one blank line before `</protect>` close tag, to
+maintain Markdown rendering compatibility.
+
+## Risks / Trade-offs
+
+**Token budget pressure**: Protected content consumes
+tokens even when DCP would otherwise compress it. The
+6 files total ~4,779 lines; protecting ~85-95% of each
+file means ~4,000-4,500 lines are non-compressible.
+This is acceptable because these commands are invoked
+one at a time (not all 6 simultaneously), and each
+command's full content is essential for correct
+execution.
+
+**Over-protection is preferable to under-protection**:
+The original design tried to minimize protected content
+to help DCP compress more. In practice, partial
+protection of orchestration pipelines is worse than
+full protection because losing any step, gate, or
+branching logic causes incorrect execution -- a more
+severe failure than token pressure.
+
+**Maintenance burden**: Future edits to protected sections
+must preserve the `<protect>` tags. This is a minor
+burden since the tags are visible markers. Convention
+pack rules could enforce this in future if needed.
+
+**Stale scaffolded copies**: Projects scaffolded before
+this change will not have `<protect>` tags until they
+run `uf init --force`. This is the existing upgrade
+model for all scaffold changes.

--- a/openspec/changes/add-protect-tags/proposal.md
+++ b/openspec/changes/add-protect-tags/proposal.md
@@ -1,0 +1,123 @@
+## Why
+
+OpenCode's DCP (Dynamic Context Preservation) plugin
+compresses conversation history during long sessions to
+stay within token limits. Slash commands are injected as
+user messages, which DCP treats as compressible content.
+Unlike skills (which use `tool_use`/`tool_result` pairs
+protected by DCP's `protectedTools` config), slash command
+content has no compression immunity.
+
+This causes critical sections -- guardrails, execution
+checklists, mandatory gates, session-resume guards -- to
+be summarized or dropped during compression. When an agent
+resumes after compression and the guardrails have been
+lost, it may skip mandatory human confirmation gates,
+post duplicate PR reviews, force-push, or violate phase
+boundaries.
+
+DCP supports `<protect>` tags that mark content as
+non-compressible. Wrapping critical slash command sections
+in `<protect>` tags ensures they survive compression
+cycles intact.
+
+Fixes #497.
+
+## What Changes
+
+Add `<protect>` tags around critical sections in the 6
+slash command source templates under
+`internal/scaffold/assets/opencode/commands/`:
+
+1. `uf.unleash.md` (769 lines, CRITICAL priority)
+2. `uf.review-pr.md` (1098 lines, CRITICAL priority)
+3. `uf.review-council.md` (875 lines, CRITICAL priority)
+4. `uf.finale.md` (971 lines, CRITICAL priority)
+5. `uf.address-feedback.md` (569 lines, HIGH priority)
+6. `uf.triage-issue.md` (497 lines, HIGH priority)
+
+Note: Issue #497 listed 10 files but 4 do not exist
+(`uf.checklist.md`, `uf.sync-issues.md`, `uf.daily.md`,
+`uf.spec-review.md`). Only 6 command templates exist in
+the scaffold assets directory.
+
+## Capabilities
+
+### New Capabilities
+- `DCP compression immunity`: Critical slash command
+  sections survive DCP compression cycles, preserving
+  guardrails, execution state, and mandatory gates
+  across long sessions.
+
+### Modified Capabilities
+- `uf.unleash`: SESSION-RESUME GUARD, EXECUTION
+  CHECKLIST, and Guardrails sections protected.
+- `uf.review-pr`: Execution mode check, session-resume
+  guard, and MANDATORY GATE sections protected.
+- `uf.review-council`: SESSION-RESUME GUARD, EXECUTION
+  CHECKLIST, CRITICAL branch diff rule, and verdict
+  confirmation gate protected.
+- `uf.finale`: SESSION-RESUME GUARD, EXECUTION CHECKLIST,
+  secret file detection gate, and Guardrails protected.
+- `uf.address-feedback`: SESSION-RESUME GUARD, EXECUTION
+  CHECKLIST, triage decision enforcement, and Guardrails
+  protected.
+- `uf.triage-issue`: Argument validation, re-run
+  detection, verdict resolution rules, and Guardrails
+  protected.
+
+### Removed Capabilities
+- None.
+
+## Impact
+
+- **Source templates**: 6 files in
+  `internal/scaffold/assets/opencode/commands/` modified.
+- **Scaffolded output**: Projects running `uf init` after
+  this change receive commands with `<protect>` tags.
+  Existing projects need `uf init --force` to update.
+- **Behavioral**: No behavioral change when DCP is not
+  compressing. When DCP compresses, protected sections
+  are preserved verbatim instead of being summarized.
+- **Token cost**: `<protect>` tags add ~20 characters per
+  protected section (tag open + close). Negligible impact
+  on token usage.
+
+## Constitution Alignment
+
+Assessed against the Unbound Force org constitution.
+
+### I. Autonomous Collaboration
+
+**Assessment**: PASS
+
+This change improves artifact-based communication by
+ensuring that slash command guardrails and execution
+state survive across session boundaries. Agents can
+autonomously resume work using the preserved execution
+checklists and session-resume guards.
+
+### II. Composability First
+
+**Assessment**: N/A
+
+No new dependencies introduced. `<protect>` tags are
+a DCP feature already available in the runtime.
+
+### III. Observable Quality
+
+**Assessment**: PASS
+
+Execution checklists and state variables remain
+observable after compression. Provenance metadata
+(branch names, commit SHAs, PR numbers) in checklists
+is preserved.
+
+### IV. Testability
+
+**Assessment**: PASS
+
+Existing scaffold drift tests verify embedded assets
+match canonical sources. The `<protect>` tags are
+plain text markers that do not affect test isolation
+or verification.

--- a/openspec/changes/add-protect-tags/tasks.md
+++ b/openspec/changes/add-protect-tags/tasks.md
@@ -1,0 +1,86 @@
+<!--
+  [P] marks tasks eligible for parallel execution.
+  Add [P] when a task: (a) touches different files from
+  other [P] tasks in the group, (b) has no dependency
+  on prior tasks in the group, (c) can safely execute
+  without ordering constraints.
+  Do NOT add [P] when tasks modify the same file —
+  parallel workers will cause merge conflicts.
+  Tasks without [P] run sequentially first, then [P]
+  tasks run in parallel.
+-->
+
+## 1. Critical Priority Commands
+
+- [x] 1.1 [P] Add `<protect>` tags to `uf.unleash.md`
+  - Wrap: SESSION-RESUME GUARD, EXECUTION CHECKLIST,
+    Step 2 Resumability Detection, Step 10 Demo output
+    fidelity guard, Guardrails section.
+  - File: `internal/scaffold/assets/opencode/commands/uf.unleash.md`
+
+- [x] 1.2 [P] Add `<protect>` tags to `uf.review-pr.md`
+  - Wrap: Execution Mode Check, session-resume guard
+    (before posting), Step E.4 Token Budget, Step F
+    deduplication logic, all MANDATORY GATE sections,
+    Step 7a-7g GitHub Review Posting gates.
+  - File: `internal/scaffold/assets/opencode/commands/uf.review-pr.md`
+
+- [x] 1.3 [P] Add `<protect>` tags to `uf.review-council.md`
+  - Wrap: SESSION-RESUME GUARD, EXECUTION CHECKLIST,
+    Phase 1a-1c pre-flight checks, CRITICAL branch diff
+    rule (Step 2), Step 7f Verdict Mapping with
+    MANDATORY GATE and session-resume guard.
+  - File: `internal/scaffold/assets/opencode/commands/uf.review-council.md`
+
+- [x] 1.4 [P] Add `<protect>` tags to `uf.finale.md`
+  - Wrap: SESSION-RESUME GUARD, EXECUTION CHECKLIST,
+    Step 2 secret file MANDATORY GATE, Step 3 commit
+    attribution model extraction, Step 5 PR creation
+    MANDATORY GATEs, Guardrails section, Branch Safety.
+  - File: `internal/scaffold/assets/opencode/commands/uf.finale.md`
+
+## 2. High Priority Commands
+
+- [x] 2.1 [P] Add `<protect>` tags to `uf.address-feedback.md`
+  - Wrap: SESSION-RESUME GUARD, EXECUTION CHECKLIST,
+    Phase 1.6 cache authority check, Phase 3 triage
+    decision enforcement, Phase 4.3 review-council gate,
+    Phase 4.5 checklist gate, Guardrails section.
+  - File: `internal/scaffold/assets/opencode/commands/uf.address-feedback.md`
+
+- [x] 2.2 [P] Add `<protect>` tags to `uf.triage-issue.md`
+  - Wrap: argument validation, Phase 1.2 re-run
+    detection, Phase 3.1 verdict resolution rules,
+    Phase 4.2 label application dual-path logic,
+    Phase 4.3 comment confirmation gate, Phase 4.4
+    child issue creation gate, Guardrails section.
+  - File: `internal/scaffold/assets/opencode/commands/uf.triage-issue.md`
+
+## 3. Design Correction — Single-Wrap
+
+The original design (3-8 selective sections per file) was
+incorrect. Command files are orchestration pipelines where
+every section is execution-critical. Partial protection
+leaves pipeline steps, branching logic, and checkpoint
+markers vulnerable to DCP compression.
+
+Corrected approach: one `<protect>` tag per file wrapping
+the entire instruction body. Only the informational header
+(description, usage) is left outside.
+
+- [x] 3.1 Remove all inner `<protect>` tags from all 6 files
+- [x] 3.2 [P] Add single outer `<protect>` wrap to `uf.unleash.md`
+- [x] 3.3 [P] Add single outer `<protect>` wrap to `uf.review-pr.md`
+- [x] 3.4 [P] Add single outer `<protect>` wrap to `uf.review-council.md`
+- [x] 3.5 [P] Add single outer `<protect>` wrap to `uf.finale.md`
+- [x] 3.6 [P] Add single outer `<protect>` wrap to `uf.address-feedback.md`
+- [x] 3.7 [P] Add single outer `<protect>` wrap to `uf.triage-issue.md`
+- [x] 3.8 Sync `.opencode/commands/` copies
+
+## 4. Verification
+
+- [x] 4.1 Run `make build` to verify Go embed compiles.
+- [x] 4.2 Run `make test` to verify scaffold drift tests
+  pass with the modified templates.
+- [x] 4.3 Verify exactly 1 `<protect>` open/close pair
+  per file (single-wrap).


### PR DESCRIPTION
## Summary

Add DCP `<protect>` tags to all 6 pipeline slash command files to
prevent OpenCode's context compression (DCP) from losing execution-
critical orchestration logic during long sessions.

Slash commands are injected as user messages, which makes them
vulnerable to DCP compression unlike skills (which use tool_use/
tool_result pairs protected by DCP's `protectedTools`). This wraps
each command's pipeline body in a single `<protect>` tag after the
informational header, preserving the entire orchestration pipeline
while leaving description/usage sections compressible.

Fixes #497

## How to Test

1. `make build` - verify compilation succeeds
2. `make test` - verify all tests pass, especially scaffold drift tests
3. Verify each source file has exactly one `<protect>`/`</protect>` pair:
   ```bash
   for f in internal/scaffold/assets/opencode/commands/uf.*.md; do
     echo "$f: $(grep -c '<protect>' $f) open, $(grep -c '</protect>' $f) close"
   done
   ```
4. Verify `.opencode/commands/` copies match source templates

## How to Demo

Run a long session using `/uf.unleash` or `/uf.review-pr`. After DCP
compression occurs, the pipeline steps, guardrails, and mandatory
gates should be preserved in full rather than summarized.

## Key Files Changed

- `internal/scaffold/assets/opencode/commands/uf.unleash.md` - Added `<protect>` wrap
- `internal/scaffold/assets/opencode/commands/uf.review-pr.md` - Added `<protect>` wrap
- `internal/scaffold/assets/opencode/commands/uf.review-council.md` - Added `<protect>` wrap
- `internal/scaffold/assets/opencode/commands/uf.finale.md` - Added `<protect>` wrap
- `internal/scaffold/assets/opencode/commands/uf.address-feedback.md` - Added `<protect>` wrap
- `internal/scaffold/assets/opencode/commands/uf.triage-issue.md` - Added `<protect>` wrap
- `.opencode/commands/uf.*.md` - Synced copies of source templates
- `openspec/changes/add-protect-tags/` - OpenSpec change artifacts

_This PR was generated by /uf.finale (AI-assisted)._
