### PR TITLE
chore: mark prerelease tags automatically in GoReleaser

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -47,6 +47,7 @@ signs:
       - --yes
 
 release:
+  prerelease: auto
   extra_files:
     - glob: dist/homebrew/Casks/unbound-force.rb
     - glob: dist/homebrew/Formula/unbound-force.rb


### PR DESCRIPTION
## Summary

Add `prerelease: auto` to `.goreleaser.yaml` so GoReleaser automatically detects semver prerelease suffixes (`-rc.N`, `-alpha.N`, `-beta.N`) and sets the GitHub release `prerelease` flag accordingly.

## Problem

Prerelease tags (e.g., `v1.0.0-rc.1`) would be published as full releases. This means `brew upgrade` would install them as the latest stable version, and the GitHub releases page shows them alongside stable releases without distinction.

## Change

One-line addition to the existing `release:` block in `.goreleaser.yaml`. Stable tags (e.g., `v1.0.0`) continue to be marked as full releases.