### PR TITLE
fix: add scope filter to pre-flight skill

### DIFF
--- a/.opencode/skills/pre-flight/SKILL.md
+++ b/.opencode/skills/pre-flight/SKILL.md
@@ -116,6 +116,82 @@ and proceed to Phase 3.
 
 ---
 
+## Phase 2b: Scope Filter
+
+After detecting available tools, determine which tools are
+relevant to the current branch by intersecting the branch
+diff with each tool's file-extension scope.
+
+### Branch diff computation
+
+Compute the list of files changed on the current branch:
+
+```bash
+git diff --name-only main...HEAD
+```
+
+If this command fails (e.g., detached HEAD, missing remote,
+no `main` branch), emit a warning that includes the git error
+message explaining why the scope filter was bypassed. Mark
+all detected tools as "In scope" and proceed (fail-open).
+
+If the diff returns an empty file list (no commits ahead of
+`main`), emit a warning: "no files changed on branch — scope
+filter has nothing to match". Mark all non-always-run tools
+as "Skipped (no in-scope files)" and always-run tools as
+"In scope".
+
+### Tool-to-extension scope mapping
+
+| Tool | In-scope extensions |
+|------|-------------------|
+| `go test` | `*.go`, `go.mod`, `go.sum` |
+| `golangci-lint` | `*.go`, `go.mod`, `go.sum` |
+| `ruff` | `*.py`, `pyproject.toml`, `setup.py`, `setup.cfg`, `requirements*.txt` |
+| `pytest` | `*.py`, `pyproject.toml`, `setup.py`, `setup.cfg`, `requirements*.txt` |
+| `yamllint` | `*.yml`, `*.yaml` |
+
+### Always-run tools
+
+The following tools MUST NOT be skipped by the scope filter
+regardless of the branch diff:
+
+- `make check` (or `make lint`)
+- `pre-commit`
+
+These meta-tools aggregate multiple concerns that may not
+map cleanly to file extensions.
+
+### Scope evaluation
+
+For each detected and available tool:
+
+1. If the tool is in the always-run list → mark "In scope"
+2. If the tool is NOT in the scope mapping table → mark
+   "In scope" (unknown tools default to always-run)
+3. If ANY file in the branch diff matches the tool's
+   in-scope extensions → mark "In scope"
+4. If NO files in the branch diff match → mark "Skipped
+   (no in-scope files)"
+
+### Output
+
+Log the diff file list and the per-tool scope decision:
+
+```
+Branch diff (git diff --name-only main...HEAD):
+  - .github/workflows/ci.yml
+  - config/settings.yaml
+
+Scope filter results:
+  - go test: Skipped (no in-scope files)
+  - golangci-lint: Skipped (no in-scope files)
+  - yamllint: In scope (matched: *.yml, *.yaml)
+  - Make (make check): In scope (always run)
+```
+
+---
+
 ## Phase 3: CI Coverage Matrix
 
 Build and display a coverage matrix that maps each
@@ -131,6 +207,12 @@ names to CI check names by matching on the tool's purpose
 (e.g., `go test` maps to a CI check containing "test",
 `golangci-lint` maps to a check containing "lint").
 
+Tools marked "Skipped (no in-scope files)" in Phase 2b
+appear in the matrix with "Run locally?" set to
+"No (no in-scope files)". These tools are not evaluated
+against CI status — the scope filter decision takes
+precedence.
+
 ### Decision rules (ci-aware mode)
 
 | CI status | Run locally? | Rationale |
@@ -142,12 +224,16 @@ names to CI check names by matching on the tool's purpose
 
 ### Decision rules (hard-gate mode)
 
-In hard-gate mode, ALL detected and available tools are
-marked "Run locally = Yes" regardless of CI status. The
-CI status column in the matrix shows the actual status if
-available, or "N/A" if CI results were not provided. The
-coverage matrix is still displayed for visibility, but
-skip decisions are not applied.
+In hard-gate mode, ALL detected, available, and in-scope
+tools are marked "Run locally = Yes" regardless of CI
+status. Tools marked "Skipped (no in-scope files)" in
+Phase 2b are marked "No (no in-scope files)" — scope
+filtering takes precedence over hard-gate's default of
+running everything.
+
+The CI status column in the matrix shows the actual status
+if available, or "N/A" if CI results were not provided.
+The coverage matrix is still displayed for visibility.
 
 ### Display format
 
@@ -155,9 +241,10 @@ skip decisions are not applied.
 ### CI Coverage Matrix
 | Local tool | CI check | CI status | Run locally? |
 |------------|----------|-----------|--------------|
-| go test | Local CI / test | PASS | No |
-| golangci-lint | CI Checks / lint | PASS | No |
+| go test | Local CI / test | PASS | No (no in-scope files) |
+| golangci-lint | CI Checks / lint | PASS | No (no in-scope files) |
 | yamllint | (none) | NONE | Yes |
+| Make (make check) | Local CI / check | PASS | Yes (always run) |
 ```
 
 ---
@@ -165,12 +252,15 @@ skip decisions are not applied.
 ## Phase 4: Execution
 
 Run only the tools marked "Run locally = Yes" in the
-coverage matrix.
+coverage matrix. Tools marked "No (no in-scope files)"
+are skipped — they count as PASS for verdict computation
+but are not executed. Their display status is
+"SKIP (scope)".
 
 ### hard-gate mode
 
-Execute each tool in order. If any tool exits with a
-non-zero exit code:
+Execute each in-scope tool in order. If any tool exits
+with a non-zero exit code:
 
 1. **STOP immediately** — do not run remaining tools.
 2. Report the failure as a CRITICAL finding with the
@@ -178,7 +268,8 @@ non-zero exit code:
 3. The consuming command MUST NOT proceed to AI review
    or implementation.
 
-If all tools pass, report success.
+If all in-scope tools pass (and scope-skipped tools count
+as PASS), report success.
 
 ### ci-aware mode
 
@@ -190,8 +281,9 @@ Record all exit codes and output.
   for AI review. Do NOT stop — the consuming command
   decides how to handle failures.
 
-If no tools are marked "Yes" (all covered by CI): report
-"All tools covered by CI — no local execution needed."
+If no tools are marked "Yes" (all covered by CI or
+scope-skipped): report "All tools covered by CI or
+out of scope — no local execution needed."
 
 ### soft-gate mode
 
@@ -358,7 +450,12 @@ After classifying all failures:
 
 ## Phase 5: Result Format
 
-Present results in a standardized format.
+Present results in a standardized format. Scope-skipped
+tools (those marked "No (no in-scope files)" by Phase
+2b) appear in the execution results table with exit
+code "-" and status "SKIP (scope)". They count as PASS
+for the verdict but are visually distinguished from tools
+that were actually executed.
 
 ### hard-gate and ci-aware modes
 
@@ -373,12 +470,16 @@ Present results in a standardized format.
 ### Execution Results
 | Tool | Command | Exit code | Status |
 |------|---------|-----------|--------|
+| go test | go test ./... | 0 | PASS |
+| golangci-lint | golangci-lint run | - | SKIP (scope) |
+| Make | make check | 0 | PASS |
 | ...  | ...     | ...       | ...    |
 
 ### Verdict
 - **Mode**: hard-gate | ci-aware
 - **Result**: PASS | FAIL
 - **Failures**: [list if any]
+- **Scope-skipped**: [list of tools skipped by scope filter]
 ```
 
 ### soft-gate mode

--- a/.opencode/skills/pre-flight/SKILL.md
+++ b/.opencode/skills/pre-flight/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pre-flight
-description: "Shared pre-flight skill for CI detection and local tool execution. Supports hard-gate, ci-aware, and soft-gate execution policies."
+description: "Shared pre-flight skill for CI detection, scope filtering, and local tool execution. Supports hard-gate, ci-aware, and soft-gate execution policies."
 ---
 <!-- scaffolded by uf vdev -->
 # Skill: Pre-flight Checks
@@ -14,9 +14,9 @@ an execution policy.
 
 | Mode | Behavior | Typical consumer |
 |------|----------|-----------------|
-| `hard-gate` | Run all detected tools. Stop on first failure. | `/unleash` (phase checkpoints) |
+| `hard-gate` | Run all detected in-scope tools. Stop on first failure. | `/unleash` (phase checkpoints) |
 | `ci-aware` | Build CI coverage matrix against PR check results. Skip tools CI already verified. Run the rest. | `/review-pr` |
-| `soft-gate` | Run all detected tools. Classify failures as branch-caused vs pre-existing. Gate only on branch-caused failures. | `/review-council` |
+| `soft-gate` | Run all detected in-scope tools. Classify failures as branch-caused vs pre-existing. Gate only on branch-caused failures. | `/review-council` |
 
 The consuming command specifies which mode to use.
 
@@ -253,9 +253,9 @@ The coverage matrix is still displayed for visibility.
 
 Run only the tools marked "Run locally = Yes" in the
 coverage matrix. Tools marked "No (no in-scope files)"
-are skipped — they count as PASS for verdict computation
-but are not executed. Their display status is
-"SKIP (scope)".
+are scope-skipped — they count as PASS for verdict
+computation but are not executed. Their display status
+is "SKIP (scope)".
 
 ### hard-gate mode
 

--- a/.uf/dewey/learnings/pre-flight-scope-filter-20260817T195621-jay-flowers.md
+++ b/.uf/dewey/learnings/pre-flight-scope-filter-20260817T195621-jay-flowers.md
@@ -1,0 +1,10 @@
+---
+tag: pre-flight-scope-filter
+author: jay-flowers
+category: pattern
+created_at: 2026-08-17T19:56:21Z
+identity: pre-flight-scope-filter-20260817T195621-jay-flowers
+tier: draft
+---
+
+When implementing instruction-only Markdown changes to skills (like the pre-flight scope filter addition), the full spec-review-implement-review pipeline still applies, but the coverage strategy must be explicitly adapted. Instead of traditional unit tests, use a three-tier approach: (1) automated scaffold drift detection via TestEmbeddedAssets_MatchSource to verify source and scaffold copies are byte-identical, (2) automated CI parity via make check to ensure no regressions, and (3) behavioral manual verification with a concrete checklist of items to confirm in the modified file. Constitution Principle IV requires the coverage strategy to be formally documented even for instruction-only changes — the strategy is different from compiled code but must still be defined.

--- a/.uf/dewey/learnings/pre-flight-scope-filter-20260817T195629-jay-flowers.md
+++ b/.uf/dewey/learnings/pre-flight-scope-filter-20260817T195629-jay-flowers.md
@@ -1,0 +1,10 @@
+---
+tag: pre-flight-scope-filter
+author: jay-flowers
+category: gotcha
+created_at: 2026-08-17T19:56:29Z
+identity: pre-flight-scope-filter-20260817T195629-jay-flowers
+tier: draft
+---
+
+When adding a new capability to a skill's instruction body (like adding Phase 2b scope filtering to the pre-flight skill), there are three locations that must be updated in sync within the same SKILL.md file: (1) the detailed phase section where the new behavior is documented, (2) the summary or overview table at the top of the file that describes each execution mode's behavior, and (3) the frontmatter description field that agents see when deciding whether to load the skill. The code review caught that the Execution Policies table still said "Run all detected tools" instead of "Run all detected in-scope tools" and the frontmatter description did not mention scope filtering. This is a skill-specific variant of the scaffold sync gotcha — within a single file, the overview and detailed sections must stay consistent.

--- a/.uf/dewey/learnings/pre-flight-scope-filter-20260817T195634-jay-flowers.md
+++ b/.uf/dewey/learnings/pre-flight-scope-filter-20260817T195634-jay-flowers.md
@@ -1,0 +1,10 @@
+---
+tag: pre-flight-scope-filter
+author: jay-flowers
+category: pattern
+created_at: 2026-08-17T19:56:34Z
+identity: pre-flight-scope-filter-20260817T195634-jay-flowers
+tier: draft
+---
+
+When reviewing scope mapping tables that map tools to file extensions, reviewers consistently found three categories of issues across both spec and code review phases: (1) phantom tool entries — tools listed in the scope table that are not detected by the tool detection phase as standalone tools (e.g., go vet and go build are CI-discovered commands, not Phase 2 detected tools), (2) asymmetric dependency file coverage — Go tools mapping go.mod/go.sum but Python tools not mapping pyproject.toml/requirements.txt, and (3) inconsistent scope breadth within the same ecosystem — golangci-lint scoped narrower than go test/go vet despite operating on the same ecosystem. All three issues were caught independently by 4-6 of 9 reviewers, validating the multi-reviewer approach for data model consistency checking.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,15 @@ Each entry follows the format: `- <change-name>: <summary>`.
 ## Unreleased
 
 ### Changed
-- pre-flight-scope-filter: Add file-scope filtering to
-  pre-flight skill. Tools are now skipped when the branch
-  diff contains no files matching their extension scope
-  (e.g., Go tools skip on YAML-only branches). Adds
-  Phase 2b between tool detection and CI coverage matrix
-  with tool-to-extension mapping, always-run designation
-  for meta-tools (`make check`, `pre-commit`), and
-  fail-open behavior on git errors. Scope-skipped tools
-  count as PASS for verdict and display as "SKIP (scope)".
+- pre-flight-scope-filter: Pre-flight checks now skip
+  tools when the branch diff contains no files matching
+  their extension scope (e.g., Go tools skip on YAML-only
+  branches). Adds Phase 2b file-scope filtering between
+  tool detection and CI coverage matrix with
+  tool-to-extension mapping, always-run designation for
+  meta-tools (`make check`, `pre-commit`), and fail-open
+  behavior on git errors. Scope-skipped tools count as
+  PASS for verdict and display as "SKIP (scope)".
   (Spec: openspec/changes/pre-flight-scope-filter/,
   Fixes: #434)
 - adopt-org-infra-release-workflows: Replace inline

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ Each entry follows the format: `- <change-name>: <summary>`.
 ## Unreleased
 
 ### Changed
+- pre-flight-scope-filter: Add file-scope filtering to
+  pre-flight skill. Tools are now skipped when the branch
+  diff contains no files matching their extension scope
+  (e.g., Go tools skip on YAML-only branches). Adds
+  Phase 2b between tool detection and CI coverage matrix
+  with tool-to-extension mapping, always-run designation
+  for meta-tools (`make check`, `pre-commit`), and
+  fail-open behavior on git errors. Scope-skipped tools
+  count as PASS for verdict and display as "SKIP (scope)".
+  (Spec: openspec/changes/pre-flight-scope-filter/,
+  Fixes: #434)
 - adopt-org-infra-release-workflows: Replace inline
   release preflight and GoReleaser jobs with org-infra
   reusable workflow callers (`reusable_release_preflight`

--- a/internal/scaffold/assets/opencode/skills/pre-flight/SKILL.md
+++ b/internal/scaffold/assets/opencode/skills/pre-flight/SKILL.md
@@ -116,6 +116,82 @@ and proceed to Phase 3.
 
 ---
 
+## Phase 2b: Scope Filter
+
+After detecting available tools, determine which tools are
+relevant to the current branch by intersecting the branch
+diff with each tool's file-extension scope.
+
+### Branch diff computation
+
+Compute the list of files changed on the current branch:
+
+```bash
+git diff --name-only main...HEAD
+```
+
+If this command fails (e.g., detached HEAD, missing remote,
+no `main` branch), emit a warning that includes the git error
+message explaining why the scope filter was bypassed. Mark
+all detected tools as "In scope" and proceed (fail-open).
+
+If the diff returns an empty file list (no commits ahead of
+`main`), emit a warning: "no files changed on branch — scope
+filter has nothing to match". Mark all non-always-run tools
+as "Skipped (no in-scope files)" and always-run tools as
+"In scope".
+
+### Tool-to-extension scope mapping
+
+| Tool | In-scope extensions |
+|------|-------------------|
+| `go test` | `*.go`, `go.mod`, `go.sum` |
+| `golangci-lint` | `*.go`, `go.mod`, `go.sum` |
+| `ruff` | `*.py`, `pyproject.toml`, `setup.py`, `setup.cfg`, `requirements*.txt` |
+| `pytest` | `*.py`, `pyproject.toml`, `setup.py`, `setup.cfg`, `requirements*.txt` |
+| `yamllint` | `*.yml`, `*.yaml` |
+
+### Always-run tools
+
+The following tools MUST NOT be skipped by the scope filter
+regardless of the branch diff:
+
+- `make check` (or `make lint`)
+- `pre-commit`
+
+These meta-tools aggregate multiple concerns that may not
+map cleanly to file extensions.
+
+### Scope evaluation
+
+For each detected and available tool:
+
+1. If the tool is in the always-run list → mark "In scope"
+2. If the tool is NOT in the scope mapping table → mark
+   "In scope" (unknown tools default to always-run)
+3. If ANY file in the branch diff matches the tool's
+   in-scope extensions → mark "In scope"
+4. If NO files in the branch diff match → mark "Skipped
+   (no in-scope files)"
+
+### Output
+
+Log the diff file list and the per-tool scope decision:
+
+```
+Branch diff (git diff --name-only main...HEAD):
+  - .github/workflows/ci.yml
+  - config/settings.yaml
+
+Scope filter results:
+  - go test: Skipped (no in-scope files)
+  - golangci-lint: Skipped (no in-scope files)
+  - yamllint: In scope (matched: *.yml, *.yaml)
+  - Make (make check): In scope (always run)
+```
+
+---
+
 ## Phase 3: CI Coverage Matrix
 
 Build and display a coverage matrix that maps each
@@ -131,6 +207,12 @@ names to CI check names by matching on the tool's purpose
 (e.g., `go test` maps to a CI check containing "test",
 `golangci-lint` maps to a check containing "lint").
 
+Tools marked "Skipped (no in-scope files)" in Phase 2b
+appear in the matrix with "Run locally?" set to
+"No (no in-scope files)". These tools are not evaluated
+against CI status — the scope filter decision takes
+precedence.
+
 ### Decision rules (ci-aware mode)
 
 | CI status | Run locally? | Rationale |
@@ -142,12 +224,16 @@ names to CI check names by matching on the tool's purpose
 
 ### Decision rules (hard-gate mode)
 
-In hard-gate mode, ALL detected and available tools are
-marked "Run locally = Yes" regardless of CI status. The
-CI status column in the matrix shows the actual status if
-available, or "N/A" if CI results were not provided. The
-coverage matrix is still displayed for visibility, but
-skip decisions are not applied.
+In hard-gate mode, ALL detected, available, and in-scope
+tools are marked "Run locally = Yes" regardless of CI
+status. Tools marked "Skipped (no in-scope files)" in
+Phase 2b are marked "No (no in-scope files)" — scope
+filtering takes precedence over hard-gate's default of
+running everything.
+
+The CI status column in the matrix shows the actual status
+if available, or "N/A" if CI results were not provided.
+The coverage matrix is still displayed for visibility.
 
 ### Display format
 
@@ -155,9 +241,10 @@ skip decisions are not applied.
 ### CI Coverage Matrix
 | Local tool | CI check | CI status | Run locally? |
 |------------|----------|-----------|--------------|
-| go test | Local CI / test | PASS | No |
-| golangci-lint | CI Checks / lint | PASS | No |
+| go test | Local CI / test | PASS | No (no in-scope files) |
+| golangci-lint | CI Checks / lint | PASS | No (no in-scope files) |
 | yamllint | (none) | NONE | Yes |
+| Make (make check) | Local CI / check | PASS | Yes (always run) |
 ```
 
 ---
@@ -165,12 +252,15 @@ skip decisions are not applied.
 ## Phase 4: Execution
 
 Run only the tools marked "Run locally = Yes" in the
-coverage matrix.
+coverage matrix. Tools marked "No (no in-scope files)"
+are skipped — they count as PASS for verdict computation
+but are not executed. Their display status is
+"SKIP (scope)".
 
 ### hard-gate mode
 
-Execute each tool in order. If any tool exits with a
-non-zero exit code:
+Execute each in-scope tool in order. If any tool exits
+with a non-zero exit code:
 
 1. **STOP immediately** — do not run remaining tools.
 2. Report the failure as a CRITICAL finding with the
@@ -178,7 +268,8 @@ non-zero exit code:
 3. The consuming command MUST NOT proceed to AI review
    or implementation.
 
-If all tools pass, report success.
+If all in-scope tools pass (and scope-skipped tools count
+as PASS), report success.
 
 ### ci-aware mode
 
@@ -190,8 +281,9 @@ Record all exit codes and output.
   for AI review. Do NOT stop — the consuming command
   decides how to handle failures.
 
-If no tools are marked "Yes" (all covered by CI): report
-"All tools covered by CI — no local execution needed."
+If no tools are marked "Yes" (all covered by CI or
+scope-skipped): report "All tools covered by CI or
+out of scope — no local execution needed."
 
 ### soft-gate mode
 
@@ -358,7 +450,12 @@ After classifying all failures:
 
 ## Phase 5: Result Format
 
-Present results in a standardized format.
+Present results in a standardized format. Scope-skipped
+tools (those marked "No (no in-scope files)" by Phase
+2b) appear in the execution results table with exit
+code "-" and status "SKIP (scope)". They count as PASS
+for the verdict but are visually distinguished from tools
+that were actually executed.
 
 ### hard-gate and ci-aware modes
 
@@ -373,12 +470,16 @@ Present results in a standardized format.
 ### Execution Results
 | Tool | Command | Exit code | Status |
 |------|---------|-----------|--------|
+| go test | go test ./... | 0 | PASS |
+| golangci-lint | golangci-lint run | - | SKIP (scope) |
+| Make | make check | 0 | PASS |
 | ...  | ...     | ...       | ...    |
 
 ### Verdict
 - **Mode**: hard-gate | ci-aware
 - **Result**: PASS | FAIL
 - **Failures**: [list if any]
+- **Scope-skipped**: [list of tools skipped by scope filter]
 ```
 
 ### soft-gate mode

--- a/internal/scaffold/assets/opencode/skills/pre-flight/SKILL.md
+++ b/internal/scaffold/assets/opencode/skills/pre-flight/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pre-flight
-description: "Shared pre-flight skill for CI detection and local tool execution. Supports hard-gate, ci-aware, and soft-gate execution policies."
+description: "Shared pre-flight skill for CI detection, scope filtering, and local tool execution. Supports hard-gate, ci-aware, and soft-gate execution policies."
 ---
 <!-- scaffolded by uf vdev -->
 # Skill: Pre-flight Checks
@@ -14,9 +14,9 @@ an execution policy.
 
 | Mode | Behavior | Typical consumer |
 |------|----------|-----------------|
-| `hard-gate` | Run all detected tools. Stop on first failure. | `/unleash` (phase checkpoints) |
+| `hard-gate` | Run all detected in-scope tools. Stop on first failure. | `/unleash` (phase checkpoints) |
 | `ci-aware` | Build CI coverage matrix against PR check results. Skip tools CI already verified. Run the rest. | `/review-pr` |
-| `soft-gate` | Run all detected tools. Classify failures as branch-caused vs pre-existing. Gate only on branch-caused failures. | `/review-council` |
+| `soft-gate` | Run all detected in-scope tools. Classify failures as branch-caused vs pre-existing. Gate only on branch-caused failures. | `/review-council` |
 
 The consuming command specifies which mode to use.
 
@@ -253,9 +253,9 @@ The coverage matrix is still displayed for visibility.
 
 Run only the tools marked "Run locally = Yes" in the
 coverage matrix. Tools marked "No (no in-scope files)"
-are skipped — they count as PASS for verdict computation
-but are not executed. Their display status is
-"SKIP (scope)".
+are scope-skipped — they count as PASS for verdict
+computation but are not executed. Their display status
+is "SKIP (scope)".
 
 ### hard-gate mode
 

--- a/openspec/changes/pre-flight-scope-filter/.openspec.yaml
+++ b/openspec/changes/pre-flight-scope-filter/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: unbound-force
+created: 2026-08-17

--- a/openspec/changes/pre-flight-scope-filter/design.md
+++ b/openspec/changes/pre-flight-scope-filter/design.md
@@ -1,0 +1,191 @@
+## Context
+
+The pre-flight skill (`.opencode/skills/pre-flight/SKILL.md`)
+runs quality tools in two modes: `hard-gate` (run all, stop on
+failure) and `ci-aware` (skip CI-verified tools). Both modes
+determine which tools to run based solely on tool availability
+(config file present + binary in PATH). Neither mode considers
+whether the branch diff actually contains files relevant to each
+tool.
+
+This causes unnecessary work: on a YAML-only branch, Go tools
+(`go vet`, `go build`, `go test`, `golangci-lint`) still execute,
+consuming ~2 minutes and significant tokens. The tools find
+nothing because no Go files changed.
+
+See proposal.md for motivation and constitution alignment.
+
+## Goals / Non-Goals
+
+### Goals
+- Skip tools whose file scope has zero intersection with the
+  branch diff
+- Preserve full tool execution when in-scope files exist
+- Count scope-skipped tools as PASS (not as failures or warnings)
+- Make the skip decision visible in the CI coverage matrix
+- Support an "always run" designation for tools like `make check`
+  that aggregate multiple concerns
+- Apply the scope filter in both `hard-gate` and `ci-aware` modes
+
+### Non-Goals
+- Changing which tools are detected (Phase 2 is unchanged)
+- Adding new tools or file extensions beyond issue #434's list
+- Path-based filtering (e.g., only run Go tools on `internal/`)
+  — extension-based is sufficient and simpler
+- Runtime configuration of scope mappings — the mapping is
+  hardcoded in the skill instructions
+
+## Decisions
+
+### D1: New Phase 2b between detection and CI matrix
+
+The scope filter is a new phase (Phase 2b: Scope Filter) inserted
+between Phase 2 (Local Tool Detection) and Phase 3 (CI Coverage
+Matrix). This placement ensures:
+
+1. Tool detection (Phase 2) completes first — we need the full
+   tool list
+2. The scope filter reduces the tool list before the CI matrix
+   is built — fewer rows, cleaner output
+3. Phase 3 and Phase 4 see only in-scope tools (plus always-run
+   tools)
+
+**Rationale**: Inserting a phase rather than modifying Phase 2
+keeps detection and filtering as separate concerns. Phase 2 asks
+"what tools exist?" Phase 2b asks "which of those tools are
+relevant to this branch?"
+
+### D2: Extension-based scope mapping table
+
+The scope filter uses a static mapping from tool to file
+extensions:
+
+| Tool | In-scope extensions |
+|------|-------------------|
+| `go test` | `*.go`, `go.mod`, `go.sum` |
+| `golangci-lint` | `*.go`, `go.mod`, `go.sum` |
+| `ruff` | `*.py`, `pyproject.toml`, `setup.py`, `setup.cfg`, `requirements*.txt` |
+| `pytest` | `*.py`, `pyproject.toml`, `setup.py`, `setup.cfg`, `requirements*.txt` |
+| `yamllint` | `*.yml`, `*.yaml` |
+| `make check` | (always run) |
+| `pre-commit` | (always run) |
+
+`go vet` and `go build` are omitted — they are not detected as
+standalone tools by Phase 2 (they run through `make check` or CI
+workflows). If Phase 2 is later extended to detect them, scope
+mapping rows MUST be added here.
+
+Tools not in this table default to "always run" — this is the
+conservative choice that prevents false skips.
+
+**Rationale**: Extension matching is simple, deterministic, and
+covers the common case. Path-based filtering (e.g., "only run
+Go tools if files under `internal/` changed") adds complexity
+with marginal benefit — if a `.go` file changed anywhere, the
+Go tools should run.
+
+### D3: Branch diff via git
+
+The scope filter computes the branch diff using:
+
+```bash
+git diff --name-only main...HEAD
+```
+
+This produces the list of files changed on the current branch
+relative to main. If the command fails (e.g., detached HEAD,
+no `main` branch), the scope filter is bypassed and all tools
+are marked as in-scope (fail-open behavior).
+
+**Rationale**: `main...HEAD` captures the complete branch diff,
+not just staged/unstaged changes. This matches the CI perspective:
+CI runs tools against the full PR diff, not incremental commits.
+
+### D4: Scope-skipped tools count as PASS
+
+When a tool is skipped because no in-scope files changed, it is
+recorded as PASS with reason "no in-scope files changed" in the
+execution results. It does NOT count as a skip in the ci-aware
+sense (which means "CI already verified").
+
+**Rationale**: A tool that has nothing to check cannot fail. The
+scope filter is a correctness-preserving optimization, not a
+risk-acceptance decision. Counting as PASS ensures the verdict
+is not affected.
+
+### D5: Always-run tools bypass the scope filter
+
+`make check` (or `make lint`) and `pre-commit` are marked as
+"always run" because they aggregate multiple concerns that may not
+map cleanly to file extensions. For example, `make check` may run
+formatters, linters, and tests across multiple languages.
+
+**Rationale**: These meta-tools are the project's "run everything"
+commands. Skipping them based on extension matching could miss
+cross-concern checks (e.g., a Makefile target that validates YAML
+schemas using Go code).
+
+### D6: Diff file list is logged for auditability
+
+Phase 2b outputs the list of changed files and the scope match
+result for each tool. This makes the skip decision visible and
+debuggable.
+
+**Rationale**: Aligns with Observable Quality — if a tool is
+unexpectedly skipped, the log shows exactly which files were in
+the diff and why the tool's scope didn't match.
+
+## Coverage Strategy
+
+This change modifies instruction files, not compiled code.
+Traditional unit test coverage is not applicable. The coverage
+strategy is:
+
+1. **Automated (scaffold sync)**: Existing `TestEmbeddedAssets_
+   MatchSource` drift detection test verifies that
+   `.opencode/skills/pre-flight/SKILL.md` and its scaffold copy
+   remain in sync. Covers FR-008.
+2. **Automated (CI parity)**: `make check` — build, lint, and
+   test pass. Covers structural correctness.
+3. **Behavioral (manual)**: Run the pre-flight skill on a
+   YAML-only branch and confirm Go tools show "SKIP (scope)".
+   Run on a Go-only branch and confirm Go tools execute.
+   Covers FR-001, FR-005, FR-007.
+
+## Risks / Trade-offs
+
+### R1: False negatives from extension-only matching
+
+A change to `go.mod` could affect test behavior even if no `.go`
+files changed. The current mapping includes `go.mod` and `go.sum`
+in the Go tool scope, which mitigates this for the Go ecosystem.
+Python dependency/config files (`pyproject.toml`, `setup.py`,
+`setup.cfg`, `requirements*.txt`) are now included in the `ruff`
+and `pytest` scope to maintain parity with the Go ecosystem.
+
+**Mitigation**: The mapping is conservative — dependency/config
+files are included for both Go (`go.mod`, `go.sum`) and Python
+(`pyproject.toml`, `setup.py`, `setup.cfg`, `requirements*.txt`).
+`make check` is always-run, providing a catch-all. Unknown tools
+default to always-run.
+
+### R2: Stale diff on long-lived branches
+
+If the branch is far behind `main`, the diff may include files
+that have since been modified on `main`. This could cause tools
+to run unnecessarily (false positives) but never to skip
+incorrectly (false negatives).
+
+**Mitigation**: False positives are harmless — the tool runs and
+finds nothing. The scope filter optimizes the common case
+(short-lived feature branches).
+
+### R3: Fail-open on git errors
+
+If `git diff --name-only main...HEAD` fails, all tools are marked
+as in-scope. This means a git configuration issue silently
+disables the optimization.
+
+**Mitigation**: The fail-open output includes a warning explaining
+why the scope filter was bypassed. This is preferable to
+fail-closed (which would skip all tools on git errors).

--- a/openspec/changes/pre-flight-scope-filter/proposal.md
+++ b/openspec/changes/pre-flight-scope-filter/proposal.md
@@ -1,0 +1,118 @@
+## Why
+
+The pre-flight skill's `hard-gate` mode unconditionally runs ALL
+detected tools regardless of whether the branch diff contains files
+in each tool's scope. On a YAML-only branch (e.g., CI workflow
+tweaks, yamllint config), the skill still executes `go vet`,
+`golangci-lint`, `go test`, and `go build` — wasting approximately
+two minutes of wall-clock time and significant tokens for zero
+diagnostic value.
+
+The root cause is in Phase 3 of the pre-flight skill (CI Coverage
+Matrix, hard-gate decision rules): "ALL detected and available
+tools are marked 'Run locally = Yes' regardless of CI status."
+There is no mechanism to intersect the tool's file scope with the
+actual branch diff.
+
+Fixes: [#434](https://github.com/unbound-force/unbound-force/issues/434)
+
+## What Changes
+
+Add a file-scope filter to the pre-flight skill that maps each
+tool to the file extensions it operates on, computes the branch
+diff (`git diff --name-only main...HEAD`), intersects the two,
+and skips tools with zero matching files. Skipped-for-scope tools
+are counted as PASS in the verdict. The filter applies in both
+`hard-gate` and `ci-aware` modes, inserted between Phase 2 (tool
+detection) and Phase 3 (CI coverage matrix).
+
+## Capabilities
+
+### New Capabilities
+- `scope filter`: A new Phase 2b in the pre-flight skill that
+  maps tools to file-extension scopes, computes the branch diff,
+  and marks tools as "Skipped (no in-scope files)" when the diff
+  contains zero files matching their scope
+
+### Modified Capabilities
+- Phase 3 (CI Coverage Matrix): The matrix gains a new possible
+  value in the "Run locally?" column: "No (no in-scope files)"
+- Phase 4 (Execution): Tools marked as scope-skipped are not
+  executed; their result is recorded as PASS with reason
+  "no in-scope files changed"
+- Phase 5 (Result Format): The execution results table shows
+  scope-skipped tools with status "SKIP (scope)"
+
+### Removed Capabilities
+- None — tools with in-scope files are still run exactly as
+  before. The scope filter only eliminates provably unnecessary
+  tool invocations.
+
+## Impact
+
+### Files Changed
+- `.opencode/skills/pre-flight/SKILL.md` (add scope filter phase)
+- `internal/scaffold/assets/opencode/skills/pre-flight/SKILL.md`
+  (scaffold sync)
+
+### Follow-up
+- The tool-to-extension mapping is hardcoded in the skill
+  instructions. If new tools are added to Phase 2, their scope
+  mapping MUST also be added to the scope filter table. This is
+  a documentation-level concern (not a code dependency).
+- The `git diff` command hardcodes `main` as the base branch.
+  Projects using a different default branch (e.g., `master`,
+  `develop`) will trigger the fail-open path. A future iteration
+  could auto-detect the default branch via `git symbolic-ref
+  refs/remotes/origin/HEAD`.
+- TypeScript/JavaScript tool mappings (e.g., `eslint` to
+  `*.ts`, `*.tsx`, `*.js`, `*.jsx`) should be added when
+  TypeScript tools are added to Phase 2's detection table.
+
+## Constitution Alignment
+
+Assessed against the Unbound Force org constitution (v1.2.0).
+
+### I. Autonomous Collaboration
+
+**Assessment**: N/A
+
+This change modifies agent instruction files only. No artifact
+formats, metadata, or inter-hero exchange patterns are affected.
+
+### II. Composability First
+
+**Assessment**: PASS
+
+The scope filter is an additive phase within the existing skill.
+Commands that load the pre-flight skill continue to work unchanged
+— they get faster execution with identical correctness guarantees.
+No new dependencies are introduced.
+
+### III. Observable Quality
+
+**Assessment**: PASS
+
+The scope filter adds visibility: the CI coverage matrix now shows
+*why* a tool was skipped (no in-scope files vs. CI-verified vs.
+tool-ran-and-passed). The filter's diff file list is logged for
+auditability.
+
+### IV. Testability
+
+**Assessment**: PASS
+
+The change is instruction-only (no compiled code). Behavioral
+verification: run `/review-council` on a YAML-only branch and
+confirm Go tools are skipped. Run on a Go-only branch and confirm
+Go tools still execute. Scaffold drift tests enforce sync.
+
+### V. Security by Default
+
+**Assessment**: PASS
+
+The scope filter reads branch diff output (already available in
+git) and compares file extensions. No new input vectors, no
+external network calls, no secrets handling. The filter is
+conservative: `make check` is always-run, and unknown tools
+default to always-run.

--- a/openspec/changes/pre-flight-scope-filter/specs/pre-flight-scope-filter.md
+++ b/openspec/changes/pre-flight-scope-filter/specs/pre-flight-scope-filter.md
@@ -1,0 +1,208 @@
+## ADDED Requirements
+
+### Requirement: FR-001 Scope Filter Phase
+
+The pre-flight skill MUST include a Phase 2b (Scope Filter)
+between Phase 2 (Local Tool Detection) and Phase 3 (CI
+Coverage Matrix). Phase 2b MUST compute the branch diff,
+map each detected tool to its file-extension scope, and mark
+tools with zero in-scope files as "Skipped (no in-scope files)".
+
+#### Scenario: Go tools skipped on YAML-only branch
+
+- **GIVEN** the branch diff contains only `*.yml` and `*.yaml`
+  files
+- **AND** `go.mod`, `.golangci.yml`, and `Makefile` are present
+  (tools detected: go test, golangci-lint, Make)
+- **WHEN** Phase 2b evaluates the scope filter
+- **THEN** `go test` is marked "Skipped (no in-scope files)"
+- **AND** `golangci-lint` is marked "Skipped (no in-scope
+  files)"
+- **AND** `make check` is marked "In scope" (always-run)
+
+#### Scenario: All tools in scope on mixed branch
+
+- **GIVEN** the branch diff contains `internal/foo.go` and
+  `.github/workflows/ci.yml`
+- **AND** `go.mod`, `.golangci.yml`, and `.yamllint.yml` are
+  present
+- **WHEN** Phase 2b evaluates the scope filter
+- **THEN** `go test`, `golangci-lint`, and `yamllint` are all
+  marked "In scope"
+
+#### Scenario: Scope filter fail-open on git error
+
+- **GIVEN** `git diff --name-only main...HEAD` fails (e.g.,
+  detached HEAD, missing remote, no `main` branch)
+- **WHEN** Phase 2b evaluates the scope filter
+- **THEN** all detected tools are marked "In scope" with a
+  warning that includes the git error message explaining
+  why the scope filter was bypassed
+- **AND** execution proceeds as if no scope filter exists
+
+#### Scenario: Empty branch diff (no commits ahead)
+
+- **GIVEN** the branch has zero commits ahead of `main`
+  (e.g., just created, or all changes reverted)
+- **WHEN** Phase 2b evaluates the scope filter
+- **THEN** `git diff` returns an empty file list
+- **AND** all non-always-run tools are marked "Skipped
+  (no in-scope files)"
+- **AND** always-run tools are marked "In scope"
+- **AND** a warning is emitted: "no files changed on
+  branch — scope filter has nothing to match"
+
+### Requirement: FR-002 Tool-to-Extension Mapping
+
+The scope filter MUST use the following tool-to-extension
+mapping:
+
+| Tool | In-scope extensions |
+|------|-------------------|
+| `go test` | `*.go`, `go.mod`, `go.sum` |
+| `golangci-lint` | `*.go`, `go.mod`, `go.sum` |
+| `ruff` | `*.py`, `pyproject.toml`, `setup.py`, `setup.cfg`, `requirements*.txt` |
+| `pytest` | `*.py`, `pyproject.toml`, `setup.py`, `setup.cfg`, `requirements*.txt` |
+| `yamllint` | `*.yml`, `*.yaml` |
+
+Tools not in this table MUST default to "always run".
+Always-run tools (FR-003) are intentionally excluded from this
+table — they bypass the scope filter entirely.
+
+#### Scenario: Unknown tool defaults to always-run
+
+- **GIVEN** a tool is detected that does not appear in the
+  scope mapping table (e.g., a custom linter)
+- **WHEN** Phase 2b evaluates the scope filter
+- **THEN** the tool is marked "In scope" (always-run default)
+
+### Requirement: FR-003 Always-Run Tools
+
+The following tools MUST be designated as "always run" and
+MUST NOT be skipped by the scope filter regardless of the
+branch diff:
+
+- `make check` (or `make lint`)
+- `pre-commit`
+
+#### Scenario: make check runs on YAML-only branch
+
+- **GIVEN** the branch diff contains only `*.yaml` files
+- **AND** `Makefile` is present with a `check` target
+- **WHEN** Phase 2b evaluates the scope filter
+- **THEN** `make check` is marked "In scope" (always run)
+
+### Requirement: FR-004 Branch Diff Computation
+
+The scope filter MUST compute the branch diff using:
+
+```bash
+git diff --name-only main...HEAD
+```
+
+The result MUST be a list of file paths changed on the
+current branch relative to `main`.
+
+#### Scenario: Diff captures all branch changes
+
+- **GIVEN** the current branch has three commits adding
+  `foo.go`, `bar.yaml`, and `baz.py`
+- **WHEN** the scope filter computes the branch diff
+- **THEN** the diff list contains `foo.go`, `bar.yaml`,
+  and `baz.py`
+
+### Requirement: FR-005 Scope-Skipped Tools Count as PASS
+
+Tools skipped by the scope filter MUST count as PASS for
+verdict computation. In the execution results table, they
+MUST appear with status "SKIP (scope)" and exit code "-".
+They MUST NOT count as failures, warnings, or ci-aware
+skips. The distinction: the tool's *verdict contribution*
+is PASS; its *display status* is "SKIP (scope)".
+
+#### Scenario: Scope-skipped tool in execution results
+
+- **GIVEN** `golangci-lint` is skipped by the scope filter
+- **WHEN** Phase 4 (Execution) processes the tool list
+- **THEN** `golangci-lint` appears in the execution results
+  table with exit code "-", status "SKIP (scope)", and does
+  not affect the verdict
+
+#### Scenario: All tools scope-skipped except always-run
+
+- **GIVEN** only `make check` is in scope (all others
+  scope-skipped)
+- **AND** `make check` exits with code 0
+- **WHEN** the verdict is computed
+- **THEN** the verdict is PASS
+
+## MODIFIED Requirements
+
+### Requirement: FR-006 CI Coverage Matrix (Modified)
+
+The CI coverage matrix (Phase 3) MUST reflect scope-filtered
+tools. Tools marked "Skipped (no in-scope files)" in Phase 2b
+MUST appear in the matrix with "Run locally?" set to
+"No (no in-scope files)".
+
+Previously: The matrix only distinguished between CI-verified
+skips and tools to run. Now it has a third skip reason.
+
+#### Scenario: Matrix shows scope-skipped tools
+
+- **GIVEN** `go test` is scope-skipped (no `.go` files in diff)
+- **AND** `yamllint` is in scope (`.yaml` files in diff)
+- **WHEN** Phase 3 builds the CI coverage matrix
+- **THEN** the matrix shows:
+  - `go test`: Run locally = "No (no in-scope files)"
+  - `yamllint`: Run locally = "Yes"
+
+### Requirement: FR-007 Scope Filter in Both Modes
+
+The scope filter MUST apply in both `hard-gate` and `ci-aware`
+execution policies. In both modes, tools with no in-scope files
+are skipped before CI status evaluation.
+
+Previously: `hard-gate` mode ran ALL detected tools
+unconditionally. Now it runs all *in-scope* detected tools.
+
+#### Scenario: Hard-gate mode with scope filter
+
+- **GIVEN** the pre-flight skill runs in `hard-gate` mode
+- **AND** the branch diff contains only `*.py` files
+- **AND** `go.mod` and `pyproject.toml` are present
+- **WHEN** Phase 2b applies the scope filter
+- **THEN** `go test` is scope-skipped
+- **AND** `pytest` and `ruff` are marked "In scope"
+- **AND** Phase 4 runs only `pytest` and `ruff`
+
+#### Scenario: CI-aware mode with scope filter
+
+- **GIVEN** the pre-flight skill runs in `ci-aware` mode
+- **AND** the branch diff contains only `*.py` files
+- **AND** CI check for `ruff` has status PASS
+- **WHEN** Phase 2b and Phase 3 evaluate
+- **THEN** `go test` is scope-skipped (Phase 2b)
+- **AND** `ruff` is CI-skipped (Phase 3, CI PASS)
+- **AND** `pytest` is run locally (in-scope, no CI coverage)
+
+### Requirement: FR-008 Scaffold Sync
+
+The modified pre-flight skill MUST be synced to its scaffold
+copy at `internal/scaffold/assets/opencode/skills/pre-flight/
+SKILL.md`. Existing drift detection tests MUST pass after sync.
+
+#### Scenario: Scaffold copy matches source
+
+- **GIVEN** `.opencode/skills/pre-flight/SKILL.md` has been
+  updated with the scope filter
+- **WHEN** the scaffold copy is synced
+- **THEN** `internal/scaffold/assets/opencode/skills/
+  pre-flight/SKILL.md` matches the source
+- **AND** drift detection tests pass
+
+## REMOVED Requirements
+
+None — this change adds a scope filter without removing any
+existing capability. Tools with in-scope files are still run
+exactly as before.

--- a/openspec/changes/pre-flight-scope-filter/tasks.md
+++ b/openspec/changes/pre-flight-scope-filter/tasks.md
@@ -16,7 +16,7 @@
 
 ## 1. Add Scope Filter to Pre-flight Skill
 
-- [ ] 1.1 Add Phase 2b (Scope Filter) to
+- [x] 1.1 Add Phase 2b (Scope Filter) to
   `.opencode/skills/pre-flight/SKILL.md` between Phase 2
   (Local Tool Detection) and Phase 3 (CI Coverage Matrix).
   Phase 2b MUST:
@@ -30,7 +30,7 @@
   - Fail open (all tools in-scope) if `git diff` fails
   Implements: FR-001, FR-002, FR-003, FR-004
 
-- [ ] 1.2 Update Phase 3 (CI Coverage Matrix) hard-gate
+- [x] 1.2 Update Phase 3 (CI Coverage Matrix) hard-gate
   decision rules to reflect scope-filtered tools. Change
   "ALL detected and available tools are marked 'Run locally
   = Yes'" to "ALL detected, available, and in-scope tools
@@ -38,7 +38,7 @@
   files)" as a possible value in the "Run locally?" column.
   Implements: FR-006, FR-007
 
-- [ ] 1.3 Update Phase 4 (Execution) and Phase 5 (Result Format)
+- [x] 1.3 Update Phase 4 (Execution) and Phase 5 (Result Format)
   for scope-filtered tools. Scope-skipped tools count as PASS
   for verdict computation. In the execution results table,
   they appear with exit code "-" and status "SKIP (scope)".
@@ -48,19 +48,19 @@
 
 ## 2. Scaffold Sync
 
-- [ ] 2.1 Sync `.opencode/skills/pre-flight/SKILL.md` to
+- [x] 2.1 Sync `.opencode/skills/pre-flight/SKILL.md` to
   `internal/scaffold/assets/opencode/skills/pre-flight/SKILL.md`
   Implements: FR-008
 
 ## 3. Verification
 
-- [ ] 3.1 Run `make check` to verify build, lint, and tests
+- [x] 3.1 Run `make check` to verify build, lint, and tests
   pass (CI parity gate)
 
-- [ ] 3.2 Run drift detection tests to confirm scaffold copy
+- [x] 3.2 Run drift detection tests to confirm scaffold copy
   matches skill source
 
-- [ ] 3.3 Behavioral verification: confirm the updated skill
+- [x] 3.3 Behavioral verification: confirm the updated skill
   instructions include: (1) Phase 2b section between Phase 2
   and Phase 3, (2) tool-to-extension mapping table matching
   FR-002, (3) always-run tool list per FR-003, (4) fail-open
@@ -68,6 +68,6 @@
   ci-aware decision rules reference scope-filtered tools
   per FR-007
 
-- [ ] 3.4 Documentation assessment: check whether AGENTS.md
+- [x] 3.4 Documentation assessment: check whether AGENTS.md
   skill description needs updating for the new scope filter
   capability; assess CHANGELOG.md for a change entry

--- a/openspec/changes/pre-flight-scope-filter/tasks.md
+++ b/openspec/changes/pre-flight-scope-filter/tasks.md
@@ -12,6 +12,10 @@
   spec-review: passed
   reviewers: 9/9 APPROVE
   auto-fixes: applied (5 MEDIUM, 6 LOW consolidated)
+
+  code-review: passed
+  code-reviewers: 9/9 APPROVE
+  code-auto-fixes: applied (2 MEDIUM, 2 LOW)
 -->
 
 ## 1. Add Scope Filter to Pre-flight Skill

--- a/openspec/changes/pre-flight-scope-filter/tasks.md
+++ b/openspec/changes/pre-flight-scope-filter/tasks.md
@@ -1,0 +1,73 @@
+<!--
+  [P] marks tasks eligible for parallel execution.
+  Add [P] when a task: (a) touches different files from
+  other [P] tasks in the group, (b) has no dependency
+  on prior tasks in the group, (c) can safely execute
+  without ordering constraints.
+  Do NOT add [P] when tasks modify the same file —
+  parallel workers will cause merge conflicts.
+  Tasks without [P] run sequentially first, then [P]
+  tasks run in parallel.
+
+  spec-review: passed
+  reviewers: 9/9 APPROVE
+  auto-fixes: applied (5 MEDIUM, 6 LOW consolidated)
+-->
+
+## 1. Add Scope Filter to Pre-flight Skill
+
+- [ ] 1.1 Add Phase 2b (Scope Filter) to
+  `.opencode/skills/pre-flight/SKILL.md` between Phase 2
+  (Local Tool Detection) and Phase 3 (CI Coverage Matrix).
+  Phase 2b MUST:
+  - Compute branch diff via `git diff --name-only main...HEAD`
+  - Include the tool-to-extension mapping table (D2)
+  - Mark always-run tools (`make check`, `pre-commit`)
+  - Intersect diff file extensions with each tool's scope
+  - Mark tools with zero matches as "Skipped (no in-scope
+    files)"
+  - Log the diff file list and per-tool scope decision
+  - Fail open (all tools in-scope) if `git diff` fails
+  Implements: FR-001, FR-002, FR-003, FR-004
+
+- [ ] 1.2 Update Phase 3 (CI Coverage Matrix) hard-gate
+  decision rules to reflect scope-filtered tools. Change
+  "ALL detected and available tools are marked 'Run locally
+  = Yes'" to "ALL detected, available, and in-scope tools
+  are marked 'Run locally = Yes'". Add "No (no in-scope
+  files)" as a possible value in the "Run locally?" column.
+  Implements: FR-006, FR-007
+
+- [ ] 1.3 Update Phase 4 (Execution) and Phase 5 (Result Format)
+  for scope-filtered tools. Scope-skipped tools count as PASS
+  for verdict computation. In the execution results table,
+  they appear with exit code "-" and status "SKIP (scope)".
+  Phase 4 skips the tool; Phase 5 includes it in the table
+  with the display status.
+  Implements: FR-005
+
+## 2. Scaffold Sync
+
+- [ ] 2.1 Sync `.opencode/skills/pre-flight/SKILL.md` to
+  `internal/scaffold/assets/opencode/skills/pre-flight/SKILL.md`
+  Implements: FR-008
+
+## 3. Verification
+
+- [ ] 3.1 Run `make check` to verify build, lint, and tests
+  pass (CI parity gate)
+
+- [ ] 3.2 Run drift detection tests to confirm scaffold copy
+  matches skill source
+
+- [ ] 3.3 Behavioral verification: confirm the updated skill
+  instructions include: (1) Phase 2b section between Phase 2
+  and Phase 3, (2) tool-to-extension mapping table matching
+  FR-002, (3) always-run tool list per FR-003, (4) fail-open
+  behavior per FR-001 scenario 3, (5) both hard-gate and
+  ci-aware decision rules reference scope-filtered tools
+  per FR-007
+
+- [ ] 3.4 Documentation assessment: check whether AGENTS.md
+  skill description needs updating for the new scope filter
+  capability; assess CHANGELOG.md for a change entry


### PR DESCRIPTION
## Summary

Pre-flight checks now skip tools when the branch diff
contains no files matching their extension scope. On a
YAML-only branch, Go tools (`go test`, `golangci-lint`)
are skipped instead of wasting ~2 minutes running with
zero diagnostic value.

Adds Phase 2b (Scope Filter) between Phase 2 (Local Tool
Detection) and Phase 3 (CI Coverage Matrix) with:
- Tool-to-extension mapping table
- Always-run designation for meta-tools (`make check`,
  `pre-commit`)
- Fail-open behavior on git errors
- Scope-skipped tools count as PASS for verdict, display
  as "SKIP (scope)"

Applies in both `hard-gate` and `ci-aware` execution
modes.

Spec: `openspec/changes/pre-flight-scope-filter/`
Fixes #434

## How to Test

1. **YAML-only branch**: Create a branch modifying only
   `.yml`/`.yaml` files. Run `/uf.review-council` or
   `/uf.unleash`. Verify Go tools show "SKIP (scope)"
   while `yamllint` and `make check` run normally.

2. **Mixed branch**: Modify both `.go` and `.yaml` files.
   Verify all relevant tools run (no incorrect skips).

3. **Scaffold drift**: Run
   `go test -race -count=1 -run TestEmbeddedAssets ./internal/scaffold/`
   to confirm scaffold copy matches source.

4. **Build/lint/test**: Run `make check` — all 20
   packages pass.

## How to Demo

On any branch that only touches YAML files (like a CI
workflow tweak), run the pre-flight skill via
`/uf.review-council`. Observe the pre-flight output —
Go tools should appear with "SKIP (scope)" status
instead of running and finding nothing. The `make check`
tool should still run as always-run.

## Key Files Changed

**Skills (instruction files)**
- `.opencode/skills/pre-flight/SKILL.md` — Phase 2b
  scope filter, phases 3-5 updates (223→323 lines)
- `internal/scaffold/assets/opencode/skills/pre-flight/SKILL.md`
  — scaffold sync (byte-identical)

**Spec artifacts**
- `openspec/changes/pre-flight-scope-filter/proposal.md`
- `openspec/changes/pre-flight-scope-filter/design.md`
- `openspec/changes/pre-flight-scope-filter/specs/pre-flight-scope-filter.md`
- `openspec/changes/pre-flight-scope-filter/tasks.md`

**Documentation**
- `CHANGELOG.md` — unreleased entry

**Learnings**
- `.uf/dewey/learnings/` — 3 retrospective learnings

_This PR was generated by /uf.finale (AI-assisted)._
