### PR TITLE
chore: add DCP config to enable protect tag preservation

### DIFF
--- a/.opencode/dcp.jsonc
+++ b/.opencode/dcp.jsonc
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://raw.githubusercontent.com/Opencode-DCP/opencode-dynamic-context-pruning/master/dcp.schema.json",
+  // Enable <protect> tag preservation during DCP compression.
+  // Slash command files in .opencode/commands/ use <protect> tags
+  // to mark execution-critical sections (guardrails, checklists,
+  // mandatory gates) that must survive context pruning.
+  "compress": {
+    "protectTags": true
+  }
+}


### PR DESCRIPTION
Add `.opencode/dcp.jsonc` with `compress.protectTags: true` so that `<protect>` tags added in PR #499 are honored by DCP during context compression. Without this config, the tags are inert.

Refs: #497