### PR TITLE
fix: restore accidentally-reverted soft-gate content in pre-flight SKILL.md

### DIFF
--- a/.opencode/skills/pre-flight/SKILL.md
+++ b/.opencode/skills/pre-flight/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pre-flight
-description: "Shared pre-flight skill for CI detection and local tool execution. Supports hard-gate and ci-aware execution policies."
+description: "Shared pre-flight skill for CI detection and local tool execution. Supports hard-gate, ci-aware, and soft-gate execution policies."
 ---
 <!-- scaffolded by uf vdev -->
 # Skill: Pre-flight Checks
@@ -14,8 +14,9 @@ an execution policy.
 
 | Mode | Behavior | Typical consumer |
 |------|----------|-----------------|
-| `hard-gate` | Run all detected tools. Stop on first failure. | `/uf.review-council`, `/uf.unleash` |
-| `ci-aware` | Build CI coverage matrix against PR check results. Skip tools CI already verified. Run the rest. | `/uf.review-pr` |
+| `hard-gate` | Run all detected tools. Stop on first failure. | `/unleash` (phase checkpoints) |
+| `ci-aware` | Build CI coverage matrix against PR check results. Skip tools CI already verified. Run the rest. | `/review-pr` |
+| `soft-gate` | Run all detected tools. Classify failures as branch-caused vs pre-existing. Gate only on branch-caused failures. | `/review-council` |
 
 The consuming command specifies which mode to use.
 
@@ -192,11 +193,174 @@ Record all exit codes and output.
 If no tools are marked "Yes" (all covered by CI): report
 "All tools covered by CI — no local execution needed."
 
+### soft-gate mode
+
+Execute ALL detected and available tools (same as
+hard-gate). Do NOT stop on first failure — record all
+exit codes and output for every tool.
+
+- If ALL tools pass: verdict is PASS. No baseline
+  establishment is needed. Skip Phase 4a and 4b.
+- If ANY tools fail: proceed to Phase 4a (Baseline
+  Establishment) to classify each failure.
+
+---
+
+## Phase 4a: Baseline Establishment (soft-gate only)
+
+This phase runs only in `soft-gate` mode, and only when
+at least one tool failed during Phase 4 execution.
+
+Establish a baseline for the default branch to determine
+which failures are branch-caused vs pre-existing. Use a
+two-tier strategy: CI API first, local worktree fallback.
+
+### Detect the default branch
+
+Before establishing a baseline, detect the repository's
+default branch. Do NOT hardcode `main` — repositories
+may use `master` or another default branch name.
+
+```bash
+DEFAULT_BRANCH=$(git symbolic-ref \
+  refs/remotes/origin/HEAD 2>/dev/null \
+  | sed 's|refs/remotes/origin/||')
+```
+
+If that fails (remote HEAD not set, which happens after
+a fresh clone without
+`git remote set-head origin --auto`), fall back to
+checking for common names:
+
+```bash
+if [ -z "${DEFAULT_BRANCH}" ]; then
+  if git rev-parse --verify origin/main \
+    >/dev/null 2>&1; then
+    DEFAULT_BRANCH="main"
+  elif git rev-parse --verify origin/master \
+    >/dev/null 2>&1; then
+    DEFAULT_BRANCH="master"
+  fi
+fi
+```
+
+If neither resolves, treat the baseline as unavailable
+and fall through to the conservative fallback (all
+failures classified as `unknown` = branch-caused).
+
+### Tier 1 — CI API baseline
+
+Check if the `gh` CLI is available:
+
+```bash
+which gh
+```
+
+If `gh` is available, query the latest check-run results
+for the default branch:
+
+```bash
+gh api \
+  repos/{owner}/{repo}/commits/${DEFAULT_BRANCH}/check-runs \
+  --jq '.check_runs[] | {name, conclusion}'
+```
+
+Use `--arg` for any dynamic values to prevent injection
+(consistent with `/review-pr` Step 3a).
+
+Map CI check names to local tool names using the same
+coverage matrix logic from Phase 3. For each failing
+tool from Phase 4, look up the corresponding CI check
+conclusion on `${DEFAULT_BRANCH}`:
+
+- `conclusion: "success"` → baseline PASS
+- `conclusion: "failure"` → baseline FAIL
+- No matching check → baseline NO DATA
+
+If `gh` is not available, or the API call returns no
+data, or the API call fails: proceed to Tier 2.
+
+### Tier 2 — Local worktree baseline
+
+Create a temporary detached worktree of the default
+branch:
+
+```bash
+SHORT_SHA=$(git rev-parse --short=8 ${DEFAULT_BRANCH})
+git worktree add /tmp/preflight-baseline-${SHORT_SHA} \
+  ${DEFAULT_BRANCH} --detach
+```
+
+Run ONLY the tools that failed on the branch in the
+worktree directory. Tools that passed on the branch
+MUST NOT be run against the baseline — they are not
+branch-caused by definition.
+
+```bash
+# For each failing tool, run it in the worktree:
+cd /tmp/preflight-baseline-${SHORT_SHA}
+<tool-command>
+# Record exit code
+```
+
+After running all failing tools, clean up the worktree:
+
+```bash
+git worktree remove \
+  /tmp/preflight-baseline-${SHORT_SHA} --force
+```
+
+Compare exit codes:
+- Tool fails in worktree → baseline FAIL
+- Tool passes in worktree → baseline PASS
+
+### Fallback — conservative classification
+
+If both Tier 1 and Tier 2 fail (e.g., `gh` unavailable
+AND worktree creation fails due to disk space or dirty
+state), or the default branch could not be detected,
+classify ALL failures as `unknown`. The `unknown`
+classification is treated as branch-caused
+(conservative), matching `/review-pr` behavior.
+
+Record which baseline method was used: `CI API`,
+`worktree`, or `unavailable`.
+
+---
+
+## Phase 4b: Causality Classification (soft-gate only)
+
+This phase runs only in `soft-gate` mode, after Phase 4a
+has established a baseline.
+
+For each failing tool from Phase 4, classify it using
+the baseline result from Phase 4a:
+
+| Baseline status | Branch status | Classification |
+|-----------------|---------------|----------------|
+| Pass            | Fail          | **branch-caused** |
+| Fail            | Fail          | **pre-existing** |
+| No data         | Fail          | **unknown** (treat as branch-caused) |
+
+### Gate decision
+
+After classifying all failures:
+
+- If ANY failures are `branch-caused` or `unknown`:
+  verdict is **FAIL (branch-caused)**. The consuming
+  command MUST NOT proceed past the pre-flight gate.
+- If ALL failures are `pre-existing`: verdict is
+  **PASS**. The consuming command MAY proceed, with
+  pre-existing failures reported as informational
+  findings.
+
 ---
 
 ## Phase 5: Result Format
 
-Present results in a standardized format:
+Present results in a standardized format.
+
+### hard-gate and ci-aware modes
 
 ```
 ## Pre-flight Results
@@ -217,7 +381,42 @@ Present results in a standardized format:
 - **Failures**: [list if any]
 ```
 
+### soft-gate mode
+
+```
+## Pre-flight Results
+
+### CI Coverage Matrix
+| Local tool | CI check | CI status | Run locally? |
+|------------|----------|-----------|--------------|
+| ...        | ...      | ...       | ...          |
+
+### Execution Results
+| Tool | Command | Exit code | Status | Causality |
+|------|---------|-----------|--------|-----------|
+| ...  | ...     | ...       | ...    | ...       |
+
+### Verdict
+- **Mode**: soft-gate
+- **Result**: PASS | FAIL (branch-caused)
+- **Branch-caused failures**: [list if any]
+- **Pre-existing failures**: [list if any]
+- **Baseline method**: CI API | worktree | unavailable
+```
+
+The `Causality` column in the Execution Results table
+contains one of: `branch-caused`, `pre-existing`,
+`unknown`, or `—` (for tools that passed).
+
+The `Result` field is:
+- `PASS` if no branch-caused or unknown failures exist
+  (even if pre-existing failures exist)
+- `FAIL (branch-caused)` if any branch-caused or unknown
+  failures exist
+
 The consuming command uses this result to decide whether
-to proceed (hard-gate: stop on FAIL) or to include
-failure context in AI review (ci-aware: continue with
-context).
+to proceed:
+- `hard-gate`: stop on FAIL
+- `ci-aware`: continue with failure context for AI review
+- `soft-gate`: stop on FAIL (branch-caused), continue
+  with pre-existing failures as informational findings

--- a/internal/scaffold/assets/opencode/skills/pre-flight/SKILL.md
+++ b/internal/scaffold/assets/opencode/skills/pre-flight/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pre-flight
-description: "Shared pre-flight skill for CI detection and local tool execution. Supports hard-gate and ci-aware execution policies."
+description: "Shared pre-flight skill for CI detection and local tool execution. Supports hard-gate, ci-aware, and soft-gate execution policies."
 ---
 <!-- scaffolded by uf vdev -->
 # Skill: Pre-flight Checks
@@ -14,8 +14,9 @@ an execution policy.
 
 | Mode | Behavior | Typical consumer |
 |------|----------|-----------------|
-| `hard-gate` | Run all detected tools. Stop on first failure. | `/uf.review-council`, `/uf.unleash` |
-| `ci-aware` | Build CI coverage matrix against PR check results. Skip tools CI already verified. Run the rest. | `/uf.review-pr` |
+| `hard-gate` | Run all detected tools. Stop on first failure. | `/unleash` (phase checkpoints) |
+| `ci-aware` | Build CI coverage matrix against PR check results. Skip tools CI already verified. Run the rest. | `/review-pr` |
+| `soft-gate` | Run all detected tools. Classify failures as branch-caused vs pre-existing. Gate only on branch-caused failures. | `/review-council` |
 
 The consuming command specifies which mode to use.
 
@@ -192,11 +193,174 @@ Record all exit codes and output.
 If no tools are marked "Yes" (all covered by CI): report
 "All tools covered by CI — no local execution needed."
 
+### soft-gate mode
+
+Execute ALL detected and available tools (same as
+hard-gate). Do NOT stop on first failure — record all
+exit codes and output for every tool.
+
+- If ALL tools pass: verdict is PASS. No baseline
+  establishment is needed. Skip Phase 4a and 4b.
+- If ANY tools fail: proceed to Phase 4a (Baseline
+  Establishment) to classify each failure.
+
+---
+
+## Phase 4a: Baseline Establishment (soft-gate only)
+
+This phase runs only in `soft-gate` mode, and only when
+at least one tool failed during Phase 4 execution.
+
+Establish a baseline for the default branch to determine
+which failures are branch-caused vs pre-existing. Use a
+two-tier strategy: CI API first, local worktree fallback.
+
+### Detect the default branch
+
+Before establishing a baseline, detect the repository's
+default branch. Do NOT hardcode `main` — repositories
+may use `master` or another default branch name.
+
+```bash
+DEFAULT_BRANCH=$(git symbolic-ref \
+  refs/remotes/origin/HEAD 2>/dev/null \
+  | sed 's|refs/remotes/origin/||')
+```
+
+If that fails (remote HEAD not set, which happens after
+a fresh clone without
+`git remote set-head origin --auto`), fall back to
+checking for common names:
+
+```bash
+if [ -z "${DEFAULT_BRANCH}" ]; then
+  if git rev-parse --verify origin/main \
+    >/dev/null 2>&1; then
+    DEFAULT_BRANCH="main"
+  elif git rev-parse --verify origin/master \
+    >/dev/null 2>&1; then
+    DEFAULT_BRANCH="master"
+  fi
+fi
+```
+
+If neither resolves, treat the baseline as unavailable
+and fall through to the conservative fallback (all
+failures classified as `unknown` = branch-caused).
+
+### Tier 1 — CI API baseline
+
+Check if the `gh` CLI is available:
+
+```bash
+which gh
+```
+
+If `gh` is available, query the latest check-run results
+for the default branch:
+
+```bash
+gh api \
+  repos/{owner}/{repo}/commits/${DEFAULT_BRANCH}/check-runs \
+  --jq '.check_runs[] | {name, conclusion}'
+```
+
+Use `--arg` for any dynamic values to prevent injection
+(consistent with `/review-pr` Step 3a).
+
+Map CI check names to local tool names using the same
+coverage matrix logic from Phase 3. For each failing
+tool from Phase 4, look up the corresponding CI check
+conclusion on `${DEFAULT_BRANCH}`:
+
+- `conclusion: "success"` → baseline PASS
+- `conclusion: "failure"` → baseline FAIL
+- No matching check → baseline NO DATA
+
+If `gh` is not available, or the API call returns no
+data, or the API call fails: proceed to Tier 2.
+
+### Tier 2 — Local worktree baseline
+
+Create a temporary detached worktree of the default
+branch:
+
+```bash
+SHORT_SHA=$(git rev-parse --short=8 ${DEFAULT_BRANCH})
+git worktree add /tmp/preflight-baseline-${SHORT_SHA} \
+  ${DEFAULT_BRANCH} --detach
+```
+
+Run ONLY the tools that failed on the branch in the
+worktree directory. Tools that passed on the branch
+MUST NOT be run against the baseline — they are not
+branch-caused by definition.
+
+```bash
+# For each failing tool, run it in the worktree:
+cd /tmp/preflight-baseline-${SHORT_SHA}
+<tool-command>
+# Record exit code
+```
+
+After running all failing tools, clean up the worktree:
+
+```bash
+git worktree remove \
+  /tmp/preflight-baseline-${SHORT_SHA} --force
+```
+
+Compare exit codes:
+- Tool fails in worktree → baseline FAIL
+- Tool passes in worktree → baseline PASS
+
+### Fallback — conservative classification
+
+If both Tier 1 and Tier 2 fail (e.g., `gh` unavailable
+AND worktree creation fails due to disk space or dirty
+state), or the default branch could not be detected,
+classify ALL failures as `unknown`. The `unknown`
+classification is treated as branch-caused
+(conservative), matching `/review-pr` behavior.
+
+Record which baseline method was used: `CI API`,
+`worktree`, or `unavailable`.
+
+---
+
+## Phase 4b: Causality Classification (soft-gate only)
+
+This phase runs only in `soft-gate` mode, after Phase 4a
+has established a baseline.
+
+For each failing tool from Phase 4, classify it using
+the baseline result from Phase 4a:
+
+| Baseline status | Branch status | Classification |
+|-----------------|---------------|----------------|
+| Pass            | Fail          | **branch-caused** |
+| Fail            | Fail          | **pre-existing** |
+| No data         | Fail          | **unknown** (treat as branch-caused) |
+
+### Gate decision
+
+After classifying all failures:
+
+- If ANY failures are `branch-caused` or `unknown`:
+  verdict is **FAIL (branch-caused)**. The consuming
+  command MUST NOT proceed past the pre-flight gate.
+- If ALL failures are `pre-existing`: verdict is
+  **PASS**. The consuming command MAY proceed, with
+  pre-existing failures reported as informational
+  findings.
+
 ---
 
 ## Phase 5: Result Format
 
-Present results in a standardized format:
+Present results in a standardized format.
+
+### hard-gate and ci-aware modes
 
 ```
 ## Pre-flight Results
@@ -217,7 +381,42 @@ Present results in a standardized format:
 - **Failures**: [list if any]
 ```
 
+### soft-gate mode
+
+```
+## Pre-flight Results
+
+### CI Coverage Matrix
+| Local tool | CI check | CI status | Run locally? |
+|------------|----------|-----------|--------------|
+| ...        | ...      | ...       | ...          |
+
+### Execution Results
+| Tool | Command | Exit code | Status | Causality |
+|------|---------|-----------|--------|-----------|
+| ...  | ...     | ...       | ...    | ...       |
+
+### Verdict
+- **Mode**: soft-gate
+- **Result**: PASS | FAIL (branch-caused)
+- **Branch-caused failures**: [list if any]
+- **Pre-existing failures**: [list if any]
+- **Baseline method**: CI API | worktree | unavailable
+```
+
+The `Causality` column in the Execution Results table
+contains one of: `branch-caused`, `pre-existing`,
+`unknown`, or `—` (for tools that passed).
+
+The `Result` field is:
+- `PASS` if no branch-caused or unknown failures exist
+  (even if pre-existing failures exist)
+- `FAIL (branch-caused)` if any branch-caused or unknown
+  failures exist
+
 The consuming command uses this result to decide whether
-to proceed (hard-gate: stop on FAIL) or to include
-failure context in AI review (ci-aware: continue with
-context).
+to proceed:
+- `hard-gate`: stop on FAIL
+- `ci-aware`: continue with failure context for AI review
+- `soft-gate`: stop on FAIL (branch-caused), continue
+  with pre-existing failures as informational findings


### PR DESCRIPTION

## Summary

Restores the soft-gate content (Phase 4a Baseline Establishment, Phase 4b Causality Classification, soft-gate mode table entry, soft-gate Phase 5 result format) that was accidentally reverted from the pre-flight skill.

Fixes #435

## Root Cause

PR #318 (`opsx/ci-causality-soft-gate`, commit `3d0fd47`) added soft-gate mode to the pre-flight skill, expanding SKILL.md from ~223 to ~422 lines. This was merged into `main`.

Commit `e3b4bb7` (`chore: prefix uf-owned slash commands with uf. namespace`) subsequently replaced both SKILL.md copies with an older version that did not contain the soft-gate content, silently reverting the entire PR #318 change.

## Fix

Both repo-level and scaffold copies are restored from the pre-revert state (commit `2f900dd`). No new content is added — this is a pure restoration.

## Verification

- `diff` confirms both copies are identical
- `go test -race -count=1 ./internal/scaffold/...` passes