### PR TITLE
chore: add DCP configuration for protect tag preservation

### DIFF
--- a/.opencode/dcp.jsonc
+++ b/.opencode/dcp.jsonc
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://raw.githubusercontent.com/Opencode-DCP/opencode-dynamic-context-pruning/master/dcp.schema.json",
+  // Enable <protect> tag preservation during DCP compression.
+  // Slash command files in .opencode/commands/ use <protect> tags
+  // to mark execution-critical sections (guardrails, checklists,
+  // mandatory gates) that must survive context pruning.
+  "compress": {
+    "protectTags": true
+  }
+}


### PR DESCRIPTION
Add `.opencode/dcp.jsonc` to enable `protectTags` for DCP (Dynamic Context Pruning).

This ensures that `<protect>` sections in slash command files under `.opencode/commands/` survive context pruning, preserving execution-critical guardrails, checklists, and mandatory gates.