### PR TITLE
fix: pass --force through to sub-tool init commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ Each entry follows the format: `- <change-name>: <summary>`.
 
 ## Unreleased
 
+### Fixed
+- fix-init-force-passthrough: `uf init --force` now
+  correctly re-initializes Group B sub-tools (specify,
+  replicator, openspec, gaze) and passes `--force`
+  through to sub-tool CLIs. Previously, `initSimpleTool`
+  silently skipped re-initialization regardless of the
+  force flag.
+  (Spec: openspec/changes/fix-init-force-passthrough/,
+  Fixes: #479)
+
 ### Changed
 - adopt-org-infra-release-workflows: Replace inline
   release preflight and GoReleaser jobs with org-infra

--- a/internal/scaffold/scaffold.go
+++ b/internal/scaffold/scaffold.go
@@ -1230,6 +1230,19 @@ func filterEmptyCustomPacks(candidates []string, root string) []string {
 	return packs
 }
 
+// simpleTool defines a Group B sub-tool entry for initSubTools.
+// Each entry maps a tool name to its sentinel path (relative to
+// TargetDir), result name, display label, optional extra args
+// for ExecCmd, and an optional forceFlag appended on re-init.
+type simpleTool struct {
+	name      string   // config + LookPath key
+	sentinel  string   // path to check (skip init if exists)
+	result    string   // subToolResult.name
+	label     string   // display text for logf
+	args      []string // extra args after "init"
+	forceFlag string   // flag appended on force re-init (empty = none)
+}
+
 // initSubTools initializes sub-tools after file scaffolding.
 // Errors are captured and reported as warnings in printSummary,
 // not hard failures (per Constitution Principle II — Composability First).
@@ -1324,26 +1337,20 @@ func initSubTools(opts *Options) []subToolResult {
 
 	// simpleTools defines Group B tools. Each entry maps a tool
 	// name to its sentinel path (relative to TargetDir), result
-	// name, display label, and optional extra args for ExecCmd.
-	type simpleTool struct {
-		name     string   // config + LookPath key
-		sentinel string   // path to check (skip init if exists)
-		result   string   // subToolResult.name
-		label    string   // display text for logf
-		args     []string // extra args after "init"
-	}
-
+	// name, display label, optional extra args for ExecCmd, and
+	// an optional forceFlag appended on force re-initialization.
 	simpleTools := []simpleTool{
 		{"replicator", ".uf/replicator", ".uf/replicator/",
-			"Replicator workspace", nil},
+			"Replicator workspace", nil, ""},
 		{"specify", ".specify", ".specify/",
 			"Speckit framework",
-			[]string{"--here", "--integration", "opencode", "--offline"}},
+			[]string{"--here", "--integration", "opencode", "--offline"},
+			"--force"},
 		{"openspec", filepath.Join("openspec", "config.yaml"),
 			"openspec/", "OpenSpec framework",
-			[]string{"--tools", "opencode"}},
+			[]string{"--tools", "opencode"}, "--force"},
 		{"gaze", filepath.Join(".opencode", "agents", "gaze-reporter.md"),
-			"gaze", "Gaze integration", nil},
+			"gaze", "Gaze integration", nil, "--force"},
 	}
 
 	for _, tool := range simpleTools {
@@ -1358,8 +1365,7 @@ func initSubTools(opts *Options) []subToolResult {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			r := initSimpleTool(opts, tool.name, tool.sentinel,
-				tool.result, tool.label, tool.args, logf)
+			r := initSimpleTool(opts, tool, logf)
 			if r != nil {
 				collect(*r)
 			}
@@ -1443,26 +1449,48 @@ func initDewey(opts *Options, logf func(string, ...interface{})) []subToolResult
 }
 
 // initSimpleTool initializes a single sub-tool by checking a
-// sentinel path and running "<name> init [args...]". Returns
-// nil if the sentinel already exists (tool already initialized).
-func initSimpleTool(opts *Options, name, sentinel, resultName, label string, extraArgs []string, logf func(string, ...interface{})) *subToolResult {
-	sentinelPath := filepath.Join(opts.TargetDir, sentinel)
-	if _, statErr := os.Stat(sentinelPath); !os.IsNotExist(statErr) {
+// sentinel path and running "<name> init [args...]". Returns nil
+// if the sentinel already exists and Force is false (tool already
+// initialized). When Force is true and the sentinel exists, the
+// tool is re-initialized with its forceFlag (if declared) and the
+// result uses action "re-initialized". When Force is true but the
+// sentinel does not exist, the tool is initialized normally and
+// the result uses action "initialized" (forceFlag is not appended
+// because there is nothing to overwrite).
+func initSimpleTool(opts *Options, tool simpleTool, logf func(string, ...interface{})) *subToolResult {
+	sentinelPath := filepath.Join(opts.TargetDir, tool.sentinel)
+	_, statErr := os.Stat(sentinelPath)
+	sentinelExists := statErr == nil
+
+	if sentinelExists && !opts.Force {
 		return nil // Already initialized.
 	}
 
-	logf("  Initializing %s...\n", label)
-	args := append([]string{"init"}, extraArgs...)
-	if out, initErr := opts.ExecCmd(name, args...); initErr != nil {
+	logf("  Initializing %s...\n", tool.label)
+	args := append([]string{"init"}, tool.args...)
+
+	// On force re-init (sentinel existed), append the tool's force
+	// flag so the sub-tool also re-initializes. First-time init
+	// never sends the force flag — there is nothing to overwrite.
+	if opts.Force && sentinelExists && tool.forceFlag != "" {
+		args = append(args, tool.forceFlag)
+	}
+
+	if out, initErr := opts.ExecCmd(tool.name, args...); initErr != nil {
 		return &subToolResult{
-			name: resultName, action: "failed",
-			detail:  fmt.Sprintf("%s init: %s", name, initErr),
+			name: tool.result, action: "failed",
+			detail:  fmt.Sprintf("%s init: %s", tool.name, initErr),
 			err:     initErr,
 			output:  out,
 		}
 	}
+
+	action := "initialized"
+	if opts.Force && sentinelExists {
+		action = "re-initialized"
+	}
 	return &subToolResult{
-		name: resultName, action: "initialized"}
+		name: tool.result, action: action}
 }
 
 // subToolSymbol returns the display symbol for a sub-tool result action.
@@ -1475,8 +1503,8 @@ func subToolSymbol(action string) string {
 	case "skipped", "dry-run":
 		return "—"
 	default:
-		// "initialized", "completed", "created", "configured",
-		// "already configured", "overwritten"
+		// "initialized", "re-initialized", "completed", "created",
+		// "configured", "already configured", "overwritten"
 		return "✓"
 	}
 }

--- a/internal/scaffold/scaffold_test.go
+++ b/internal/scaffold/scaffold_test.go
@@ -6537,3 +6537,306 @@ func TestWarnStaleCommandRefs_NoAgentFiles(t *testing.T) {
 		t.Errorf("expected no output when no agent dir exists, got: %s", buf.String())
 	}
 }
+
+// --- initSimpleTool force re-init tests ---
+
+func TestInitSimpleTool_SentinelExistsForceTrue(t *testing.T) {
+	dir := t.TempDir()
+	// Create sentinel so the tool appears already initialized.
+	sentinel := filepath.Join(dir, ".specify")
+	if err := os.MkdirAll(sentinel, 0o755); err != nil {
+		t.Fatalf("mkdir sentinel: %v", err)
+	}
+
+	rec := &scaffoldCmdRecorder{errors: map[string]error{}}
+	opts := &Options{
+		TargetDir: dir,
+		Force:     true,
+		LookPath:  stubScaffoldLookPath(map[string]string{"specify": "/usr/local/bin/specify"}),
+		ExecCmd:   rec.execCmd,
+	}
+
+	tool := simpleTool{
+		name:      "specify",
+		sentinel:  ".specify",
+		result:    ".specify/",
+		label:     "Speckit framework",
+		args:      []string{"--here", "--integration", "opencode", "--offline"},
+		forceFlag: "--force",
+	}
+	logf := func(string, ...interface{}) {}
+
+	r := initSimpleTool(opts, tool, logf)
+	if r == nil {
+		t.Fatal("expected non-nil result when Force=true and sentinel exists")
+	}
+	if r.action != "re-initialized" {
+		t.Errorf("expected action %q, got %q", "re-initialized", r.action)
+	}
+
+	// Verify ExecCmd was called.
+	if len(rec.calls) == 0 {
+		t.Error("expected ExecCmd to be called")
+	}
+}
+
+func TestInitSimpleTool_SentinelExistsNoForce(t *testing.T) {
+	dir := t.TempDir()
+	sentinel := filepath.Join(dir, ".specify")
+	if err := os.MkdirAll(sentinel, 0o755); err != nil {
+		t.Fatalf("mkdir sentinel: %v", err)
+	}
+
+	rec := &scaffoldCmdRecorder{errors: map[string]error{}}
+	opts := &Options{
+		TargetDir: dir,
+		Force:     false,
+		LookPath:  stubScaffoldLookPath(map[string]string{"specify": "/usr/local/bin/specify"}),
+		ExecCmd:   rec.execCmd,
+	}
+
+	tool := simpleTool{
+		name:      "specify",
+		sentinel:  ".specify",
+		result:    ".specify/",
+		label:     "Speckit framework",
+		args:      []string{"--here", "--integration", "opencode", "--offline"},
+		forceFlag: "--force",
+	}
+	logf := func(string, ...interface{}) {}
+
+	r := initSimpleTool(opts, tool, logf)
+	if r != nil {
+		t.Errorf("expected nil result when Force=false and sentinel exists, got %+v", r)
+	}
+
+	// Verify ExecCmd was NOT called.
+	if len(rec.calls) != 0 {
+		t.Errorf("expected no ExecCmd calls, got: %v", rec.calls)
+	}
+}
+
+func TestInitSimpleTool_ForcePassesForceFlag(t *testing.T) {
+	dir := t.TempDir()
+	sentinel := filepath.Join(dir, ".specify")
+	if err := os.MkdirAll(sentinel, 0o755); err != nil {
+		t.Fatalf("mkdir sentinel: %v", err)
+	}
+
+	rec := &scaffoldCmdRecorder{errors: map[string]error{}}
+	opts := &Options{
+		TargetDir: dir,
+		Force:     true,
+		LookPath:  stubScaffoldLookPath(map[string]string{"specify": "/usr/local/bin/specify"}),
+		ExecCmd:   rec.execCmd,
+	}
+
+	tool := simpleTool{
+		name:      "specify",
+		sentinel:  ".specify",
+		result:    ".specify/",
+		label:     "Speckit framework",
+		args:      []string{"--here", "--integration", "opencode", "--offline"},
+		forceFlag: "--force",
+	}
+	logf := func(string, ...interface{}) {}
+
+	r := initSimpleTool(opts, tool, logf)
+	if r == nil {
+		t.Fatal("expected non-nil result")
+	}
+
+	// Verify the recorded command includes --force at the end.
+	expected := "specify init --here --integration opencode --offline --force"
+	found := false
+	for _, call := range rec.calls {
+		if call == expected {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected call %q, got: %v", expected, rec.calls)
+	}
+}
+
+func TestInitSimpleTool_NoForceFlagDeclared(t *testing.T) {
+	dir := t.TempDir()
+	sentinel := filepath.Join(dir, ".uf", "replicator")
+	if err := os.MkdirAll(sentinel, 0o755); err != nil {
+		t.Fatalf("mkdir sentinel: %v", err)
+	}
+
+	rec := &scaffoldCmdRecorder{errors: map[string]error{}}
+	opts := &Options{
+		TargetDir: dir,
+		Force:     true,
+		LookPath:  stubScaffoldLookPath(map[string]string{"replicator": "/usr/local/bin/replicator"}),
+		ExecCmd:   rec.execCmd,
+	}
+
+	tool := simpleTool{
+		name:      "replicator",
+		sentinel:  ".uf/replicator",
+		result:    ".uf/replicator/",
+		label:     "Replicator workspace",
+		args:      nil,
+		forceFlag: "", // empty — no force flag
+	}
+	logf := func(string, ...interface{}) {}
+
+	r := initSimpleTool(opts, tool, logf)
+	if r == nil {
+		t.Fatal("expected non-nil result on force re-init")
+	}
+	if r.action != "re-initialized" {
+		t.Errorf("expected action %q, got %q", "re-initialized", r.action)
+	}
+
+	// Verify ExecCmd was called with "replicator init" only — no
+	// extraneous --force flag because forceFlag is empty.
+	expected := "replicator init"
+	found := false
+	for _, call := range rec.calls {
+		if call == expected {
+			found = true
+		}
+		if strings.Contains(call, "--force") {
+			t.Errorf("unexpected --force in command: %s", call)
+		}
+	}
+	if !found {
+		t.Errorf("expected call %q, got: %v", expected, rec.calls)
+	}
+}
+
+func TestInitSubTools_SpecifyForcePassthrough(t *testing.T) {
+	dir := t.TempDir()
+	// Create .specify/ so sentinel exists — force should re-init.
+	if err := os.MkdirAll(filepath.Join(dir, ".specify"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	rec := &scaffoldCmdRecorder{errors: map[string]error{}}
+	opts := &Options{
+		TargetDir: dir,
+		Force:     true,
+		LookPath:  stubScaffoldLookPath(map[string]string{"specify": "/usr/local/bin/specify"}),
+		ExecCmd:   rec.execCmd,
+	}
+
+	results := initSubTools(opts)
+
+	// Verify .specify/ result with "re-initialized" action.
+	foundReInit := false
+	for _, r := range results {
+		if r.name == ".specify/" && r.action == "re-initialized" {
+			foundReInit = true
+		}
+	}
+	if !foundReInit {
+		t.Errorf("expected .specify/ re-initialized result, got %v", results)
+	}
+
+	// Verify the recorded command includes --force.
+	expected := "specify init --here --integration opencode --offline --force"
+	found := false
+	for _, call := range rec.calls {
+		if call == expected {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected call %q, got: %v", expected, rec.calls)
+	}
+}
+
+func TestInitSimpleTool_ForceReinitFails(t *testing.T) {
+	dir := t.TempDir()
+	sentinel := filepath.Join(dir, ".specify")
+	if err := os.MkdirAll(sentinel, 0o755); err != nil {
+		t.Fatalf("mkdir sentinel: %v", err)
+	}
+
+	rec := &scaffoldCmdRecorder{
+		errors: map[string]error{
+			"specify init --here --integration opencode --offline --force": fmt.Errorf("specify crashed"),
+		},
+	}
+	opts := &Options{
+		TargetDir: dir,
+		Force:     true,
+		LookPath:  stubScaffoldLookPath(map[string]string{"specify": "/usr/local/bin/specify"}),
+		ExecCmd:   rec.execCmd,
+	}
+
+	tool := simpleTool{
+		name:      "specify",
+		sentinel:  ".specify",
+		result:    ".specify/",
+		label:     "Speckit framework",
+		args:      []string{"--here", "--integration", "opencode", "--offline"},
+		forceFlag: "--force",
+	}
+	logf := func(string, ...interface{}) {}
+
+	r := initSimpleTool(opts, tool, logf)
+	if r == nil {
+		t.Fatal("expected non-nil result on failed re-init")
+	}
+	if r.action != "failed" {
+		t.Errorf("expected action %q, got %q", "failed", r.action)
+	}
+	if r.err == nil {
+		t.Error("expected non-nil err on failed re-init")
+	}
+}
+
+func TestInitSimpleTool_NoSentinelForceTrue(t *testing.T) {
+	dir := t.TempDir()
+	// Do NOT create sentinel — first-time init even with Force=true.
+
+	rec := &scaffoldCmdRecorder{errors: map[string]error{}}
+	opts := &Options{
+		TargetDir: dir,
+		Force:     true,
+		LookPath:  stubScaffoldLookPath(map[string]string{"specify": "/usr/local/bin/specify"}),
+		ExecCmd:   rec.execCmd,
+	}
+
+	tool := simpleTool{
+		name:      "specify",
+		sentinel:  ".specify",
+		result:    ".specify/",
+		label:     "Speckit framework",
+		args:      []string{"--here", "--integration", "opencode", "--offline"},
+		forceFlag: "--force",
+	}
+	logf := func(string, ...interface{}) {}
+
+	r := initSimpleTool(opts, tool, logf)
+	if r == nil {
+		t.Fatal("expected non-nil result on first-time init")
+	}
+	if r.action != "initialized" {
+		t.Errorf("expected action %q, got %q", "initialized", r.action)
+	}
+
+	// Verify ExecCmd args do NOT include --force (first-time init).
+	for _, call := range rec.calls {
+		if strings.Contains(call, "--force") {
+			t.Errorf("--force should NOT be passed on first-time init, got: %s", call)
+		}
+	}
+
+	// Verify the base command was called.
+	expected := "specify init --here --integration opencode --offline"
+	found := false
+	for _, call := range rec.calls {
+		if call == expected {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected call %q, got: %v", expected, rec.calls)
+	}
+}

--- a/openspec/changes/fix-init-force-passthrough/.openspec.yaml
+++ b/openspec/changes/fix-init-force-passthrough/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: unbound-force
+created: 2026-08-18

--- a/openspec/changes/fix-init-force-passthrough/design.md
+++ b/openspec/changes/fix-init-force-passthrough/design.md
@@ -1,0 +1,144 @@
+## Context
+
+`uf init --force` correctly re-initializes Dewey (Group A)
+via `initDewey`, which explicitly checks `opts.Force` and
+re-indexes when the workspace already exists. However,
+Group B tools (specify, replicator, openspec, gaze) use
+`initSimpleTool`, which ignores `opts.Force` entirely —
+returning nil when the sentinel exists regardless of the
+force flag.
+
+The `simpleTool` struct also lacks a mechanism to declare
+tool-specific force flags, so even if the sentinel guard
+were bypassed, sub-tool CLIs like `specify init` would
+fail in non-empty directories without receiving `--force`.
+
+This is a bug fix, not a new feature. The design aligns
+`initSimpleTool` with the existing `initDewey` pattern.
+
+## Goals / Non-Goals
+
+### Goals
+- `initSimpleTool` respects `opts.Force` when sentinel
+  exists, matching `initDewey` behavior
+- Each `simpleTool` entry can declare its tool-specific
+  force flag (or empty for idempotent tools)
+- Force re-initialization produces a distinct action label
+  (`"re-initialized"`) for observable output
+- Test coverage parity with `initDewey` force tests
+
+### Non-Goals
+- Changing `initDewey` behavior (already correct)
+- Adding new sub-tools to the `simpleTools` slice
+- Modifying the `subToolResult` struct itself
+- Adding verbose/debug logging beyond the existing `logf`
+  pattern
+
+## Decisions
+
+### D1: Add `forceFlag` field to `simpleTool` struct
+
+The `simpleTool` struct gains a `forceFlag string` field.
+Each tool entry declares its own flag value. This keeps
+force-flag knowledge local to the tool definition rather
+than hardcoding flag names in `initSimpleTool`.
+
+**Rationale**: Mirrors how `args` already captures
+tool-specific extra arguments. Different tools may use
+different flag names (though all current tools use
+`--force` or none). The struct-field approach is
+extensible without modifying the init function.
+
+**Constitution alignment**: Composability First — each
+tool's integration contract is self-contained in its
+struct definition.
+
+### D2: Conditional sentinel bypass in `initSimpleTool`
+
+The sentinel-exists check at line 1450-1451 becomes:
+
+```
+if sentinel exists AND NOT opts.Force:
+    return nil
+```
+
+When `opts.Force` is true and sentinel exists, execution
+falls through to the init command. If `forceFlag` is
+non-empty, it is appended to the args slice.
+
+**Rationale**: Direct pattern match with `initDewey`
+lines 1387-1441, which uses the same conditional
+structure. Minimal change surface.
+
+### D3: Pass `simpleTool` struct to `initSimpleTool`
+
+Refactor `initSimpleTool` to accept the `simpleTool`
+struct directly instead of individual parameters. This
+avoids parameter proliferation when adding `forceFlag`
+and improves readability.
+
+Current signature:
+```go
+func initSimpleTool(opts *Options, name, sentinel,
+    resultName, label string, extraArgs []string,
+    logf func(string, ...interface{})) *subToolResult
+```
+
+New signature:
+```go
+func initSimpleTool(opts *Options, tool simpleTool,
+    logf func(string, ...interface{})) *subToolResult
+```
+
+**Rationale**: The current function takes 7 parameters,
+all of which are fields of `simpleTool` except `opts`
+and `logf`. Passing the struct reduces parameter count
+to 3 and makes the call site cleaner.
+
+### D4: Distinct action label for force re-initialization
+
+When `initSimpleTool` re-runs a tool due to `opts.Force`,
+the result uses action `"re-initialized"` instead of
+`"initialized"`. This matches the `initDewey` pattern
+where force produces `"re-indexed"` (line 1438).
+
+**Rationale**: Observable Quality — the output
+distinguishes between first-time init and force
+re-initialization, giving users and downstream
+consumers clear signal about what happened.
+
+## Risks / Trade-offs
+
+### Risk: Sub-tool `--force` semantics vary
+
+Each sub-tool may interpret `--force` differently. For
+example, `specify init --force` overwrites existing files,
+while `gaze init --force` may have different behavior.
+This is acceptable because `uf init --force` already
+implies the user wants to override existing state for
+all tools. The per-tool `forceFlag` field allows each
+tool to declare its own flag semantics.
+
+**Mitigation**: The `forceFlag` field is optional (empty
+string means no flag). Tools that are naturally idempotent
+(like replicator, which overwrites without needing a
+flag) do not declare a force flag.
+
+### Risk: Signature change to `initSimpleTool`
+
+Changing the function signature from individual parameters
+to a struct parameter requires updating the call site in
+the `for` loop (line 1361-1362). This is a single call
+site, so the risk is minimal.
+
+**Mitigation**: The call site change is mechanical and
+covered by existing tests that exercise the init loop.
+
+### Trade-off: No logging for force-skip-sentinel
+
+When `opts.Force` is true and sentinel exists, we re-run
+the tool without logging "Sentinel exists, forcing
+re-initialization" — we simply run the init command with
+the force flag. This keeps the log output clean and
+matches the `initDewey` pattern, which also does not log
+the force bypass explicitly.

--- a/openspec/changes/fix-init-force-passthrough/proposal.md
+++ b/openspec/changes/fix-init-force-passthrough/proposal.md
@@ -1,0 +1,104 @@
+## Why
+
+`uf init --force` does not re-initialize Group B sub-tools
+(specify, replicator, openspec, gaze) or pass `--force`
+through to their CLIs. This breaks the recovery path for
+partial or interrupted initialization and prevents force-
+refreshing sub-tool configuration after upgrades.
+
+Two defects exist in `internal/scaffold/scaffold.go`:
+
+1. **`initSimpleTool` ignores `opts.Force`** (line 1448-1452):
+   Returns `nil` unconditionally when the sentinel exists,
+   unlike `initDewey` which explicitly checks `opts.Force`
+   and re-indexes when forced.
+
+2. **`--force` not passed to sub-tool CLIs** (line 1336-1347):
+   The `simpleTool` struct has no `forceFlag` field, so
+   sub-tools like `specify init` fail in non-empty
+   directories because they never receive `--force`.
+
+This is tracked as GitHub issue #479.
+
+## What Changes
+
+The `simpleTool` struct and `initSimpleTool` function gain
+force-mode awareness, matching the existing `initDewey`
+behavior.
+
+## Capabilities
+
+### New Capabilities
+- None
+
+### Modified Capabilities
+- `uf init --force`: Correctly re-initializes all sub-tools
+  (Group A and Group B) and passes tool-specific force flags
+  through to each sub-tool CLI
+
+### Removed Capabilities
+- None
+
+## Impact
+
+- **Files**: `internal/scaffold/scaffold.go`,
+  `internal/scaffold/scaffold_test.go`
+- **Behaviors**: `uf init --force` will re-run sub-tool init
+  commands with their respective `--force` flags instead of
+  silently skipping when sentinels exist
+- **Spec alignment**: Closes the gap between spec 017 FR-007
+  (`uf init --force` MUST overwrite stale config) and spec
+  027 FR-011 (idempotency) — force mode is an explicit
+  override of the idempotency guard
+
+## Constitution Alignment
+
+Assessed against the Unbound Force org constitution.
+
+### I. Autonomous Collaboration
+
+**Assessment**: N/A
+
+This change does not affect artifact-based communication
+between heroes. It modifies internal initialization
+plumbing within the `uf` CLI.
+
+### II. Composability First
+
+**Assessment**: PASS
+
+This fix restores composability. Currently, `uf init --force`
+fails to re-initialize independently-installable heroes
+(specify, openspec, gaze, replicator), forcing users to
+bypass `uf init` and invoke each tool's init command
+directly. The fix ensures the unified orchestrator
+correctly propagates force semantics to all composed tools.
+
+### III. Observable Quality
+
+**Assessment**: PASS
+
+The current behavior produces a silent skip — no output,
+no error, no indication that sub-tools were skipped during
+force re-initialization. The fix ensures sub-tools are
+re-run when `--force` is specified, producing visible
+init results (success or failure) for each tool.
+
+### IV. Testability
+
+**Assessment**: PASS
+
+The fix adds test coverage for the force path in
+`initSimpleTool`, closing a parity gap with `initDewey`
+which already has 4 dedicated force-related tests. All
+new tests will use `t.TempDir()` for isolation and
+standard library assertions only.
+
+### V. Security by Default
+
+**Assessment**: PASS
+
+The fix appends static, developer-defined flag strings
+(e.g., `"--force"`) to the args slice passed to
+`exec.Command`. No untrusted input is involved. No new
+dependencies are added.

--- a/openspec/changes/fix-init-force-passthrough/specs/027-externalize-tool-init/spec.md
+++ b/openspec/changes/fix-init-force-passthrough/specs/027-externalize-tool-init/spec.md
@@ -1,0 +1,112 @@
+## ADDED Requirements
+
+### Requirement: FR-014 — Force flag passthrough for Group B tools
+
+`initSimpleTool` MUST check `opts.Force` before applying
+the sentinel-exists guard. When `opts.Force` is true and
+the sentinel path exists, the function MUST re-run the
+sub-tool's init command instead of returning nil.
+
+When `opts.Force` is true, the sentinel path exists, and
+the `simpleTool` entry declares a non-empty `forceFlag`,
+`initSimpleTool` MUST append that flag to the args slice
+passed to `ExecCmd`.
+
+When `opts.Force` is true, the sentinel path exists, and
+the `simpleTool` entry has an empty `forceFlag`,
+`initSimpleTool` MUST re-run the init command without an
+additional force flag (the tool is assumed idempotent).
+
+On first-time initialization (sentinel does not exist),
+the `forceFlag` MUST NOT be appended regardless of
+`opts.Force`. The function MUST proceed with the standard
+init args and report action `"initialized"`.
+
+#### Scenario: Force re-initializes specify with --force flag
+
+- **GIVEN** the `.specify` sentinel directory exists
+- **WHEN** the user runs `uf init --force`
+- **THEN** `initSimpleTool` MUST invoke
+  `specify init --here --integration opencode --offline --force`
+- **AND** the result MUST report action "re-initialized"
+
+#### Scenario: Force re-initializes replicator without force flag
+
+- **GIVEN** the `.uf/replicator` sentinel directory exists
+- **WHEN** the user runs `uf init --force`
+- **THEN** `initSimpleTool` MUST invoke `replicator init`
+  (no additional force flag, since replicator declares no
+  forceFlag)
+- **AND** the result MUST report action "re-initialized"
+
+#### Scenario: First-time init with force (no sentinel)
+
+- **GIVEN** the `.specify` sentinel directory does NOT exist
+- **WHEN** the user runs `uf init --force`
+- **THEN** `initSimpleTool` MUST invoke
+  `specify init --here --integration opencode --offline`
+  (without `--force`, since sentinel did not exist)
+- **AND** the result MUST report action "initialized"
+
+#### Scenario: Force re-init failure reports error
+
+- **GIVEN** the `.specify` sentinel directory exists
+- **WHEN** the user runs `uf init --force` and `ExecCmd`
+  returns an error
+- **THEN** the result MUST report action "failed"
+- **AND** the error detail MUST be preserved
+
+#### Scenario: No-force skips existing sentinel (unchanged)
+
+- **GIVEN** the `.specify` sentinel directory exists
+- **WHEN** the user runs `uf init` (without `--force`)
+- **THEN** `initSimpleTool` MUST return nil
+- **AND** the tool MUST NOT be re-initialized
+
+### Requirement: FR-015 — simpleTool struct forceFlag field
+
+The `simpleTool` struct MUST include a `forceFlag` field
+of type `string`. Each tool entry in the `simpleTools`
+slice MUST declare its tool-specific force flag:
+
+| Tool     | forceFlag |
+|----------|-----------|
+| specify  | `--force` |
+| openspec | `--force` |
+| gaze     | `--force` |
+| replicator | (empty) |
+
+An empty `forceFlag` means the tool does not require a
+force flag for re-initialization.
+
+### Requirement: FR-016 — Re-initialized action label
+
+When `initSimpleTool` re-runs a tool due to `opts.Force`,
+the returned `subToolResult` MUST use action
+`"re-initialized"` to distinguish force re-initialization
+from first-time initialization (action `"initialized"`).
+
+#### Scenario: Action label distinguishes force from first-time
+
+- **GIVEN** the sentinel path exists and `opts.Force` is true
+- **WHEN** `initSimpleTool` completes successfully
+- **THEN** the `subToolResult.action` MUST be
+  `"re-initialized"`
+
+## MODIFIED Requirements
+
+### Requirement: FR-011 — Idempotency (clarification)
+
+Each tool delegation MUST be idempotent — if the tool's
+directory already exists **and** `opts.Force` is false,
+the step is skipped. When `opts.Force` is true, the
+idempotency guard is bypassed and the tool is
+re-initialized.
+
+Previously: "Each tool delegation MUST be idempotent —
+if the tool's directory already exists, the step is
+skipped." (No mention of force override.)
+
+## REMOVED Requirements
+
+None.

--- a/openspec/changes/fix-init-force-passthrough/tasks.md
+++ b/openspec/changes/fix-init-force-passthrough/tasks.md
@@ -1,0 +1,115 @@
+<!--
+  [P] marks tasks eligible for parallel execution.
+  Add [P] when a task: (a) touches different files from
+  other [P] tasks in the group, (b) has no dependency
+  on prior tasks in the group, (c) can safely execute
+  without ordering constraints.
+  Do NOT add [P] when tasks modify the same file —
+  parallel workers will cause merge conflicts.
+  Tasks without [P] run sequentially first, then [P]
+  tasks run in parallel.
+
+  All tasks in this change modify the same two files
+  (scaffold.go and scaffold_test.go), so no tasks are
+  parallel-eligible.
+-->
+
+## 1. Struct and Function Changes
+
+- [x] 1.1 Add `forceFlag string` field to the `simpleTool`
+  struct in `internal/scaffold/scaffold.go` (after `args`
+  field, line 1333). Update each entry in the
+  `simpleTools` slice: specify `"--force"`,
+  openspec `"--force"`, gaze `"--force"`,
+  replicator `""`. (FR-015, D1)
+
+- [x] 1.2 Refactor `initSimpleTool` signature to accept
+  `tool simpleTool` instead of individual parameters
+  `name, sentinel, resultName, label string,
+  extraArgs []string`. Update the function body to
+  reference `tool.name`, `tool.sentinel`, etc. Update the
+  single call site in the `for` loop (line 1361-1362).
+  Update the GoDoc comment to reflect force-aware
+  behavior (the current comment states "Returns nil if
+  the sentinel already exists" which will be inaccurate
+  after the change). (D3, DR-001)
+
+- [x] 1.3 Modify `initSimpleTool` sentinel guard: change
+  the early return condition from
+  `if !os.IsNotExist(statErr) { return nil }` to
+  `if !os.IsNotExist(statErr) && !opts.Force { return nil }`.
+  (FR-014, D2)
+
+- [x] 1.4 Add force flag injection in `initSimpleTool`:
+  after the args construction (`append([]string{"init"},
+  tool.args...)`), if `opts.Force`, the sentinel existed,
+  and `tool.forceFlag` is non-empty, append
+  `tool.forceFlag` to args. On first-time init (sentinel
+  did not exist), do NOT append forceFlag regardless of
+  `opts.Force`. (FR-014)
+
+- [x] 1.5 Add action label branching: when `opts.Force` is
+  true and sentinel existed (sentinel was found at the
+  guard check), the successful result MUST use action
+  `"re-initialized"` instead of `"initialized"`. Track
+  whether sentinel existed before the guard. (FR-016, D4)
+
+## 2. Test Coverage
+
+- [x] 2.1 Add `TestInitSimpleTool_SentinelExistsForceTrue`:
+  Create sentinel via `t.TempDir()`, set `Force=true`,
+  verify `ExecCmd` IS called with the tool's init command
+  and result is non-nil with action `"re-initialized"`.
+
+- [x] 2.2 Add `TestInitSimpleTool_SentinelExistsNoForce`:
+  Create sentinel via `t.TempDir()`, set `Force=false`,
+  verify `initSimpleTool` returns nil and `ExecCmd` is
+  NOT called.
+
+- [x] 2.3 Add `TestInitSimpleTool_ForcePassesForceFlag`:
+  Set `Force=true`, tool declares `forceFlag: "--force"`,
+  verify ExecCmd args include `"--force"`. Assert specific
+  arg values.
+
+- [x] 2.4 Add `TestInitSimpleTool_NoForceFlagDeclared`:
+  Set `Force=true`, tool declares empty `forceFlag`,
+  verify init is re-run without an extraneous force flag
+  in args.
+
+- [x] 2.5 Add `TestInitSubTools_SpecifyForcePassthrough`:
+  Integration-level test with `Force=true`, specify
+  sentinel existing, stubbed ExecCmd. Verify recorded
+  command includes
+  `specify init --here --integration opencode --offline --force`.
+
+- [x] 2.6 Add `TestInitSimpleTool_ForceReinitFails`:
+  Create sentinel via `t.TempDir()`, set `Force=true`,
+  stub ExecCmd to return an error. Verify the result has
+  `action: "failed"` and `err` is non-nil. Confirms
+  error handling is preserved through the force path.
+
+- [x] 2.7 Add `TestInitSimpleTool_NoSentinelForceTrue`:
+  Set `Force=true`, do NOT create sentinel. Verify result
+  has `action: "initialized"` (not `"re-initialized"`)
+  and ExecCmd args do NOT include the `forceFlag`. This
+  confirms first-time init behavior is unchanged when
+  `Force` is true.
+
+## 3. Verification
+
+- [x] 3.1 Run `go vet ./internal/scaffold/...` and
+  `golangci-lint run ./internal/scaffold/...` — no new
+  lint warnings.
+
+- [x] 3.2 Run `go test -race -count=1 ./internal/scaffold/...`
+  — all existing and new tests pass.
+
+- [x] 3.3 Verify constitution alignment: Composability
+  (Principle II) — `uf init --force` re-initializes all
+  tools. Observable Quality (Principle III) — force
+  produces visible `"re-initialized"` output. Testability
+  (Principle IV) — force path has test parity with
+  `initDewey`.
+
+<!-- spec-review: passed -->
+<!-- code-review: passed -->


### PR DESCRIPTION
## Summary

`uf init --force` silently skipped re-initialization for Group B sub-tools (specify, replicator, openspec, gaze) because `initSimpleTool` ignored`opts.Force` and the `simpleTool` struct had no mechanism to pass tool-specific force flags. This fix restores force semantics for all sub-tools, bringing `initSimpleTool` to behavioral parity with `initDewey`.

Two defects fixed:
1. **Sentinel bypass**: `initSimpleTool` now checks `sentinelExists && !opts.Force` instead of unconditionally returning nil when the sentinel exists
2. **Force flag passthrough**: New `forceFlag` field on `simpleTool` struct enables per-tool force flag declaration (specify/openspec/gaze: `--force`, replicator: empty)

Fixes #479

## How to Test

```bash
# Run the 7 new tests that exercise all force-path scenarios
go test -race -count=1 ./internal/scaffold/... \
  -run "TestInitSimpleTool|TestInitSubTools_SpecifyForce"

# Full scaffold test suite
go test -race -count=1 ./internal/scaffold/...
```

Scenarios covered by the new tests:
- Force=true + sentinel exists → ExecCmd called, action="re-initialized"
- Force=false + sentinel exists → nil returned, ExecCmd NOT called
- Force=true + sentinel + forceFlag="--force" → args include "--force"
- Force=true + sentinel + empty forceFlag → no "--force" in args
- Force=true + no sentinel → action="initialized", no forceFlag appended
- Force re-init + ExecCmd error → action="failed", err non-nil
- Integration: Force=true + .specify/ exists → full specify command with --force

## How to Demo

```bash
# Initialize a workspace
uf init /tmp/test-workspace

# Force re-initialization — previously silent-skipped Group B tools
uf init --force /tmp/test-workspace
# Observe: all tools now show "re-initialized" instead of being silently skipped
```

## Key Files Changed

**Implementation:**
- `internal/scaffold/scaffold.go` — Add `forceFlag` field to `simpleTool` struct, refactor `initSimpleTool` signature, add sentinel guard bypass for force mode, inject per-tool force flags, add "re-initialized" action label (+78/-27)
- `internal/scaffold/scaffold_test.go` — 7 new tests for force path coverage (+300)

**OpenSpec Change Artifacts:**
- `openspec/changes/fix-init-force-passthrough/proposal.md` — Motivation and constitution alignment
- `openspec/changes/fix-init-force-passthrough/design.md` — 4 design decisions (D1-D4)
- `openspec/changes/fix-init-force-passthrough/specs/027-externalize-tool-init/spec.md` — Delta spec with FR-014, FR-015, FR-016
- `openspec/changes/fix-init-force-passthrough/tasks.md` — 15 tasks (all checked)

_This PR was generated by /uf.finale (AI-assisted)._