### PR TITLE
feat: add file-scope filter to pre-flight skill (Fixes #434)

### DIFF
--- a/.opencode/skills/pre-flight/SKILL.md
+++ b/.opencode/skills/pre-flight/SKILL.md
@@ -116,6 +116,108 @@ and proceed to Phase 3.
 
 ---
 
+## Phase 2a: File-Scope Filter
+
+Before building the CI coverage matrix, filter out tools
+that have no applicable files in the branch diff. This
+avoids running tools whose scope does not intersect with
+the changes on this branch.
+
+### File-scope mapping
+
+| Tool | In-scope file patterns |
+|------|----------------------|
+| `go test` | `*.go`, `go.mod`, `go.sum` |
+| `golangci-lint` | `*.go`, `go.mod`, `go.sum`, `.golangci.yml`, `.golangci.yaml` |
+| `ruff` | `*.py`, `ruff.toml`, `pyproject.toml` |
+| `pytest` | `*.py`, `pyproject.toml`, `setup.py`, `conftest.py` |
+| `yamllint` | `*.yml`, `*.yaml`, `.yamllint.yml`, `.yamllint.yaml` |
+| `make check` | _always in scope_ |
+| `pre-commit` | _always in scope_ |
+
+Tools marked "always in scope" MUST NOT be skipped by the
+file-scope filter. These are aggregate tools whose scope
+cannot be reliably determined from file extensions alone.
+
+Additional tools added to Phase 2's tool-to-command mapping
+in the future MUST have a corresponding file-scope entry
+added to this table.
+
+Note: `go vet` and `go build` are CI commands discovered
+in Phase 1 (CI Workflow Parsing), not independently detected
+tools in Phase 2 (Tool Detection). They do not need scope
+entries because they are not individually executed by the
+pre-flight skill. They are covered by the `make check`
+aggregate tool entry (always in scope) and, in the case of
+`go vet`, by `golangci-lint`'s inclusion of vet rules.
+
+File patterns use suffix matching against the full path
+returned by `git diff --name-only`. A pattern `*.go`
+matches any file whose path ends in `.go`, regardless of
+directory depth (e.g., `internal/scaffold/foo.go` matches
+`*.go`).
+
+### Branch diff computation
+
+Compute the list of files changed on this branch relative
+to the default branch:
+
+```bash
+DEFAULT_BRANCH=<detected per Phase 4a: Baseline Establishment, "Detect the default branch" subsection>
+MERGE_BASE=$(git merge-base HEAD origin/${DEFAULT_BRANCH})
+CHANGED_FILES=$(git diff --name-only ${MERGE_BASE}...HEAD)
+```
+
+Use the same default branch detection logic described in
+Phase 4a ("Detect the default branch" subsection). If the
+default branch cannot be
+detected, or if the diff command fails, skip the file-scope
+filter entirely and proceed to Phase 3 with all tools
+(conservative fallback).
+
+If the diff is empty (no changed files) and the current
+branch is NOT the default branch, skip the file-scope
+filter and run all tools (conservative fallback), since
+an empty diff on a feature branch may indicate a git state
+anomaly. Report: "Empty diff detected — running all tools
+as conservative fallback."
+
+If the repository is a shallow clone (detected via
+`git rev-parse --is-shallow-repository`), skip the
+file-scope filter and run all tools, since the merge-base
+computation may produce incomplete results in shallow
+clones.
+
+### Filter logic
+
+For each detected and available tool from Phase 2:
+
+1. Look up the tool's in-scope file patterns in the
+   mapping table above.
+2. If the tool is marked "always in scope," it proceeds
+   to Phase 3 unconditionally.
+3. Intersect the branch diff file list with the tool's
+   file-scope patterns using suffix matching.
+4. If zero diff files match the tool's patterns, mark the
+   tool as "SKIP — no in-scope files."
+5. If one or more diff files match, the tool proceeds to
+   Phase 3 as normal.
+
+### Output
+
+Report the file-scope filter results:
+
+```
+File-scope filter (Phase 2a):
+  Branch diff: 2 files (release.yml, .goreleaser.yaml)
+  - go test: SKIP — no in-scope files
+  - golangci-lint: SKIP — no in-scope files
+  - yamllint: in scope (1 file matches)
+  - make check: always in scope
+```
+
+---
+
 ## Phase 3: CI Coverage Matrix
 
 Build and display a coverage matrix that maps each
@@ -125,11 +227,16 @@ visible and auditable.
 
 ### Matrix construction
 
-For each detected and available tool, determine which CI
-check (if any) covers the same verification. Map tool
-names to CI check names by matching on the tool's purpose
-(e.g., `go test` maps to a CI check containing "test",
-`golangci-lint` maps to a check containing "lint").
+For each detected and available tool that has in-scope
+files in the branch diff (i.e., tools that survived
+Phase 2a's file-scope filter), determine which CI check
+(if any) covers the same verification. Tools marked
+"SKIP — no in-scope files" in Phase 2a are excluded from
+the matrix and are not evaluated for CI coverage. Map
+tool names to CI check names by matching on the tool's
+purpose (e.g., `go test` maps to a CI check containing
+"test", `golangci-lint` maps to a check containing
+"lint").
 
 ### Decision rules (ci-aware mode)
 
@@ -142,12 +249,15 @@ names to CI check names by matching on the tool's purpose
 
 ### Decision rules (hard-gate mode)
 
-In hard-gate mode, ALL detected and available tools are
-marked "Run locally = Yes" regardless of CI status. The
-CI status column in the matrix shows the actual status if
-available, or "N/A" if CI results were not provided. The
-coverage matrix is still displayed for visibility, but
-skip decisions are not applied.
+In hard-gate mode, all detected and available tools that
+have in-scope files in the branch diff (per Phase 2a) are
+marked "Run locally = Yes" regardless of CI status. Tools
+marked "SKIP — no in-scope files" in Phase 2a are excluded
+from the coverage matrix's "Run locally" decisions and are
+not executed. The CI status column in the matrix shows the
+actual status if available, or "N/A" if CI results were
+not provided. The coverage matrix is still displayed for
+visibility.
 
 ### Display format
 
@@ -195,9 +305,11 @@ If no tools are marked "Yes" (all covered by CI): report
 
 ### soft-gate mode
 
-Execute ALL detected and available tools (same as
-hard-gate). Do NOT stop on first failure — record all
-exit codes and output for every tool.
+Execute all detected and available tools that have
+in-scope files in the branch diff (same scope filtering
+as hard-gate, per Phase 2a). Do NOT stop on first
+failure — record all exit codes and output for every
+tool.
 
 - If ALL tools pass: verdict is PASS. No baseline
   establishment is needed. Skip Phase 4a and 4b.
@@ -247,6 +359,9 @@ fi
 If neither resolves, treat the baseline as unavailable
 and fall through to the conservative fallback (all
 failures classified as `unknown` = branch-caused).
+
+Record which baseline method was used: `CI API`,
+`worktree`, or `unavailable`.
 
 ### Tier 1 — CI API baseline
 
@@ -368,16 +483,19 @@ Present results in a standardized format.
 ### CI Coverage Matrix
 | Local tool | CI check | CI status | Run locally? |
 |------------|----------|-----------|--------------|
-| ...        | ...      | ...       | ...          |
+| ...        | ...      | ...       | Yes          |
+| ...        | ...      | ...       | SKIP — no in-scope files |
 
 ### Execution Results
 | Tool | Command | Exit code | Status |
 |------|---------|-----------|--------|
 | ...  | ...     | ...       | ...    |
+| ...  | ...     | —         | SKIP — no in-scope files |
 
 ### Verdict
 - **Mode**: hard-gate | ci-aware
 - **Result**: PASS | FAIL
+- **Skipped — no in-scope files**: N tools
 - **Failures**: [list if any]
 ```
 
@@ -389,24 +507,35 @@ Present results in a standardized format.
 ### CI Coverage Matrix
 | Local tool | CI check | CI status | Run locally? |
 |------------|----------|-----------|--------------|
-| ...        | ...      | ...       | ...          |
+| ...        | ...      | ...       | Yes          |
+| ...        | ...      | ...       | SKIP — no in-scope files |
 
 ### Execution Results
 | Tool | Command | Exit code | Status | Causality |
 |------|---------|-----------|--------|-----------|
 | ...  | ...     | ...       | ...    | ...       |
+| ...  | ...     | —         | SKIP — no in-scope files | — |
 
 ### Verdict
 - **Mode**: soft-gate
 - **Result**: PASS | FAIL (branch-caused)
+- **Skipped — no in-scope files**: N tools
 - **Branch-caused failures**: [list if any]
 - **Pre-existing failures**: [list if any]
 - **Baseline method**: CI API | worktree | unavailable
 ```
 
+Tools skipped by the file-scope filter (Phase 2a) use the
+canonical status string `SKIP — no in-scope files` (em
+dash) in both the coverage matrix "Run locally?" column
+and the execution results Status column. Skipped tools are
+counted as PASS for the overall verdict — a tool with zero
+applicable files in the diff cannot produce findings.
+
 The `Causality` column in the Execution Results table
 contains one of: `branch-caused`, `pre-existing`,
-`unknown`, or `—` (for tools that passed).
+`unknown`, `—` (for tools that passed), or `—` (for
+skipped tools).
 
 The `Result` field is:
 - `PASS` if no branch-caused or unknown failures exist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ Each entry follows the format: `- <change-name>: <summary>`.
 ## Unreleased
 
 ### Changed
+- pre-flight-file-scope-filter: Add Phase 2a file-scope
+  filtering to skip tools that have zero in-scope files
+  in the branch diff. Applies to all three execution
+  modes (hard-gate, ci-aware, soft-gate). Conservative
+  fallbacks ensure all tools run when diff computation
+  fails, the repository is a shallow clone, or the diff
+  is empty on a feature branch. Aggregate tools
+  (make check, pre-commit) are always in scope. Tool
+  config files are included in their respective tool
+  scopes.
+  (Spec: openspec/changes/pre-flight-file-scope-filter/,
+  Fixes: #434)
 - adopt-org-infra-release-workflows: Replace inline
   release preflight and GoReleaser jobs with org-infra
   reusable workflow callers (`reusable_release_preflight`

--- a/internal/scaffold/assets/opencode/skills/pre-flight/SKILL.md
+++ b/internal/scaffold/assets/opencode/skills/pre-flight/SKILL.md
@@ -116,6 +116,108 @@ and proceed to Phase 3.
 
 ---
 
+## Phase 2a: File-Scope Filter
+
+Before building the CI coverage matrix, filter out tools
+that have no applicable files in the branch diff. This
+avoids running tools whose scope does not intersect with
+the changes on this branch.
+
+### File-scope mapping
+
+| Tool | In-scope file patterns |
+|------|----------------------|
+| `go test` | `*.go`, `go.mod`, `go.sum` |
+| `golangci-lint` | `*.go`, `go.mod`, `go.sum`, `.golangci.yml`, `.golangci.yaml` |
+| `ruff` | `*.py`, `ruff.toml`, `pyproject.toml` |
+| `pytest` | `*.py`, `pyproject.toml`, `setup.py`, `conftest.py` |
+| `yamllint` | `*.yml`, `*.yaml`, `.yamllint.yml`, `.yamllint.yaml` |
+| `make check` | _always in scope_ |
+| `pre-commit` | _always in scope_ |
+
+Tools marked "always in scope" MUST NOT be skipped by the
+file-scope filter. These are aggregate tools whose scope
+cannot be reliably determined from file extensions alone.
+
+Additional tools added to Phase 2's tool-to-command mapping
+in the future MUST have a corresponding file-scope entry
+added to this table.
+
+Note: `go vet` and `go build` are CI commands discovered
+in Phase 1 (CI Workflow Parsing), not independently detected
+tools in Phase 2 (Tool Detection). They do not need scope
+entries because they are not individually executed by the
+pre-flight skill. They are covered by the `make check`
+aggregate tool entry (always in scope) and, in the case of
+`go vet`, by `golangci-lint`'s inclusion of vet rules.
+
+File patterns use suffix matching against the full path
+returned by `git diff --name-only`. A pattern `*.go`
+matches any file whose path ends in `.go`, regardless of
+directory depth (e.g., `internal/scaffold/foo.go` matches
+`*.go`).
+
+### Branch diff computation
+
+Compute the list of files changed on this branch relative
+to the default branch:
+
+```bash
+DEFAULT_BRANCH=<detected per Phase 4a: Baseline Establishment, "Detect the default branch" subsection>
+MERGE_BASE=$(git merge-base HEAD origin/${DEFAULT_BRANCH})
+CHANGED_FILES=$(git diff --name-only ${MERGE_BASE}...HEAD)
+```
+
+Use the same default branch detection logic described in
+Phase 4a ("Detect the default branch" subsection). If the
+default branch cannot be
+detected, or if the diff command fails, skip the file-scope
+filter entirely and proceed to Phase 3 with all tools
+(conservative fallback).
+
+If the diff is empty (no changed files) and the current
+branch is NOT the default branch, skip the file-scope
+filter and run all tools (conservative fallback), since
+an empty diff on a feature branch may indicate a git state
+anomaly. Report: "Empty diff detected — running all tools
+as conservative fallback."
+
+If the repository is a shallow clone (detected via
+`git rev-parse --is-shallow-repository`), skip the
+file-scope filter and run all tools, since the merge-base
+computation may produce incomplete results in shallow
+clones.
+
+### Filter logic
+
+For each detected and available tool from Phase 2:
+
+1. Look up the tool's in-scope file patterns in the
+   mapping table above.
+2. If the tool is marked "always in scope," it proceeds
+   to Phase 3 unconditionally.
+3. Intersect the branch diff file list with the tool's
+   file-scope patterns using suffix matching.
+4. If zero diff files match the tool's patterns, mark the
+   tool as "SKIP — no in-scope files."
+5. If one or more diff files match, the tool proceeds to
+   Phase 3 as normal.
+
+### Output
+
+Report the file-scope filter results:
+
+```
+File-scope filter (Phase 2a):
+  Branch diff: 2 files (release.yml, .goreleaser.yaml)
+  - go test: SKIP — no in-scope files
+  - golangci-lint: SKIP — no in-scope files
+  - yamllint: in scope (1 file matches)
+  - make check: always in scope
+```
+
+---
+
 ## Phase 3: CI Coverage Matrix
 
 Build and display a coverage matrix that maps each
@@ -125,11 +227,16 @@ visible and auditable.
 
 ### Matrix construction
 
-For each detected and available tool, determine which CI
-check (if any) covers the same verification. Map tool
-names to CI check names by matching on the tool's purpose
-(e.g., `go test` maps to a CI check containing "test",
-`golangci-lint` maps to a check containing "lint").
+For each detected and available tool that has in-scope
+files in the branch diff (i.e., tools that survived
+Phase 2a's file-scope filter), determine which CI check
+(if any) covers the same verification. Tools marked
+"SKIP — no in-scope files" in Phase 2a are excluded from
+the matrix and are not evaluated for CI coverage. Map
+tool names to CI check names by matching on the tool's
+purpose (e.g., `go test` maps to a CI check containing
+"test", `golangci-lint` maps to a check containing
+"lint").
 
 ### Decision rules (ci-aware mode)
 
@@ -142,12 +249,15 @@ names to CI check names by matching on the tool's purpose
 
 ### Decision rules (hard-gate mode)
 
-In hard-gate mode, ALL detected and available tools are
-marked "Run locally = Yes" regardless of CI status. The
-CI status column in the matrix shows the actual status if
-available, or "N/A" if CI results were not provided. The
-coverage matrix is still displayed for visibility, but
-skip decisions are not applied.
+In hard-gate mode, all detected and available tools that
+have in-scope files in the branch diff (per Phase 2a) are
+marked "Run locally = Yes" regardless of CI status. Tools
+marked "SKIP — no in-scope files" in Phase 2a are excluded
+from the coverage matrix's "Run locally" decisions and are
+not executed. The CI status column in the matrix shows the
+actual status if available, or "N/A" if CI results were
+not provided. The coverage matrix is still displayed for
+visibility.
 
 ### Display format
 
@@ -195,9 +305,11 @@ If no tools are marked "Yes" (all covered by CI): report
 
 ### soft-gate mode
 
-Execute ALL detected and available tools (same as
-hard-gate). Do NOT stop on first failure — record all
-exit codes and output for every tool.
+Execute all detected and available tools that have
+in-scope files in the branch diff (same scope filtering
+as hard-gate, per Phase 2a). Do NOT stop on first
+failure — record all exit codes and output for every
+tool.
 
 - If ALL tools pass: verdict is PASS. No baseline
   establishment is needed. Skip Phase 4a and 4b.
@@ -247,6 +359,9 @@ fi
 If neither resolves, treat the baseline as unavailable
 and fall through to the conservative fallback (all
 failures classified as `unknown` = branch-caused).
+
+Record which baseline method was used: `CI API`,
+`worktree`, or `unavailable`.
 
 ### Tier 1 — CI API baseline
 
@@ -368,16 +483,19 @@ Present results in a standardized format.
 ### CI Coverage Matrix
 | Local tool | CI check | CI status | Run locally? |
 |------------|----------|-----------|--------------|
-| ...        | ...      | ...       | ...          |
+| ...        | ...      | ...       | Yes          |
+| ...        | ...      | ...       | SKIP — no in-scope files |
 
 ### Execution Results
 | Tool | Command | Exit code | Status |
 |------|---------|-----------|--------|
 | ...  | ...     | ...       | ...    |
+| ...  | ...     | —         | SKIP — no in-scope files |
 
 ### Verdict
 - **Mode**: hard-gate | ci-aware
 - **Result**: PASS | FAIL
+- **Skipped — no in-scope files**: N tools
 - **Failures**: [list if any]
 ```
 
@@ -389,24 +507,35 @@ Present results in a standardized format.
 ### CI Coverage Matrix
 | Local tool | CI check | CI status | Run locally? |
 |------------|----------|-----------|--------------|
-| ...        | ...      | ...       | ...          |
+| ...        | ...      | ...       | Yes          |
+| ...        | ...      | ...       | SKIP — no in-scope files |
 
 ### Execution Results
 | Tool | Command | Exit code | Status | Causality |
 |------|---------|-----------|--------|-----------|
 | ...  | ...     | ...       | ...    | ...       |
+| ...  | ...     | —         | SKIP — no in-scope files | — |
 
 ### Verdict
 - **Mode**: soft-gate
 - **Result**: PASS | FAIL (branch-caused)
+- **Skipped — no in-scope files**: N tools
 - **Branch-caused failures**: [list if any]
 - **Pre-existing failures**: [list if any]
 - **Baseline method**: CI API | worktree | unavailable
 ```
 
+Tools skipped by the file-scope filter (Phase 2a) use the
+canonical status string `SKIP — no in-scope files` (em
+dash) in both the coverage matrix "Run locally?" column
+and the execution results Status column. Skipped tools are
+counted as PASS for the overall verdict — a tool with zero
+applicable files in the diff cannot produce findings.
+
 The `Causality` column in the Execution Results table
 contains one of: `branch-caused`, `pre-existing`,
-`unknown`, or `—` (for tools that passed).
+`unknown`, `—` (for tools that passed), or `—` (for
+skipped tools).
 
 The `Result` field is:
 - `PASS` if no branch-caused or unknown failures exist

--- a/openspec/changes/pre-flight-file-scope-filter/.openspec.yaml
+++ b/openspec/changes/pre-flight-file-scope-filter/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: unbound-force
+created: 2026-08-14

--- a/openspec/changes/pre-flight-file-scope-filter/design.md
+++ b/openspec/changes/pre-flight-file-scope-filter/design.md
@@ -1,0 +1,160 @@
+## Context
+
+The pre-flight skill is a Markdown instruction file consumed by
+AI agents through three commands: `/unleash` (hard-gate),
+`/review-pr` (ci-aware), and `/review-council` (soft-gate). It
+defines a 5-phase pipeline: CI workflow parsing, tool detection,
+CI coverage matrix, execution, and result formatting.
+
+Currently, Phase 4 executes all tools detected in Phase 2
+regardless of whether the branch diff contains files relevant
+to each tool. This wastes time and tokens on branches that only
+modify non-code files (YAML, Markdown, agent definitions).
+
+The skill exists in two locations that must stay in sync:
+- `~/.config/opencode/skills/pre-flight/SKILL.md` (user-level)
+- `internal/scaffold/assets/opencode/skills/pre-flight/SKILL.md`
+  (scaffold-deployed copy)
+
+## Goals / Non-Goals
+
+### Goals
+
+- Skip tools that have zero applicable files in the branch diff
+- Apply consistently across all three execution modes
+- Maintain clear auditability (distinguish "skipped" from
+  "passed")
+- Preserve conservative defaults (aggregate tools always run,
+  config file changes trigger their tools)
+- Keep the skill as a declarative Markdown document (no code)
+
+### Non-Goals
+
+- Adding new tools to the detection phase (that's #390's scope)
+- Changing how `ci-aware` mode interacts with the GitHub API
+- Making the file-scope mapping user-configurable (the mapping
+  is hardcoded in the skill; extensibility comes from editing
+  the skill file)
+- Implementing the filter as Go code — this is purely a skill
+  instruction change
+
+## Decisions
+
+### D1: Insert as Phase 2a (between detection and coverage matrix)
+
+The file-scope filter runs after tool detection (Phase 2) and
+before the CI coverage matrix (Phase 3). This position is
+optimal because:
+
+1. Tools filtered out in Phase 2a never appear as "Run locally
+   = Yes" in the matrix, reducing noise.
+2. The filter is orthogonal to CI coverage — a tool can be
+   skipped by file-scope (no applicable files) independently
+   of being skipped by CI coverage (CI already verified).
+3. Phase 2a uses only `git` (already a prerequisite) and the
+   static mapping table — no new dependencies.
+
+The alternative of filtering during Phase 4 (execution) was
+rejected because it would still show skipped tools as "Run
+locally = Yes" in the matrix, creating a confusing display.
+
+### D2: Aggregate tools always run
+
+`make check` and `pre-commit` are marked "always in scope"
+because they aggregate multiple underlying tools whose file
+scope cannot be reliably determined from the aggregate's
+config file alone. A Makefile's `check` target may proxy to
+`go vet`, `golangci-lint`, `shellcheck`, and other tools not
+individually detected.
+
+This is the conservative default. If `make check` becomes too
+noisy on non-code branches, the mapping can be refined in a
+future change.
+
+### D3: Include tool config files in scope patterns
+
+Tool configuration files (`.golangci.yml`, `ruff.toml`,
+`go.mod`, `go.sum`, `pyproject.toml`, `.yamllint.yml`) are
+included in their respective tool's scope patterns. A change
+to a linter's configuration can alter its behavior (enable/
+disable rules, change thresholds) even without source file
+changes. Omitting these would create a blind spot where
+config changes bypass validation.
+
+This aligns with Constitution Principle V (Security by Default):
+the scope mapping must not create bypass opportunities.
+
+### D4: Diff uses merge-base, not HEAD~1
+
+The branch diff is computed against the merge base with the
+default branch (`git merge-base HEAD origin/${DEFAULT_BRANCH}`),
+not against the previous commit. This captures all files changed
+across the entire branch, preventing a scenario where:
+
+1. Commit 1 adds `foo.go`
+2. Commit 2 modifies only `config.yaml`
+3. A HEAD~1 diff would miss `foo.go` and skip Go tools
+
+The merge-base approach matches how CI evaluates PRs and is
+consistent with how `/review-pr` computes diffs.
+
+### D5: Conservative fallback when diff unavailable
+
+If the default branch cannot be detected or the diff command
+fails, the file-scope filter is bypassed entirely and all tools
+run. This preserves the current behavior as a safe fallback and
+prevents the filter from silently suppressing tools due to a
+transient git issue.
+
+### D6: Scaffold sync required
+
+Both copies of SKILL.md must be updated atomically in the same
+commit. The scaffold copy at `internal/scaffold/assets/opencode/
+skills/pre-flight/SKILL.md` must match the user-level copy.
+Drift detection tests (per existing scaffold conventions) will
+catch any desynchronization.
+
+### D7: Skip status is distinct from pass status
+
+Skipped tools use the status string "SKIP — no in-scope files"
+rather than "PASS" in both the coverage matrix and execution
+results. This distinction serves Observable Quality (Constitution
+Principle III) by making the filter's decisions auditable. A
+reviewer can see at a glance which tools were actually exercised
+versus which were determined to be irrelevant.
+
+## Risks / Trade-offs
+
+### Risk: Incomplete scope mapping
+
+If a tool can be affected by a file type not listed in its
+scope patterns, the filter could skip the tool when it should
+run. Mitigated by:
+- Including config files in scope patterns (D3)
+- Conservative fallback for aggregate tools (D2)
+- The mapping is visible in the skill file and easy to extend
+
+### Risk: False sense of security
+
+Skipping tools might give reviewers the impression that fewer
+checks are needed. Mitigated by:
+- Explicit "SKIP — no in-scope files" status (D7)
+- Skip count in the verdict section
+- The coverage matrix is always displayed
+
+### Trade-off: Always running aggregate tools
+
+`make check` runs even on YAML-only branches. This means some
+waste remains, but it's the safe default. The trade-off is
+acceptable because `make check` typically includes `go vet`
+and `golangci-lint`, which exit quickly when no `.go` files
+changed — the actual cost is the Go module initialization
+overhead, not the tool execution itself.
+
+### Trade-off: Git dependency for diff
+
+The filter requires `git` to compute the branch diff. This is
+not a new dependency — Phase 4a already requires `git` for
+worktree operations. However, if the repo is in a detached
+HEAD state or a shallow clone, the merge-base computation may
+fail. The conservative fallback (D5) handles this.

--- a/openspec/changes/pre-flight-file-scope-filter/proposal.md
+++ b/openspec/changes/pre-flight-file-scope-filter/proposal.md
@@ -1,0 +1,146 @@
+<!-- spec-review: passed -->
+
+## Why
+
+The pre-flight skill runs ALL detected tools regardless of whether
+the branch diff contains files relevant to each tool's scope. On
+branches that only modify YAML, Markdown, or agent files, Go tools
+(`go vet`, `golangci-lint`, `go test -race`, `go build`) still
+execute, wasting ~2 minutes of wall time and significant LLM token
+budget on tool output that cannot produce findings.
+
+This was identified in issue #434, observed on PR #433 (branch
+`428-adopt-org-infra-release-workflows`) which modified only
+`.github/workflows/release.yml` and `.goreleaser.yaml`. All five
+triage panelists assessed the issue as VALID.
+
+The current behavior is by design — SKILL.md lines 145-150 state
+hard-gate mode runs "ALL detected and available tools...regardless
+of CI status." The spec lacks a file-scope awareness concept. This
+change adds that concept.
+
+Fixes #434.
+
+## What Changes
+
+Add a file-scope filtering phase to the pre-flight skill that
+intersects the branch diff file list with each tool's applicable
+file extensions. Tools with zero in-scope files are skipped with
+an informational note. Skipped tools are counted as PASS (no
+findings possible = no failures).
+
+The change applies to all three execution modes: `hard-gate`,
+`ci-aware`, and `soft-gate`.
+
+## Capabilities
+
+### New Capabilities
+
+- `file-scope-filter`: A tool-to-file-extension mapping that
+  determines which tools are relevant to the current branch diff.
+  Tools with no applicable files in the diff are skipped.
+- `scope-skip-reporting`: Skipped tools are reported with a
+  distinct status ("SKIP — no in-scope files") in both the CI
+  coverage matrix and the execution results, distinguishing them
+  from tools that ran and passed.
+
+### Modified Capabilities
+
+- `hard-gate execution`: Now skips tools with zero in-scope files
+  instead of running all tools unconditionally.
+- `ci-aware execution`: File-scope filter applied before the CI
+  coverage matrix decision, providing an additional skip reason.
+- `soft-gate execution`: File-scope filter applied before
+  execution, preventing unnecessary baseline establishment for
+  tools that have no applicable files.
+- `coverage-matrix display`: Adds a "Scope" column or status to
+  show whether each tool has in-scope files.
+
+### Removed Capabilities
+
+- None.
+
+## Impact
+
+### Files affected
+
+- `~/.config/opencode/skills/pre-flight/SKILL.md` — primary
+  skill definition (user-level)
+- `internal/scaffold/assets/opencode/skills/pre-flight/SKILL.md`
+  — scaffold-deployed copy (must stay in sync)
+
+### Behavioral changes
+
+- Branches with no `.go` files in the diff will skip Go tools.
+- Branches with no `.py` files in the diff will skip Python tools.
+- Branches with no `.yml`/`.yaml` files in the diff will skip
+  yamllint.
+- `make check` and `pre-commit` always run (scope-ambiguous
+  aggregate tools).
+- Tool config file changes (`.golangci.yml`, `ruff.toml`,
+  `go.mod`, `go.sum`) trigger their respective tools even when
+  no source files changed.
+
+### Complementary work
+
+- Issue #390 (GitHub Actions security linters) adds scope-
+  appropriate tooling for workflow files. These issues are
+  complementary, not conflicting.
+
+## Constitution Alignment
+
+Assessed against the Unbound Force org constitution.
+
+### I. Autonomous Collaboration
+
+**Assessment**: N/A
+
+This change modifies a shared skill consumed by AI agents. It
+does not alter inter-hero artifact formats, communication
+protocols, or metadata structures. The skill remains a
+self-contained instruction document.
+
+### II. Composability First
+
+**Assessment**: PASS
+
+The file-scope filter is additive — it does not introduce
+dependencies on other heroes or tools. The pre-flight skill
+remains independently consumable. The diff computation uses
+only `git`, which is already a prerequisite for the skill's
+operation (Phase 4a already uses git worktrees).
+
+### III. Observable Quality
+
+**Assessment**: PASS
+
+The change maintains and improves observability. Skipped tools
+are explicitly reported with a distinct status ("SKIP — no
+in-scope files") rather than silently omitted. The coverage
+matrix remains visible and auditable. The file-scope mapping
+table itself is declarative and inspectable.
+
+### IV. Testability
+
+**Assessment**: PASS
+
+The file-scope filter is a deterministic mapping (file
+extensions → tool set) intersected with a deterministic input
+(branch diff file list). Both inputs are observable and
+reproducible. The filter logic can be verified by inspecting
+the coverage matrix output — testable through the existing
+Phase 5 result format.
+
+### V. Security by Default
+
+**Assessment**: PASS
+
+The file-scope filter is a gate-narrowing mechanism, which
+requires care. However, skipping a tool that has zero applicable
+files in the diff is semantically equivalent to running it and
+getting a clean exit — no false negatives are introduced. The
+scope mapping includes tool config files (`.golangci.yml`,
+`ruff.toml`, `go.mod`, `go.sum`) to ensure that configuration
+changes trigger their respective tools. Aggregate tools
+(`make check`, `pre-commit`) always run as a conservative
+default. No gatekeeping integrity is violated.

--- a/openspec/changes/pre-flight-file-scope-filter/specs/file-scope-filter.md
+++ b/openspec/changes/pre-flight-file-scope-filter/specs/file-scope-filter.md
@@ -1,0 +1,248 @@
+## ADDED Requirements
+
+### FR-020: File-Scope Mapping Table
+
+The pre-flight skill MUST define a declarative mapping from
+each detected tool to the set of file patterns that determine
+whether the tool is in scope for a given branch diff.
+
+The mapping MUST include:
+
+| Tool | In-scope file patterns |
+|------|----------------------|
+| `go test` | `*.go`, `go.mod`, `go.sum` |
+| `golangci-lint` | `*.go`, `go.mod`, `go.sum`, `.golangci.yml`, `.golangci.yaml` |
+| `ruff` | `*.py`, `ruff.toml`, `pyproject.toml` |
+| `pytest` | `*.py`, `pyproject.toml`, `setup.py`, `conftest.py` |
+| `yamllint` | `*.yml`, `*.yaml`, `.yamllint.yml`, `.yamllint.yaml` |
+| `make check` | _always in scope_ |
+| `pre-commit` | _always in scope_ |
+
+Tools marked "always in scope" MUST NOT be skipped by the
+file-scope filter. These are aggregate tools whose scope
+cannot be reliably determined from file extensions alone.
+
+The mapping SHOULD be extensible — additional tools added
+to Phase 2's tool-to-command mapping in the future MUST
+have a corresponding file-scope entry.
+
+Note: `go vet` and `go build` are CI commands discovered in
+Phase 1 (CI Workflow Parsing), not independently detected
+tools in Phase 2 (Tool Detection). They do not need scope
+entries because they are not individually executed by the
+pre-flight skill. They are covered by the `make check`
+aggregate tool entry (always in scope) and, in the case of
+`go vet`, by `golangci-lint`'s inclusion of vet rules.
+
+File patterns use suffix matching against the full path
+returned by `git diff --name-only`. A pattern `*.go` matches
+any file whose path ends in `.go`, regardless of directory
+depth (e.g., `internal/scaffold/foo.go` matches `*.go`).
+
+#### Scenario: Go-only tool mapping
+
+- **GIVEN** the pre-flight skill is executing
+- **WHEN** the branch diff contains only `.yaml` files
+- **THEN** `go test` and `golangci-lint` are marked as
+  out-of-scope because no diff files match `*.go`,
+  `go.mod`, `go.sum`, `.golangci.yml`, or `.golangci.yaml`
+
+#### Scenario: Config file triggers tool
+
+- **GIVEN** the branch diff contains only `.golangci.yml`
+- **WHEN** the file-scope filter runs
+- **THEN** `golangci-lint` is marked as in-scope because
+  `.golangci.yml` is in its file-scope pattern list
+
+### FR-021: Branch Diff Computation
+
+The pre-flight skill MUST compute the branch diff file list
+using `git diff --name-only` against the merge base of the
+current branch and the default branch.
+
+The diff command MUST be:
+
+```bash
+git diff --name-only $(git merge-base HEAD origin/${DEFAULT_BRANCH})...HEAD
+```
+
+Where `${DEFAULT_BRANCH}` is detected using the same logic
+as Phase 4a (lines 218-249 of the current SKILL.md).
+
+If the default branch cannot be detected, or if the diff
+command fails, the file-scope filter MUST be skipped and
+all tools MUST run (conservative fallback).
+
+If the diff is empty (no changed files) and the current
+branch is NOT the default branch, the file-scope filter
+MUST be skipped and all tools MUST run (conservative
+fallback), since an empty diff on a feature branch may
+indicate a git state anomaly. An informational note MUST
+explain: "Empty diff detected — running all tools as
+conservative fallback." Always-in-scope tools (FR-020)
+run regardless.
+
+If the repository is a shallow clone (detected via
+`git rev-parse --is-shallow-repository`), the file-scope
+filter MUST be skipped and all tools MUST run, since the
+merge-base computation may produce incomplete results in
+shallow clones.
+
+#### Scenario: Empty diff on feature branch
+
+- **GIVEN** the branch diff is empty (no files changed)
+  and the current branch is not the default branch
+- **WHEN** Phase 2a runs
+- **THEN** the file-scope filter is bypassed, all tools
+  run, and an informational note explains the fallback
+
+#### Scenario: Shallow clone
+
+- **GIVEN** the repository is a shallow clone
+- **WHEN** the branch diff computation is attempted
+- **THEN** the file-scope filter is skipped, all tools run,
+  and an informational note explains the shallow clone
+  limitation
+
+#### Scenario: Diff against merge base
+
+- **GIVEN** a feature branch with 3 commits ahead of `main`
+- **WHEN** the branch diff is computed
+- **THEN** the diff includes all files changed across all 3
+  commits relative to the merge base, not just the latest
+  commit
+
+#### Scenario: Default branch unavailable
+
+- **GIVEN** the default branch cannot be detected
+- **WHEN** the branch diff computation is attempted
+- **THEN** the file-scope filter is skipped, all tools run,
+  and an informational note explains the fallback
+
+### FR-022: File-Scope Filter Phase
+
+The pre-flight skill MUST add a file-scope filtering step
+between Phase 2 (Tool Detection) and Phase 3 (CI Coverage
+Matrix). This step is designated Phase 2a.
+
+Phase 2a MUST:
+
+1. Compute the branch diff file list (per FR-021).
+2. For each detected and available tool from Phase 2,
+   intersect the diff file list with the tool's file-scope
+   patterns (per FR-020).
+3. If zero diff files match a tool's patterns, mark the tool
+   as "SKIP — no in-scope files."
+4. If one or more diff files match, the tool proceeds to
+   Phase 3 as normal.
+
+Phase 2a MUST apply in all three execution modes:
+`hard-gate`, `ci-aware`, and `soft-gate`.
+
+#### Scenario: YAML-only branch with Go tools detected
+
+- **GIVEN** the branch diff contains only `release.yml`
+  and `.goreleaser.yaml`
+- **AND** Phase 2 detected `go test`, `golangci-lint`,
+  `yamllint`, and `make check`
+- **WHEN** Phase 2a runs
+- **THEN** `go test` is marked "SKIP — no in-scope files"
+- **AND** `golangci-lint` is marked "SKIP — no in-scope files"
+- **AND** `yamllint` proceeds to Phase 3 (`.yaml` matches)
+- **AND** `make check` proceeds to Phase 3 (always in scope)
+
+#### Scenario: Mixed diff with Go and YAML files
+
+- **GIVEN** the branch diff contains `main.go` and
+  `config.yaml`
+- **WHEN** Phase 2a runs
+- **THEN** all detected tools proceed to Phase 3 (both Go
+  and YAML tools have matching files)
+
+### FR-023: Skip Reporting
+
+Skipped tools MUST be reported with a distinct status that
+differentiates them from tools that ran and passed.
+
+The coverage matrix (Phase 3) MUST include skipped tools
+with status "SKIP — no in-scope files" in the "Run locally?"
+column.
+
+The execution results (Phase 5) MUST include skipped tools
+with:
+- Exit code: `—` (not applicable)
+- Status: `SKIP — no in-scope files`
+
+Skipped tools MUST be counted as PASS for the purposes of
+the overall verdict. A tool with zero applicable files in
+the diff cannot produce findings, so skipping it is
+semantically equivalent to a clean exit.
+
+The verdict section (Phase 5) SHOULD include a count of
+skipped tools, e.g., "2 tools skipped — no in-scope files."
+
+Note: The canonical skip status string is
+`SKIP — no in-scope files` (em dash). This string MUST be
+used consistently in the coverage matrix "Run locally?"
+column, the execution results Status column, and the
+verdict summary.
+
+#### Scenario: Skip reporting in coverage matrix
+
+- **GIVEN** `golangci-lint` has no in-scope files
+- **WHEN** the coverage matrix is displayed
+- **THEN** the matrix row shows:
+  `| golangci-lint | ... | ... | SKIP — no in-scope files |`
+
+#### Scenario: Skip reporting in verdict
+
+- **GIVEN** 4 tools were detected, 2 were skipped, 2 ran
+  and passed
+- **WHEN** the verdict is displayed
+- **THEN** the result is PASS with a note: "2 tools skipped
+  (no in-scope files)"
+
+## MODIFIED Requirements
+
+### FR-005: Hard-Gate Execution (lines 145-150)
+
+In hard-gate mode, all detected and available tools that
+have in-scope files in the branch diff are marked "Run
+locally = Yes." Tools with zero in-scope files are marked
+"SKIP — no in-scope files" and are not executed. The CI
+status column in the matrix shows the actual status if
+available. Skip decisions based on file scope are applied
+before CI coverage matrix evaluation.
+
+Previously: "In hard-gate mode, ALL detected and available
+tools are marked 'Run locally = Yes' regardless of CI
+status."
+
+### FR-006: CI-Aware Execution (lines 128-141)
+
+In ci-aware mode, the CI coverage matrix is built from
+detected and available tools that have in-scope files in
+the branch diff. Tools with zero in-scope files are marked
+"SKIP — no in-scope files" and are excluded from CI
+coverage evaluation. The file-scope filter (Phase 2a) is
+applied before CI coverage matrix construction (Phase 3),
+so tools removed by the filter never appear in the matrix's
+"Run locally?" decision.
+
+Previously: "For each detected and available tool, determine
+which CI check covers the same verification" (no file-scope
+filtering before matrix construction).
+
+### FR-007: Soft-Gate Execution (lines 198-200)
+
+Execute all detected and available tools that have in-scope
+files in the branch diff (same scope filtering as hard-gate).
+Do NOT stop on first failure — record all exit codes and
+output for every tool.
+
+Previously: "Execute ALL detected and available tools (same
+as hard-gate)."
+
+## REMOVED Requirements
+
+None.

--- a/openspec/changes/pre-flight-file-scope-filter/tasks.md
+++ b/openspec/changes/pre-flight-file-scope-filter/tasks.md
@@ -1,0 +1,144 @@
+<!--
+  [P] marks tasks eligible for parallel execution.
+  Add [P] when a task: (a) touches different files from
+  other [P] tasks in the group, (b) has no dependency
+  on prior tasks in the group, (c) can safely execute
+  without ordering constraints.
+  Do NOT add [P] when tasks modify the same file —
+  parallel workers will cause merge conflicts.
+  Tasks without [P] run sequentially first, then [P]
+  tasks run in parallel.
+-->
+
+## 1. Add Phase 2a: File-Scope Filter to SKILL.md
+
+All tasks in this group modify the same file
+(`~/.config/opencode/skills/pre-flight/SKILL.md`) and
+MUST run sequentially.
+
+- [x] 1.1 Add the file-scope mapping table after Phase 2
+  (Tool Detection), before the Phase 3 heading. The new
+  section is "Phase 2a: File-Scope Filter." Include the
+  mapping table from FR-020:
+
+  | Tool | In-scope file patterns |
+  |------|----------------------|
+  | `go test` | `*.go`, `go.mod`, `go.sum` |
+  | `golangci-lint` | `*.go`, `go.mod`, `go.sum`, `.golangci.yml`, `.golangci.yaml` |
+  | `ruff` | `*.py`, `ruff.toml`, `pyproject.toml` |
+  | `pytest` | `*.py`, `pyproject.toml`, `setup.py`, `conftest.py` |
+  | `yamllint` | `*.yml`, `*.yaml`, `.yamllint.yml`, `.yamllint.yaml` |
+  | `make check` | _always in scope_ |
+  | `pre-commit` | _always in scope_ |
+
+  Include the branch diff computation instructions per
+  FR-021:
+  ```bash
+  git diff --name-only \
+    $(git merge-base HEAD origin/${DEFAULT_BRANCH})...HEAD
+  ```
+  Include the default branch detection reference (reuse
+  Phase 4a logic, lines 218-249). Include the conservative
+  fallback: if diff computation fails, skip the filter and
+  run all tools.
+
+  File: `~/.config/opencode/skills/pre-flight/SKILL.md`
+
+- [x] 1.2 Modify the Phase 3 decision rules for hard-gate
+  mode (lines 145-150) per modified FR-005. Change from
+  "ALL detected and available tools" to "all detected and
+  available tools that have in-scope files." Add a note
+  that tools marked "SKIP — no in-scope files" in Phase 2a
+  are excluded from the coverage matrix's "Run locally"
+  decisions.
+
+  File: `~/.config/opencode/skills/pre-flight/SKILL.md`
+
+- [x] 1.3 Modify the ci-aware mode section (Phase 3
+  decision rules, lines 128-141) per modified FR-006.
+  Clarify that the CI coverage matrix is built only from
+  tools that survived Phase 2a's file-scope filter. Tools
+  removed by the filter are marked "SKIP — no in-scope
+  files" and are excluded from CI coverage evaluation.
+
+  File: `~/.config/opencode/skills/pre-flight/SKILL.md`
+
+- [x] 1.4 Modify the Phase 4 soft-gate mode section
+  (lines 198-200) per modified FR-007. Change from
+  "Execute ALL detected and available tools" to "Execute
+  all detected and available tools that have in-scope
+  files in the branch diff."
+
+  File: `~/.config/opencode/skills/pre-flight/SKILL.md`
+
+- [x] 1.5 Update Phase 5 result format to include skip
+  reporting per FR-023. Add "SKIP — no in-scope files"
+  as a valid status in the Execution Results tables for
+  all three modes. Add a skip count line to the Verdict
+  sections: "- **Skipped — no in-scope files**: N tools".
+  Include the distinct status in the coverage matrix
+  "Run locally?" column.
+
+  File: `~/.config/opencode/skills/pre-flight/SKILL.md`
+
+## 2. Sync Scaffold Copy
+
+This task depends on Group 1 being complete.
+
+- [x] 2.1 Copy the updated SKILL.md to the scaffold
+  assets directory. The user-level copy is the
+  authoritative source — copy from user-level to
+  scaffold, not the reverse. The scaffold copy MUST be
+  identical to the user-level copy. Note: the scaffold
+  copy currently has an older description; this sync
+  will resolve that pre-existing drift.
+
+  Source: `~/.config/opencode/skills/pre-flight/SKILL.md`
+  Target: `internal/scaffold/assets/opencode/skills/pre-flight/SKILL.md`
+
+## 3. Verification
+
+- [x] 3.1 Verify scaffold sync: diff the two SKILL.md
+  copies and confirm they are identical.
+  ```bash
+  diff ~/.config/opencode/skills/pre-flight/SKILL.md \
+    internal/scaffold/assets/opencode/skills/pre-flight/SKILL.md
+  ```
+
+- [x] 3.2 [P] Verify constitution alignment:
+  - **Observable Quality (III)**: Confirm skip status is
+    distinct from pass status in both coverage matrix and
+    execution results tables.
+  - **Security by Default (V)**: Confirm tool config files
+    are included in scope patterns. Confirm aggregate tools
+    are always in scope. Confirm conservative fallback when
+    diff is unavailable.
+  - **Testability (IV)**: Confirm the mapping table is
+    declarative and the diff command is deterministic.
+
+- [x] 3.3 [P] Run existing tests to verify no regressions:
+  ```bash
+  go test -race -count=1 ./internal/scaffold/...
+  ```
+  Scaffold drift detection tests must pass with the
+  updated asset.
+
+- [x] 3.4 [P] Smoke test: run the pre-flight skill in
+  hard-gate mode against the current branch (which
+  modifies only Markdown files under `openspec/`) and
+  verify:
+  - Go tools (`go test`, `golangci-lint`) are reported
+    as "SKIP — no in-scope files"
+  - `make check` runs (always in scope)
+  - The verdict section includes a skip count
+  - The coverage matrix shows distinct SKIP status
+
+## 4. Documentation Assessment
+
+- [x] 4.1 Assess CHANGELOG.md impact: add entry under
+  the next release section noting the file-scope filter
+  addition. Category: "Changed" (pre-flight skill behavior).
+
+- [x] 4.2 [P] Assess AGENTS.md impact: no structural
+  changes needed (no new packages, commands, or build
+  steps). No update required.


### PR DESCRIPTION
## Summary

Add Phase 2a file-scope filtering to the pre-flight skill to skip tools that have zero in-scope files in the branch diff. On YAML-only or docs-only branches, Go tools (`go test`, `golangci-lint`) are skipped, saving ~2 minutes of wall time and significant LLM token budget.

Fixes #434.

## Changes

- **Phase 2a: File-Scope Filter** — new phase between Tool Detection (Phase 2) and CI Coverage Matrix (Phase 3). Defines a declarative tool-to-file-extension mapping table, computes the branch diff via `git merge-base`, and filters tools with zero matching files.

- **All three modes updated** — hard-gate (FR-005), ci-aware (FR-006), and soft-gate (FR-007) now scope execution to tools with in-scope files.

- **Conservative fallbacks** — when diff computation fails, the repository is a shallow clone, or the diff is empty on a feature branch, all tools run (same as pre-change behavior).

- **Aggregate tool exemption** — `make check` and `pre-commit` are marked "always in scope" and cannot be skipped.

- **Config files in scope** — `.golangci.yml`, `go.mod`, `go.sum`, `ruff.toml`, `pyproject.toml`, `.yamllint.yml` trigger their respective tools even without source file changes.

- **Distinct skip status** — `SKIP — no in-scope files` (em dash) in both coverage matrix and execution results, with skip count in verdict.

## Spec

OpenSpec: `openspec/changes/pre-flight-file-scope-filter/`
- 4 new requirements (FR-020 through FR-023)
- 3 modified requirements (FR-005, FR-006, FR-007)
- 7 design decisions (D1-D7)

## Testing

- Scaffold drift detection tests pass (`go test -race -count=1 ./internal/scaffold/...`)
- Constitution alignment: 5/5 PASS
- Code review council: 5/5 APPROVE (after fixing 2 MEDIUM bookkeeping findings)